### PR TITLE
Use one local index for files-diff and target-confirmed files-push commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,15 +517,18 @@ whatever tool was reading stdout (typically `mysql` CLI).
 
 Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
-name itself. State-directory-wide command progress and the audit log live directly in the
-state directory. Pull and push operation state live under the remote state
-directory at `remotes/<md5-of-trimmed-remote-reprint-api-url>/`, in `pull/` and
-`push/` respectively. State-directory-wide and pull filenames do not begin
-with a dot or repeat the scope supplied by their parent directory.
+name itself. State-directory-wide command progress and the audit log live
+directly in the state directory. The retained local index lives at
+`remotes/<md5-of-trimmed-remote-reprint-api-url>/local_index.jsonl`. Pull and
+push operation state live in the sibling `pull/` and `push/` directories.
+State-directory-wide and pull filenames do not begin with a dot or repeat the
+scope supplied by their parent directory.
 
 The directory name is `md5(rtrim(<remote-reprint-api-url>, "?&"))`. Commands
 which read local pull state receive the same remote Reprint API URL even when
-they make no network request; the URL selects the remote state directory.
+they make no network request; the URL selects the remote state directory. The
+filesystem root is not part of that directory name, so a different filesystem
+root uses a different state directory.
 
 `<remote-state-directory>/pull/state.json` and the state-directory-wide
 `progress.json` are written atomically:

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -7,9 +7,9 @@ the end maps it to a PR stack.
 
 ## Shape of a push
 
-1. The local machine knows what changed locally since its last push to this
-   remote (files, deletions, database rows), by comparing against the local
-   paths and rows stored after that push.
+1. The local machine knows what changed locally since the last target-confirmed
+   push to this remote (files, deletions, database rows), by comparing against
+   the local paths and rows stored after that push.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
@@ -19,10 +19,10 @@ the end maps it to a PR stack.
    moves work files into place, executes deletions, and commits the database
    diff, and fixes symlinks — inside a maintenance window that lasts seconds,
    not the length of the transfer.
-5. It stores the current local paths as the previous local index for that
-   remote Reprint API URL and stores the current rows as the previously pushed
-   rows. The push is complete only after this step; a crashed push is
-   re-driven from the top and converges.
+5. It stores the current local paths as the local index for that remote Reprint
+   API URL and stores the current rows as the previously pushed rows. The push
+   is complete only after this step. A later process resumes an interrupted
+   sender from its stored phase.
 
 Both sides act only when the local machine calls: no worker, no polling, no
 sessions. The remote is a passive authenticated API.
@@ -77,24 +77,25 @@ managed `false` hard-disables push without abandoning durable commit recovery.
 ## Change detection: local machine compared against itself
 
 ctime is machine-local, so push never compares a local timestamp to a remote
-one. It only answers "what changed locally since my last successful push to
-this remote" by comparing the current local paths and rows against the previous
-local index and previously pushed rows for that remote Reprint API URL.
+one. It answers "what changed locally since my last target-confirmed push
+commit to this remote" by comparing the current local paths and rows against
+the local index and previously pushed rows for that remote Reprint API URL.
 
-The local machine keeps these files **per remote Reprint API URL**, overwritten
-after each successful commit. The state directory already selects one
-filesystem root:
+The local machine keeps these files **per remote Reprint API URL**. The caller
+uses a different state directory for each filesystem root:
 
-    <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/previous_local_index.jsonl
+    <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/local_index.jsonl
     <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/previously_pushed_rows.jsonl   (phase two)
 
-The previous local index records the local path type, size, and ctime as the
-completing push observed them. Besides planning the next push, it feeds the
-local `files-diff` command, which reports the same comparison without pushing.
+The local index records local relative paths and the locally observed type,
+size, ctime, and directory emptiness from the most recent fresh scan the sender
+finished saving after the target confirmed its corresponding files-push
+commit. Besides planning the next push, it feeds the local `files-diff` command,
+which reports the same comparison without pushing.
 
 `PushPlan` first builds a path-sorted fresh local index, then derives the local
-paths to push and delete by diffing it against the previous local index its
-caller supplies. The indexer marks physical emptiness while
+paths to push and delete by diffing it against the local index its caller
+supplies. The indexer marks physical emptiness while
 it observes each directory, so a completed index distinguishes empty
 directories from non-empty ones. Files and symlinks change when their `type`,
 `ctime`, or `size` changes; unrelated index values do not select a path for
@@ -127,13 +128,12 @@ A push plan is an internal part of the sender lifecycle:
    `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
-6. After the receiver commits successfully, the sender saves the retained fresh
-   local index as `previous_local_index.jsonl` through the same swap-file
-   copy. It then removes the complete `plan/` directory and the sender-owned
-   exclusions file. After the target
-   confirms removal of a discarded push session, the sender removes the same
-   files without changing the previous local index for that remote Reprint API
-   URL.
+6. After the target confirms commit, the sender saves the retained fresh local
+   index as `<remote-state-directory>/local_index.jsonl` through the same
+   swap-file copy. It then removes the complete `plan/` directory and the
+   sender-owned exclusions file. After the target confirms removal of a
+   discarded push session, the sender removes the same files without changing
+   the local index for that remote Reprint API URL.
 
 Until the sender stores the initial PushPlan cursor, `starting_plan` remains
 the durable phase. An interrupted start is repeated and overwrites its initial
@@ -151,8 +151,8 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, filesystem root, previous local
-index, and current planning position. During indexing, that
+The cursor contains the plan directory, filesystem root, local index file, and
+current planning position. During indexing, that
 position contains the `FileIndexProcessor` cursor and committed fresh-index byte
 offset. During diffing, each step flushes only the path list or append-only
 deleted-directory stack changed by that step before updating the two index
@@ -162,9 +162,9 @@ entry. A later process passes the stored cursor to `PushPlan::resume()`. The
 plan uses its private exclusions copy, discards bytes beyond the stored output
 offsets, and continues from the retained internal phase.
 
-The first push to a site has no previous local index or previously
-pushed rows. Every current file, symlink, and empty directory is selected, and
-no local deletion can be detected yet.
+The first push to a site has no local index or previously pushed rows. Every
+current file, symlink, and empty directory is selected, and no local deletion
+can be detected yet.
 
 Push is intentionally local-wins. If a developer edited the remote site
 outside Reprint, a later push of the same path or row overwrites that remote
@@ -173,8 +173,8 @@ manager.
 
 ## Deletes
 
-Local deletions since the last push come from paths present in
-the previous local index but absent from the fresh local index. They
+Local deletions since the last push come from paths present in the local index
+but absent from the fresh local index. They
 travel as NUL-delimited document-root-relative paths in `work/deletes`. Commit
 records its byte offset before and after every destructive mutation, so a later
 request can resume from a durable checkpoint instead of repeating a delete.
@@ -284,19 +284,21 @@ caller supplies none. The one state-directory-wide Reprint process lock
 prevents concurrent pull, push, diff, and other local Reprint processes from
 using that site state, regardless of their remote Reprint API URLs.
 
-An active push keeps these files under
-`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`:
+The remote state directory keeps the retained local index beside active push
+state:
 
 ```text
-previous_local_index.jsonl          index saved after the previous commit
-excluded_paths.json                 sender-owned target exclusions
-sender.json                         active push state
-plan/
-  excluded_paths.json               target exclusions for the active push
-  fresh_local_index.jsonl           plan-owned fresh local index
-  local_paths_to_push.jsonl         local paths to push
-  local_paths_to_delete             raw NUL-delimited local paths to delete
-  deleted_directories_stack.jsonl   append-only planning stack
+<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/
+  local_index.jsonl                     index saved after target-confirmed commit
+  push/
+    excluded_paths.json                 sender-owned target exclusions
+    sender.json                         active push state
+    plan/
+      excluded_paths.json               target exclusions for the active push
+      fresh_local_index.jsonl           plan-owned fresh local index
+      local_paths_to_push.jsonl         local paths to push
+      local_paths_to_delete             raw NUL-delimited local paths to delete
+      deleted_directories_stack.jsonl   append-only planning stack
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.
@@ -339,9 +341,9 @@ and phase, the PushPlan cursor, the next byte offset in
 `local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
 sizing state. Its phases are `creating`, `starting_plan`, `planning`,
 `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_previous_local_index`, `completing`, `removing`, and
+`saving_local_index`, `completing`, `removing`, and
 `discarding_plan`.
-The separate start, index-save, completion, removal, and discard phases ensure
+The separate start, local-index-save, completion, removal, and discard phases ensure
 that a process stop between durable actions repeats only the current action.
 During `planning`, the PushPlan cursor in `sender.json` contains the
 plan's internal phase and continuation offsets. A completed cursor remains until
@@ -377,8 +379,8 @@ captured by the completed fresh local index rather than attempting to describe
 the live tree at commit time.
 
 Repeated `push_commit` calls drive the receiver to `complete`. Only then does
-the sender enter `saving_previous_local_index` and copy the plan-owned
-fresh local index to `previous_local_index.jsonl`. Excluded entries
+the sender enter `saving_local_index` and copy the plan-owned fresh local index
+to `<remote-state-directory>/local_index.jsonl`. Excluded entries
 remain in that complete index; exclusions suppress remote work rather than
 creating a second retained index representation. The sender then removes the
 entire plan directory before deleting active sender state.
@@ -449,7 +451,7 @@ continues through the same hard-death contract used after SIGKILL.
 The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
-shared audit log records opening mode, phase changes, planned pauses, handled
+state-directory-wide audit log records opening mode, phase changes, planned pauses, handled
 interruptions, and terminal outcomes. The flat progress file records only
 `command`, `status`, `phase`, `reason`, `detail`, and `ts`; neither file copies
 receiver cursors or tentative upload positions.
@@ -458,15 +460,16 @@ receiver cursors or tentative upload positions.
 
 `reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
-files-push would send or delete, compared against the previous local index for
-that remote Reprint API URL published by a completed files-push. It uses the
-files-push local push state directory formula, including its trailing `?` and
-`&` trim, so another URL query cannot reuse the index. A different filesystem
-root uses a different state directory. It accepts only `--state-dir` and
-`--fs-root`; it needs no secret, performs no preflight, and makes no network
-request. It runs one complete PushPlan against `previous_local_index.jsonl` in
-`files-diff-plan/` while the command holds the state-directory-wide Reprint
-process lock.
+files-push would send or delete, compared against
+`<remote-state-directory>/local_index.jsonl`. Files-push replaces that local
+index after the target confirms commit. The remote state directory is
+`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>`, so another URL
+query cannot reuse the index. A different filesystem root uses a different
+state directory. The command accepts only `--state-dir` and `--fs-root`; it
+needs no secret, performs no preflight, and makes no network request. It runs
+one complete PushPlan against the local index in
+`<remote-state-directory>/push/files-diff-plan/` while the command holds the
+state-directory-wide Reprint process lock.
 
 Output is JSONL. Each selected current file, symlink, or empty directory has
 `action: "push"`, `path_b64`, `type`, `size`, and `ctime`; its type is `file`,
@@ -512,8 +515,8 @@ Order:
    `commit.json` checkpoint written before each document-root mutation. The
    future database batch and symlink updates follow the same bounded cursor.
 4. **Maintenance off:** commit releases its `commit-state` ownership after
-   completion; the driver saves the previous local index and rows for that
-   remote Reprint API URL after commit completes.
+   completion; the driver saves the local index and previously pushed rows for
+   that remote Reprint API URL after the target confirms commit.
 
 If the driver dies mid-commit: WordPress stops honoring the `.maintenance`
 file after 10 minutes on its own, and the next commit request resumes from
@@ -605,8 +608,8 @@ Files first, database second, each PR small and stacked in this order:
     one sender per process, applies caller time and memory admission budgets,
     and reports completion, continuation, restart, or failure without retrying.
 12. **`reprint files-diff`** — a local-only command that reports the paths a
-    files-push would send or delete against the previous local index for that
-    remote Reprint API URL, without contacting the target.
+    files-push would send or delete against the local index for that remote
+    Reprint API URL, without contacting the target.
 13. **`reprint push`** — the high-level command that adds a change summary,
     confirmation boundary, database work, transfer, commit, and resume.
 14. **Budgets and resumable limits** — push requests stay bounded by two

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -52,6 +52,12 @@ local relative path to a push-root-relative path.
 - A **next remote index** is the snapshot of the remote paths selected for the
   current pull. Its entries use remote absolute paths and remote-observed
   metadata. Use `$next_remote_index_file`.
+- A **local index** is the retained filesystem-root snapshot in one remote
+  state directory. Its entries use local relative paths and locally observed
+  type, size, ctime, and directory emptiness. The remote Reprint API URL selects
+  the remote state directory; a different filesystem root uses a different
+  state directory. Files-push atomically replaces the local index only after
+  the target confirms commit. Use `$local_index_file`.
 - A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
