### PR TITLE
Store each remote Reprint API URL's pull state under remotes/<hash>/pull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `--state-dir/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `<remote-state-directory>/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
 
 ### Progress Tracking
 
@@ -239,11 +239,13 @@ Always consult these when working on the respective components.
 
 ### Progress Computation
 
-Progress is computed client-side by reading state files (all in `--state-dir`):
-- `pull/state.json`: Current command, status, cursor, stage
-- `pull/remote-index.jsonl`: Remote index (line count = accounted entries)
-- `pull/remote-index.next.jsonl`: Next remote index (for delta comparison)
-- `pull/fetch-list.jsonl`: Files pending download
+Progress is computed client-side by reading state files. The remote state
+directory is
+`--state-dir/remotes/<md5-of-trimmed-remote-reprint-api-url>`:
+- `<remote-state-directory>/pull/state.json`: Current command, status, cursor, stage
+- `<remote-state-directory>/pull/remote-index.jsonl`: Remote index (line count = accounted entries)
+- `<remote-state-directory>/pull/remote-index.next.jsonl`: Next remote index (for delta comparison)
+- `<remote-state-directory>/pull/fetch-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
 
 And from `--fs-root`:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ First, we'll make sure the server is reachable and the environment is in a good 
 php reprint.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
-The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/pull/state.json` under the `preflight` key.
+The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json` under the `preflight` key.
 
 All other commands check that a preflight has been completed and refuse to start without one.
 
@@ -253,7 +253,8 @@ php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 The pipeline proceeds as usual through indexing and diffing, but skips uploads. When the essential
 files are done, the sync marks itself **complete**. The skipped file list stays on disk at
-`$STATE_DIR/pull/skipped-fetch-list.jsonl`. At this point you can apply the database and bring the site online.
+`$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/skipped-fetch-list.jsonl`.
+At this point you can apply the database and bring the site online.
 
 ```bash
 # Step 2: download the uploads
@@ -346,7 +347,8 @@ All three modes recover from server crashes mid-stream (PHP fatal errors,
 OOM kills, `max_execution_time` expiry). When the server dies before sending
 a completion chunk, the importer detects the transport failure, saves its
 cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/pull/sql-buffer` so the next run reloads it and continues.
+persisted in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/sql-buffer`
+so the next run reloads it and continues.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -438,7 +440,7 @@ hosting provider, and generates the configuration files your target server needs
 For PHP's built-in development server:
 
 ```bash
-php reprint.phar apply-runtime --state-dir="$STATE_DIR" \
+php reprint.phar apply-runtime "$URL" --state-dir="$STATE_DIR" \
     --flat-document-root="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=php-builtin
 bash "$RUNTIME_DIR/start.sh"
 ```
@@ -446,7 +448,7 @@ bash "$RUNTIME_DIR/start.sh"
 For nginx + PHP-FPM:
 
 ```bash
-php reprint.phar apply-runtime --state-dir="$STATE_DIR" \
+php reprint.phar apply-runtime "$URL" --state-dir="$STATE_DIR" \
     --flat-document-root="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=nginx-fpm
 # Include $RUNTIME_DIR/nginx.conf in your nginx configuration, then reload
 ```
@@ -515,13 +517,18 @@ whatever tool was reading stdout (typically `mysql` CLI).
 
 Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
-name itself. Shared command progress and the audit log live directly in the
-state directory. Pull-owned state lives in `pull/`, while remote-specific push
-state lives in
-`remotes/<md5-of-trimmed-remote-reprint-api-url>/push/`. Shared and pull filenames
-do not begin with a dot or repeat the scope supplied by their parent directory.
+name itself. State-directory-wide command progress and the audit log live directly in the
+state directory. Pull and push operation state live under the remote state
+directory at `remotes/<md5-of-trimmed-remote-reprint-api-url>/`, in `pull/` and
+`push/` respectively. State-directory-wide and pull filenames do not begin
+with a dot or repeat the scope supplied by their parent directory.
 
-`pull/state.json` and `progress.json` are written atomically:
+The directory name is `md5(rtrim(<remote-reprint-api-url>, "?&"))`. Commands
+which read local pull state receive the same remote Reprint API URL even when
+they make no network request; the URL selects the remote state directory.
+
+`<remote-state-directory>/pull/state.json` and the state-directory-wide
+`progress.json` are written atomically:
 a `.tmp` file is written first and then renamed to its final name so readers
 never see partially written state.
 
@@ -529,7 +536,7 @@ While there's many of these files, most of them are for internal use only.
 The two that might be particularly useful for integrators are:
 
 * `progress.json` – the current progress
-* `pull/state.json` – the pull state store
+* `<remote-state-directory>/pull/state.json` – the pull state store
 
 #### `progress.json` – the current progress
 
@@ -576,7 +583,7 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
-#### `pull/state.json` — the pull state store
+#### `<remote-state-directory>/pull/state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it
 back periodically and on shutdown. It stores everything needed to resume after
@@ -585,7 +592,8 @@ state, and per-phase bookmarks.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to
-`pull/state.json.corrupt.<timestamp>` and starts fresh.
+`state.json.corrupt.<timestamp>` in the same pull state directory and starts
+fresh.
 
 ```jsonc
 {
@@ -649,22 +657,23 @@ tell you where the pipeline is. The `stage` field gives finer granularity
 (e.g., `"scanning"`, `"sorting"`, `"streaming"` for file sync).
 
 For pull lifecycle and source-site details, prefer `pull-metadata` over reading
-`pull/state.json` directly. It exposes a small, stable JSON contract for host
-integrations:
+`<remote-state-directory>/pull/state.json` directly. It exposes a small, stable
+JSON contract for host integrations:
 
 ```bash
-php reprint.phar pull-metadata --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
+php reprint.phar pull-metadata "$URL" --state-dir="$STATE_DIR" | jq '.hasCompletedOnce'
 ```
 
 The `sourceSite` object contains the source WordPress home URL, site URL, table
 prefix, WordPress database charset, and database server charset reported by
 preflight. Each field is `null` when preflight did not report it.
 
-#### `pull/volatile-files.json` — files that changed during sync
+#### `<remote-state-directory>/pull/volatile-files.json` — files that changed during sync
 
 During `files-pull`, a file on the source may be modified while the importer is
 streaming it. When that happens, the server returns a different content hash than
-expected and the importer records the file in `pull/volatile-files.json`
+expected and the importer records the file in
+`<remote-state-directory>/pull/volatile-files.json`
 instead of failing.
 
 The file is a flat JSON object mapping paths to the number of times each file
@@ -692,7 +701,7 @@ truncated or rotated, so it provides a complete history of the migration.
 ```
 [2025-01-15 10:30:01] VOLATILE | path=/srv/htdocs/wp-content/debug.log | count=1
 [2025-01-15 10:30:05] VOLATILE CLEARED | path=/srv/htdocs/wp-content/debug.log
-[2025-01-15 10:31:12] FILE TRUNCATE | /tmp/reprint-state/pull/remote-index.wal | remote index WAL batch applied
+[2025-01-15 10:31:12] FILE TRUNCATE | /tmp/reprint-state/remotes/0123456789abcdef0123456789abcdef/pull/remote-index.wal | remote index WAL batch applied
 ```
 
 Pass `--verbose` to also print audit log entries to the console as they happen.
@@ -714,10 +723,10 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
-* `db-domains` — Lists domains discovered in the SQL dump. Reads `pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
+* `db-domains` — Lists domains discovered in the SQL dump. Reads `<remote-state-directory>/pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `pull-metadata` — Prints pull lifecycle and source-site metadata as JSON. Requires only `--state-dir`; no network calls are made.
+* `pull-metadata` — Prints pull lifecycle and source-site metadata as JSON. The remote Reprint API URL selects the pull state; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
-* `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
+* `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from the pull state selected by the remote Reprint API URL. No network calls are made. See [Step 6](#step-6--generate-runtime-configuration).
 
 All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the remote index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -413,9 +413,9 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 `PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
 It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
 the operator passes `--force-http`. It does not run pull preflight, read or
-write `pull/state.json`, show a plan, ask for confirmation, transfer a
-database, retry a failed request, or start a replacement sender after a
-`restart` outcome.
+write `<remote-state-directory>/pull/state.json`, show a plan, ask for
+confirmation, transfer a database, retry a failed request, or start a
+replacement sender after a `restart` outcome.
 
 The local push state directory is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -159,32 +159,32 @@ development. There are no compatibility aliases or migration paths.
 
 The **state directory** is the caller-supplied `<state-dir>`; use `$state_dir`.
 Reprint uses it exactly as supplied and does not append `.reprint`. A consumer
-may choose `.reprint` or any other private directory name. The **pull state
-directory** is `<state-dir>/pull`; use `$pull_state_directory`. Filenames
-inside the state directory do not begin with a dot or repeat the scope supplied
-by their parent directories. A **remote state directory** contains state for
-one remote Reprint API URL. It is
+may choose `.reprint` or any other private directory name. A **remote state
+directory** contains state for one remote Reprint API URL. It is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>`; use
-`$remote_state_directory`.
+`$remote_state_directory`. The **pull state directory** is
+`<remote-state-directory>/pull`; use `$pull_state_directory`. Filenames inside
+the state directory do not begin with a dot or repeat the scope supplied by
+their parent directories.
 
 ```text
 <state-dir>/
 ├── process.lock
 ├── progress.json
 ├── audit.log
-├── pull/
-│   ├── state.json
-│   ├── remote-index.jsonl
-│   ├── remote-index.wal
-│   ├── remote-index.next.jsonl
-│   ├── fetch-list.jsonl
-│   ├── skipped-fetch-list.jsonl
-│   ├── volatile-files.json
-│   ├── domains.json
-│   ├── sql-stats.json
-│   └── sql-buffer
 └── remotes/
     └── <md5-of-trimmed-remote-reprint-api-url>/