@@ -174,6 +180,7 @@ their parent directories.
 ├── audit.log
 └── remotes/
     └── <md5-of-trimmed-remote-reprint-api-url>/
+        ├── local_index.jsonl
         ├── pull/
         │   ├── state.json
         │   ├── remote-index.jsonl
@@ -195,6 +202,7 @@ Use these path names:
 | State directory | `$state_dir` |
 | Pull state directory | `$pull_state_directory` |
 | Remote state directory | `$remote_state_directory` |
+| Local index file | `$local_index_file` |
 | Pull state file | `$pull_state_file` |
 | Remote index file | `$remote_index_file` |
 | Remote index WAL | `$remote_index_wal_path` |
@@ -244,19 +252,21 @@ files-pull completes. A retained WAL is consumed only while resuming or
 aborting the interrupted files-pull, including through a high-level pull
 command; unrelated commands do not consume it.
 
-## Local push state
+## Local index and push state
 
-The local machine keeps planning and active state outside the receiver push
-directory. Under
-`<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`, use these
-names verbatim:
+The local index is `<remote-state-directory>/local_index.jsonl`.
+`files-diff` and PushPlan read it. PushFilesSender replaces it only after the
+target confirms commit. Planning and active push state remain under
+`<remote-state-directory>/push/`.
+
+Use these names verbatim:
 
 | Surface | Name |
 | --- | --- |
 | Active plan directory | `plan`, `$plan_directory` |
-| Plan-owned fresh local index | `fresh_local_index.jsonl`, `$fresh_local_index` |
-| Previous local index | `previous_local_index.jsonl`, `previous_local_index`, `$previous_local_index` |
-| Byte offset in the previous local index | `byte_offset_in_previous_local_index`, `$byte_offset_in_previous_local_index` |
+| Plan-owned fresh local index file | `fresh_local_index.jsonl`, `$fresh_local_index_file` |
+| Local index file | `local_index.jsonl`, `local_index_file`, `$local_index_file` |
+| Byte offset in the local index | `byte_offset_in_local_index`, `$byte_offset_in_local_index` |
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
@@ -267,34 +277,32 @@ names verbatim:
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
-`sender.json`, `excluded_paths.json`, and
-`previous_local_index.jsonl` live directly under the local push state
-directory. The sender creates `plan/` for one active plan. PushPlan copies the
-sender-owned exclusions to `plan/excluded_paths.json` when it starts.
+`sender.json` and `excluded_paths.json` live directly under the local push
+state directory. The sender creates `plan/` for one active plan. PushPlan
+copies the sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-The **previous local index** describes the filesystem root as its last
-completed push to the remote Reprint API URL observed it. The sender saves it
-after a successful commit, and `files-diff` reads it. PushPlan diffs its fresh
-local index against the copy its caller supplies.
-`byte_offset_in_previous_local_index` is the position from which its current
+The local index contains the most recent fresh filesystem-root scan the sender
+finished saving after the target confirmed its corresponding files-push
+commit. PushPlan diffs its fresh local index against the local index its caller
+supplies. `byte_offset_in_local_index` is the position from which its current
 lookahead entry is read again after resume.
 
-The PushPlan cursor is stored in `sender.json`. It contains the plan
-directory, filesystem root, previous local index, and current
+The PushPlan cursor is stored in `sender.json`. It contains `plan_directory`,
+`filesystem_root`, `local_index_file`, and the current
 planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
 `fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
 output offsets, and the active byte offset in
 `deleted_directories_stack.jsonl`. The stack file is append-only; each entry
 links to the preceding active directory. The exclusions have a maximum of 100
-paths. `sender.json` phases are `creating`, `starting_plan`,
+paths. The `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_previous_local_index`, `completing`,
+`saving_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
 path-list cursor, receiver part limit, and request-sizing state. The index diff
-completes before local paths are sent. The index copy after a successful commit
+completes before local paths are sent. The index copy after a target-confirmed commit
 has no separate copy cursor and is repeated after interruption. After the index
 is saved or the remote confirms removal, the sender clears the PushPlan
 cursor, then removes the entire plan directory and its exclusions file. It
@@ -330,11 +338,10 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `remote Reprint API URL`,
-`filesystem root`, and `local push state directory` have the same meanings and
-directory formula as `files-push`. It reads
-`previous_local_index.jsonl` for that remote Reprint API URL, which a completed
-files-push publishes, and never changes it.
+The local-only command is `files-diff`. Its `remote Reprint API URL` and
+`filesystem root` have the same meanings as for `files-push`. It reads
+`<remote-state-directory>/local_index.jsonl`, which files-push writes after the
+target confirms commit, and never changes it.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,
@@ -434,18 +441,23 @@ Use these names verbatim inside `PushPlan`:
 | --- | --- |
 | Active plan directory | `$plan_directory` |
 | Filesystem root | `$filesystem_root`, `set_filesystem_root()` |
-| Previous local index | `$previous_local_index` |
-| Open previous local index | `$previous_local_index_handle` |
-| Previous local index lookahead entry | `$previous_local_index_lookahead_entry`, `$previous_local_index_lookahead_entry_loaded` |
-| Byte offset in the previous local index | `$byte_offset_in_previous_local_index` |
+| Local index file | `$local_index_file` |
+| Open local index file | `$local_index_file_handle` |
+| Local index lookahead entry | `$local_index_lookahead_entry`, `$local_index_lookahead_entry_loaded` |
+| Byte offset in the local index | `$byte_offset_in_local_index` |
+| Read the next index entry | `read_next_index_entry()`, `$index_file_handle` |
+| Index entry and shape | `$index_entry`, `$local_index_entry`, `$local_index_entry_shape`, `index_entry_shape()` |
 | Cursor | `$cursor`, `get_cursor()` |
 | Plan-owned excluded paths | `$excluded_paths_file` |
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
 | Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |
+| Byte offset in the fresh local index during diff | `$byte_offset_in_fresh_local_index` |
 | Open fresh local index | `$fresh_local_index_handle` |
 | Index diff cursor | `IndexDiffCursor` |
 | Start index diff | `start_index_diff()` |
+| Seek an index file | `seek_index_file_to_byte_offset()`, `$index_file_handle` |
+| Open push-plan output file | `open_push_plan_output_file_at_byte_offset()`, `$push_plan_output_file_handle` |
 
 ## Protocol names
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1272,11 +1272,10 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
     /**
-     * Reports local paths changed since the previous push to this remote
-     * Reprint API URL.
+     * Reports changes between the filesystem root and its local index.
      *
      * files-diff makes no network request. It runs one complete PushPlan
-     * against the previous local index a completed files-push published, then
+     * against the local index, then
      * streams the finished push and delete lists from the beginning. Every run
      * reports the whole diff, so an interrupted report needs no resume state:
      * running the command again prints the complete report.
@@ -1300,18 +1299,17 @@ class ImportClient
             throw new InvalidArgumentException('files-diff requires its resolved local push state directory.');
         }
 
-        $previous_local_index = $push_state_directory . '/previous_local_index.jsonl';
-        $missing_previous_local_index_message =
-            'files-diff requires the previous local index published by a completed files-push '
-            . 'for the same remote Reprint API URL and state directory.';
-        if (!is_dir($push_state_directory)) {
-            throw new RuntimeException($missing_previous_local_index_message);
-        }
+        $remote_state_directory = dirname($push_state_directory);
+        $local_index_file = $remote_state_directory . '/local_index.jsonl';
+        $missing_local_index_message =
+            'files-diff requires <remote-state-directory>/local_index.jsonl. '
+            . 'files-push writes it after the target confirms commit for the same '
+            . 'remote Reprint API URL and state directory.';
 
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
-            if (!is_file($previous_local_index)) {
-                throw new RuntimeException($missing_previous_local_index_message);
+            if (!is_file($local_index_file)) {
+                throw new RuntimeException($missing_local_index_message);
             }
 
             // Build the complete local-only plan from scratch without target
@@ -1327,7 +1325,7 @@ class ImportClient
             $plan = PushPlan::start(
                 $plan_directory,
                 $this->filesystem_root,
-                $previous_local_index,
+                $local_index_file,
                 $excluded_paths_path
             );
             try {
@@ -12662,13 +12660,14 @@ if (
         ],
         "files-diff" => [
             "level" => "low",
-            "short" => "Show local file changes since the last push",
+            "short" => "Compare local files with the local index",
             "usage" => "reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR",
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
-                "the filesystem root at --fs-root with the previous local index for this remote Reprint API URL —\n" .
-                "the index a completed files-push publishes for the same remote Reprint API URL,\n" .
-                "state directory, and filesystem root.\n" .
+                "the filesystem root at --fs-root with the local index for this remote\n" .
+                "Reprint API URL. files-push writes that index after the target confirms\n" .
+                "commit. Use the same remote Reprint API URL, state directory, and\n" .
+                "filesystem root for both commands.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -10,8 +10,8 @@
  * PushFilesSender owns the only caller-visible push lifecycle. Its caller holds
  * the Reprint process lock while the sender creates and removes the target push
  * session, drives its internal PushPlan, streams the selected paths, commits the
- * push, and saves the completed fresh local index as the previous local index
- * for this remote Reprint API URL. The target owns the
+ * push, and saves the completed fresh local index as the local index for this
+ * remote Reprint API URL. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
  * retains the top-level phase, the selected path-list cursor, and learned
  * request limits and the PushPlan cursor needed after a process restart.
@@ -56,13 +56,14 @@
  *
  * A new sender calls `push_create` to learn target-owned exclusions before
  * starting PushPlan. The plan builds the fresh local index and diffs it against
- * the previous local index for this remote Reprint API URL, one bounded step
- * at a time. That index is saved by the previous successful push and also read
- * by files-diff. After planning
+ * the local index for this remote Reprint API URL, one bounded step at a time.
+ * That index contains the most recent fresh scan the sender finished saving
+ * after the target confirmed its corresponding files-push commit, and is also
+ * read by files-diff. After planning
  * completes, local files, symlinks, and empty directories stream through
  * multipart requests. The raw deletion list follows, and repeated `push_commit`
- * calls let the target install the work in bounded steps. A confirmed commit
- * enters another phase which saves the fresh local index as the previous local
+ * calls let the target install the work in bounded steps. A target-confirmed
+ * commit enters another phase which saves the fresh local index as the local
  * index for this remote Reprint API URL through a swap file. Index completion,
  * plan completion, local-index saving, and plan discard each have a separate
  * durable phase. A stopped process therefore repeats only an idempotent
@@ -72,9 +73,9 @@
  * PushPlan. PushFilesSender stores that cursor after every completed planning
  * step but never interprets its internal phase or offsets. The sender creates
  * the active plan directory before planning and removes the whole directory
- * only after success or target-session removal. The previous local index for
- * this remote Reprint API URL remains beside sender.json. Once the plan result
- * is saved or discarded, the sender clears its cursor before removing the
+ * only after success or target-session removal. The local index for this remote
+ * Reprint API URL remains in the remote state directory. Once the plan result
+ * is saved or discarded, the sender clears its cursor before removing the plan
  * directory without reopening PushPlan.
  *
  * ## Resume after local changes
@@ -123,7 +124,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_previous_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -136,8 +137,8 @@ final class PushFilesSender
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Previous local index for this remote Reprint API URL. */
-    private string $previous_local_index;
+    /** @var string Local index file for this remote Reprint API URL. */
+    private string $local_index_file;
 
     /** @var string Path where the serialized sender state is stored. */
     private string $state_path;
@@ -365,7 +366,8 @@ final class PushFilesSender
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
-        $this->previous_local_index = $this->push_state_directory . '/previous_local_index.jsonl';
+        $remote_state_directory = dirname($this->push_state_directory);
+        $this->local_index_file = $remote_state_directory . '/local_index.jsonl';
         $this->state_path = $this->push_state_directory . '/sender.json';
         $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
         $this->request_sizer_options = $request_sizer_options;
@@ -414,8 +416,8 @@ final class PushFilesSender
             case 'committing':
                 $this->commit_push();
                 break;
-            case 'saving_previous_local_index':
-                $this->save_previous_local_index();
+            case 'saving_local_index':
+                $this->save_local_index();
                 break;
             case 'completing':
                 $this->complete_push();
@@ -588,7 +590,7 @@ final class PushFilesSender
         $this->plan = PushPlan::start(
             $this->plan_directory,
             $this->filesystem_root,
-            $this->previous_local_index,
+            $this->local_index_file,
             $this->excluded_paths_path
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
@@ -1184,7 +1186,7 @@ final class PushFilesSender
         if ($response['send_next_request']) {
             return;
         }
-        $this->state['phase'] = 'saving_previous_local_index';
+        $this->state['phase'] = 'saving_local_index';
         $this->store_state($this->state);
     }
 
@@ -1195,13 +1197,13 @@ final class PushFilesSender
      * deliberate whole-index copy is safe and leaves readers on either the old
      * or complete new index.
      */
-    private function save_previous_local_index(): void
+    private function save_local_index(): void
     {
-        $fresh_local_index = $this->plan->get_fresh_local_index_path();
+        $fresh_local_index_file = $this->plan->get_fresh_local_index_path();
         try {
             $this->copy_through_swap_file(
-                $fresh_local_index,
-                $this->previous_local_index
+                $fresh_local_index_file,
+                $this->local_index_file
             );
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -6,7 +6,7 @@
  * Internal bounded local-index and change planner.
  *
  * PushPlan builds a path-sorted fresh local index, then diffs it against the
- * previous local index supplied by its caller. It writes durable lists of
+ * local index supplied by its caller. It writes durable lists of
  * local paths to push and local paths to delete without accumulating an index
  * or path list in memory.
  *
@@ -26,14 +26,13 @@
  *
  * ## Change detection
  *
- * ctime is machine-local, so the previous local index must describe the same
- * local machine: PushFilesSender supplies the index saved after the previous
- * push, and files-diff supplies the index captured after the previous pull.
- * File and symlink changes are determined by type, ctime, and size. Directory
- * changes use the indexer's empty-directory marker; non-empty directories are
- * represented by their descendants.
+ * ctime is machine-local, so the local index must describe the same filesystem
+ * root on the same local machine. The caller supplies the local index for its
+ * remote Reprint API URL. File and symlink changes are determined by type,
+ * ctime, and size. Directory changes use the indexer's empty-directory marker;
+ * non-empty directories are represented by their descendants.
  *
- * With no previous local index, every file, symlink, and empty directory is
+ * With no local index, every file, symlink, and empty directory is
  * selected, and no deletion can be detected. Excluded paths are omitted from
  * both path lists but remain in the fresh local index.
  *
@@ -58,10 +57,10 @@
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_index:int,byte_offset_in_previous_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,local_tree_root:string,previous_local_index:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
@@ -72,8 +71,8 @@ class PushPlan
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
 
-    /** @var string Previous local index supplied by the caller. */
-    private string $previous_local_index;
+    /** @var string Local index supplied by the caller. */
+    private string $local_index_file;
 
     /** @var string JSONL file of local paths to push. */
     private string $local_paths_to_push;
@@ -81,8 +80,8 @@ class PushPlan
     /** @var string Raw NUL-delimited local paths to delete. */
     private string $local_paths_to_delete;
 
-    /** @var string Plan-owned fresh local index. */
-    private string $fresh_local_index;
+    /** @var string Plan-owned fresh local index file. */
+    private string $fresh_local_index_file;
 
     /** @var string Plan path containing receiver-owned exclusions for the active push. */
     private string $excluded_paths_file;
@@ -109,10 +108,10 @@ class PushPlan
     private bool $fresh_local_index_entry_loaded = false;
 
     /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
-    private ?array $previous_local_index_lookahead_entry = null;
+    private ?array $local_index_lookahead_entry = null;
 
-    /** @var bool Whether $previous_local_index_lookahead_entry has been read, including EOF. */
-    private bool $previous_local_index_lookahead_entry_loaded = false;
+    /** @var bool Whether $local_index_lookahead_entry has been read, including EOF. */
+    private bool $local_index_lookahead_entry_loaded = false;
 
     /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
     private ?array $deleted_directory_stack_entry = null;
@@ -120,7 +119,7 @@ class PushPlan
     /** @var resource|null Open fresh local index retained during indexing or the index diff. */
     private $fresh_local_index_handle = null;
     /** @var resource|null */
-    private $previous_local_index_handle = null;
+    private $local_index_file_handle = null;
     /** @var resource|null */
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
@@ -135,26 +134,26 @@ class PushPlan
      * fresh local index traversal. Until the caller stores the returned cursor,
      * an interrupted start is repeated and overwrites these initial plan files.
      *
-     * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $filesystem_root              Resolved filesystem root.
-     * @param string $previous_local_index Previous local index this plan diffs against.
-     * @param string $excluded_paths_path          Caller-owned target exclusions file.
+     * @param string $plan_directory      Caller-owned active plan directory.
+     * @param string $filesystem_root     Resolved filesystem root.
+     * @param string $local_index_file    Local index file this plan diffs against.
+     * @param string $excluded_paths_path Caller-owned target exclusions file.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $filesystem_root,
-        string $previous_local_index,
+        string $local_index_file,
         string $excluded_paths_path
     ): self {
-        $plan = new self($plan_directory, $filesystem_root, $previous_local_index);
+        $plan = new self($plan_directory, $filesystem_root, $local_index_file);
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
         $plan->excluded_paths = $plan->load_excluded_paths();
-        $plan->fresh_local_index_handle = fopen($plan->fresh_local_index, "w+b");
+        $plan->fresh_local_index_handle = fopen($plan->fresh_local_index_file, "w+b");
         if (!is_resource($plan->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index}");
+            throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index_file}");
         }
         $plan->file_index_processor = FileIndexProcessor::start(
             [$plan->filesystem_root],
@@ -165,8 +164,8 @@ class PushPlan
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
-            "local_tree_root" => $plan->filesystem_root,
-            "previous_local_index" => $plan->previous_local_index,
+            "filesystem_root" => $plan->filesystem_root,
+            "local_index_file" => $plan->local_index_file,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -189,8 +188,8 @@ class PushPlan
     {
         $plan = new self(
             $cursor["plan_directory"],
-            $cursor["local_tree_root"],
-            $cursor["previous_local_index"]
+            $cursor["filesystem_root"],
+            $cursor["local_index_file"]
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
@@ -236,20 +235,20 @@ class PushPlan
      */
     public function get_fresh_local_index_path(): string
     {
-        return $this->fresh_local_index;
+        return $this->fresh_local_index_file;
     }
 
     /**
      * Initializes paths in the caller-owned active plan directory.
      *
-     * @param string $plan_directory              Caller-owned active plan directory.
-     * @param string $filesystem_root              Resolved filesystem root.
-     * @param string $previous_local_index Previous local index this plan diffs against.
+     * @param string $plan_directory   Caller-owned active plan directory.
+     * @param string $filesystem_root  Resolved filesystem root.
+     * @param string $local_index_file Local index file this plan diffs against.
      */
     private function __construct(
         string $plan_directory,
         string $filesystem_root,
-        string $previous_local_index
+        string $local_index_file
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -257,10 +256,10 @@ class PushPlan
         }
         $this->plan_directory = $plan_directory;
         $this->set_filesystem_root($filesystem_root);
-        $this->previous_local_index = $previous_local_index;
+        $this->local_index_file = $local_index_file;
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
-        $this->fresh_local_index = $plan_directory . "/fresh_local_index.jsonl";
+        $this->fresh_local_index_file = $plan_directory . "/fresh_local_index.jsonl";
         $this->excluded_paths_file = $plan_directory . "/excluded_paths.json";
         $this->deleted_directories_stack = $plan_directory . "/deleted_directories_stack.jsonl";
     }
@@ -290,9 +289,9 @@ class PushPlan
     {
         /** @var IndexingCursor $cursor */
         $cursor = $this->cursor["position"];
-        $this->fresh_local_index_handle = fopen($this->fresh_local_index, "r+b");
+        $this->fresh_local_index_handle = fopen($this->fresh_local_index_file, "r+b");
         if (!is_resource($this->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index}");
+            throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index_file}");
         }
         if (!ftruncate($this->fresh_local_index_handle, $cursor["fresh_local_index_byte_offset"])) {
             throw new RuntimeException("Failed to discard uncommitted fresh-local-index bytes.");
@@ -321,38 +320,38 @@ class PushPlan
         $cursor = $this->cursor["position"];
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_lookahead_entry = null;
-        $this->previous_local_index_lookahead_entry_loaded = false;
+        $this->local_index_lookahead_entry = null;
+        $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
-        $this->local_paths_to_push_handle = $this->open_and_truncate_and_seek(
+        $this->local_paths_to_push_handle = $this->open_push_plan_output_file_at_byte_offset(
             $this->local_paths_to_push,
             $cursor["byte_offset_in_local_paths_to_push"]
         );
-        $this->local_paths_to_delete_handle = $this->open_and_truncate_and_seek(
+        $this->local_paths_to_delete_handle = $this->open_push_plan_output_file_at_byte_offset(
             $this->local_paths_to_delete,
             $cursor["byte_offset_in_local_paths_to_delete"]
         );
-        $this->fresh_local_index_handle = fopen($this->fresh_local_index, "rb");
+        $this->fresh_local_index_handle = fopen($this->fresh_local_index_file, "rb");
         if (!is_resource($this->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to open the retained fresh local index: {$this->fresh_local_index}");
+            throw new RuntimeException("Failed to open the retained fresh local index: {$this->fresh_local_index_file}");
         }
 
-        if (is_file($this->previous_local_index)) {
-            $this->previous_local_index_handle = fopen($this->previous_local_index, "rb");
-            if (!is_resource($this->previous_local_index_handle)) {
-                throw new RuntimeException("Failed to open the previous local index: {$this->previous_local_index}");
+        if (is_file($this->local_index_file)) {
+            $this->local_index_file_handle = fopen($this->local_index_file, "rb");
+            if (!is_resource($this->local_index_file_handle)) {
+                throw new RuntimeException("Failed to open the local index: {$this->local_index_file}");
             }
         }
-        $this->seek_to_cursor(
+        $this->seek_index_file_to_byte_offset(
             $this->fresh_local_index_handle,
-            $cursor["byte_offset_in_fresh_index"],
+            $cursor["byte_offset_in_fresh_local_index"],
             "fresh local index"
         );
-        if ($this->previous_local_index_handle) {
-            $this->seek_to_cursor(
-                $this->previous_local_index_handle,
-                $cursor["byte_offset_in_previous_local_index"],
-                "previous local index"
+        if ($this->local_index_file_handle) {
+            $this->seek_index_file_to_byte_offset(
+                $this->local_index_file_handle,
+                $cursor["byte_offset_in_local_index"],
+                "local index"
             );
         }
         $this->deleted_directories_stack_handle = fopen($this->deleted_directories_stack, "a+b");
@@ -414,8 +413,8 @@ class PushPlan
         $fresh_local_index_changed = false;
         switch ($this->file_index_processor->get_step_status()) {
             case FileIndexProcessor::STATUS_INDEXED:
-                foreach ($this->file_index_processor->get_index_entries() as $index_entry) {
-                    $this->append_fresh_local_index_entry($index_entry);
+                foreach ($this->file_index_processor->get_index_entries() as $file_index_processor_entry) {
+                    $this->append_fresh_local_index_entry($file_index_processor_entry);
                     $fresh_local_index_changed = true;
                 }
                 break;
@@ -456,8 +455,8 @@ class PushPlan
         }
         $this->cursor["position"] = [
             "phase" => "diffing",
-            "byte_offset_in_fresh_index" => 0,
-            "byte_offset_in_previous_local_index" => 0,
+            "byte_offset_in_fresh_local_index" => 0,
+            "byte_offset_in_local_index" => 0,
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
@@ -469,33 +468,49 @@ class PushPlan
      * Appends one FileIndexProcessor entry in the JSONL format consumed by the
      * index diff.
      *
-     * @param array<string,mixed> $index_entry Filesystem path details from FileIndexProcessor.
+     * @param array<string,mixed> $file_index_processor_entry Filesystem path details from FileIndexProcessor.
      */
-    private function append_fresh_local_index_entry(array $index_entry): void
+    private function append_fresh_local_index_entry(array $file_index_processor_entry): void
     {
-        if ($index_entry["type"] === "other") {
+        if ($file_index_processor_entry["type"] === "other") {
             throw new RuntimeException(
-                "Cannot push the unsupported local path: " . base64_encode($index_entry["path"]) . "."
+                "Cannot push the unsupported local path: "
+                . base64_encode($file_index_processor_entry["path"])
+                . "."
             );
         }
-        if ($index_entry["type"] === "dir" && !array_key_exists("empty", $index_entry)) {
+        if (
+            $file_index_processor_entry["type"] === "dir"
+            && !array_key_exists("empty", $file_index_processor_entry)
+        ) {
             throw new RuntimeException(
-                "Could not inspect the local directory: " . base64_encode($index_entry["path"]) . "."
+                "Could not inspect the local directory: "
+                . base64_encode($file_index_processor_entry["path"])
+                . "."
             );
         }
 
-        $local_path = substr($index_entry["path"], strlen($this->filesystem_root) + 1);
+        $local_relative_path = substr(
+            $file_index_processor_entry["path"],
+            strlen($this->filesystem_root) + 1
+        );
         $fresh_local_index_entry = [
-            "path" => base64_encode($local_path),
-            "ctime" => $index_entry["ctime"],
-            "size" => $index_entry["size"],
-            "type" => $index_entry["type"],
+            "path" => base64_encode($local_relative_path),
+            "ctime" => $file_index_processor_entry["ctime"],
+            "size" => $file_index_processor_entry["size"],
+            "type" => $file_index_processor_entry["type"],
         ];
-        if ($index_entry["type"] === "dir") {
-            $fresh_local_index_entry["empty"] = $index_entry["empty"];
+        if ($file_index_processor_entry["type"] === "dir") {
+            $fresh_local_index_entry["empty"] = $file_index_processor_entry["empty"];
         }
-        $line = json_encode($fresh_local_index_entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-        if (fwrite($this->fresh_local_index_handle, $line) !== strlen($line)) {
+        $fresh_local_index_json_line = json_encode(
+            $fresh_local_index_entry,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (
+            fwrite($this->fresh_local_index_handle, $fresh_local_index_json_line)
+            !== strlen($fresh_local_index_json_line)
+        ) {
             throw new RuntimeException("Failed to write a fresh local index entry.");
         }
     }
@@ -513,56 +528,56 @@ class PushPlan
         /** @var IndexDiffCursor $cursor */
         $cursor = $this->cursor["position"];
 
-        $byte_offset_in_fresh_index = $cursor["byte_offset_in_fresh_index"];
-        $byte_offset_in_previous_local_index = $cursor["byte_offset_in_previous_local_index"];
+        $byte_offset_in_fresh_local_index = $cursor["byte_offset_in_fresh_local_index"];
+        $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
         $deleted_directories_stack_changed = false;
 
         if (!$this->fresh_local_index_entry_loaded) {
-            $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
+            $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
             $this->fresh_local_index_entry_loaded = true;
         }
-        if (!$this->previous_local_index_lookahead_entry_loaded) {
-            $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
-                $this->previous_local_index_handle
+        if (!$this->local_index_lookahead_entry_loaded) {
+            $this->local_index_lookahead_entry = $this->read_next_index_entry(
+                $this->local_index_file_handle
             );
-            $this->previous_local_index_lookahead_entry_loaded = true;
+            $this->local_index_lookahead_entry_loaded = true;
         }
-        $entry_fresh_index = $this->fresh_local_index_entry;
-        $entry_previous_local_index = $this->previous_local_index_lookahead_entry;
+        $fresh_local_index_entry = $this->fresh_local_index_entry;
+        $local_index_entry = $this->local_index_lookahead_entry;
 
-        if ($entry_fresh_index !== null || $entry_previous_local_index !== null) {
+        if ($fresh_local_index_entry !== null || $local_index_entry !== null) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
             // in ASCII but encodes a higher value), so ordering uses the
             // decoded path bytes.
-            if ($entry_previous_local_index === null) {
+            if ($local_index_entry === null) {
                 $path_comparison = -1;
-            } elseif ($entry_fresh_index === null) {
+            } elseif ($fresh_local_index_entry === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = strcmp($entry_fresh_index["path"], $entry_previous_local_index["path"]);
+                $path_comparison = strcmp($fresh_local_index_entry["path"], $local_index_entry["path"]);
             }
 
-            $current_shape = null;
+            $fresh_local_index_entry_shape = null;
             if ($path_comparison <= 0) {
-                $current_shape = $this->entry_shape($entry_fresh_index);
+                $fresh_local_index_entry_shape = $this->index_entry_shape($fresh_local_index_entry);
             }
 
-            $previous_local_index_shape = null;
+            $local_index_entry_shape = null;
             if ($path_comparison >= 0) {
-                $previous_local_index_shape = $this->entry_shape($entry_previous_local_index);
+                $local_index_entry_shape = $this->index_entry_shape($local_index_entry);
 
                 // Byte sorting can put a sibling such as `a-other` before
                 // `a/child`. Every retained non-empty directory has a later
-                // descendant, so adjacent previous-index entries can pass at
+                // descendant, so adjacent local index entries can pass at
                 // most the top sibling range.
                 if ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
-                        strpos($entry_previous_local_index["path"], $descendant_prefix) !== 0
-                        && strcmp($entry_previous_local_index["path"], $descendant_prefix) > 0
+                        strpos($local_index_entry["path"], $descendant_prefix) !== 0
+                        && strcmp($local_index_entry["path"], $descendant_prefix) > 0
                     ) {
                         $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
                         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
@@ -577,85 +592,88 @@ class PushPlan
                 // pushed. A new non-empty directory is represented by its
                 // descendants.
                 if (
-                    $current_shape !== "non_empty_directory"
-                    && !$this->path_conflicts_with_excluded_paths($entry_fresh_index["path"])
+                    $fresh_local_index_entry_shape !== "non_empty_directory"
+                    && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
                 ) {
-                    $this->append_local_path_to_push($entry_fresh_index);
+                    $this->append_local_path_to_push($fresh_local_index_entry);
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
                 // A deleted non-empty directory emits one root. Its later
                 // descendant entries are already covered by that path.
                 if (
-                    !$this->path_conflicts_with_excluded_paths($entry_previous_local_index["path"])
+                    !$this->path_conflicts_with_excluded_paths($local_index_entry["path"])
                     && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_local_index["path"],
+                        $local_index_entry["path"],
                         $this->deleted_directory_stack_entry
                     )
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
+                    $this->append_local_path_to_delete($local_index_entry["path"]);
                     $local_paths_to_delete_changed = true;
-                    if ($previous_local_index_shape === "non_empty_directory") {
+                    if ($local_index_entry_shape === "non_empty_directory") {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_local_index["path"],
+                            $local_index_entry["path"],
                             $deleted_directory_stack_top_byte_offset
                         );
                         $deleted_directories_stack_changed = true;
                     }
                 }
             } else {
-                $current_is_file_or_symlink = $current_shape === "file" || $current_shape === "symlink";
-                $previous_local_index_is_file_or_symlink = $previous_local_index_shape === "file" || $previous_local_index_shape === "symlink";
-                $non_empty_directory_becomes_empty = $current_shape === "empty_directory"
-                    && $previous_local_index_shape === "non_empty_directory";
-                $empty_directory_needs_push = $current_shape === "empty_directory"
-                    && $previous_local_index_shape !== "empty_directory";
+                $fresh_local_index_entry_is_file_or_symlink = $fresh_local_index_entry_shape === "file"
+                    || $fresh_local_index_entry_shape === "symlink";
+                $local_index_entry_is_file_or_symlink = $local_index_entry_shape === "file"
+                    || $local_index_entry_shape === "symlink";
+                $non_empty_directory_becomes_empty = $fresh_local_index_entry_shape === "empty_directory"
+                    && $local_index_entry_shape === "non_empty_directory";
+                $empty_directory_needs_push = $fresh_local_index_entry_shape === "empty_directory"
+                    && $local_index_entry_shape !== "empty_directory";
                 // File and symlink changes are defined by type, ctime, and
                 // size. Other index values do not select a path for upload.
-                $changed_file_or_symlink_needs_push = $current_is_file_or_symlink
+                $changed_file_or_symlink_needs_push = $fresh_local_index_entry_is_file_or_symlink
                     && (
-                        $entry_fresh_index["ctime"] !== $entry_previous_local_index["ctime"]
-                        || $entry_fresh_index["size"] !== $entry_previous_local_index["size"]
-                        || $entry_fresh_index["type"] !== $entry_previous_local_index["type"]
+                        $fresh_local_index_entry["ctime"] !== $local_index_entry["ctime"]
+                        || $fresh_local_index_entry["size"] !== $local_index_entry["size"]
+                        || $fresh_local_index_entry["type"] !== $local_index_entry["type"]
                     );
-                $needs_delete = $current_is_file_or_symlink !== $previous_local_index_is_file_or_symlink
+                $needs_delete =
+                    $fresh_local_index_entry_is_file_or_symlink !== $local_index_entry_is_file_or_symlink
                     || $non_empty_directory_becomes_empty;
                 $needs_push = $empty_directory_needs_push
                     || $changed_file_or_symlink_needs_push;
-                $path_is_excluded = $this->path_conflicts_with_excluded_paths($entry_fresh_index["path"]);
+                $path_is_excluded = $this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"]);
 
                 if (
                     $needs_delete
                     && !$path_is_excluded
                     && !$this->deleted_directory_stack_covers_path(
-                        $entry_previous_local_index["path"],
+                        $local_index_entry["path"],
                         $this->deleted_directory_stack_entry
                     )
                 ) {
-                    $this->append_local_path_to_delete($entry_previous_local_index["path"]);
+                    $this->append_local_path_to_delete($local_index_entry["path"]);
                     $local_paths_to_delete_changed = true;
-                    if ($previous_local_index_shape === "non_empty_directory") {
+                    if ($local_index_entry_shape === "non_empty_directory") {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $entry_previous_local_index["path"],
+                            $local_index_entry["path"],
                             $deleted_directory_stack_top_byte_offset
                         );
                         $deleted_directories_stack_changed = true;
                     }
                 }
                 if ($needs_push && !$path_is_excluded) {
-                    $this->append_local_path_to_push($entry_fresh_index);
+                    $this->append_local_path_to_push($fresh_local_index_entry);
                     $local_paths_to_push_changed = true;
                 }
             }
 
             if ($path_comparison <= 0) {
-                $byte_offset_in_fresh_index = ftell($this->fresh_local_index_handle);
-                $this->fresh_local_index_entry = $this->parse_next_index_entry($this->fresh_local_index_handle);
+                $byte_offset_in_fresh_local_index = ftell($this->fresh_local_index_handle);
+                $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
             }
             if ($path_comparison >= 0) {
-                $byte_offset_in_previous_local_index = ftell($this->previous_local_index_handle);
-                $this->previous_local_index_lookahead_entry = $this->parse_next_index_entry(
-                    $this->previous_local_index_handle
+                $byte_offset_in_local_index = ftell($this->local_index_file_handle);
+                $this->local_index_lookahead_entry = $this->read_next_index_entry(
+                    $this->local_index_file_handle
                 );
             }
         }
@@ -669,7 +687,7 @@ class PushPlan
         }
 
         $complete = $this->fresh_local_index_entry === null
-            && $this->previous_local_index_lookahead_entry === null;
+            && $this->local_index_lookahead_entry === null;
         if ($complete) {
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
@@ -678,8 +696,8 @@ class PushPlan
             ? ["phase" => "complete"]
             : [
                 "phase" => "diffing",
-                "byte_offset_in_fresh_index" => $byte_offset_in_fresh_index,
-                "byte_offset_in_previous_local_index" => $byte_offset_in_previous_local_index,
+                "byte_offset_in_fresh_local_index" => $byte_offset_in_fresh_local_index,
+                "byte_offset_in_local_index" => $byte_offset_in_local_index,
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
@@ -701,8 +719,8 @@ class PushPlan
             $this->file_index_processor->close();
         }
         $this->close_fresh_local_index_handle();
-        if (is_resource($this->previous_local_index_handle)) {
-            fclose($this->previous_local_index_handle);
+        if (is_resource($this->local_index_file_handle)) {
+            fclose($this->local_index_file_handle);
         }
         if (is_resource($this->local_paths_to_push_handle)) {
             fclose($this->local_paths_to_push_handle);
@@ -713,14 +731,14 @@ class PushPlan
         if (is_resource($this->deleted_directories_stack_handle)) {
             fclose($this->deleted_directories_stack_handle);
         }
-        $this->previous_local_index_handle = null;
+        $this->local_index_file_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
         $this->deleted_directories_stack_handle = null;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
-        $this->previous_local_index_lookahead_entry = null;
-        $this->previous_local_index_lookahead_entry_loaded = false;
+        $this->local_index_lookahead_entry = null;
+        $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->closed = true;
     }
@@ -744,45 +762,58 @@ class PushPlan
      * but before storing its next cursor. Truncating to the saved offset
      * removes only that uncommitted tail before the plan continues.
      *
-     * @param string $path        Path to the push-plan output file.
-     * @param int    $byte_offset Durable byte offset at which writing resumes.
+     * @param string $push_plan_output_file Path to the push-plan output file.
+     * @param int    $byte_offset           Durable byte offset at which writing resumes.
      * @return resource Writable output handle positioned at the durable offset.
      */
-    private function open_and_truncate_and_seek(string $path, int $byte_offset)
+    private function open_push_plan_output_file_at_byte_offset(
+        string $push_plan_output_file,
+        int $byte_offset
+    )
     {
-        $handle = fopen($path, "c+b");
-        if (!$handle) {
-            throw new RuntimeException("Failed to open push plan output for writing: {$path}");
+        $push_plan_output_file_handle = fopen($push_plan_output_file, "c+b");
+        if (!$push_plan_output_file_handle) {
+            throw new RuntimeException("Failed to open push plan output for writing: {$push_plan_output_file}");
         }
-        if (!ftruncate($handle, $byte_offset) || fseek($handle, $byte_offset) !== 0) {
-            fclose($handle);
-            throw new RuntimeException("Failed to truncate and seek push plan output {$path} to byte {$byte_offset}.");
+        if (
+            !ftruncate($push_plan_output_file_handle, $byte_offset)
+            || fseek($push_plan_output_file_handle, $byte_offset) !== 0
+        ) {
+            fclose($push_plan_output_file_handle);
+            throw new RuntimeException(
+                "Failed to truncate and seek push plan output "
+                . "{$push_plan_output_file} to byte {$byte_offset}."
+            );
         }
-        return $handle;
+        return $push_plan_output_file_handle;
     }
 
     /**
-     * Positions an index handle at its durable cursor offset.
+     * Positions an index file handle at its durable byte offset.
      *
      * The plan owns immutable index files, and records their consumed byte
      * offsets only after finishing the corresponding step.
      *
-     * @param resource $handle      Open index handle to position.
-     * @param int      $byte_offset Durable byte offset saved in the cursor.
-     * @param string   $description Human-readable index name used in failures.
+     * @param resource $index_file_handle Open index file handle to position.
+     * @param int      $byte_offset       Durable byte offset saved in the cursor.
+     * @param string   $index_description Human-readable index name used in failures.
      */
-    private function seek_to_cursor($handle, int $byte_offset, string $description): void
+    private function seek_index_file_to_byte_offset(
+        $index_file_handle,
+        int $byte_offset,
+        string $index_description
+    ): void
     {
-        if (fseek($handle, $byte_offset) !== 0) {
-            throw new RuntimeException("Failed to seek the {$description} to byte {$byte_offset}.");
+        if (fseek($index_file_handle, $byte_offset) !== 0) {
+            throw new RuntimeException("Failed to seek the {$index_description} to byte {$byte_offset}.");
         }
     }
 
     /**
      * Returns the logical entry kind used by the transition table.
      *
-     * @param array $entry {
-     *     Parsed local index entry.
+     * @param array $index_entry {
+     *     Parsed index entry.
      *
      *     @type string $path  Decoded filesystem path.
      *     @type string $type  Entry type: `file`, `link`, or `dir`.
@@ -790,18 +821,18 @@ class PushPlan
      *     @type int    $size  Indexed size used for change detection.
      *     @type bool   $empty Whether a directory is empty. Present for directory entries.
      * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $entry
+     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $index_entry
      * @return 'file'|'symlink'|'empty_directory'|'non_empty_directory'
      */
-    private function entry_shape(array $entry): string
+    private function index_entry_shape(array $index_entry): string
     {
-        if ($entry["type"] === "file") {
+        if ($index_entry["type"] === "file") {
             return "file";
         }
-        if ($entry["type"] === "link") {
+        if ($index_entry["type"] === "link") {
             return "symlink";
         }
-        return $entry["empty"] ? "empty_directory" : "non_empty_directory";
+        return $index_entry["empty"] ? "empty_directory" : "non_empty_directory";
     }
 
     /**
@@ -809,7 +840,7 @@ class PushPlan
      *
      * Base64 keeps arbitrary filesystem path bytes representable in JSON.
      *
-     * @param array $entry {
+     * @param array $fresh_local_index_entry {
      *     Fresh local index entry selected for push.
      *
      *     @type string $path  Decoded filesystem path.
@@ -817,20 +848,25 @@ class PushPlan
      *     @type int    $size  Indexed size used for change detection.
      *     @type int    $ctime Indexed change timestamp.
      * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $entry
+     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $fresh_local_index_entry
      */
-    private function append_local_path_to_push(array $entry): void
+    private function append_local_path_to_push(array $fresh_local_index_entry): void
     {
-        $line = json_encode(
+        $local_path_to_push_json_line = json_encode(
             [
-                "path" => base64_encode($entry["path"]),
-                "type" => $entry["type"] === "link" ? "symlink" : ($entry["type"] === "dir" ? "directory" : "file"),
-                "size" => $entry["size"],
-                "ctime" => $entry["ctime"],
+                "path" => base64_encode($fresh_local_index_entry["path"]),
+                "type" => $fresh_local_index_entry["type"] === "link"
+                    ? "symlink"
+                    : ($fresh_local_index_entry["type"] === "dir" ? "directory" : "file"),
+                "size" => $fresh_local_index_entry["size"],
+                "ctime" => $fresh_local_index_entry["ctime"],
             ],
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         ) . "\n";
-        if (fwrite($this->local_paths_to_push_handle, $line) !== strlen($line)) {
+        if (
+            fwrite($this->local_paths_to_push_handle, $local_path_to_push_json_line)
+            !== strlen($local_path_to_push_json_line)
+        ) {
             throw new RuntimeException("Short write on local push path list {$this->local_paths_to_push}, is the disk full?");
         }
     }
@@ -980,13 +1016,13 @@ class PushPlan
     }
 
     /**
-     * Reads and decodes the next local index entry.
+     * Reads and decodes the next index entry.
      *
-     * A null handle represents a missing previous local index.
+     * A null index file handle represents a missing local index.
      * The indexer's entry schema is trusted; only file reads, JSON decoding,
      * and base64 path decoding are handled here as fallible operations.
      *
-     * @param resource|null $handle Open local index handle, or null when no previous local index exists.
+     * @param resource|null $index_file_handle Open index file handle, or null when no local index exists.
      * @return array|null {
      *     Decoded index entry, or null at EOF or when the handle is null.
      *
@@ -998,35 +1034,37 @@ class PushPlan
      * }
      * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null
      */
-    private function parse_next_index_entry($handle): ?array
+    private function read_next_index_entry($index_file_handle): ?array
     {
-        if (!$handle) {
+        if (!$index_file_handle) {
             return null;
         }
-        $raw_line = fgets($handle);
-        if ($raw_line === false) {
-            if (!feof($handle)) {
-                throw new RuntimeException("Failed to read a local index line.");
+        $index_entry_json = fgets($index_file_handle);
+        if ($index_entry_json === false) {
+            if (!feof($index_file_handle)) {
+                throw new RuntimeException("Failed to read an index line.");
             }
             return null;
         }
 
         try {
-            $entry = json_decode($raw_line, true, 512, JSON_THROW_ON_ERROR);
+            $index_entry = json_decode($index_entry_json, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $exception) {
             throw new RuntimeException(
-                "Unexpected index line, it is not valid JSON: " . substr($raw_line, 0, 120),
+                "Unexpected index line, it is not valid JSON: " . substr($index_entry_json, 0, 120),
                 0,
                 $exception
             );
         }
-        /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $entry */
-        $path = base64_decode($entry["path"], true);
-        if ($path === false) {
-            throw new RuntimeException("The index path is not valid base64: " . substr($raw_line, 0, 120));
+        /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $index_entry */
+        $local_relative_path = base64_decode($index_entry["path"], true);
+        if ($local_relative_path === false) {
+            throw new RuntimeException(
+                "The index path is not valid base64: " . substr($index_entry_json, 0, 120)
+            );
         }
-        $entry["path"] = $path;
-        return $entry;
+        $index_entry["path"] = $local_relative_path;
+        return $index_entry;
     }
 
 }

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -120,8 +120,8 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('Usage: reprint files-diff <remote-reprint-api-url>', $output);
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
-        $this->assertStringContainsString('previous local index', $output);
-        $this->assertStringContainsString('completed files-push', $output);
+        $this->assertStringContainsString('local index', $output);
+        $this->assertStringContainsString('target confirms', $output);
         $this->assertStringContainsString('push operation plan', $output);
         $this->assertStringContainsString('default-skipped paths', $output);
         $this->assertStringContainsString('No network calls', $output);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -12,19 +12,19 @@ require_once __DIR__ . '/../../importer/import.php';
 /**
  * The files-diff user contract.
  *
- * files-diff compares the filesystem root with the previous local index for
- * the remote Reprint API URL — the index a completed files-push publishes —
+ * files-diff compares the filesystem root with the local index for the remote
+ * Reprint API URL — the index a completed files-push writes —
  * without contacting the target, and reports the complete diff on every run.
  * These tests pin that contract: local-only operation, correct change records,
- * arbitrary path bytes, the previous-local-index requirement, no mutation of
- * that index, and a complete report after an interrupted run.
+ * arbitrary path bytes, the local-index requirement, no mutation of the local
+ * index, and a complete report after an interrupted run.
  */
 final class FilesDiffCommandTest extends TestCase
 {
     private string $root;
     private string $stateDirectory;
-    private string $localTree;
-    private string $targetUrl = 'https://example.test/export.php?site-export-api';
+    private string $filesystemRoot;
+    private string $remoteReprintApiUrl = 'https://example.test/export.php?site-export-api';
     private ?string $invalidBytePathInIndex = null;
 
     /** @var array<string,string> */
@@ -40,17 +40,17 @@ final class FilesDiffCommandTest extends TestCase
         parent::setUp();
         $this->root = sys_get_temp_dir() . '/files-diff-command-' . bin2hex(random_bytes(6));
         $this->stateDirectory = $this->root . '/state';
-        $this->localTree = $this->root . '/local-tree';
+        $this->filesystemRoot = $this->root . '/filesystem-root';
         mkdir($this->stateDirectory, 0700, true);
-        mkdir($this->localTree, 0700, true);
+        mkdir($this->filesystemRoot, 0700, true);
 
         $invalidBytePathInIndex = "delete-invalid-\xff.txt";
-        if (@file_put_contents($this->localTree . '/' . $invalidBytePathInIndex, 'invalid path bytes') !== false) {
+        if (@file_put_contents($this->filesystemRoot . '/' . $invalidBytePathInIndex, 'invalid path bytes') !== false) {
             $this->initialFiles[$invalidBytePathInIndex] = 'invalid path bytes';
             $this->invalidBytePathInIndex = $invalidBytePathInIndex;
         }
         foreach ($this->initialFiles as $path => $contents) {
-            file_put_contents($this->localTree . '/' . $path, $contents);
+            file_put_contents($this->filesystemRoot . '/' . $path, $contents);
         }
     }
 
@@ -60,9 +60,11 @@ final class FilesDiffCommandTest extends TestCase
         parent::tearDown();
     }
 
-    public function testFilesDiffReportsAnEmptyDiffWhenTheLocalTreeMatchesTheIndex(): void
+    public function testFilesDiffReportsAnEmptyDiffWhenTheFilesystemRootMatchesTheLocalIndex(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
+
+        $this->assertDirectoryDoesNotExist($this->pushStateDirectory());
 
         $result = $this->runFilesDiff();
 
@@ -79,15 +81,15 @@ final class FilesDiffCommandTest extends TestCase
 
     public function testFilesDiffReportsAddedEditedDeletedAndTypeChangedPaths(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $arbitraryBytePath = "arbitrary-\nname.txt";
-        file_put_contents($this->localTree . '/added.txt', 'new file');
-        file_put_contents($this->localTree . '/' . $arbitraryBytePath, 'raw path byte');
-        file_put_contents($this->localTree . '/edited.txt', 'edited local contents');
-        unlink($this->localTree . '/deleted.txt');
-        unlink($this->localTree . '/swap');
-        mkdir($this->localTree . '/swap');
+        file_put_contents($this->filesystemRoot . '/added.txt', 'new file');
+        file_put_contents($this->filesystemRoot . '/' . $arbitraryBytePath, 'raw path byte');
+        file_put_contents($this->filesystemRoot . '/edited.txt', 'edited local contents');
+        unlink($this->filesystemRoot . '/deleted.txt');
+        unlink($this->filesystemRoot . '/swap');
+        mkdir($this->filesystemRoot . '/swap');
 
         $result = $this->runFilesDiff();
 
@@ -165,13 +167,13 @@ final class FilesDiffCommandTest extends TestCase
         if ($this->invalidBytePathInIndex === null) {
             $this->markTestSkipped('This filesystem does not accept invalid UTF-8 path bytes.');
         }
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
         $invalidBytePathToPush = "push-invalid-\xfe.txt";
-        if (@file_put_contents($this->localTree . '/' . $invalidBytePathToPush, 'new invalid path bytes') === false) {
+        if (@file_put_contents($this->filesystemRoot . '/' . $invalidBytePathToPush, 'new invalid path bytes') === false) {
             $this->markTestSkipped('This filesystem does not accept a second invalid UTF-8 path.');
         }
-        unlink($this->localTree . '/' . $this->invalidBytePathInIndex);
+        unlink($this->filesystemRoot . '/' . $this->invalidBytePathInIndex);
 
         $result = $this->runFilesDiff();
 
@@ -197,13 +199,13 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertStringNotContainsString($this->invalidBytePathInIndex, $result['stdout']);
     }
 
-    public function testFilesDiffDoesNotChangeThePreviousLocalIndexAndRepeatsTheSameReport(): void
+    public function testFilesDiffDoesNotChangeTheLocalIndexAndRepeatsTheSameReport(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
-        $previousLocalIndex = $this->pushStateDirectory() . '/previous_local_index.jsonl';
-        $previousLocalIndexContents = file_get_contents($previousLocalIndex);
-        $this->assertIsString($previousLocalIndexContents);
-        file_put_contents($this->localTree . '/added-after-index.txt', 'new');
+        $this->writeLocalIndex(array_keys($this->initialFiles));
+        $localIndexFile = $this->localIndexFile();
+        $localIndexContents = file_get_contents($localIndexFile);
+        $this->assertIsString($localIndexContents);
+        file_put_contents($this->filesystemRoot . '/added-after-index.txt', 'new');
 
         $firstResult = $this->runFilesDiff();
         $secondResult = $this->runFilesDiff();
@@ -211,7 +213,7 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertSame(0, $firstResult['exit'], $firstResult['output']);
         $this->assertSame(0, $secondResult['exit'], $secondResult['output']);
         $this->assertSame($firstResult['stdout'], $secondResult['stdout']);
-        $this->assertSame($previousLocalIndexContents, file_get_contents($previousLocalIndex));
+        $this->assertSame($localIndexContents, file_get_contents($localIndexFile));
         $records = $this->filesDiffRecords($secondResult['stdout']);
         $this->assertSame(
             $this->expectedPushRecord('added-after-index.txt', 'file'),
@@ -219,33 +221,39 @@ final class FilesDiffCommandTest extends TestCase
         );
     }
 
-    public function testFilesDiffWithoutAPreviousLocalIndexFailsWithPointedGuidance(): void
+    public function testFilesDiffWithoutALocalIndexFailsWithPointedGuidance(): void
     {
         $result = $this->runFilesDiff();
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
         $this->assertCanonicalSingleJsonLine($result['stderr']);
-        $this->assertStringContainsString('completed files-push', $result['output']);
-        $this->assertStringContainsString(
-            'same remote Reprint API URL and state directory',
-            $result['output']
+        $errorRecord = json_decode($result['stderr'], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($errorRecord);
+        $this->assertSame(
+            'files-diff requires <remote-state-directory>/local_index.jsonl. '
+            . 'files-push writes it after the target confirms commit for the same '
+            . 'remote Reprint API URL and state directory.',
+            $errorRecord['error'] ?? null
         );
     }
 
-    public function testFilesDiffDoesNotReuseThePreviousLocalIndexForADifferentTargetUrlQuery(): void
+    public function testFilesDiffDoesNotUseTheLocalIndexForADifferentRemoteReprintApiUrl(): void
     {
-        $this->writePreviousLocalIndex(array_keys($this->initialFiles));
+        $this->writeLocalIndex(array_keys($this->initialFiles));
 
-        $result = $this->runFilesDiff($this->targetUrl . '&site=other');
+        $result = $this->runFilesDiff($this->remoteReprintApiUrl . '&site=other');
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
         $this->assertCanonicalSingleJsonLine($result['stderr']);
-        $this->assertStringContainsString('completed files-push', $result['output']);
-        $this->assertStringContainsString(
-            'same remote Reprint API URL and state directory',
-            $result['output']
+        $errorRecord = json_decode($result['stderr'], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($errorRecord);
+        $this->assertSame(
+            'files-diff requires <remote-state-directory>/local_index.jsonl. '
+            . 'files-push writes it after the target confirms commit for the same '
+            . 'remote Reprint API URL and state directory.',
+            $errorRecord['error'] ?? null
         );
     }
 
@@ -261,19 +269,19 @@ final class FilesDiffCommandTest extends TestCase
 
     public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void
     {
-        // An empty previous local index selects every current path for push.
-        $this->removeTree($this->localTree);
-        mkdir($this->localTree, 0700, true);
-        $this->writePreviousLocalIndex([]);
+        // An empty local index selects every current path for push.
+        $this->removeTree($this->filesystemRoot);
+        mkdir($this->filesystemRoot, 0700, true);
+        $this->writeLocalIndex([]);
         $bulkPaths = $this->createBulkFiles('rerun');
 
         // Backpressure from the unread stdout pipe holds the first process
         // mid-report, so the kill interrupts an in-progress record stream.
         [$process, $pipes] = $this->startCliProcess([
             'files-diff',
-            $this->targetUrl,
+            $this->remoteReprintApiUrl,
             '--state-dir=' . $this->stateDirectory,
-            '--fs-root=' . $this->localTree,
+            '--fs-root=' . $this->filesystemRoot,
         ]);
         stream_set_blocking($pipes[1], false);
         $firstOutput = '';
@@ -322,45 +330,45 @@ final class FilesDiffCommandTest extends TestCase
     }
 
     /**
-     * Publishes a previous local index describing the named paths as they
-     * exist right now, the way a completed files-push saves its index.
+     * Writes a local index describing the named paths as they exist right now,
+     * the way a completed files-push writes its local index.
      *
-     * @param list<string> $paths Document-root-relative paths to record.
+     * @param list<string> $localRelativePaths Local relative paths to record.
      */
-    private function writePreviousLocalIndex(array $paths): void
+    private function writeLocalIndex(array $localRelativePaths): void
     {
-        usort($paths, 'strcmp');
+        usort($localRelativePaths, 'strcmp');
         $lines = '';
-        foreach ($paths as $path) {
-            $stat = lstat($this->localTree . '/' . $path);
+        foreach ($localRelativePaths as $localRelativePath) {
+            $stat = lstat($this->filesystemRoot . '/' . $localRelativePath);
             $this->assertIsArray($stat);
             $fileTypeBits = $stat['mode'] & 0170000;
             $type = $fileTypeBits === 0040000 ? 'dir' : ( $fileTypeBits === 0120000 ? 'link' : 'file' );
             $entry = [
-                'path' => base64_encode($path),
+                'path' => base64_encode($localRelativePath),
                 'ctime' => (int) $stat['ctime'],
                 'size' => $type === 'dir' ? 0 : (int) $stat['size'],
                 'type' => $type,
             ];
             if ($type === 'dir') {
                 $entry['empty'] = count(array_diff(
-                    scandir($this->localTree . '/' . $path) ?: [],
+                    scandir($this->filesystemRoot . '/' . $localRelativePath) ?: [],
                     ['.', '..']
                 )) === 0;
             }
             $lines .= json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         }
-        $pushStateDirectory = $this->pushStateDirectory();
-        if (!is_dir($pushStateDirectory)) {
-            mkdir($pushStateDirectory, 0700, true);
+        $remoteStateDirectory = $this->remoteStateDirectory();
+        if (!is_dir($remoteStateDirectory)) {
+            mkdir($remoteStateDirectory, 0700, true);
         }
-        file_put_contents($pushStateDirectory . '/previous_local_index.jsonl', $lines);
+        file_put_contents($this->localIndexFile(), $lines);
     }
 
     /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
     private function expectedPushRecord(string $path, string $type): array
     {
-        $stat = lstat($this->localTree . '/' . $path);
+        $stat = lstat($this->filesystemRoot . '/' . $path);
         $this->assertIsArray($stat);
         return [
             'command' => 'files-diff',
@@ -383,7 +391,7 @@ final class FilesDiffCommandTest extends TestCase
                 $index,
                 str_repeat('x', 180)
             );
-            if (file_put_contents($this->localTree . '/' . $path, 'x') === false) {
+            if (file_put_contents($this->filesystemRoot . '/' . $path, 'x') === false) {
                 $this->fail('Failed to create a bulk files-diff test path.');
             }
             $paths[] = $path;
@@ -393,22 +401,31 @@ final class FilesDiffCommandTest extends TestCase
 
     private function pushStateDirectory(): string
     {
+        return $this->remoteStateDirectory() . '/push';
+    }
+
+    private function remoteStateDirectory(): string
+    {
         return realpath($this->stateDirectory)
             . '/remotes/'
-            . md5(rtrim($this->targetUrl, '?&'))
-            . '/push';
+            . md5(rtrim($this->remoteReprintApiUrl, '?&'));
+    }
+
+    private function localIndexFile(): string
+    {
+        return $this->remoteStateDirectory() . '/local_index.jsonl';
     }
 
     /** @param list<string> $extraArguments
      *  @return array{exit:int,stdout:string,stderr:string,output:string}
      */
-    private function runFilesDiff(?string $targetUrl = null, array $extraArguments = []): array
+    private function runFilesDiff(?string $remoteReprintApiUrl = null, array $extraArguments = []): array
     {
         return $this->runCli(array_merge([
             'files-diff',
-            $targetUrl ?? $this->targetUrl,
+            $remoteReprintApiUrl ?? $this->remoteReprintApiUrl,
             '--state-dir=' . $this->stateDirectory,
-            '--fs-root=' . $this->localTree,
+            '--fs-root=' . $this->filesystemRoot,
         ], $extraArguments));
     }
 

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -7,10 +7,10 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-plan.php';
 
 /**
- * Coverage for PushPlan's previous local index and bounded steps.
+ * Coverage for PushPlan's local index and bounded steps.
  *
  * The plan diffs the fresh local index, whose directory entries carry an
- * `empty` boolean from the indexer, against the previous local index.
+ * `empty` boolean from the indexer, against the local index.
  * The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
  * local paths to delete, cursor replay, and every transition among files,
  * symlinks, empty directories, and non-empty directories.
@@ -22,7 +22,7 @@ final class PushPlanTest extends TestCase
     /** @var array<string,mixed> Cursor stored by the test caller after each plan step. */
     private array $cursor;
 
-    /** @var array<string,array<string,mixed>> Last tree shape created by materializeLocalTree(). */
+    /** @var array<string,array<string,mixed>> Last filesystem-root shape created by materializeFilesystemRoot(). */
     private array $materializedIndexEntries = [];
 
     protected function setUp(): void
@@ -43,24 +43,24 @@ final class PushPlanTest extends TestCase
     // ------------------------------------------------------------------
 
     // ------------------------------------------------------------------
-    //  Previous local index
+    //  Local index
     // ------------------------------------------------------------------
 
-    public function testSavedIndexCanBeUsedByTheNextPlan(): void
+    public function testLocalIndexCanBeUsedByTheNextPlan(): void
     {
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
+        $this->assertFileDoesNotExist($this->localIndexFile());
 
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'a.txt' => [100, 5, 'file'],
         ]));
-        $this->assertFileExists($this->previousLocalIndexPath());
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath() . '.tmp');
+        $this->assertFileExists($this->localIndexFile());
+        $this->assertFileDoesNotExist($this->localIndexFile() . '.tmp');
         $this->assertDirectoryDoesNotExist($this->planDirectory());
 
         // A second successful push replaces the first. Comparing that same index
         // again produces no paths to push or delete.
         $second = $this->writeIndex(['b.txt' => [200, 9, 'file']]);
-        $this->savePreviousLocalIndex($second);
+        $this->saveLocalIndex($second);
         $plan = $this->startPlan($second);
         $this->planToCompletion($plan);
         $this->assertPathCounts(0, 0);
@@ -72,8 +72,8 @@ final class PushPlanTest extends TestCase
         $this->expectExceptionMessage('without its directory');
         PushPlan::start(
             $this->planDirectory(),
-            $this->localTreeRoot(),
-            $this->previousLocalIndexPath(),
+            $this->filesystemRoot(),
+            $this->localIndexFile(),
             $this->excludedPathsPath()
         );
     }
@@ -86,7 +86,7 @@ final class PushPlanTest extends TestCase
         $this->removePlanDirectory();
 
         $this->assertDirectoryDoesNotExist($this->planDirectory());
-        $this->assertFileDoesNotExist($this->previousLocalIndexPath());
+        $this->assertFileDoesNotExist($this->localIndexFile());
 
         $secondIndex = $this->writeIndex(['second.txt' => [200, 6, 'file']]);
         $secondPlan = $this->startPlan($secondIndex);
@@ -137,7 +137,7 @@ final class PushPlanTest extends TestCase
 
     public function testPlanCopiesEveryFreshLocalIndexEntryAndExcludesOnlyPushAndDeletePaths(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
             'private' => [1, 0, 'dir', false],
             'private/gone.txt' => [1, 1, 'file'],
@@ -175,7 +175,7 @@ final class PushPlanTest extends TestCase
             'a.txt' => [100, 5, 'file'],
             'b/c.txt' => [200, 7, 'file'],
         ]);
-        $this->savePreviousLocalIndex($index);
+        $this->saveLocalIndex($index);
 
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);
@@ -187,13 +187,13 @@ final class PushPlanTest extends TestCase
 
     public function testCtimeSizeOrTypeChangeEachMarksThePathChanged(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'ctime-bump.txt' => [100, 5, 'file'],
             'size-bump.txt' => [100, 5, 'file'],
             'type-swap' => [100, 5, 'file'],
             'same.txt' => [100, 5, 'file'],
         ]));
-        $previousStat = lstat($this->localTreeRoot() . '/ctime-bump.txt');
+        $previousStat = lstat($this->filesystemRoot() . '/ctime-bump.txt');
         $this->assertIsArray($previousStat);
         $previousCtime = $previousStat['ctime'];
         while (time() <= $previousCtime) {
@@ -247,7 +247,7 @@ final class PushPlanTest extends TestCase
 
         foreach ($matrix as $previousType => $transitions) {
             foreach ($transitions as $currentType => [$expectedPushes, $expectedDeletes]) {
-                $this->savePreviousLocalIndex($this->writeLogicalIndex($previousType, 1));
+                $this->saveLocalIndex($this->writeLogicalIndex($previousType, 1));
                 $current = $this->writeLogicalIndex($currentType, 2);
 
                 $plan = $this->startPlan($current);
@@ -264,7 +264,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedSubtreeEmitsOnlyItsRootAsALocalPathToDelete(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone' => [1, 0, 'dir', false],
             'gone/child.txt' => [1, 1, 'file'],
             'gone/nested' => [1, 0, 'dir', false],
@@ -283,7 +283,7 @@ final class PushPlanTest extends TestCase
 
     public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
             'b.txt' => [1, 1, 'file'],
@@ -309,7 +309,7 @@ final class PushPlanTest extends TestCase
 
     public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -333,7 +333,7 @@ final class PushPlanTest extends TestCase
 
     public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
@@ -353,7 +353,7 @@ final class PushPlanTest extends TestCase
 
     public function testNewChangedDeletedAndUnchangedPathsArePlannedTogether(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'changed.txt' => [100, 5, 'file'],
             'deleted.txt' => [100, 5, 'file'],
             'unchanged.txt' => [100, 5, 'file'],
@@ -373,7 +373,7 @@ final class PushPlanTest extends TestCase
         $this->assertSame("deleted.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testSavingTheFreshIndexAsThePreviousLocalIndexClearsPlanOutput(): void
+    public function testSavingTheFreshLocalIndexAsTheLocalIndexClearsPlanOutput(): void
     {
         $index = $this->writeIndex(['a.txt' => [100, 5, 'file']]);
         $plan = $this->startPlan($index);
@@ -381,7 +381,7 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
         $this->assertSame(['a.txt'], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
 
-        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
+        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexFile());
         $this->removePlanDirectory();
         $this->assertDirectoryDoesNotExist($this->planDirectory());
         $plan = $this->startPlan($index);
@@ -397,7 +397,7 @@ final class PushPlanTest extends TestCase
         // Newlines and non-ASCII bytes are why JSONL indexes encode paths.
         $newPath = "wp-content/uploads/line\nbreak.png";
         $deletedPath = 'wp-content/uploads/naïve-café.jpg';
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             $deletedPath => [100, 6, 'file'],
         ]));
         $current = $this->writeIndex([
@@ -418,7 +418,7 @@ final class PushPlanTest extends TestCase
 
     public function testIndexingFinishesBeforeDiffingAndClearsOldOutput(): void
     {
-        $this->savePreviousLocalIndex($this->writeIndex([
+        $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
         ]));
         $oldIndex = $this->writeIndex(['old.txt' => [1, 1, 'file']]);
@@ -481,29 +481,29 @@ final class PushPlanTest extends TestCase
         );
     }
 
-    public function testStepRetainsTheNextIndexEntryUntilClose(): void
+    public function testStepRetainsTheNextFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
-        $fresh_index_handle_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_handle');
-        $fresh_index_entry_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_entry');
+        $fresh_local_index_handle_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_handle');
+        $fresh_local_index_entry_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_entry');
 
         $this->assertTrue($this->nextPlanStep($plan));
-        $first_cursor = $this->planCursor();
-        $fresh_index_handle = $fresh_index_handle_property->getValue($plan);
-        $this->assertIsResource($fresh_index_handle);
+        $first_plan_cursor = $this->planCursor();
+        $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
+        $this->assertIsResource($fresh_local_index_handle);
         $this->assertGreaterThan(
-            $first_cursor['byte_offset_in_fresh_index'],
-            ftell($fresh_index_handle)
+            $first_plan_cursor['byte_offset_in_fresh_local_index'],
+            ftell($fresh_local_index_handle)
         );
-        $retained_entry = $fresh_index_entry_property->getValue($plan);
-        $this->assertIsArray($retained_entry);
-        $this->assertSame('file-0001.txt', $retained_entry['path']);
+        $retained_fresh_local_index_entry = $fresh_local_index_entry_property->getValue($plan);
+        $this->assertIsArray($retained_fresh_local_index_entry);
+        $this->assertSame('file-0001.txt', $retained_fresh_local_index_entry['path']);
 
         $this->assertTrue($this->nextPlanStep($plan));
-        $second_cursor = $this->planCursor();
+        $second_plan_cursor = $this->planCursor();
         $this->assertGreaterThan(
-            $second_cursor['byte_offset_in_fresh_index'],
-            ftell($fresh_index_handle)
+            $second_plan_cursor['byte_offset_in_fresh_local_index'],
+            ftell($fresh_local_index_handle)
         );
         $this->assertPathCounts(2, 0);
 
@@ -525,17 +525,17 @@ final class PushPlanTest extends TestCase
         $cursor = $plan->get_cursor();
         $this->assertSame([
             'plan_directory',
-            'local_tree_root',
-            'previous_local_index',
+            'filesystem_root',
+            'local_index_file',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
-        $this->assertSame(realpath($this->localTreeRoot()), $cursor['local_tree_root']);
-        $this->assertSame($this->previousLocalIndexPath(), $cursor['previous_local_index']);
+        $this->assertSame(realpath($this->filesystemRoot()), $cursor['filesystem_root']);
+        $this->assertSame($this->localIndexFile(), $cursor['local_index_file']);
         $this->assertSame([
             'phase',
-            'byte_offset_in_fresh_index',
-            'byte_offset_in_previous_local_index',
+            'byte_offset_in_fresh_local_index',
+            'byte_offset_in_local_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
@@ -555,15 +555,15 @@ final class PushPlanTest extends TestCase
     public function testNewInstanceResumesFromTheRetainedCursor(): void
     {
         $currentEntries = [];
-        $previousLocalIndexEntries = [];
+        $localIndexEntries = [];
         for ($index = 0; $index < 3; ++$index) {
             // The current and deleted names alternate in decoded sort order,
             // so every batch appends to both path files.
             $currentEntries[sprintf('item-%04d-current.txt', $index)] = [$index + 1, 1, 'file'];
-            $previousLocalIndexEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
+            $localIndexEntries[sprintf('item-%04d-deleted.txt', $index)] = [$index + 1, 1, 'file'];
         }
         $current = $this->writeIndex($currentEntries);
-        $this->savePreviousLocalIndex($this->writeIndex($previousLocalIndexEntries));
+        $this->saveLocalIndex($this->writeIndex($localIndexEntries));
         $plan = $this->startPlan($current);
 
         $this->assertTrue($this->nextPlanStep($plan));
@@ -586,7 +586,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(3, 3);
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertSame(array_keys($previousLocalIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
+        $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
@@ -644,15 +644,15 @@ final class PushPlanTest extends TestCase
     // ------------------------------------------------------------------
 
     /** @param list<string> $excludedPaths */
-    private function startPlan(?string $treeDescriptionPath = null, array $excludedPaths = []): PushPlan
+    private function startPlan(?string $filesystemRootDescriptionFile = null, array $excludedPaths = []): PushPlan
     {
-        if ($treeDescriptionPath === null) {
-            $treeDescriptionPath = $this->tempDir . '/empty-tree.jsonl';
-            if (!is_file($treeDescriptionPath)) {
-                file_put_contents($treeDescriptionPath, '');
+        if ($filesystemRootDescriptionFile === null) {
+            $filesystemRootDescriptionFile = $this->tempDir . '/empty-filesystem-root.jsonl';
+            if (!is_file($filesystemRootDescriptionFile)) {
+                file_put_contents($filesystemRootDescriptionFile, '');
             }
         }
-        $this->materializeLocalTree($treeDescriptionPath);
+        $this->materializeFilesystemRoot($filesystemRootDescriptionFile);
         if (!is_dir($this->planDirectory())) {
             mkdir($this->planDirectory(), 0755, true);
         }
@@ -665,8 +665,8 @@ final class PushPlanTest extends TestCase
         );
         $plan = PushPlan::start(
             $this->planDirectory(),
-            $this->localTreeRoot(),
-            $this->previousLocalIndexPath(),
+            $this->filesystemRoot(),
+            $this->localIndexFile(),
             $this->excludedPathsPath()
         );
         $this->cursor = $plan->get_cursor();
@@ -684,11 +684,11 @@ final class PushPlanTest extends TestCase
         return PushPlan::resume($this->cursor);
     }
 
-    private function savePreviousLocalIndex(string $treeDescriptionPath): void
+    private function saveLocalIndex(string $filesystemRootDescriptionFile): void
     {
-        $plan = $this->startPlan($treeDescriptionPath);
+        $plan = $this->startPlan($filesystemRootDescriptionFile);
         $this->planToCompletion($plan);
-        copy($this->planPath('fresh_local_index.jsonl'), $this->previousLocalIndexPath());
+        copy($this->planPath('fresh_local_index.jsonl'), $this->localIndexFile());
         $this->removePlanDirectory();
     }
 
@@ -750,12 +750,17 @@ final class PushPlanTest extends TestCase
 
     private function pushStateDirectory(): string
     {
-        return $this->tempDir . '/state/push/example.com';
+        return $this->remoteStateDirectory() . '/push';
     }
 
-    private function previousLocalIndexPath(): string
+    private function remoteStateDirectory(): string
     {
-        return $this->pushStateDirectory() . '/previous_local_index.jsonl';
+        return $this->tempDir . '/state/remotes/example.com';
+    }
+
+    private function localIndexFile(): string
+    {
+        return $this->remoteStateDirectory() . '/local_index.jsonl';
     }
 
     private function excludedPathsPath(): string
@@ -768,21 +773,21 @@ final class PushPlanTest extends TestCase
         $this->recursiveDelete($this->planDirectory());
     }
 
-    private function localTreeRoot(): string
+    private function filesystemRoot(): string
     {
-        return $this->tempDir . '/local-tree-root';
+        return $this->tempDir . '/filesystem-root';
     }
 
     /**
      * Makes the filesystem root match one test description while preserving unchanged paths.
      *
-     * @param string $treeDescriptionPath JSONL path descriptions created by writeIndex().
+     * @param string $filesystemRootDescriptionFile JSONL path descriptions created by writeIndex().
      */
-    private function materializeLocalTree(string $treeDescriptionPath): void
+    private function materializeFilesystemRoot(string $filesystemRootDescriptionFile): void
     {
-        $entries = $this->indexEntries($treeDescriptionPath);
-        if (!is_dir($this->localTreeRoot())) {
-            mkdir($this->localTreeRoot(), 0755, true);
+        $entries = $this->indexEntries($filesystemRootDescriptionFile);
+        if (!is_dir($this->filesystemRoot())) {
+            mkdir($this->filesystemRoot(), 0755, true);
         }
 
         $pathsToKeep = $this->pathsRequiredByIndexEntries($entries);
@@ -790,13 +795,13 @@ final class PushPlanTest extends TestCase
         $pathsToRemove = array_keys(array_diff_key($previousPaths, $pathsToKeep));
         usort($pathsToRemove, static fn(string $left, string $right): int => strlen($right) <=> strlen($left));
         foreach ($pathsToRemove as $path) {
-            $this->recursiveDelete($this->localTreeRoot() . '/' . $path);
+            $this->recursiveDelete($this->filesystemRoot() . '/' . $path);
         }
 
         $implicitDirectories = array_keys(array_diff_key($pathsToKeep, $entries));
         usort($implicitDirectories, static fn(string $left, string $right): int => strlen($left) <=> strlen($right));
         foreach ($implicitDirectories as $path) {
-            $localPath = $this->localTreeRoot() . '/' . $path;
+            $localPath = $this->filesystemRoot() . '/' . $path;
             if (!is_dir($localPath) || is_link($localPath)) {
                 $this->recursiveDelete($localPath);
                 mkdir($localPath, 0755, true);
@@ -808,7 +813,7 @@ final class PushPlanTest extends TestCase
             return $depthComparison !== 0 ? $depthComparison : strcmp($left, $right);
         });
         foreach ($entries as $path => $entry) {
-            $localPath = $this->localTreeRoot() . '/' . $path;
+            $localPath = $this->filesystemRoot() . '/' . $path;
             $parentDirectory = dirname($localPath);
             if (!is_dir($parentDirectory)) {
                 mkdir($parentDirectory, 0755, true);

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1350,17 +1350,21 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/replace-directory/old.txt', 'old');
         file_put_contents($local_docroot . '/replace-directory', 'replacement');
 
-        $previous_local_index_path = $this->root . '/previous-local-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture_file = $this->root . '/local-index-fixture.jsonl';
+        $this->writeIndex($local_index_fixture_file, [
             'remove.txt' => [1, 3, 'file'],
             'replace-directory' => [1, 0, 'dir', false],
             'replace-directory/old.txt' => [1, 3, 'file'],
             'same-size.txt' => [1, 4, 'file'],
         ]);
         $push_state_directory = $this->root . '/sender-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
+        $local_index_file = $this->localIndexFile(dirname($push_state_directory));
+        $initial_local_index_contents = file_get_contents($local_index_file);
+        $this->assertIsString($initial_local_index_contents);
 
         $commit_advances = 0;
+        $saw_saving_local_index = false;
         $saw_completing = false;
         for ($step = 0; $step < 200; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -1369,9 +1373,19 @@ final class PushEndpointsTest extends TestCase {
             if (is_array($state) && $state['phase'] === 'committing') {
                 ++$commit_advances;
             }
+            if (is_array($state) && $state['phase'] === 'saving_local_index') {
+                $this->assertSame($initial_local_index_contents, file_get_contents($local_index_file));
+                $saw_saving_local_index = true;
+            }
             if (is_array($state) && $state['phase'] === 'completing') {
                 $this->assertNull($state['push_plan_cursor']);
                 $this->assertDirectoryExists($push_state_directory . '/plan');
+                $fresh_local_index_file = $push_state_directory . '/plan/fresh_local_index.jsonl';
+                $this->assertFileExists($fresh_local_index_file);
+                $this->assertSame(
+                    file_get_contents($fresh_local_index_file),
+                    file_get_contents($local_index_file)
+                );
                 $saw_completing = true;
             }
             if ($result['status'] !== 'continue') {
@@ -1380,6 +1394,7 @@ final class PushEndpointsTest extends TestCase {
         }
 
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertTrue($saw_saving_local_index);
         $this->assertTrue($saw_completing);
         $this->assertGreaterThan(1, $commit_advances, 'The endpoint work budget must require repeated commit requests.');
         $this->assertSame(str_repeat('A', 2000), file_get_contents($this->docroot . '/nested/large.bin'));
@@ -1392,7 +1407,12 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist($push_state_directory . '/excluded_paths.json');
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileExists($local_index_file);
+        $this->assertSame(
+            [],
+            glob($push_state_directory . '/*index*'),
+            'The push state directory must not retain another local index.'
+        );
     }
 
     /**
@@ -1440,14 +1460,14 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/retained-deleted-paths-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/retained-deleted-paths-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture_file = $this->root . '/retained-deleted-paths-local-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 60; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture_file, $local_index_entries);
         $push_state_directory = $this->root . '/retained-deleted-paths-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
         $sender = $this->startSender(
             $this->senderOptions($local_docroot, $push_state_directory)
         );
@@ -1469,14 +1489,14 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/single-delete-part-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/single-delete-part-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture_file = $this->root . '/single-delete-part-local-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 20; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture_file, $local_index_entries);
         $push_state_directory = $this->root . '/single-delete-part-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -1519,12 +1539,12 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/reappeared-delete-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($this->docroot . '/returned.txt', 'old');
-        $previous_local_index_path = $this->root . '/reappeared-delete-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture_file = $this->root . '/reappeared-delete-local-index.jsonl';
+        $this->writeIndex($local_index_fixture_file, [
             'returned.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/reappeared-delete-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $sender = $this->startSender($options);
@@ -1551,13 +1571,13 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($local_docroot . '/replace.txt', 'new');
         mkdir($this->docroot . '/replace.txt');
         file_put_contents($this->docroot . '/replace.txt/old.txt', 'old');
-        $previous_local_index_path = $this->root . '/disappeared-replacement-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture_file = $this->root . '/disappeared-replacement-local-index.jsonl';
+        $this->writeIndex($local_index_fixture_file, [
             'replace.txt' => [1, 0, 'dir', false],
             'replace.txt/old.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/disappeared-replacement-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -1757,12 +1777,12 @@ final class PushEndpointsTest extends TestCase {
         $result = $this->runSender($local_docroot, $push_state_directory);
 
         $this->assertSame('complete', $result['status']);
-        $index_lines = file(
-            $push_state_directory . '/previous_local_index.jsonl',
+        $local_index_lines = file(
+            $this->localIndexFile(dirname($push_state_directory)),
             FILE_IGNORE_NEW_LINES
         );
-        $this->assertIsArray($index_lines);
-        $this->assertCount(2, $index_lines);
+        $this->assertIsArray($local_index_lines);
+        $this->assertCount(2, $local_index_lines);
     }
 
     /**
@@ -1773,14 +1793,14 @@ final class PushEndpointsTest extends TestCase {
         $local_docroot = $this->root . '/retained-handles-local-docroot';
         mkdir($local_docroot, 0700, true);
         file_put_contents($local_docroot . '/file.bin', str_repeat('A', 130));
-        $previous_local_index_path = $this->root . '/retained-handles-previous-index.jsonl';
-        $previous_entries = [];
+        $local_index_fixture_file = $this->root . '/retained-handles-local-index.jsonl';
+        $local_index_entries = [];
         for ($index = 0; $index < 20; ++$index) {
-            $previous_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
+            $local_index_entries[sprintf('delete-%02d.txt', $index)] = [1, 1, 'file'];
         }
-        $this->writeIndex($previous_local_index_path, $previous_entries);
+        $this->writeIndex($local_index_fixture_file, $local_index_entries);
         $push_state_directory = $this->root . '/retained-handles-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
 
         $local_paths_to_push_handle_property = new ReflectionProperty(
             PushFilesSender::class,
@@ -2190,7 +2210,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
         $this->assertSame('public-change', file_get_contents($this->docroot . '/public.txt'));
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $saved_local_index = file_get_contents($push_state_directory . '/previous_local_index.jsonl');
+        $saved_local_index = file_get_contents($this->localIndexFile(dirname($push_state_directory)));
         $this->assertIsString($saved_local_index);
         $this->assertStringContainsString(
             '"path":"' . base64_encode('preserved/value.txt') . '"',
@@ -2459,12 +2479,12 @@ final class PushEndpointsTest extends TestCase {
         file_put_contents($this->docroot . '/delete-after-lost-response.txt', 'old');
         $local_docroot = $this->root . '/lost-response-local-docroot';
         mkdir($local_docroot, 0700, true);
-        $previous_local_index_path = $this->root . '/lost-response-previous-index.jsonl';
-        $this->writeIndex($previous_local_index_path, [
+        $local_index_fixture_file = $this->root . '/lost-response-local-index.jsonl';
+        $this->writeIndex($local_index_fixture_file, [
             'delete-after-lost-response.txt' => [1, 3, 'file'],
         ]);
         $push_state_directory = $this->root . '/lost-response-state';
-        $this->seedPreviousLocalIndex($push_state_directory, $previous_local_index_path);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
 
         for ($step = 0; $step < 30; ++$step) {
             $result = $this->nextSenderDurableBoundary($local_docroot, $push_state_directory);
@@ -2524,7 +2544,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertNull($this->loadActiveState($push_state_directory));
     }
 
-    public function testCompletedFilesPushPublishesThePreviousLocalIndexForFilesDiff(): void
+    public function testCompletedFilesPushWritesTheLocalIndexUsedByFilesDiff(): void
     {
         $local_docroot = $this->root . '/push-diff-local-docroot';
         $state_directory = $this->root . '/push-diff-state';
@@ -2534,6 +2554,8 @@ final class PushEndpointsTest extends TestCase {
 
         $push = $this->runFilesPushCli($local_docroot, $state_directory);
         $this->assertSame(0, $push['exit'], $push['output']);
+        $push_state_directory = $this->filesPushStateDirectory($state_directory);
+        $this->assertFileExists($this->localIndexFile(dirname($push_state_directory)));
 
         $empty_diff = $this->runFilesDiffCli($local_docroot, $state_directory);
         $this->assertSame(0, $empty_diff['exit'], $empty_diff['output']);
@@ -2639,7 +2661,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertTrue(is_link($this->docroot . '/file-link'));
         $this->assertSame('nested/multi-chunk.bin', readlink($this->docroot . '/file-link'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileExists($this->localIndexFile(dirname($push_state_directory)));
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
         $this->assertFileDoesNotExist(
@@ -2691,7 +2713,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileDoesNotExist($this->docroot . '/delete-later.txt');
         $this->assertSame('added', file_get_contents($this->docroot . '/added.txt'));
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
-        $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
+        $this->assertFileExists($this->localIndexFile(dirname($push_state_directory)));
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
     }
@@ -3534,14 +3556,20 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
-     * Seeds the previous local index for one remote Reprint API URL.
+     * Seeds the local index for the remote state directory containing push state.
      */
-    private function seedPreviousLocalIndex(string $push_state_directory, string $index_path): void
+    private function seedLocalIndex(string $push_state_directory, string $local_index_fixture_file): void
     {
-        if (!is_dir($push_state_directory)) {
-            mkdir($push_state_directory, 0700, true);
+        $remote_state_directory = dirname($push_state_directory);
+        if (!is_dir($remote_state_directory)) {
+            mkdir($remote_state_directory, 0700, true);
         }
-        $this->assertTrue(copy($index_path, $push_state_directory . '/previous_local_index.jsonl'));
+        $this->assertTrue(copy($local_index_fixture_file, $this->localIndexFile($remote_state_directory)));
+    }
+
+    private function localIndexFile(string $remote_state_directory): string
+    {
+        return $remote_state_directory . '/local_index.jsonl';
     }
 
     /**


### PR DESCRIPTION
`files-diff` and `files-push` now read one retained local index at `<remote-state-directory>/local_index.jsonl`. After the target confirms a `files-push` commit, `files-push` replaces that index with the completed filesystem-root scan.

Most changed lines rename the old **previous local index** vocabulary. The behavioral change is the index path and the point at which the completed scan replaces it; PushPlan's index merge and path-selection rules do not change.

| Artifact | Before | After |
| --- | --- | --- |
| Local index retained between commands | `<remote-state-directory>/push/previous_local_index.jsonl` | `<remote-state-directory>/local_index.jsonl` |
| Fresh local index for one active push plan | `<remote-state-directory>/push/plan/fresh_local_index.jsonl` | Unchanged |

## Behavioral change

The retained local index no longer belongs to the push state directory. `files-diff` reads it without changing it. PushPlan reads it as the baseline for the current filesystem-root scan.

After the target confirms the `files-push` commit, PushFilesSender copies the completed fresh local index to `<remote-state-directory>/local_index.jsonl.swap`, then atomically renames that file to `<remote-state-directory>/local_index.jsonl`. Until that rename, a reader sees the previous complete local index. If the process stops during the copy, the next sender run overwrites the incomplete swap file and repeats the copy.

Because the retained local index is outside `push/`, `files-diff` no longer requires the push state directory to exist before it starts. It creates its temporary `push/files-diff-plan/` directory when needed.

This PR does not make `files-pull` write the local index.

## Code and state names

The old name described the index relative to one completed push. The new name describes the artifact itself: the retained index of the filesystem root for one remote Reprint API URL.

| Before | After |
| --- | --- |
| `previous_local_index` | `local_index_file` |
| `previous_local_index_handle` | `local_index_file_handle` |
| `byte_offset_in_previous_local_index` | `byte_offset_in_local_index` |
| `local_tree_root` | `filesystem_root` |
| `fresh_local_index` | `fresh_local_index_file` |
| `saving_previous_local_index` | `saving_local_index` |

These changes rename properties, arguments, file handles, cursor fields, and the sender phase. They account for most of the diff, especially in PushPlan, but do not change which local paths PushPlan selects to push or delete.

## Existing state

There is no migration from `<remote-state-directory>/push/previous_local_index.jsonl`. `files-diff` and `files-push` neither read nor move that file.

Persisted sender state using `saving_previous_local_index`, or PushPlan state using the old cursor field names, cannot resume through this change and must be discarded. Without `<remote-state-directory>/local_index.jsonl`, `files-diff` reports that the local index is missing. A new `files-push` treats the missing local index as an empty baseline, scans the filesystem root, and writes the completed scan only after the target confirms commit.

## Testing

Complete a `files-push` and confirm that the retained index is written at `<remote-state-directory>/local_index.jsonl`, not inside `push/`. Run `files-diff` without changing the filesystem root and confirm that it reports no operations. Change one local path and confirm that `files-diff` reports the operation without changing the retained local index.