+        ├── pull/
+        │   ├── state.json
+        │   ├── remote-index.jsonl
+        │   ├── remote-index.wal
+        │   ├── remote-index.next.jsonl
+        │   ├── fetch-list.jsonl
+        │   ├── skipped-fetch-list.jsonl
+        │   ├── volatile-files.json
+        │   ├── domains.json
+        │   ├── sql-stats.json
+        │   └── sql-buffer
         └── push/
 ```
 
@@ -211,6 +211,9 @@ Use these path names:
 
 Caller-facing outputs such as `db.sql`, `db-tables.jsonl`, generated runtime
 files, and database files remain directly under the state directory.
+Commands which read or write remote state receive the remote Reprint API URL
+even when they make no network request. The URL selects the remote state
+directory.
 
 ## Local Reprint process lock
 
@@ -233,7 +236,8 @@ push-session and commit locks.
 ## Pull remote index WAL
 
 Call the single pull-side write-ahead log the **remote index WAL**. It lives at
-`<state-dir>/pull/remote-index.wal`; use `pull/remote-index.wal`,
+`<remote-state-directory>/pull/remote-index.wal`; use
+`pull/remote-index.wal`,
 `$remote_index_wal_path`, and `$remote_index_wal_handle`.
 Applied batch records are cleared, but the empty WAL remains as a marker until
 files-pull completes. A retained WAL is consumed only while resuming or
@@ -367,7 +371,8 @@ directory for a different filesystem root; the filesystem root does not
 participate in the directory name. `files-push` chooses `start` or `resume`
 only from whether `sender.json` exists there. The receiver-confirmed upload
 positions remain receiver-owned; they are not a files-push cursor and are not
-copied into `pull/state.json` or `progress.json`.
+copied into `<remote-state-directory>/pull/state.json` or the state-directory-wide
+`progress.json`.
 
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -232,6 +232,9 @@ class ImportClient
     /** @var string Caller-selected state directory for this filesystem root. */
     public $state_dir;
 
+    /** @var string Pull state directory for this remote Reprint API URL. */
+    public $pull_state_directory;
+
     /** @var string Filesystem root where the remote filesystem is reconstructed. */
     public $filesystem_root;
 
@@ -518,18 +521,22 @@ class ImportClient
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->filesystem_root = rtrim($filesystem_root, "/");
-        $this->pull_state_file = $this->state_dir . "/pull/state.json";
-        $this->remote_index_file = $this->state_dir . "/pull/remote-index.jsonl";
+        $this->pull_state_directory = self::remote_state_directory_path(
+            $this->remote_reprint_api_url,
+            $this->state_dir
+        ) . "/pull";
+        $this->pull_state_file = $this->pull_state_directory . "/state.json";
+        $this->remote_index_file = $this->pull_state_directory . "/remote-index.jsonl";
         $this->remote_index_wal_path =
-            $this->state_dir . "/pull/remote-index.wal";
+            $this->pull_state_directory . "/remote-index.wal";
         $this->next_remote_index_file =
-            $this->state_dir . "/pull/remote-index.next.jsonl";
+            $this->pull_state_directory . "/remote-index.next.jsonl";
         $this->fetch_list_file =
-            $this->state_dir . "/pull/fetch-list.jsonl";
+            $this->pull_state_directory . "/fetch-list.jsonl";
         $this->skipped_fetch_list_file =
-            $this->state_dir . "/pull/skipped-fetch-list.jsonl";
+            $this->pull_state_directory . "/skipped-fetch-list.jsonl";
         $this->audit_log_file = $this->state_dir . "/audit.log";
-        $this->volatile_files_file = $this->state_dir . "/pull/volatile-files.json";
+        $this->volatile_files_file = $this->pull_state_directory . "/volatile-files.json";
         $this->progress_file = $this->state_dir . "/progress.json";
 
         // Detect TTY for progress display. In stdout mode this is re-evaluated
@@ -540,9 +547,9 @@ class ImportClient
         $this->pull = new Pull($this, $this->progress);
 
         // Create directories
-        if (!is_dir($this->state_dir . "/pull")) {
-            if (!mkdir($this->state_dir . "/pull", 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->state_dir}/pull");
+        if (!is_dir($this->pull_state_directory)) {
+            if (!mkdir($this->pull_state_directory, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->pull_state_directory}");
             }
         }
         if (!is_dir($this->filesystem_root)) {
@@ -698,7 +705,7 @@ class ImportClient
     {
         // Mask the remote URL (argv[2]) to avoid logging secrets embedded in query strings.
         $masked = $argv;
-        if (isset($masked[2]) && $command !== 'apply-runtime') {
+        if (isset($masked[2])) {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
             if ($command === 'files-push') {
                 $masked[2] = self::mask_url_credentials($masked[2]);
@@ -1812,10 +1819,11 @@ class ImportClient
             );
         }
         $resolved_local_filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
-        $remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
         // Resolve an absolute physical path even when its final components do not exist.
-        $remote_state_directory =
-            $state_dir . '/remotes/' . md5($remote_reprint_api_url);
+        $remote_state_directory = self::remote_state_directory_path(
+            $remote_reprint_api_url,
+            $state_dir
+        );
         $push_state_directory = $remote_state_directory . '/push';
         if (strpos($push_state_directory, '/') !== 0) {
             $working_directory = getcwd();
@@ -1855,6 +1863,17 @@ class ImportClient
         }
 
         return $push_state_directory;
+    }
+
+    /** Returns `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>`. */
+    private static function remote_state_directory_path(
+        string $remote_reprint_api_url,
+        string $state_dir
+    ): string {
+        return
+            rtrim($state_dir, '/')
+            . '/remotes/'
+            . md5(rtrim($remote_reprint_api_url, '?&'));
     }
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
@@ -1969,7 +1988,7 @@ class ImportClient
                         "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
-                $domains_file = $this->state_dir . "/pull/domains.json";
+                $domains_file = $this->pull_state_directory . "/domains.json";
                 if (file_exists($domains_file)) {
                     unlink($domains_file);
                     $this->audit_log(
@@ -3767,7 +3786,7 @@ class ImportClient
      */
     private function run_db_domains(): void
     {
-        $domains_file = $this->state_dir . "/pull/domains.json";
+        $domains_file = $this->pull_state_directory . "/domains.json";
         $sql_file = $this->state_dir . "/db.sql";
 
         if (file_exists($domains_file)) {
@@ -4345,11 +4364,13 @@ class ImportClient
         }
 
         $manifest->constants["REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL"] = $base_url;
-        $state_dir = realpath($this->state_dir) ?: $this->state_dir;
+        $pull_state_directory =
+            realpath($this->pull_state_directory)
+            ?: $this->pull_state_directory;
         $manifest->constants["REPRINT_PULL_STATE_FILE"] =
-            rtrim($state_dir, "/") . "/pull/state.json";
+            rtrim($pull_state_directory, "/") . "/state.json";
         $manifest->constants["REPRINT_PULL_SKIPPED_FETCH_LIST_FILE"] =
-            rtrim($state_dir, "/") . "/pull/skipped-fetch-list.jsonl";
+            rtrim($pull_state_directory, "/") . "/skipped-fetch-list.jsonl";
         $manifest->routes[] = [
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
@@ -5236,7 +5257,7 @@ class ImportClient
         }
 
         // Show discovered domains if available
-        $domains_file = $this->state_dir . "/pull/domains.json";
+        $domains_file = $this->pull_state_directory . "/domains.json";
         if (file_exists($domains_file)) {
             $domains = json_decode(file_get_contents($domains_file), true);
             if (is_array($domains) && !empty($domains)) {
@@ -5403,7 +5424,7 @@ class ImportClient
         $stmts_since_save = 0;
 
         // Load pre-computed statement count from db-pull for progress reporting
-        $sql_stats_file = $this->state_dir . "/pull/sql-stats.json";
+        $sql_stats_file = $this->pull_state_directory . "/sql-stats.json";
         $statements_total = null;
         if (file_exists($sql_stats_file)) {
             $stats = json_decode(file_get_contents($sql_stats_file), true);
@@ -7653,7 +7674,7 @@ class ImportClient
             // Each SQL chunk is appended to this file as it arrives; when the
             // query completes and executes, the file is truncated. If the process
             // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = $this->state_dir . "/pull/sql-buffer";
+            $sql_buffer_file = $this->pull_state_directory . "/sql-buffer";
             if (file_exists($sql_buffer_file)) {
                 $sql_buffer = file_get_contents($sql_buffer_file);
                 $this->audit_log(
@@ -7676,8 +7697,8 @@ class ImportClient
         $domain_collector = class_exists('DomainCollector')
             ? new \DomainCollector()
             : null;
-        $domains_file = $this->state_dir . "/pull/domains.json";
-        $sql_stats_file = $this->state_dir . "/pull/sql-stats.json";
+        $domains_file = $this->pull_state_directory . "/domains.json";
+        $sql_stats_file = $this->pull_state_directory . "/sql-stats.json";
         $sql_statements_counted = (int) ($this->get_state()->sql_statements_counted ?? 0);
 
         // Auto-detect the source site domain from the export URL so it
@@ -8015,7 +8036,7 @@ class ImportClient
                 $mysql_conn = null;
                 // Clean up buffer file — if we got here with an empty buffer,
                 // all queries were executed successfully.
-                $sql_buffer_file = $this->state_dir . "/pull/sql-buffer";
+                $sql_buffer_file = $this->pull_state_directory . "/sql-buffer";
                 if ($pending === "" && file_exists($sql_buffer_file)) {
                     unlink($sql_buffer_file);
                 }
@@ -12627,11 +12648,16 @@ if (
                 "\n" .
                 "Output files:\n" .
                 "  (filesystem root)/                       Downloaded files\n" .
-                "  pull/remote-index.jsonl         Remote index\n" .
-                "  pull/remote-index.next.jsonl    Next remote index\n" .
-                "  pull/fetch-list.jsonl           Files pending download\n" .
-                "  pull/skipped-fetch-list.jsonl   Files skipped by --filter=essential-files\n" .
-                "  pull/state.json                 Resumable pull state\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/remote-index.jsonl\n" .
+                "                                           Remote index\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/remote-index.next.jsonl\n" .
+                "                                           Next remote index\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/fetch-list.jsonl\n" .
+                "                                           Files pending download\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/skipped-fetch-list.jsonl\n" .
+                "                                           Files skipped by --filter=essential-files\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json\n" .
+                "                                           Resumable pull state\n" .
                 "  audit.log                       Audit log\n",
         ],
         "files-diff" => [
@@ -12681,7 +12707,7 @@ if (
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
                 "entry (path, size, ctime, type, and directory emptiness) to\n" .
-                "pull/remote-index.next.jsonl.\n" .
+                "<remote-state-directory>/pull/remote-index.next.jsonl.\n" .
                 "\n" .
                 "On the first run, builds the complete index. On subsequent runs,\n" .
                 "re-indexes and diffs against the prior snapshot to produce a\n" .
@@ -12737,24 +12763,25 @@ if (
             "description" =>
                 "Prints domains found in the SQL dump, one per line.\n" .
                 "\n" .
-                "If pull/domains.json exists (cached by db-pull), it is read\n" .
+                "If <remote-state-directory>/pull/domains.json exists (cached by db-pull), it is read\n" .
                 "directly. Otherwise, db.sql is scanned and the result is cached\n" .
                 "for future calls. No network calls.\n" .
                 "\n" .
                 "Example:\n" .
-                "  reprint db-domains - --state-dir=/path/to/state\n",
+                "  reprint db-domains https://example.com --state-dir=/path/to/state\n",
             "extra" => null,
         ],
         "pull-metadata" => [
             "level" => "low",
             "short" => "Print local pull metadata for host integrations as JSON",
-            "usage" => "reprint pull-metadata --state-dir=DIR",
+            "usage" => "reprint pull-metadata <remote-reprint-api-url> --state-dir=DIR",
             "description" =>
-                "Reads --state-dir/pull/state.json and prints pull lifecycle and\n" .
-                "source-site metadata for host integrations. No network calls are made.\n",
+                "Reads <remote-state-directory>/pull/state.json and prints pull\n" .
+                "lifecycle and source-site metadata for host integrations. The remote\n" .
+                "Reprint API URL selects the state; no network calls are made.\n",
             "extra" =>
                 "Example:\n" .
-                "  reprint pull-metadata --state-dir=./state | jq '.hasCompletedOnce'\n",
+                "  reprint pull-metadata https://example.com --state-dir=./state | jq '.hasCompletedOnce'\n",
         ],
         "db-apply" => [
             "level" => "low",
@@ -12765,12 +12792,12 @@ if (
                 "database credentials to state for use by apply-runtime.\n",
             "extra" =>
                 "MySQL example:\n" .
-                "  reprint db-apply - --state-dir=./state --fs-root=./files \\\n" .
+                "  reprint db-apply https://example.com --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-user=root --target-db=wp_new \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n" .
                 "\n" .
                 "SQLite example:\n" .
-                "  reprint db-apply - --state-dir=./state --fs-root=./files \\\n" .
+                "  reprint db-apply https://example.com --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
@@ -12795,6 +12822,9 @@ if (
         "apply-runtime" => [
             "level" => "low",
             "short" => "Generate server config and prepare the site to run locally",
+            "usage" =>
+                "reprint apply-runtime <remote-reprint-api-url> --state-dir=DIR " .
+                "(--fs-root=DIR|--flat-document-root=DIR) [options]",
             "description" =>
                 "Generates server configuration (runtime.php, nginx.conf or start.sh)\n" .
                 "from preflight data and removes production-only drop-ins and mu-plugins\n" .
@@ -12803,7 +12833,8 @@ if (
                 "If db-apply was run first, embeds the target database credentials\n" .
                 "into runtime.php automatically.\n" .
                 "\n" .
-                "Does not require a remote URL — reads only from local state.\n" .
+                "The remote Reprint API URL selects the state used to generate the\n" .
+                "runtime configuration; no network calls are made.\n" .
                 "\n" .
                 "Pass --fs-root for the raw download directory (the remote document_root\n" .
                 "path is appended automatically), or --flat-document-root for a directory\n" .
@@ -12840,11 +12871,11 @@ if (
                 "\n" .
                 "Examples:\n" .
                 "  # From raw download directory:\n" .
-                "  reprint apply-runtime --state-dir=./state \\\n" .
+                "  reprint apply-runtime https://example.com --state-dir=./state \\\n" .
                 "    --fs-root=./files --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  # From flattened layout:\n" .
-                "  reprint apply-runtime --state-dir=./state \\\n" .
+                "  reprint apply-runtime https://example.com --state-dir=./state \\\n" .
                 "    --flat-document-root=./flat --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  bash ./runtime/start.sh\n",
@@ -12884,24 +12915,19 @@ if (
         exit(0);
     }
 
-    // apply-runtime and pull-metadata don't need a remote URL. Other
-    // local-only commands (db-domains, db-apply, etc.) still accept it for
-    // CLI consistency and backward compatibility with existing callers.
-    $local_only_commands = ["apply-runtime", "pull-metadata"];
-    $is_local_only = in_array($command, $local_only_commands, true);
-
-    if ($is_local_only) {
-        $remote_reprint_api_url = "-";
-        $option_start_index = 2; // options start right after the command
-    } else {
-        $remote_reprint_api_url = $argv[2] ?? null;
-        if (!$remote_reprint_api_url) {
-            fwrite(STDERR, "Error: <remote-reprint-api-url> is required\n");
-            fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
-            exit(1);
-        }
-        $option_start_index = 3;
+    // Every command which reads or writes state names the remote Reprint API
+    // URL whose remote state directory it uses. Local commands use the URL to
+    // select state without making a network request.
+    $remote_reprint_api_url = $argv[2] ?? null;
+    if (
+        !$remote_reprint_api_url
+        || strpos($remote_reprint_api_url, '-') === 0
+    ) {
+        fwrite(STDERR, "Error: <remote-reprint-api-url> is required\n");
+        fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        exit(1);
     }
+    $option_start_index = 3;
 
     [$state_dir, $filesystem_root, $options] = _cli_parse_options(
         $argv, $argc, $option_start_index, $option_defs

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -278,6 +278,7 @@ class Pull
             // recorded that stage as complete. Clear the direct command
             // checkpoint first so the stage computes a fresh delta.
             $state_dir = $this->client->state_dir;
+            $pull_state_directory = $this->client->pull_state_directory;
             if ($state_command === 'files-pull' && in_array('files-pull', $stages, true)) {
                 // Keep the remote index, but clear transient files-pull state
                 // so this pipeline downloads a next remote index and compares
@@ -298,9 +299,9 @@ class Pull
                 $state->files_pull_only_fingerprint = null;
                 $this->client->save_state();
                 foreach ([
-                    "{$state_dir}/pull/remote-index.next.jsonl",
-                    "{$state_dir}/pull/fetch-list.jsonl",
-                    "{$state_dir}/pull/skipped-fetch-list.jsonl",
+                    "{$pull_state_directory}/remote-index.next.jsonl",
+                    "{$pull_state_directory}/fetch-list.jsonl",
+                    "{$pull_state_directory}/skipped-fetch-list.jsonl",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -320,7 +321,7 @@ class Pull
                 foreach ([
                     "{$state_dir}/db.sql",
                     "{$state_dir}/db-tables.jsonl",
-                    "{$state_dir}/pull/domains.json",
+                    "{$pull_state_directory}/domains.json",
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -768,6 +769,7 @@ class Pull
     private function prepare_repull(string $command): void
     {
         $state_dir = $this->client->state_dir;
+        $pull_state_directory = $this->client->pull_state_directory;
         switch ($command) {
             case 'pull':
                 $reset_file_transfer_state = true;
@@ -826,14 +828,14 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $state_dir . "/pull/remote-index.next.jsonl";
-            $paths[] = $state_dir . "/pull/fetch-list.jsonl";
-            $paths[] = $state_dir . "/pull/skipped-fetch-list.jsonl";
+            $paths[] = $pull_state_directory . "/remote-index.next.jsonl";
+            $paths[] = $pull_state_directory . "/fetch-list.jsonl";
+            $paths[] = $pull_state_directory . "/skipped-fetch-list.jsonl";
         }
         if ($reset_db_state) {
             $paths[] = $state_dir . "/db.sql";
             $paths[] = $state_dir . "/db-tables.jsonl";
-            $paths[] = $state_dir . "/pull/domains.json";
+            $paths[] = $pull_state_directory . "/domains.json";
         }
 
         foreach ($paths as $path) {

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -345,7 +345,7 @@ class PullPipelineCheckpointState
 /**
  * In-process pull state with typed properties for each persisted field.
  *
- * This object mirrors pull/state.json. Add new persistent state here first;
+ * This object mirrors the pull state file. Add new persistent state here first;
  * from_array() requires the complete current schema.
  */
 class PullState

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -56,7 +56,42 @@ class CliHelpTest extends TestCase
     {
         $output = $this->runHelp('import-metadata');
 
-        $this->assertStringContainsString('Usage: reprint pull-metadata --state-dir=DIR', $output);
+        $this->assertStringContainsString(
+            'Usage: reprint pull-metadata <remote-reprint-api-url> --state-dir=DIR',
+            $output
+        );
+    }
+
+    public function testApplyRuntimeHelpRequiresTheRemoteReprintApiUrlWhichSelectsState(): void
+    {
+        $output = $this->runHelp('apply-runtime');
+
+        $this->assertStringContainsString(
+            'Usage: reprint apply-runtime <remote-reprint-api-url>',
+            $output
+        );
+        $this->assertStringContainsString('no network calls are made', $output);
+    }
+
+    public function testPullMetadataRejectsAnInvocationWithoutARemoteReprintApiUrl(): void
+    {
+        $entry = __DIR__ . '/../../importer/import.php';
+        $stateDirectory =
+            sys_get_temp_dir() . '/pull-metadata-missing-remote-' . uniqid('', true);
+        $command =
+            escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($entry)
+            . ' pull-metadata --state-dir='
+            . escapeshellarg($stateDirectory)
+            . ' 2>&1';
+        $output = shell_exec($command) ?? '';
+
+        $this->assertStringContainsString(
+            'Error: <remote-reprint-api-url> is required',
+            $output
+        );
+        $this->assertDirectoryDoesNotExist($stateDirectory);
     }
 
     public function testFilesPushHelpShowsOnlyItsCommandOptions(): void

--- a/tests/Import/CommandAliasTest.php
+++ b/tests/Import/CommandAliasTest.php
@@ -13,6 +13,7 @@ class CommandAliasTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -20,9 +21,11 @@ class CommandAliasTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-alias-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $this->pullStateDirectory =
+            $this->stateDir . '/remotes/' . md5('http://fake.invalid') . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -66,7 +69,7 @@ class CommandAliasTest extends TestCase
 
         // Write a preflight so commands that require it don't bail early.
         file_put_contents(
-            $this->stateDir . '/pull/state.json',
+            $this->pullStateDirectory . '/state.json',
             json_encode([
                 "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             ]),
@@ -102,7 +105,7 @@ class CommandAliasTest extends TestCase
     public function testRetiredStateShapeIsRejected(): void
     {
         file_put_contents(
-            $this->stateDir . '/pull/state.json',
+            $this->pullStateDirectory . '/state.json',
             json_encode([
                 "command" => "files-pull",
                 "status" => "in_progress",

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -20,6 +20,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -27,9 +28,11 @@ class CurlTimeoutRecoveryTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/curl-timeout-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $this->pullStateDirectory =
+            $this->stateDir . '/remotes/' . md5('http://fake.url') . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -76,7 +79,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
     private function readState(): array
     {
-        $contents = file_get_contents($this->stateDir . '/pull/state.json');
+        $contents = file_get_contents($this->pullStateDirectory . '/state.json');
         return json_decode($contents, true);
     }
 

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -28,7 +28,6 @@ class DeactivateHostPluginsTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -25,7 +25,6 @@ class ExportDirectoryAutoDetectTest extends TestCase
         $this->fsRoot = $this->tempDir . '/fs-root';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -16,6 +16,7 @@ class FetchListProgressTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -23,9 +24,11 @@ class FetchListProgressTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/fetch-list-progress-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $this->pullStateDirectory =
+            $this->stateDir . '/remotes/' . md5('http://fake.url') . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -64,15 +67,23 @@ class FetchListProgressTest extends TestCase
     /**
      * Build a fetch list JSONL file with N entries.
      */
-    private function writeFetchList(int $count, ?string $file = null): string
+    private function writeFetchList(
+        int $count,
+        ?string $fetchListFilePath = null
+    ): string
     {
-        $file = $file ?? $this->stateDir . '/pull/fetch-list.jsonl';
-        $handle = fopen($file, 'w');
+        $fetchListFilePath =
+            $fetchListFilePath
+            ?? $this->pullStateDirectory . '/fetch-list.jsonl';
+        $fetchListFileHandle = fopen($fetchListFilePath, 'w');
         for ($i = 0; $i < $count; $i++) {
-            fwrite($handle, json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n");
+            fwrite(
+                $fetchListFileHandle,
+                json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n"
+            );
         }
-        fclose($handle);
-        return $file;
+        fclose($fetchListFileHandle);
+        return $fetchListFilePath;
     }
 
     private function writeState(array $state): void
@@ -109,15 +120,18 @@ class FetchListProgressTest extends TestCase
         ];
     }
 
-    private function byteOffsetAfterLines(string $file, int $n): int
+    private function byteOffsetAfterLines(
+        string $fetchListFilePath,
+        int $lineCount
+    ): int
     {
-        $handle = fopen($file, 'r');
-        for ($i = 0; $i < $n; $i++) {
-            fgets($handle);
+        $fetchListFileHandle = fopen($fetchListFilePath, 'r');
+        for ($lineNumber = 0; $lineNumber < $lineCount; $lineNumber++) {
+            fgets($fetchListFileHandle);
         }
-        $offset = ftell($handle);
-        fclose($handle);
-        return $offset;
+        $fetchListByteOffset = ftell($fetchListFileHandle);
+        fclose($fetchListFileHandle);
+        return $fetchListByteOffset;
     }
 
     // ---------------------------------------------------------------
@@ -271,7 +285,7 @@ class FetchListProgressTest extends TestCase
     public function testSkippedListHasOwnCounters()
     {
         $this->writeFetchList(50);
-        $skippedList = $this->stateDir . '/pull/skipped-fetch-list.jsonl';
+        $skippedList = $this->pullStateDirectory . '/skipped-fetch-list.jsonl';
         $this->writeFetchList(200, $skippedList);
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -18,6 +18,7 @@ class FilesPullStateTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -25,8 +26,10 @@ class FilesPullStateTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-state-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $this->pullStateDirectory =
+            $this->stateDir . '/remotes/' . md5('http://fake.url') . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -79,7 +82,7 @@ class FilesPullStateTest extends TestCase
      */
     private function readState(): array
     {
-        $contents = file_get_contents($this->stateDir . '/pull/state.json');
+        $contents = file_get_contents($this->pullStateDirectory . '/state.json');
         return json_decode($contents, true);
     }
 
@@ -101,12 +104,12 @@ class FilesPullStateTest extends TestCase
      */
     private function readFetchList(): array
     {
-        $file = $this->stateDir . '/pull/fetch-list.jsonl';
-        if (!file_exists($file)) {
+        $fetchListFilePath = $this->pullStateDirectory . '/fetch-list.jsonl';
+        if (!file_exists($fetchListFilePath)) {
             return [];
         }
         $paths = [];
-        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        foreach (file($fetchListFilePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
             $data = json_decode($line, true);
             if (isset($data["path"])) {
                 $paths[] = base64_decode($data["path"]);
@@ -177,7 +180,7 @@ class FilesPullStateTest extends TestCase
             "filter" => "essential-files",
         ]);
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $this->pullStateDirectory . '/skipped-fetch-list.jsonl',
             json_encode([
                 "path" => base64_encode('/wp-content/uploads/2024/01/photo.jpg'),
             ], JSON_UNESCAPED_SLASHES) . "\n",
@@ -201,7 +204,7 @@ class FilesPullStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
         $this->assertNull($state["active_resumable_command"]["current_stage"]);
         $this->assertEquals("skipped-earlier", $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
     }
 
     /**
@@ -209,7 +212,7 @@ class FilesPullStateTest extends TestCase
      */
     public function testAbortClearsCompletedStatus()
     {
-        $remoteIndexFile = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndexFile = $this->pullStateDirectory . '/remote-index.jsonl';
         file_put_contents($remoteIndexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -239,7 +242,7 @@ class FilesPullStateTest extends TestCase
      */
     public function testAbortThenRerunStartsFresh()
     {
-        $remoteIndexFile = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndexFile = $this->pullStateDirectory . '/remote-index.jsonl';
         file_put_contents($remoteIndexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
@@ -281,7 +284,7 @@ class FilesPullStateTest extends TestCase
     public function testSkippedEarlierAfterCompositePullAdoptsFilesPullState(): void
     {
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $this->pullStateDirectory . '/skipped-fetch-list.jsonl',
             $this->indexLine('/wp-content/uploads/2024/01/photo.jpg', 1000, 100),
         );
         $this->writeState([
@@ -332,11 +335,11 @@ class FilesPullStateTest extends TestCase
     public function testDeltaDiffRedownloadsChangedIndexedFile()
     {
         // Remote index: file synced at ctime 1000
-        $remoteIndexFile = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndexFile = $this->pullStateDirectory . '/remote-index.jsonl';
         file_put_contents($remoteIndexFile, $this->indexLine('/wp-content/themes/flavor/style.css', 1000, 200));
 
         // Next remote index: same file at ctime 2000 (changed)
-        $nextRemoteIndexFile = $this->stateDir . '/pull/remote-index.next.jsonl';
+        $nextRemoteIndexFile = $this->pullStateDirectory . '/remote-index.next.jsonl';
         file_put_contents($nextRemoteIndexFile, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
@@ -372,11 +375,11 @@ class FilesPullStateTest extends TestCase
     public function testDeltaDiffSkipsPreExistingLocalFile()
     {
         // Remote index: empty (file was never synced by us)
-        $remoteIndexFile = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndexFile = $this->pullStateDirectory . '/remote-index.jsonl';
         file_put_contents($remoteIndexFile, '');
 
         // Next remote index: file exists on remote
-        $nextRemoteIndexFile = $this->stateDir . '/pull/remote-index.next.jsonl';
+        $nextRemoteIndexFile = $this->pullStateDirectory . '/remote-index.next.jsonl';
         file_put_contents($nextRemoteIndexFile, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -122,7 +122,7 @@ final class FilesPushCommandTest extends TestCase
 
         $rewriteUrlWithForceHttpSource = $this->runCli([
             'db-apply',
-            '-',
+            'https://example.test/?reprint-api=1',
             '--state-dir=' . $this->stateDirectory,
             '--fs-root=' . $this->localTree,
             '--rewrite-url',
@@ -227,7 +227,11 @@ final class FilesPushCommandTest extends TestCase
         $this->assertStringContainsString( (string) realpath($this->localTree), $nestedStateError['error'] ?? '' );
 
         $this->assertNoSenderState($this->stateDirectory);
-        $this->assertFileDoesNotExist($this->stateDirectory . '/pull/state.json');
+        $this->assertFileDoesNotExist(
+            $this->pullStateFileForRemoteReprintApiUrl(
+                'https://example.test/?reprint-api=1'
+            )
+        );
     }
 
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
@@ -244,7 +248,9 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame('files-push', $finalLine['command'] ?? null);
         $this->assertSame('failed', $finalLine['status'] ?? null);
         $this->assertSame(1, $result['exit']);
-        $this->assertFileDoesNotExist($this->stateDirectory . '/pull/state.json');
+        $this->assertFileDoesNotExist(
+            $this->pullStateFileForRemoteReprintApiUrl($remoteReprintApiUrl)
+        );
     }
 
     public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
@@ -363,6 +369,16 @@ final class FilesPushCommandTest extends TestCase
         $senderPaths = glob($stateDirectory . '/remotes/*/push/sender.json');
         $this->assertIsArray($senderPaths);
         $this->assertSame([], $senderPaths);
+    }
+
+    private function pullStateFileForRemoteReprintApiUrl(
+        string $remoteReprintApiUrl
+    ): string
+    {
+        return $this->stateDirectory
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull/state.json';
     }
 
     private function readTree(string $path): string

--- a/tests/Import/FlatDocrootWpConfigTest.php
+++ b/tests/Import/FlatDocrootWpConfigTest.php
@@ -23,7 +23,6 @@ class FlatDocrootWpConfigTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -279,7 +279,7 @@ class FollowedSymlinksRootTest extends TestCase
             'type' => 'link',
             'intermediate' => true,
         ]);
-        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', $entry . "\n");
+        file_put_contents($c->pull_state_directory . '/remote-index.next.jsonl', $entry . "\n");
 
         $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
 

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -101,10 +101,17 @@ class NewSiteUrlSqliteTest extends TestCase
     /**
      * Write the pull state file that db-apply expects.
      */
-    private function writeState(array $extra = []): void
+    private function writeState(
+        string $remoteReprintApiUrl,
+        array $extra = []
+    ): void
     {
         \write_current_pull_state(
-            new \ImportClient('http://example.invalid', $this->tempDir, $this->tempDir),
+            new \ImportClient(
+                $remoteReprintApiUrl,
+                $this->tempDir,
+                $this->tempDir . '/fs-root'
+            ),
             $extra
         );
     }
@@ -145,7 +152,7 @@ class NewSiteUrlSqliteTest extends TestCase
 
         // Prepare db.sql
         file_put_contents($this->tempDir . '/db.sql', $this->buildSqlDump($oldUrl));
-        $this->writeState();
+        $this->writeState($exportUrl);
 
         // Run db-apply via ImportClient
         $client = new \ImportClient(
@@ -205,7 +212,7 @@ class NewSiteUrlSqliteTest extends TestCase
 
         // Build dump with HTTPS siteurl — note that the export URL uses HTTP
         file_put_contents($this->tempDir . '/db.sql', $this->buildSqlDump($httpsUrl));
-        $this->writeState();
+        $this->writeState($exportUrl);
 
         $client = new \ImportClient(
             $exportUrl,
@@ -271,7 +278,7 @@ class NewSiteUrlSqliteTest extends TestCase
         );
 
         file_put_contents($this->tempDir . '/db.sql', $sql);
-        $this->writeState([
+        $this->writeState($exportUrl, [
             'preflight' => [
                 'data' => [
                     'database' => ['wp' => ['table_prefix' => 'wp_']],
@@ -312,6 +319,7 @@ class NewSiteUrlSqliteTest extends TestCase
 
     public function testSqliteDbApplyPreservesArbitraryBase64Bytes(): void
     {
+        $remoteReprintApiUrl = 'https://old-site.example.com/?reprint-api';
         $bytes = '';
         for ($i = 0; $i <= 255; $i++) {
             $bytes .= chr($i);
@@ -337,10 +345,10 @@ class NewSiteUrlSqliteTest extends TestCase
         );
 
         file_put_contents($this->tempDir . '/db.sql', implode("\n", $stmts) . "\n");
-        $this->writeState();
+        $this->writeState($remoteReprintApiUrl);
 
         $client = new \ImportClient(
-            'https://old-site.example.com/?reprint-api',
+            $remoteReprintApiUrl,
             $this->tempDir,
             $this->tempDir . '/fs-root',
         );
@@ -367,6 +375,7 @@ class NewSiteUrlSqliteTest extends TestCase
 
     public function testSqlitePragmasDoNotChangeProgressCounters(): void
     {
+        $remoteReprintApiUrl = 'https://old-site.example.com/?reprint-api';
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
         $drop = "DROP TABLE IF EXISTS `wp_options`;";
         $create = "CREATE TABLE `wp_options` ("
@@ -386,10 +395,10 @@ class NewSiteUrlSqliteTest extends TestCase
         $sql = implode("\n", [$drop, $create, $insert]);
 
         file_put_contents($this->tempDir . '/db.sql', $sql);
-        $this->writeState();
+        $this->writeState($remoteReprintApiUrl);
 
         $client = new \ImportClient(
-            'https://old-site.example.com/?reprint-api',
+            $remoteReprintApiUrl,
             $this->tempDir,
             $this->tempDir . '/fs-root',
         );
@@ -404,7 +413,10 @@ class NewSiteUrlSqliteTest extends TestCase
             'target_db' => 'wp_test',
         ]);
 
-        $state = json_decode(file_get_contents($this->tempDir . '/pull/state.json'), true);
+        $state = json_decode(
+            file_get_contents($client->pull_state_directory . '/state.json'),
+            true
+        );
         $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
         $this->assertSame(3, $state['apply']['statements_executed']);
         $this->assertSame(strlen($sql), $state['apply']['bytes_read']);

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -24,7 +24,6 @@ class OnlyCliParseTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-cli-' . uniqid();
         mkdir($this->tempDir . '/state', 0755, true);
-        mkdir($this->tempDir . '/state/pull', 0755, true);
         mkdir($this->tempDir . '/fs', 0755, true);
     }
 
@@ -42,8 +41,8 @@ class OnlyCliParseTest extends TestCase
             $this->serverPipes = array();
         }
 
-        // The real CLI run may drop state files (pull/state.json, audit log)
-        // into the state dir, so a plain rmdir wouldn't clear it — recurse.
+        // The real CLI run may write remote pull state and an audit log into
+        // the state directory, so a plain rmdir wouldn't clear it — recurse.
         $this->recursiveDelete($this->tempDir);
         parent::tearDown();
     }
@@ -152,7 +151,10 @@ PHP, var_export($requestsLog, true)));
         return $requests;
     }
 
-    private function writePreflightState(bool $includeRoots = false): void
+    private function writePreflightState(
+        string $remoteReprintApiUrl,
+        bool $includeRoots = false
+    ): void
     {
         $data = array(
             'ok' => true,
@@ -175,7 +177,7 @@ PHP, var_export($requestsLog, true)));
 
         \write_current_pull_state(
             new \ImportClient(
-                'http://fake.invalid/',
+                $remoteReprintApiUrl,
                 $this->tempDir . '/state',
                 $this->tempDir . '/fs'
             ),
@@ -217,7 +219,7 @@ PHP, var_export($requestsLog, true)));
         // succeed because :wp-content: is resolvable. Preserving both values
         // forces resolution of :abspath:, which this preflight intentionally
         // omits.
-        $this->writePreflightState();
+        $this->writePreflightState('http://fake.invalid/?site-export-api');
 
         $output = $this->runCli(array(
             'files-pull',
@@ -304,14 +306,13 @@ PHP, var_export($requestsLog, true)));
 
     public function testRepeatedOnlyOptionsAreUsedByFilesPull(): void
     {
-        $this->writePreflightState(true);
-
         $requestsLog = $this->tempDir . '/requests.jsonl';
-        $remoteUrl = $this->startDirectoryCaptureServer($requestsLog);
+        $remoteReprintApiUrl = $this->startDirectoryCaptureServer($requestsLog);
+        $this->writePreflightState($remoteReprintApiUrl, true);
 
         $output = $this->runCli(array(
             'files-pull',
-            $remoteUrl,
+            $remoteReprintApiUrl,
             '--only',
             ':wp-content:/plugins',
             '--only',
@@ -344,7 +345,7 @@ PHP, var_export($requestsLog, true)));
     {
         // --abort runs after --only resolution, avoiding a network request while
         // still proving the CLI did not split the SOURCE at the comma.
-        $this->writePreflightState();
+        $this->writePreflightState('http://fake.invalid/?site-export-api');
 
         $output = $this->runCli(array(
             'files-pull',

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -17,6 +17,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -24,9 +25,15 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-diff-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $remoteReprintApiUrl = 'http://fake.url';
+        $this->pullStateDirectory =
+            $this->stateDir
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -80,12 +87,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     private function writeIndex(string $name, string $contents): void
     {
-        file_put_contents($this->stateDir . '/' . $name, $contents);
+        file_put_contents($this->pullStateDirectory . '/' . $name, $contents);
     }
 
     private function readRemoteIndexEntryPaths(): array
     {
-        $remoteIndexFile = $this->stateDir . '/pull/remote-index.jsonl';
+        $remoteIndexFile = $this->pullStateDirectory . '/remote-index.jsonl';
         if (!file_exists($remoteIndexFile)) {
             return [];
         }
@@ -132,12 +139,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // and a selected orphan absent from the --only next remote index. The
         // delete drains must reconcile only within the --only file prefixes, so the remote index
         // accumulates as a union across files-pull --only runs.
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('remote-index.jsonl',
             $this->indexLine('/wp-config.php', 1000, 10)               // unselected
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
             . $this->indexLine('/wp-content/old/orphan.txt', 1000, 10) // selected orphan
         );
-        $this->writeIndex('pull/remote-index.next.jsonl',
+        $this->writeIndex('remote-index.next.jsonl',
             $this->indexLine('/wp-content/keep.txt', 1000, 10)
         );
 
@@ -164,12 +171,12 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         // delete them: that would recursively remove the very directories
         // the user asked to pull, while the matched children keep the
         // fetch list empty — silent data loss.
-        $this->writeIndex('pull/remote-index.jsonl',
+        $this->writeIndex('remote-index.jsonl',
             $this->indexLine('/wp-content/themes', 1000, 0, 'dir')
             . $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
             . $this->indexLine('/wp-content/themes/old/orphan.css', 1000, 10)
         );
-        $this->writeIndex('pull/remote-index.next.jsonl',
+        $this->writeIndex('remote-index.next.jsonl',
             $this->indexLine('/wp-content/themes/keep/style.css', 1000, 10)
         );
 

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -19,6 +19,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $fsRoot;
 
     protected function setUp(): void
@@ -26,9 +27,15 @@ class OnlyFilesPathPrefixTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/only-files-prefix-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $remoteReprintApiUrl = 'https://src.example/export.php';
+        $this->pullStateDirectory =
+            $this->stateDir
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 
@@ -139,7 +146,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     private function readState(): array
     {
-        return json_decode(file_get_contents($this->stateDir . '/pull/state.json'), true);
+        return json_decode(file_get_contents($this->pullStateDirectory . '/state.json'), true);
     }
 
     public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
@@ -268,7 +275,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', '');
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => $this->onlyFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
@@ -285,7 +292,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testRunRecordsOnlyFingerprintForInProgressFilesPullState(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.next.jsonl', '');
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
         $this->writeFilesPullState(array(
             'files_pull_only_fingerprint' => null,
         ));

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -26,7 +26,6 @@ class ProductionDropInRemovalTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
         mkdir($this->outputDir, 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
@@ -333,7 +332,7 @@ class ProductionDropInRemovalTest extends TestCase
 
         // Re-read the state file to verify paths_removed was persisted.
         $state = json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($client->pull_state_directory . '/state.json'),
             true,
         );
 
@@ -498,7 +497,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->runApplyRuntime($client);
 
         $state = json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($client->pull_state_directory . '/state.json'),
             true,
         );
 

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -103,11 +103,11 @@ class PullFilterFakeClient extends \ImportClient
         $this->files_pull_runs++;
         if ($this->create_skipped_list) {
             file_put_contents(
-                $this->state_dir . '/pull/skipped-fetch-list.jsonl',
+                $this->pull_state_directory . '/skipped-fetch-list.jsonl',
                 "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
             );
         } else {
-            @unlink($this->state_dir . '/pull/skipped-fetch-list.jsonl');
+            @unlink($this->pull_state_directory . '/skipped-fetch-list.jsonl');
         }
 
         $state = $this->get_state();
@@ -183,6 +183,7 @@ class PullFilterOptionTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $filesystem_root;
 
     protected function setUp(): void
@@ -190,9 +191,14 @@ class PullFilterOptionTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/pull-filter-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $remoteReprintApiUrl = 'http://fake.invalid';
+        $this->pullStateDirectory =
+            $this->stateDir
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 
@@ -231,7 +237,7 @@ class PullFilterOptionTest extends TestCase
     private function readState(): array
     {
         return json_decode(
-            file_get_contents($this->stateDir . '/pull/state.json'),
+            file_get_contents($this->pullStateDirectory . '/state.json'),
             true,
         );
     }
@@ -262,7 +268,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/state.json');
     }
 
     public function testPullDoesNotAdvancePastFailedPreflight(): void
@@ -420,7 +426,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/state.json');
     }
 
     public function testPullFilesSummaryReportsNoChangedFilesPulled(): void
@@ -775,7 +781,7 @@ class PullFilterOptionTest extends TestCase
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/state.json');
     }
 
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
@@ -796,7 +802,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertTrue($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('essential-files', $state["filter"]);
-        $this->assertFileExists($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileExists($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
     }
 
     public function testPullWithoutFilterRecordsFullDownloadMode(): void
@@ -816,7 +822,7 @@ class PullFilterOptionTest extends TestCase
         $this->assertFalse($state["pull_pipeline"]["skipped_pending"]);
         $this->assertTrue($state["pull_pipeline"]["has_completed_once"]);
         $this->assertSame('none', $state["filter"]);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/skipped-fetch-list.jsonl');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/skipped-fetch-list.jsonl');
     }
 
     public function testPullDerivesFlatDocumentRootFromFlattenTo(): void

--- a/tests/Import/PullMetadataTest.php
+++ b/tests/Import/PullMetadataTest.php
@@ -11,6 +11,7 @@ class PullMetadataTest extends TestCase
     private string $tempDir;
     private string $stateDir;
     private string $fsRoot;
+    private string $pullStateDirectory;
 
     /**
      * Creates an isolated state directory for each metadata scenario.
@@ -21,8 +22,12 @@ class PullMetadataTest extends TestCase
         $this->tempDir = sys_get_temp_dir() . '/reprint-pull-metadata-' . uniqid('', true);
         $this->stateDir = $this->tempDir . '/state';
         $this->fsRoot = $this->tempDir . '/fs-root';
+        $this->pullStateDirectory =
+            $this->stateDir
+            . '/remotes/'
+            . md5('http://example.invalid')
+            . '/pull';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
     }
 
@@ -62,10 +67,13 @@ class PullMetadataTest extends TestCase
     /**
      * Writes pull state directly so each test can model one lifecycle shape.
      */
-    private function writeState(array $state): void
+    private function writeState(
+        array $state,
+        string $remoteReprintApiUrl = 'http://example.invalid'
+    ): void
     {
         \write_current_pull_state(
-            new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot),
+            new \ImportClient($remoteReprintApiUrl, $this->stateDir, $this->fsRoot),
             $state
         );
     }
@@ -73,9 +81,12 @@ class PullMetadataTest extends TestCase
     /**
      * Runs the metadata command and returns its decoded JSON response.
      */
-    private function readMetadata(string $command = 'pull-metadata'): array
+    private function readMetadata(
+        string $command = 'pull-metadata',
+        string $remoteReprintApiUrl = 'http://example.invalid'
+    ): array
     {
-        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client = new \ImportClient($remoteReprintApiUrl, $this->stateDir, $this->fsRoot);
 
         ob_start();
         $client->run(['command' => $command]);
@@ -106,7 +117,7 @@ class PullMetadataTest extends TestCase
         $metadata = $this->readMetadata();
 
         $this->assertFalse($metadata['hasCompletedOnce']);
-        $this->assertFileDoesNotExist($this->stateDir . '/pull/state.json');
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/state.json');
         $this->assertNull($metadata['pullStage']);
         $this->assertSame([
             'homeUrl' => null,
@@ -212,5 +223,33 @@ class PullMetadataTest extends TestCase
 
         $this->assertTrue($metadata['hasCompletedOnce']);
         $this->assertNull($metadata['pullStage']);
+    }
+
+    /**
+     * Verifies each remote Reprint API URL reads only its own pull state.
+     */
+    public function testPullMetadataReadsTheSelectedRemoteStateDirectory(): void
+    {
+        $firstRemoteReprintApiUrl = 'https://first.example/?reprint-api';
+        $secondRemoteReprintApiUrl = 'https://second.example/?reprint-api';
+        $this->writeState([
+            'pull_pipeline' => [
+                'last_completed_stage' => 'files-pull',
+            ],
+        ], $firstRemoteReprintApiUrl);
+        $this->writeState([
+            'pull_pipeline' => [
+                'last_completed_stage' => 'db-apply',
+            ],
+        ], $secondRemoteReprintApiUrl);
+
+        $this->assertSame(
+            'files-pull',
+            $this->readMetadata('pull-metadata', $firstRemoteReprintApiUrl)['pullStage']
+        );
+        $this->assertSame(
+            'db-apply',
+            $this->readMetadata('pull-metadata', $secondRemoteReprintApiUrl)['pullStage']
+        );
     }
 }

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -18,6 +18,7 @@ class RemapResolveTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
+    private $pullStateDirectory;
     private $fsRoot;
     private $root; // realpath of fsRoot (targets are rooted under it)
 
@@ -26,9 +27,15 @@ class RemapResolveTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/remap-resolve-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
+        $remoteReprintApiUrl = 'https://src.example/export.php';
+        $this->pullStateDirectory =
+            $this->stateDir
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull';
         $this->fsRoot = $this->tempDir . '/srv/htdocs';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
+        mkdir($this->pullStateDirectory, 0755, true);
         mkdir($this->fsRoot, 0755, true);
         $this->root = realpath($this->fsRoot);
     }
@@ -85,7 +92,7 @@ class RemapResolveTest extends TestCase
 
     private function writeRemoteIndex(): void
     {
-        file_put_contents($this->stateDir . '/pull/remote-index.jsonl', "{}\n");
+        file_put_contents($this->pullStateDirectory . '/remote-index.jsonl', "{}\n");
     }
 
     // --- resolution: SOURCE TARGET → one source => target rule -------------

--- a/tests/Import/RemoteIndexWalTest.php
+++ b/tests/Import/RemoteIndexWalTest.php
@@ -13,6 +13,7 @@ final class RemoteIndexWalTest extends TestCase
 {
     private string $root;
     private string $stateDirectory;
+    private string $pullStateDirectory;
     private string $fileRoot;
 
     protected function setUp(): void
@@ -21,8 +22,14 @@ final class RemoteIndexWalTest extends TestCase
             . '/remote-index-wal-'
             . bin2hex(random_bytes(6));
         $this->stateDirectory = $this->root . '/state';
+        $remoteReprintApiUrl = 'https://example.com/?site-export-api';
+        $this->pullStateDirectory =
+            $this->stateDirectory
+            . '/remotes/'
+            . md5(rtrim($remoteReprintApiUrl, '?&'))
+            . '/pull';
         $this->fileRoot = $this->root . '/files';
-        mkdir($this->stateDirectory . '/pull', 0700, true);
+        mkdir($this->pullStateDirectory, 0700, true);
         mkdir($this->fileRoot, 0700, true);
     }
 
@@ -44,7 +51,7 @@ final class RemoteIndexWalTest extends TestCase
         );
         $reflection->getMethod('apply_remote_index_wal')->invoke($client);
 
-        $remoteIndexWalPath = $this->stateDirectory . '/pull/remote-index.wal';
+        $remoteIndexWalPath = $this->pullStateDirectory . '/remote-index.wal';
         $this->assertFileExists($remoteIndexWalPath);
         $this->assertSame('', file_get_contents($remoteIndexWalPath));
         $this->assertSame(
@@ -66,7 +73,7 @@ final class RemoteIndexWalTest extends TestCase
             'type' => 'file',
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         file_put_contents(
-            $this->stateDirectory . '/pull/remote-index.wal',
+            $this->pullStateDirectory . '/remote-index.wal',
             $completeRecord . '{"op":"F","path":"'
         );
 
@@ -78,7 +85,7 @@ final class RemoteIndexWalTest extends TestCase
         $this->assertSame(
             '',
             file_get_contents(
-                $this->stateDirectory . '/pull/remote-index.wal'
+                $this->pullStateDirectory . '/remote-index.wal'
             )
         );
     }
@@ -89,7 +96,7 @@ final class RemoteIndexWalTest extends TestCase
     public function testAbortReplaysAndRemovesTheRemoteIndexWal(string $command): void
     {
         file_put_contents(
-            $this->stateDirectory . '/pull/remote-index.wal',
+            $this->pullStateDirectory . '/remote-index.wal',
             json_encode([
                 'op' => 'F',
                 'path' => base64_encode('/site/aborted.txt'),
@@ -112,7 +119,7 @@ final class RemoteIndexWalTest extends TestCase
 
         $this->assertSame('/site/aborted.txt', $this->firstRemoteIndexEntryPath());
         $this->assertFileDoesNotExist(
-            $this->stateDirectory . '/pull/remote-index.wal'
+            $this->pullStateDirectory . '/remote-index.wal'
         );
     }
 
@@ -137,7 +144,7 @@ final class RemoteIndexWalTest extends TestCase
     private function firstRemoteIndexEntryPath(): string
     {
         $lines = file(
-            $this->stateDirectory . '/pull/remote-index.jsonl',
+            $this->pullStateDirectory . '/remote-index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($lines);

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -22,7 +22,6 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot, 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
     }
@@ -142,6 +141,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
 
     public function testApplyRuntimeAddsProxyWhenSkippedUploadsRemain(): void
     {
+        $client = $this->makeClient();
         $this->writeState([
             'active_resumable_command' => [
                 'command_name' => 'db-apply',
@@ -150,24 +150,30 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             'filter' => 'essential-files',
         ]);
         file_put_contents(
-            $this->stateDir . '/pull/skipped-fetch-list.jsonl',
+            $client->pull_state_directory . '/skipped-fetch-list.jsonl',
             json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
         );
 
-        $client = $this->makeClient();
         $this->loadClientState($client);
         $runtime = $this->runApplyRuntime($client);
+        $resolvedPullStateDirectory =
+            realpath($client->pull_state_directory)
+            ?: $client->pull_state_directory;
 
         $this->assertStringContainsString(
             "REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL",
             $runtime,
         );
         $this->assertStringContainsString(
-            "REPRINT_PULL_STATE_FILE",
+            "define('REPRINT_PULL_STATE_FILE', '"
+                . $resolvedPullStateDirectory
+                . "/state.json');",
             $runtime,
         );
         $this->assertStringContainsString(
-            "REPRINT_PULL_SKIPPED_FETCH_LIST_FILE",
+            "define('REPRINT_PULL_SKIPPED_FETCH_LIST_FILE', '"
+                . $resolvedPullStateDirectory
+                . "/skipped-fetch-list.jsonl');",
             $runtime,
         );
         $this->assertStringContainsString(

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -27,28 +27,43 @@ final class ReprintProcessLockTest extends TestCase
 
     public function testLocalStateLayoutUsesMatchingDirectoriesAndFileNames(): void
     {
+        $remote_reprint_api_url = 'https://example.com/?site-export-api';
         $process_lock = new \ReprintProcessLock($this->root . '/state');
         $client = new \ImportClient(
-            'https://example.com/?site-export-api',
+            $remote_reprint_api_url,
             $this->root . '/state',
             $this->root . '/files'
         );
+        $remote_state_directory =
+            $this->root . '/state/remotes/' . md5($remote_reprint_api_url);
+        $pull_state_directory = $remote_state_directory . '/pull';
 
         $this->assertFileExists($this->root . '/state/process.lock');
-        $this->assertDirectoryExists($this->root . '/state/pull');
+        $this->assertDirectoryExists($pull_state_directory);
+        $this->assertDirectoryDoesNotExist($this->root . '/state/pull');
         $this->assertDirectoryDoesNotExist($this->root . '/state/.reprint');
         $this->assertFileDoesNotExist($this->root . '/state/.reprint.lock');
+        $this->assertSame(
+            realpath($remote_state_directory) . '/push',
+            \ImportClient::resolve_push_state_directory(
+                $remote_reprint_api_url,
+                $this->root . '/state',
+                $this->root . '/files',
+                'files-diff'
+            )
+        );
 
         $reflection = new \ReflectionClass($client);
         $expected_paths = [
             'state_dir' => $this->root . '/state',
-            'pull_state_file' => $this->root . '/state/pull/state.json',
-            'remote_index_file' => $this->root . '/state/pull/remote-index.jsonl',
-            'remote_index_wal_path' => $this->root . '/state/pull/remote-index.wal',
-            'next_remote_index_file' => $this->root . '/state/pull/remote-index.next.jsonl',
-            'fetch_list_file' => $this->root . '/state/pull/fetch-list.jsonl',
-            'skipped_fetch_list_file' => $this->root . '/state/pull/skipped-fetch-list.jsonl',
-            'volatile_files_file' => $this->root . '/state/pull/volatile-files.json',
+            'pull_state_directory' => $pull_state_directory,
+            'pull_state_file' => $pull_state_directory . '/state.json',
+            'remote_index_file' => $pull_state_directory . '/remote-index.jsonl',
+            'remote_index_wal_path' => $pull_state_directory . '/remote-index.wal',
+            'next_remote_index_file' => $pull_state_directory . '/remote-index.next.jsonl',
+            'fetch_list_file' => $pull_state_directory . '/fetch-list.jsonl',
+            'skipped_fetch_list_file' => $pull_state_directory . '/skipped-fetch-list.jsonl',
+            'volatile_files_file' => $pull_state_directory . '/volatile-files.json',
             'audit_log_file' => $this->root . '/state/audit.log',
             'progress_file' => $this->root . '/state/progress.json',
         ];

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -31,7 +31,6 @@ class RuntimeFilesTest extends TestCase
         $this->stateDir = $this->tempDir . '/state';
         $this->filesystem_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->filesystem_root, 0755, true);
     }
 

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -23,7 +23,6 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->outputDir = $this->tempDir . '/runtime';
 
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->stateDir . '/pull', 0755, true);
         mkdir($this->fsRoot . '/wp-content/database', 0755, true);
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
     }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2642,7 +2642,9 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($push_state_directory . '/previous_local_index.jsonl');
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist($state_directory . '/pull/state.json');
+        $this->assertFileDoesNotExist(
+            dirname($push_state_directory) . '/pull/state.json'
+        );
 
         $progress = json_decode(
             (string) file_get_contents($state_directory . '/progress.json'),

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -136,13 +136,13 @@ async function provisionDatabase() {
     await conn.end();
 }
 
-function runStage(stage, stateDir, extraArgs = [], { includeUrl = true, phpBinary = PHP_BINARY, env = {} } = {}) {
+function runStage(stage, stateDir, extraArgs = [], { phpBinary = PHP_BINARY, env = {} } = {}) {
     const url = `${getSiteUrl(SITE)}&directory=${getSiteDir(SITE)}`;
     const importerPath = stage === 'preflight' ? PREFLIGHT_IMPORTER_PATH : IMPORTER_PATH;
     const args = [
         importerPath,
         stage,
-        ...(includeUrl ? [url] : []),
+        url,
         `--state-dir=${stateDir}`,
         `--fs-root=${fsRootDir(stateDir)}`,
         `--secret=${getSiteSecret(SITE)}`,
@@ -629,15 +629,14 @@ async function main() {
         { name: 'files-pull', extra: [] },
         { name: 'db-pull', extra: [] },
         { name: 'db-apply', extra: dbApplyArgs },
-        // apply-runtime is local-only; it doesn't take a remote URL.
-        { name: 'apply-runtime', extra: runtimeArgs, includeUrl: false },
+        { name: 'apply-runtime', extra: runtimeArgs },
     ];
 
     const results = [];
-    for (const { name, extra, includeUrl } of stages) {
+    for (const { name, extra } of stages) {
         if (!shouldRun(name)) continue;
         console.log(`-> ${name}`);
-        const r = runStage(name, stateDir, extra, { includeUrl });
+        const r = runStage(name, stateDir, extra);
         results.push(r);
         console.log(`   ${r.ok ? 'ok' : 'FAIL'} in ${fmtMs(r.elapsedMs)} (attempts=${r.attempts})`);
         if (!r.ok) {

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -213,6 +213,23 @@ export function fsRootDir(outputDir) {
 }
 
 /**
+ * Return the pull state directory for a remote Reprint API URL.
+ */
+export function pullStateDirectory(outputDirectory, remoteReprintApiUrl) {
+    return join(remoteStateDirectory(outputDirectory, remoteReprintApiUrl), 'pull');
+}
+
+/**
+ * Return the remote state directory for a remote Reprint API URL.
+ */
+export function remoteStateDirectory(outputDirectory, remoteReprintApiUrl) {
+    const remoteReprintApiUrlHash = createHash('md5')
+        .update(remoteReprintApiUrl.replace(/[?&]+$/, ''))
+        .digest('hex');
+    return join(outputDirectory, 'remotes', remoteReprintApiUrlHash);
+}
+
+/**
  * Run the importer CLI.
  * @param {string} url - Export URL
  * @param {string} outputDir - Local output directory (state files live here; fs-root is outputDir/fs-root)
@@ -266,7 +283,7 @@ export function runImporter(url, outputDir, command, options = {}) {
     // Non-preflight commands require a prior preflight run.
     // Automatically run one if the state file doesn't already have preflight data.
     if (command !== 'preflight' && command !== 'preflight-assert' && options.skipPreflight !== true) {
-        const stateFile = join(outputDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(outputDir, url), 'state.json');
         let needsPreflight = true;
         try {
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
@@ -678,10 +695,13 @@ export function readAuditLog(outputDir) {
 
 /**
  * Assert that the remote index contains at least minCount entries.
- * Checks pull/remote-index.jsonl line count.
+ * Checks the remote-scoped pull/remote-index.jsonl line count.
  */
-export function assertRemoteIndexEntryCount(outputDir, minCount = 3000) {
-    const remoteIndexFile = join(outputDir, 'pull/remote-index.jsonl');
+export function assertRemoteIndexEntryCount(outputDir, remoteReprintApiUrl, minCount = 3000) {
+    const remoteIndexFile = join(
+        pullStateDirectory(outputDir, remoteReprintApiUrl),
+        'remote-index.jsonl',
+    );
     assert.ok(existsSync(remoteIndexFile), `Expected ${remoteIndexFile} to exist`);
     const remoteIndexEntryCount = countJsonlLines(remoteIndexFile);
     assert.ok(remoteIndexEntryCount >= minCount,

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertRemoteIndexEntryCount, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -40,7 +40,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('state file shows complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.command_name, 'files-pull');
@@ -57,14 +57,14 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('pull/remote-index.jsonl has entries', () => {
-        const remoteIndexFile = join(tempDir, 'pull/remote-index.jsonl');
+        const remoteIndexFile = join(pullStateDirectory(tempDir, importUrl()), 'remote-index.jsonl');
         assert.ok(existsSync(remoteIndexFile), 'Expected pull/remote-index.jsonl to exist');
         const lines = readFileSync(remoteIndexFile, 'utf-8').trim().split('\n').filter(l => l);
         assert.ok(lines.length > 0, 'Expected at least one index entry');
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {
@@ -93,12 +93,18 @@ describe('Import: Basic File Sync', () => {
         assert.equal(restart.exitCode, 0, `Expected restart exit 0, got ${restart.exitCode}\nstderr: ${restart.stderr}\nstdout: ${restart.stdout}`);
 
         // Remote index should still exist (restart preserves it)
-        const remoteIndexFile = join(tempDir, 'pull/remote-index.jsonl');
+        const remoteIndexFile = join(pullStateDirectory(tempDir, importUrl()), 'remote-index.jsonl');
         assert.ok(existsSync(remoteIndexFile), 'Expected remote index to be preserved after --abort');
 
         // Transient files should be cleaned up
-        assert.ok(!existsSync(join(tempDir, 'pull/remote-index.next.jsonl')), 'Expected next remote index to be deleted');
-        assert.ok(!existsSync(join(tempDir, 'pull/fetch-list.jsonl')), 'Expected fetch list to be deleted');
+        assert.ok(!existsSync(join(
+            pullStateDirectory(tempDir, importUrl()),
+            'remote-index.next.jsonl',
+        )), 'Expected next remote index to be deleted');
+        assert.ok(!existsSync(join(
+            pullStateDirectory(tempDir, importUrl()),
+            'fetch-list.jsonl',
+        )), 'Expected fetch list to be deleted');
     });
 
     it('running after --abort performs a delta sync', () => {
@@ -107,7 +113,7 @@ describe('Import: Basic File Sync', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-03-delta-sync.test.js
+++ b/tests/e2e/tests/import-03-delta-sync.test.js
@@ -45,7 +45,7 @@ describe('Import: Delta Sync', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-04-files-index.test.js
+++ b/tests/e2e/tests/import-04-files-index.test.js
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    countJsonlLines,
+    countJsonlLines, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -36,7 +36,7 @@ describe('Import: Files Index', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const nextRemoteIndexFile = join(pullStateDirectory(tempDir, importUrl()), 'remote-index.next.jsonl');
         const completion = result.stdout
             .split('\n')
             .map(line => {
@@ -73,7 +73,7 @@ describe('Import: Files Index', () => {
     });
 
     it('next remote index has at least 3000 entries', () => {
-        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const nextRemoteIndexFile = join(pullStateDirectory(tempDir, importUrl()), 'remote-index.next.jsonl');
         const count = countJsonlLines(nextRemoteIndexFile);
         assert.ok(count >= 3000,
             `Expected at least 3000 entries in next remote index, got ${count}`);

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -96,7 +96,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertRemoteIndexEntryCount, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -58,7 +58,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('accounted for at least 3000 remote index entries', () => {
-            assertRemoteIndexEntryCount(tempDir);
+            assertRemoteIndexEntryCount(tempDir, importUrl());
         });
 
         it('imported files form a valid WordPress site mirror', () => {
@@ -66,7 +66,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('sync completed without error despite symlinks', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -12,7 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -116,7 +116,7 @@ INSERT INTO wp_secret_table VALUES (1, 'top secret');
         });
 
         it('state shows complete', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-08-large-directory.test.js
+++ b/tests/e2e/tests/import-08-large-directory.test.js
@@ -59,7 +59,7 @@ describe('Import: Large Directory', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -11,6 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -47,7 +48,7 @@ describe('Import: Resume SQL', { timeout: 120000 }, () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', 'Expected status to be complete');
     });

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertRemoteIndexEntryCount, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -56,7 +56,7 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('state shows complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected state file to exist');
 
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
@@ -64,7 +64,7 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-12-gzip-corruption.test.js
+++ b/tests/e2e/tests/import-12-gzip-corruption.test.js
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    writeTestHooks, removeTestHooks,
+    writeTestHooks, removeTestHooks, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -87,7 +87,7 @@ describe('Import: Gzip Corruption', () => {
             // Same as above: must not hang. Either succeeds (partial data OK)
             // or fails with a clear error.
             if (result.exitCode === 0) {
-                const stateFile = join(tempDir, 'pull/state.json');
+                const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
                 if (existsSync(stateFile)) {
                     const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
                     assert.ok(

--- a/tests/e2e/tests/import-13-sha1-integrity.test.js
+++ b/tests/e2e/tests/import-13-sha1-integrity.test.js
@@ -57,7 +57,7 @@ describe('Import: SHA1 Integrity', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-14-buffered-response.test.js
+++ b/tests/e2e/tests/import-14-buffered-response.test.js
@@ -45,7 +45,7 @@ describe('Import: Buffered Response', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -14,7 +14,7 @@ import {
     hashDirectory, assertTreesMatch, readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -154,7 +154,7 @@ describe('Import: Volatile Files', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -54,7 +54,7 @@ describe('Import: Custom WP Content', () => {
     });
 
     it('accounted for at least 3000 remote index entries', () => {
-        assertRemoteIndexEntryCount(tempDir);
+        assertRemoteIndexEntryCount(tempDir, importUrl());
     });
 
     it('imported files form a valid WordPress site mirror', () => {

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -15,7 +15,7 @@ import {
     assertTreesMatch,
     assertSiteMirror, createMysqlConnection,
     compareDatabases, getDbName,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -53,7 +53,7 @@ describe('Import: Full Round-Trip', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -15,7 +15,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -66,7 +66,7 @@ describe('Import: Request Cutoff', () => {
             `Expected exit 2 after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
         );
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(
             state.active_resumable_command.completion_state,
@@ -98,7 +98,7 @@ describe('Import: Request Cutoff', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0 on resume\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected complete status, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -12,7 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -83,7 +83,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('fetch list includes deleted files', () => {
-        const dlPath = join(tempDir, 'pull/fetch-list.jsonl');
+        const dlPath = join(pullStateDirectory(tempDir, importUrl()), 'fetch-list.jsonl');
         if (existsSync(dlPath)) {
             const content = readFileSync(dlPath, 'utf-8');
             // The fetch list should reference the deleted files
@@ -94,7 +94,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('state shows complete after delta', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -11,7 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -31,9 +31,12 @@ describe('Import: State Corruption', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-state-corrupt-json');
-            mkdirSync(join(tempDir, 'pull'), { recursive: true });
+            mkdirSync(pullStateDirectory(tempDir, importUrl()), { recursive: true });
             // Write invalid JSON to state file
-            writeFileSync(join(tempDir, 'pull/state.json'), '{invalid json here!!!');
+            writeFileSync(
+                join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+                '{invalid json here!!!',
+            );
         });
 
         afterAll(() => {
@@ -47,7 +50,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 (graceful recovery)\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
@@ -61,7 +64,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('corrupt state file was renamed', () => {
-            const files = readdirSync(join(tempDir, 'pull'));
+            const files = readdirSync(pullStateDirectory(tempDir, importUrl()));
             const corruptFiles = files.filter(f => f.includes('.corrupt.'));
             assert.ok(corruptFiles.length > 0, 'Expected corrupt state file to be renamed');
         });
@@ -81,7 +84,7 @@ describe('Import: State Corruption', () => {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
-            const statePath = join(tempDir, 'pull/state.json');
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(statePath, 'utf-8'));
             state.active_resumable_command.command_name = 'db-pull';
             state.active_resumable_command.completion_state = 'complete';
@@ -99,7 +102,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.command_name, 'files-pull', 'Expected command to be updated');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
@@ -115,7 +118,7 @@ describe('Import: State Corruption', () => {
                 secret: getSiteSecret(site),
             });
             assert.equal(result.exitCode, 0, `Preflight failed:\n${result.stderr}`);
-            const statePath = join(tempDir, 'pull/state.json');
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(statePath, 'utf-8'));
             state.active_resumable_command.command_name = 'files-pull';
             state.active_resumable_command.completion_state = 'in_progress';
@@ -134,7 +137,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0 with --abort\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.notEqual(state.active_resumable_command.completion_state, 'in_progress', 'Expected status to be cleared');
             assert.ok(!state.active_resumable_command.remote_cursor, 'Expected cursor to be cleared');
@@ -146,7 +149,7 @@ describe('Import: State Corruption', () => {
             });
             assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -25,7 +25,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -213,7 +213,10 @@ describe('Import: Follow Symlinks', () => {
     });
 
     it('state shows complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
         assert.equal(state.follow_symlinks, true, 'follow_symlinks should be persisted in state');
     });
@@ -328,7 +331,10 @@ describe('Import: Follow Symlinks', () => {
 
     it('multiple symlinks to same target do not create duplicate index entries', () => {
         // After sort+dedup, each path should appear at most once
-        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const nextRemoteIndexFile = join(
+            pullStateDirectory(tempDir, importUrl()),
+            'remote-index.next.jsonl',
+        );
         if (!existsSync(nextRemoteIndexFile)) return;
 
         const lines = readFileSync(nextRemoteIndexFile, 'utf-8').split('\n').filter(l => l.trim());

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -15,7 +15,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -221,7 +221,7 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
     });
 
     it('state stores path fields in base64 form', () => {
-        const statePath = join(tempDir, 'pull/state.json');
+        const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(statePath, 'utf-8'));
 
         assert.equal(typeof state.diff.last_consumed_remote_index_entry_path, 'string', 'Expected diff.last_consumed_remote_index_entry_path to be persisted');

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -42,7 +43,10 @@ describe('Import: Preflight state path encoding', () => {
     });
 
     it('stores requested preflight path fields as base64 in state file', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrlWithDirectory()), 'state.json'),
+            'utf-8',
+        ));
         const data = state.preflight?.data;
         assert.ok(data, 'Expected preflight.data in state');
 
@@ -110,7 +114,7 @@ describe('Import: Preflight state path encoding', () => {
     });
 
     it('decodes encoded preflight roots when loading state', () => {
-        const result = runImporter(getSiteUrl(site), tempDir, 'files-index', {
+        const result = runImporter(importUrlWithDirectory(), tempDir, 'files-index', {
             secret: getSiteSecret(site),
             skipPreflight: true,
         });

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -13,20 +13,20 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Protocol Version Mismatch', () => {
     const site = 'basic';
     let tempDir;
-    const stateFileName = 'pull/state.json';
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
     function stateFilePath() {
-        return join(tempDir, stateFileName);
+        return join(pullStateDirectory(tempDir, importUrl()), 'state.json');
     }
 
     function readState() {

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -10,6 +10,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -114,7 +115,13 @@ describe('Import: SQL Output Modes', () => {
         });
 
         it('state file records sql_output mode', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(
+                pullStateDirectory(
+                    tempDir,
+                    `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
+                ),
+                'state.json',
+            );
             assert.ok(existsSync(stateFile), 'Expected state file to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.sql_output, 'mysql',

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -19,7 +19,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    readAuditLog,
+    readAuditLog, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -80,7 +80,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         });
 
         it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/sql-buffer')),
+            assert.ok(!existsSync(join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer')),
                 'Expected pull/sql-buffer to be cleaned up after successful completion');
         });
 
@@ -118,7 +118,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
             // Seed a pull/sql-buffer file before running db-pull.
             // The content is a harmless SQL comment that won't affect execution
             // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(tempDir, 'pull/sql-buffer');
+            const bufferFile = join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer');
             writeFileSync(bufferFile, '-- pre-seeded buffer\n');
 
             // Run a fresh db-pull — the importer should detect the buffer file

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    createMysqlConnection,
+    createMysqlConnection, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -99,7 +99,7 @@ describe('Import: URL Rewriting', () => {
     });
 
     it('domain discovery produces pull/domains.json', () => {
-        const domainsFile = join(tempDir, 'pull/domains.json');
+        const domainsFile = join(pullStateDirectory(tempDir, importUrl()), 'domains.json');
         assert.ok(existsSync(domainsFile), 'Expected pull/domains.json to exist');
 
         const domains = JSON.parse(readFileSync(domainsFile, 'utf-8'));

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -40,7 +40,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
@@ -161,7 +161,7 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state shows complete with preserve_local persisted', () => {
-            const stateFile = join(tempDir, 'pull/state.json');
+            const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
@@ -334,7 +334,10 @@ describe('Import: --preserve-local', () => {
         });
 
         it('state preserves preserve_local across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(
+                join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+                'utf-8',
+            ));
             assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
     });

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -24,7 +24,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -113,7 +113,10 @@ require_once ABSPATH . 'wp-settings.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -151,7 +154,10 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-admin files exist at the resolved core path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         const wpAdminPath = state.preflight?.data?.database?.wp?.paths_urls?.wp_admin_path;
         assert.ok(wpAdminPath, 'wp_admin_path not found in state');
 
@@ -167,7 +173,10 @@ require_once ABSPATH . 'wp-settings.php';
     });
 
     it('wp-content files exist at the separate content path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         const contentDir = state.preflight?.data?.database?.wp?.paths_urls?.content_dir;
         assert.ok(contentDir, 'content_dir not found in state');
 

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -39,7 +40,10 @@ describe('Import: Runtime files', () => {
     });
 
     it('preflight state contains ini_get_all with core PHP directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrlWithDirectory()), 'state.json'),
+            'utf-8',
+        ));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         assert.ok(iniAll && typeof iniAll === 'object', 'runtime.ini_get_all should be an object');
 
@@ -55,7 +59,10 @@ describe('Import: Runtime files', () => {
     });
 
     it('ini_get_all includes auto_prepend_file and auto_append_file directives', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrlWithDirectory()), 'state.json'),
+            'utf-8',
+        ));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
 
         // These directives should always be present in ini_get_all,

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -17,7 +17,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -80,7 +80,10 @@ describe('Import: --filter', () => {
         });
 
         it('state shows complete with filter persisted', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(
+                join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+                'utf-8',
+            ));
             assert.equal(state.active_resumable_command.command_name, 'files-pull');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
             assert.equal(state.filter, 'essential-files');
@@ -105,7 +108,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped fetch list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(existsSync(join(
+                pullStateDirectory(tempDir, importUrl()),
+                'skipped-fetch-list.jsonl',
+            )),
                 'Expected skipped fetch list to remain on disk');
         });
 
@@ -134,7 +140,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped fetch list was cleaned up', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(!existsSync(join(
+                pullStateDirectory(tempDir, importUrl()),
+                'skipped-fetch-list.jsonl',
+            )),
                 'Expected skipped fetch list to be cleaned up');
         });
 
@@ -142,7 +151,10 @@ describe('Import: --filter', () => {
             // Regression: the skipped-earlier fetch must mark the sync
             // complete. If it leaves status="in_progress", the filter-change
             // guard blocks the next delta re-pull below.
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(
+                join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+                'utf-8',
+            ));
             assert.equal(state.active_resumable_command.completion_state, 'complete',
                 `Expected completion_state=complete after skipped-earlier, got ${state.active_resumable_command?.completion_state}`);
         });
@@ -192,7 +204,10 @@ describe('Import: --filter', () => {
         });
 
         it('state preserves filter across resume cycles', () => {
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(
+                join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+                'utf-8',
+            ));
             assert.equal(state.filter, 'essential-files');
             assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
@@ -206,7 +221,10 @@ describe('Import: --filter', () => {
         });
 
         it('skipped list remains on disk', () => {
-            assert.ok(existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(existsSync(join(
+                pullStateDirectory(tempDir, importUrl()),
+                'skipped-fetch-list.jsonl',
+            )),
                 'Expected skipped fetch list to remain');
         });
     });
@@ -234,7 +252,10 @@ describe('Import: --filter', () => {
         });
 
         it('no skipped fetch list was created', () => {
-            assert.ok(!existsSync(join(tempDir, 'pull/skipped-fetch-list.jsonl')),
+            assert.ok(!existsSync(join(
+                pullStateDirectory(tempDir, importUrl()),
+                'skipped-fetch-list.jsonl',
+            )),
                 'Expected no skipped fetch list without --filter');
         });
 

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -15,7 +15,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir, PHP_BINARY,
+    fsRootDir, PHP_BINARY, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -71,7 +71,10 @@ describe('Import: Playground CLI runtime', () => {
         assert.equal(result.exitCode, 0,
             `files-pull failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assert.equal(state.active_resumable_command.completion_state, 'complete');
     });
 
@@ -103,6 +106,7 @@ describe('Import: Playground CLI runtime', () => {
         execFileSync(PHP_BINARY, [
             IMPORTER_PATH,
             'apply-runtime',
+            importUrl(),
             `--state-dir=${tempDir}`,
             `--fs-root=${fsRootDir(tempDir)}`,
             `--runtime=playground-cli`,

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -29,7 +29,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -77,7 +77,10 @@ require ABSPATH . 'wp-blog-header.php';
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
@@ -104,7 +107,10 @@ require ABSPATH . 'wp-blog-header.php';
     });
 
     it('WP core files exist at the resolved path in fs-root', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         const abspath = state.preflight?.data?.database?.wp?.paths_urls?.abspath;
         assert.ok(abspath, 'abspath not found in state');
 

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -18,6 +18,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -181,7 +182,7 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     }
                 }
 
-                const stateFile = join(tempDir, 'pull/state.json');
+                const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
                 assert.ok(existsSync(stateFile), 'Expected state file to exist');
                 const state = JSON.parse(readFileSync(stateFile, 'utf8'));
                 assert.equal(state.active_resumable_command.completion_state, 'complete',
@@ -194,7 +195,10 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(tempDir, 'pull/sql-buffer')),
+                assert.ok(!existsSync(join(
+                    pullStateDirectory(tempDir, importUrl()),
+                    'sql-buffer',
+                )),
                     'Expected pull/sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -29,7 +29,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     countJsonlLines,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -79,7 +79,10 @@ describe('Import: Symlink cycle detection', () => {
         // A WordPress site has ~4000-6000 files.  Without cycle detection
         // the self-symlink would double that on every depth level.  With
         // cycle detection the total should stay in the normal range.
-        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const nextRemoteIndexFile = join(
+            pullStateDirectory(tempDir, importUrl()),
+            'remote-index.next.jsonl',
+        );
         assert.ok(existsSync(nextRemoteIndexFile), 'Next remote index should exist');
 
         const count = countJsonlLines(nextRemoteIndexFile);
@@ -93,7 +96,10 @@ describe('Import: Symlink cycle detection', () => {
     });
 
     it('the marker file is indexed exactly once per reachable path', () => {
-        const nextRemoteIndexFile = join(tempDir, 'pull/remote-index.next.jsonl');
+        const nextRemoteIndexFile = join(
+            pullStateDirectory(tempDir, importUrl()),
+            'remote-index.next.jsonl',
+        );
         const content = readFileSync(nextRemoteIndexFile, 'utf-8');
         const lines = content.split('\n').filter(l => l.trim());
 

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { writeFileSync, mkdirSync } from 'node:fs';
@@ -70,7 +71,10 @@ describe('Import: Runtime file download', () => {
             assert.equal(preflightResult.exitCode, 0,
                 `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
 
-            const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+            const state = JSON.parse(readFileSync(
+                join(pullStateDirectory(tempDir, importUrlWithDirectory()), 'state.json'),
+                'utf-8',
+            ));
             const prepend = state.preflight?.data?.runtime?.ini_get_all?.auto_prepend_file ?? '';
             if (prepend.includes('scripts/env.php')) {
                 break;
@@ -93,7 +97,10 @@ describe('Import: Runtime file download', () => {
     });
 
     it('preflight state reports auto_prepend_file path', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrlWithDirectory()), 'state.json'),
+            'utf-8',
+        ));
         const iniAll = state.preflight?.data?.runtime?.ini_get_all;
         const prepend = iniAll?.auto_prepend_file ?? '';
         assert.ok(

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -17,7 +17,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    getDbName, createMysqlConnection,
+    getDbName, createMysqlConnection, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -111,7 +111,10 @@ describe('Import: SiteGround plugin stripping', () => {
         });
         assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assert.equal(state.webhost, 'siteground',
             `Expected webhost 'siteground', got '${state.webhost}'`);
     });
@@ -207,6 +210,7 @@ describe('Import: SiteGround plugin stripping', () => {
             execFileSync('php', [
                 IMPORTER_PATH,
                 'apply-runtime',
+                importUrl(),
                 `--state-dir=${tempDir}`,
                 `--flat-document-root=${flatDir}`,
                 `--runtime=php-builtin`,

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -15,6 +15,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -64,7 +65,7 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
@@ -98,7 +99,10 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0 on re-pull, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -17,6 +17,7 @@ import {
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -74,7 +75,10 @@ describe('Import: Pull Multi-Request', { timeout: 300000 }, () => {
     });
 
     it('state shows pull complete', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
     });
 

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -23,6 +23,7 @@ import {
     assertTreesMatch, assertSiteMirror,
     fsRootDir, assertPullPipelineComplete,
     compareDatabases, createMysqlConnection, getDbName,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -70,7 +71,10 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
     });
 
@@ -84,12 +88,18 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
             `Expected abort exit 0, got ${result.exitCode}`);
 
         // The completed-stage marker should be cleared.
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assert.equal(state.pull_pipeline.last_completed_stage, null,
             'Expected pull_pipeline.last_completed_stage to be null after abort');
 
         // Remote index should be preserved (for delta sync)
-        assert.ok(existsSync(join(tempDir, 'pull/remote-index.jsonl')),
+        assert.ok(existsSync(join(
+            pullStateDirectory(tempDir, importUrl()),
+            'remote-index.jsonl',
+        )),
             'Expected remote index to be preserved after abort');
     });
 
@@ -104,7 +114,10 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
     });
 
@@ -138,7 +151,10 @@ describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected auto re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
     });
 });

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -14,6 +14,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     fsRootDir, assertPullPipelineComplete, compareDatabases, createMysqlConnection, getDbName,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -84,7 +85,7 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('state records deferred files in the pull metadata', () => {
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
@@ -93,7 +94,10 @@ describe('Import: Pull essential-files', { timeout: 180000 }, () => {
     });
 
     it('skipped fetch list remains on disk', () => {
-        const skippedList = join(tempDir, 'pull/skipped-fetch-list.jsonl');
+        const skippedList = join(
+            pullStateDirectory(tempDir, importUrl()),
+            'skipped-fetch-list.jsonl',
+        );
         assert.ok(existsSync(skippedList), 'Expected skipped fetch list to exist');
         assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
             'Expected skipped fetch list to be non-empty');

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -31,7 +31,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks,
     clearHookState,
-    fsRootDir,
+    fsRootDir, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -142,7 +142,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const localPath = join(importedRoot, fileRel);
         const serializedLocalPath = `base64:${Buffer.from(localPath).toString('base64')}`;
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected import state file to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.notEqual(
@@ -165,7 +165,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected resume to complete\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
 
-        const stateFile = join(tempDir, 'pull/state.json');
+        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected status=complete after resume, got ${state.active_resumable_command.completion_state}`);
     });

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    assertPullPipelineComplete,
+    assertPullPipelineComplete, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -61,7 +61,10 @@ describe('Import: Pull start-runtime none', { timeout: 180000 }, () => {
     });
 
     it('marks the pull complete and generates playground runtime files', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'));
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
         assertPullPipelineComplete(state);
         assert.equal(state.active_resumable_command.completion_state, 'complete');
 

--- a/tests/e2e/tests/import-53-adversarial-database-pull.test.js
+++ b/tests/e2e/tests/import-53-adversarial-database-pull.test.js
@@ -16,6 +16,7 @@ import {
     compareDatabases, createMysqlConnection, assertPullPipelineComplete,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -91,7 +92,7 @@ describe('Import: Adversarial database pull', { timeout: 300000 }, () => {
                 `${result.stdout.slice(-4000)}`,
         );
         const importState = JSON.parse(
-            readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'),
+            readFileSync(join(pullStateDirectory(tempDir, importUrl()), 'state.json'), 'utf-8'),
         );
         assertPullPipelineComplete(importState, 'pull-db');
 

--- a/tests/e2e/tests/import-54-db-index-interruption.test.js
+++ b/tests/e2e/tests/import-54-db-index-interruption.test.js
@@ -13,7 +13,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks,
-    readHookState, clearHookState,
+    readHookState, clearHookState, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -64,7 +64,7 @@ describe('Import: Database Index Response Interruption', () => {
         );
 
         const state = JSON.parse(
-            readFileSync(join(tempDir, 'pull/state.json'), 'utf-8'),
+            readFileSync(join(pullStateDirectory(tempDir, importUrl()), 'state.json'), 'utf-8'),
         );
         assert.equal(
             state.active_resumable_command.completion_state,


### PR DESCRIPTION
`$pull_state_directory` now resolves to `<state-dir>/remotes/<hash>/pull` instead of `<state-dir>/pull`.

| | Before | After |
| --- | --- | --- |
| Pull state directory | `<state-dir>/pull` | `<state-dir>/remotes/<hash>/pull` |

`<hash>` has the same definition used by `files-push` and `files-diff`:

```text
md5(rtrim(<remote-reprint-api-url>, "?&"))
```

The state directory identifies one filesystem root. The hash identifies one trimmed remote Reprint API URL. This lets one state directory retain independent pull state for multiple remote Reprint API URLs.

## State ownership

The entire pull state directory moves beneath the remote state directory. This includes:

- `state.json`, which stores the resumable pull lifecycle;
- `remote-index.jsonl`, `remote-index.next.jsonl`, and `remote-index.wal`;
- fetch lists and the volatile-file record;
- pull-generated database metadata and the SQL buffer.

The `pull/` and `push/` directories are siblings beneath `<state-dir>/remotes/<hash>` because both are selected by the same remote Reprint API URL.

State belonging to the filesystem root rather than one remote Reprint API URL does not move. `process.lock`, `progress.json`, `audit.log`, `db.sql`, `db-tables.jsonl`, generated runtime files, and database files remain directly beneath `<state-dir>`.

## Local commands now select remote state

`pull-metadata` and `apply-runtime` now require the positional remote Reprint API URL. They use it only to select `<state-dir>/remotes/<hash>/pull`; they still make no network request.

```text
reprint pull-metadata <remote-reprint-api-url> --state-dir=<state-dir>
reprint apply-runtime <remote-reprint-api-url> --state-dir=<state-dir> ...
```

The pull algorithm, pull state schema, remote index format, and remote URL hash do not change.

## Existing state

There is no migration from `<state-dir>/pull`. Commands neither read nor move pull state from that former path. A command using the new layout therefore does not see preflight or resumable state retained there.

## Testing

The full Import PHPUnit suite passes with 471 tests and 3,476 assertions. The files-push endpoint integration test confirms that creating push state does not create pull state. PHPStan, PHP 7.4 compatibility, PHP syntax, JavaScript syntax, and `git diff --check` pass.
