### PR TITLE
Reuse the index between push and pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,8 +535,11 @@ Reprint uses `$STATE_DIR` exactly as supplied. Consumers that want the state
 hidden can choose a directory named `.reprint`; Reprint does not append that
 name itself. State-directory-wide command progress and the audit log live
 directly in the state directory. The retained local index lives at
-`remotes/<md5-of-trimmed-remote-reprint-api-url>/local_index.jsonl`. Pull and
-push operation state live in the sibling `pull/` and `push/` directories.
+`remotes/<md5-of-trimmed-remote-reprint-api-url>/local_index.jsonl`.
+`files-pull` advances it for each completed local mutation without scanning
+unrelated paths; `files-push` replaces it only after the target confirms
+commit. Pull and push operation state live in the sibling `pull/`
+and `push/` directories.
 State-directory-wide and pull filenames do not begin with a dot or repeat the
 scope supplied by their parent directory.
 

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -7,9 +7,10 @@ the end maps it to a PR stack.
 
 ## Shape of a push
 
-1. The local machine knows what changed locally since the last target-confirmed
-   push to this remote (files, deletions, database rows), by comparing against
-   the local paths and rows stored after that push.
+1. The local machine knows what changed locally since the local index for this
+   remote was advanced by completed pull mutations or replaced after a
+   target-confirmed push, and since the database rows were stored after that
+   push.
 2. It shows a summary of local uploads and deletions. The user confirms that
    local should win for those paths and rows.
 3. It transfers everything into a private push directory on the remote — file bytes,
@@ -88,10 +89,26 @@ uses a different state directory for each filesystem root:
     <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push/previously_pushed_rows.jsonl   (phase two)
 
 The local index records local relative paths and the locally observed type,
-size, ctime, and directory emptiness from the most recent fresh scan the sender
-finished saving after the target confirmed its corresponding files-push
-commit. Besides planning the next push, it feeds the local `files-diff` command,
-which reports the same comparison without pushing.
+size, ctime, and directory emptiness. A target-confirmed files-push replaces it
+with the sender's fresh scan. A later files-pull advances only the local paths
+that it actually changes. Besides planning the next push, the index feeds the
+local `files-diff` command, which reports the same comparison without pushing.
+
+Files-pull records each completed file, directory, symlink, or deletion in
+`<remote-state-directory>/pull/index.wal`. Each record carries the
+remote index projection and, for a non-skipped path beneath the filesystem
+root, the mapped local relative path plus its locally observed type, size, and
+ctime. Applying a batch updates the remote index first, advances the local
+index second, and clears the WAL only after both replacements finish. Resume
+and abort replay the same batch.
+
+This is deliberately not a post-pull filesystem scan. Path selection, filters,
+remapping, preserve-local behavior, and failed local mutations leave unrelated
+local index entries unchanged, so pending local additions, edits, and
+deletions remain visible to files-diff and files-push. The merge applies the
+sorted path mutations directly and removes an indexed subtree when its root is
+deleted or replaced. Non-empty directories remain implicit. A successful
+initial pull with no local mutations creates an empty local index.
 
 `PushPlan` first builds a path-sorted fresh local index, then derives the local
 paths to push and delete by diffing it against the local index its caller
@@ -289,7 +306,9 @@ state:
 
 ```text
 <state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/
-  local_index.jsonl                     index saved after target-confirmed commit
+  local_index.jsonl                     retained filesystem-root snapshot for pull, diff, and push
+  pull/
+    index.wal                           completed pull mutations awaiting application to both indexes
   push/
     excluded_paths.json                 sender-owned target exclusions
     sender.json                         active push state
@@ -461,8 +480,9 @@ receiver cursors or tentative upload positions.
 `reprint files-diff <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR` reports a local
 minimized push operation plan before target exclusions: the local paths a
 files-push would send or delete, compared against
-`<remote-state-directory>/local_index.jsonl`. Files-push replaces that local
-index after the target confirms commit. The remote state directory is
+`<remote-state-directory>/local_index.jsonl`. Files-pull advances that local
+index after completed local mutations, and files-push replaces it after the
+target confirms commit. The remote state directory is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>`, so another URL
 query cannot reuse the index. A different filesystem root uses a different
 state directory. The command accepts only `--state-dir` and `--fs-root`; it
@@ -609,7 +629,8 @@ Files first, database second, each PR small and stacked in this order:
     and reports completion, continuation, restart, or failure without retrying.
 12. **`reprint files-diff`** — a local-only command that reports the paths a
     files-push would send or delete against the local index for that remote
-    Reprint API URL, without contacting the target.
+    Reprint API URL, without contacting the target. Files-pull advances that
+    index only for completed local mutations through its pull index WAL.
 13. **`reprint push`** — the high-level command that adds a change summary,
     confirmation boundary, database work, transfer, commit, and resume.
 14. **Budgets and resumable limits** — push requests stay bounded by two

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -56,14 +56,15 @@ local relative path to a push-root-relative path.
   state directory. Its entries use local relative paths and locally observed
   type, size, ctime, and directory emptiness. The remote Reprint API URL selects
   the remote state directory; a different filesystem root uses a different
-  state directory. Files-push atomically replaces the local index only after
-  the target confirms commit. Use `$local_index_file`.
+  state directory. Files-pull advances only the entries for completed local
+  mutations; files-push atomically replaces the local index only after the
+  target confirms commit. Use `$local_index_file`.
 - A **fresh local index** is the current filesystem-root scan created while
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
 - The **pull index WAL** records completed pull mutations awaiting application
-  to the remote index.
+  to the remote and local indexes.
 - A **pull plan** lists remote absolute paths still scheduled for download or
   deletion. A **push plan** maps local relative paths to push-root-relative
   paths.
@@ -243,21 +244,27 @@ push-session and commit locks.
 
 Call the single pull-side write-ahead log the **pull index WAL**. It lives at
 `<remote-state-directory>/pull/index.wal`; use
-`pull/index.wal`,
-`$pull_index_wal_path`, and `$pull_index_wal_handle`.
-Applied batch records are cleared, but the empty WAL remains as a marker until
-files-pull completes. A retained WAL is consumed only while resuming or
-aborting the interrupted files-pull, including through a high-level pull
-command. Files-diff and files-push reject the unfinished files-pull instead of
-consuming its WAL. Files-pull rejects an unfinished files-push while
+`pull/index.wal`, `$pull_index_wal_path`, and
+`$pull_index_wal_handle`. Each record always carries the remote index
+projection and also carries the local index projection when files-pull
+completed a non-skipped local mutation beneath the filesystem root. Applying
+a batch updates the remote index first, then the local index, and clears the
+records only after both replacements finish.
+
+The empty WAL remains as a marker until files-pull completes. A retained WAL
+is consumed only while resuming or aborting the interrupted files-pull,
+including through a high-level pull command. Files-diff and files-push reject
+the unfinished files-pull instead of consuming its WAL.
+Files-pull rejects an unfinished files-push while
 `<remote-state-directory>/push/sender.json` exists.
 
 ## Local index and push state
 
 The local index is `<remote-state-directory>/local_index.jsonl`.
-`files-diff` and PushPlan read it. PushFilesSender replaces it only after the
-target confirms commit. Planning and active push state remain under
-`<remote-state-directory>/push/`.
+`files-diff` and PushPlan read it. Files-pull advances it only for local paths
+changed by completed file, directory, symlink, or deletion mutations.
+PushFilesSender replaces it only after the target confirms commit. Planning
+and active push state remain under `<remote-state-directory>/push/`.
 
 Use these names verbatim:
 
@@ -283,9 +290,11 @@ copies the sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
 
-The local index contains the most recent fresh filesystem-root scan the sender
-finished saving after the target confirmed its corresponding files-push
-commit. PushPlan diffs its fresh local index against the local index its caller
+The local index contains the fresh filesystem-root scan the sender saved after
+a target-confirmed files-push commit, advanced path by path by later completed
+files-pull mutations.
+Files-pull does not scan unrelated paths or accept their pending local changes.
+PushPlan diffs its fresh local index against the local index its caller
 supplies. `byte_offset_in_local_index` is the position from which its current
 lookahead entry is read again after resume.
 
@@ -340,8 +349,9 @@ reports `complete`, `restart`, or `failed`.
 
 The local-only command is `files-diff`. Its `remote Reprint API URL` and
 `filesystem root` have the same meanings as for `files-push`. It reads
-`<remote-state-directory>/local_index.jsonl`, which files-push writes after the
-target confirms commit, and never changes it.
+`<remote-state-directory>/local_index.jsonl`, which files-pull advances after
+completed local mutations and files-push writes after the target confirms
+commit. Files-diff never changes it.
 
 Each JSONL change record has `command: "files-diff"`, an `action` of `push` or
 `delete`, and `path_b64`. A push record also has the local path `type`, `size`,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -35,6 +35,8 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function Reprint\Importer\merge_local_index_mutations;
+use function Reprint\Importer\write_local_index_update;
 
 error_reporting(E_ALL);
 ini_set("display_errors", "stderr");
@@ -74,6 +76,7 @@ require_once __DIR__ . '/lib/host/load.php';
 require_once __DIR__ . '/lib/target-runtime/load.php';
 
 require_once __DIR__ . '/lib/sort-index-file.php';
+require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
@@ -165,17 +168,16 @@ class ImportClient
     /** @var float Minimum seconds between progress output lines. */
     private $progress_throttle = 1.0;
 
-    /**
-     * @var string Remote index file pull/remote-index.jsonl. It records remote
-     * absolute paths and remote-observed type, size, and ctime for pull
-     * operations already accounted for in the filesystem root.
-     */
+    /** @var string Retained filesystem-root snapshot for this remote state directory. */
+    private $local_index_file;
+
+    /** @var string Remote index for pull operations accounted for in the filesystem root. */
     private $remote_index_file;
 
     /**
      * @var string Path to pull/index.wal — the append-only write-ahead
-     * log for the current files-pull. Applied batches are cleared, but the file
-     * remains until the lifecycle completes or is aborted.
+     * log for completed files-pull mutations. Applied batches are cleared, but
+     * the file remains until the lifecycle completes or is aborted.
      */
     private $pull_index_wal_path;
 
@@ -417,10 +419,12 @@ class ImportClient
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
         $this->filesystem_root = rtrim($filesystem_root, "/");
-        $this->pull_state_directory = self::remote_state_directory_path(
+        $remote_state_directory = self::remote_state_directory_path(
             $this->remote_reprint_api_url,
             $this->state_dir
-        ) . "/pull";
+        );
+        $this->pull_state_directory = $remote_state_directory . "/pull";
+        $this->local_index_file = $remote_state_directory . "/local_index.jsonl";
         $this->pull_state_file = $this->pull_state_directory . "/state.json";
         $this->remote_index_file = $this->pull_state_directory . "/remote-index.jsonl";
         $this->pull_index_wal_path =
@@ -493,13 +497,23 @@ class ImportClient
         ]);
     }
 
-    /** Records a remote deletion which this pull applied locally. */
-    private function wal_append_successful_deletion(string $remote_absolute_path): void
-    {
-        $this->write_pull_index_wal_record([
+    /** Appends a completed local deletion to the pull index WAL. */
+    private function wal_append_successful_deletion(
+        string $remote_absolute_path,
+        string $local_absolute_path
+    ): void {
+        $pull_index_wal_record = [
             "op" => "-",
             "remote_absolute_path_b64" => base64_encode($remote_absolute_path),
-        ]);
+        ];
+        $local_relative_path = $this->local_relative_path_from_local_absolute_path(
+            $local_absolute_path
+        );
+        if ($local_relative_path !== null) {
+            $pull_index_wal_record["local_relative_path_b64"] =
+                base64_encode($local_relative_path);
+        }
+        $this->write_pull_index_wal_record($pull_index_wal_record);
     }
 
     /** Invalidates remote state which this pull did not account for locally. */
@@ -512,21 +526,124 @@ class ImportClient
     }
 
     /**
+     * Appends a completed local upsert to the pull index WAL.
+     *
+     * Files-pull calls this only after the local absolute path contains the
+     * pulled file, symlink, or empty directory. For example:
+     *
+     *     filesystem root:      /var/www
+     *     remote absolute path: /srv/site/file.txt
+     *     local absolute path:  /var/www/file.txt
+     *
+     * Applying the WAL produces decoded entries such as:
+     *
+     *     remote index: /srv/site/file.txt  file, size 4, ctime 10
+     *     local index:  file.txt            file, size 4, ctime 12
+     *
+     * The remote index records the remote state files-pull accounted for. The
+     * local index records the resulting local path type, size, and ctime.
+     * Without that local index entry, files-diff and PushPlan would compare
+     * the pulled path with the older local index and select it as a local
+     * change. A local absolute path outside the filesystem root, or a
+     * default-skipped path, has no local index entry.
+     */
+    private function record_pulled_path(
+        string $remote_absolute_path,
+        string $local_absolute_path,
+        int $remote_path_ctime,
+        int $remote_path_size,
+        string $remote_path_type
+    ): void {
+        $pull_index_wal_record = [
+            "op" => "+",
+            "remote_absolute_path_b64" => base64_encode($remote_absolute_path),
+            "remote_path_ctime" => $remote_path_ctime,
+            "remote_path_size" => $remote_path_size,
+            "remote_path_type" => $remote_path_type,
+        ];
+        $local_relative_path = $this->local_relative_path_from_local_absolute_path(
+            $local_absolute_path
+        );
+        if ($local_relative_path !== null) {
+            clearstatcache(true, $local_absolute_path);
+            $local_path_stat = lstat($local_absolute_path);
+            if ($local_path_stat === false) {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI filesystem path, never HTML output.
+                throw new RuntimeException(
+                    "Failed to inspect the pulled local absolute path: {$local_absolute_path}."
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+            $local_file_type_bits = $local_path_stat["mode"] & 0170000;
+            if ($local_file_type_bits === 0120000) {
+                $local_path_type = "link";
+            } elseif ($local_file_type_bits === 0040000) {
+                $local_path_type = "dir";
+            } elseif ($local_file_type_bits === 0100000) {
+                $local_path_type = "file";
+            } else {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI filesystem path, never HTML output.
+                throw new RuntimeException(
+                    "The pulled local absolute path has an unsupported type: {$local_absolute_path}."
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+            $pull_index_wal_record["local_relative_path_b64"] =
+                base64_encode($local_relative_path);
+            $pull_index_wal_record["local_path_ctime"] = (int) $local_path_stat["ctime"];
+            $pull_index_wal_record["local_path_size"] =
+                $local_path_type === "dir" ? 0 : (int) $local_path_stat["size"];
+            $pull_index_wal_record["local_path_type"] = $local_path_type;
+        }
+        $this->write_pull_index_wal_record($pull_index_wal_record);
+    }
+
+    /** Returns the local relative path stored in the local index. */
+    private function local_relative_path_from_local_absolute_path(
+        string $local_absolute_path
+    ): ?string {
+        $local_relative_path = self::path_remainder_under(
+            $local_absolute_path,
+            $this->get_filesystem_root_path()
+        );
+        if (
+            $local_relative_path === null
+            || $local_relative_path === ""
+        ) {
+            return null;
+        }
+        $local_relative_path = ltrim($local_relative_path, "/");
+        return FileIndexProcessor::path_is_default_skipped(
+            $local_relative_path
+        )
+            ? null
+            : $local_relative_path;
+    }
+
+    /**
      * Appends one complete record to the pull index WAL.
      *
      * @param array $pull_index_wal_record {
-     *     One completed remote-index mutation.
+     *     One completed pull mutation, with local fields when files-pull
+     *     changed a non-skipped path beneath the filesystem root.
      *
      *     @type string $op                       `+` upsert or `-` deletion.
      *     @type string $remote_absolute_path_b64 Base64 remote absolute path.
      *     @type int    $remote_path_ctime        Remote ctime for `+`.
      *     @type int    $remote_path_size         Remote size for `+`.
      *     @type string $remote_path_type         Remote type for `+`.
+     *     @type string $local_relative_path_b64  Base64 local relative path
+     *                                             when the completed mutation
+     *                                             belongs in the local index.
+     *     @type int    $local_path_ctime         Local ctime for a local `+`.
+     *     @type int    $local_path_size          Local size for a local `+`.
+     *     @type string $local_path_type          Local type for a local `+`.
      * }
      */
     private function write_pull_index_wal_record(
         array $pull_index_wal_record
-    ): void {
+    ): void
+    {
         if (!$this->pull_index_wal_handle) {
             $this->open_pull_index_wal();
         }
@@ -1248,16 +1365,15 @@ class ImportClient
             throw new InvalidArgumentException('files-diff requires its resolved local push state directory.');
         }
 
-        $remote_state_directory = dirname($push_state_directory);
-        $local_index_file = $remote_state_directory . '/local_index.jsonl';
         $missing_local_index_message =
             'files-diff requires <remote-state-directory>/local_index.jsonl. '
-            . 'files-push writes it after the target confirms commit for the same '
+            . 'files-pull writes it from completed local mutations; files-push '
+            . 'writes it after the target finishes applying the push. Use the same '
             . 'remote Reprint API URL and state directory.';
 
         $plan_directory = $push_state_directory . '/files-diff-plan';
         try {
-            if (!is_file($local_index_file)) {
+            if (!is_file($this->local_index_file)) {
                 throw new RuntimeException($missing_local_index_message);
             }
 
@@ -1274,7 +1390,7 @@ class ImportClient
             $plan = PushPlan::start(
                 $plan_directory,
                 $this->filesystem_root,
-                $local_index_file,
+                $this->local_index_file,
                 $excluded_paths_path
             );
             try {
@@ -2866,7 +2982,9 @@ class ImportClient
         if ($this->follow_symlinks) {
             $this->recreate_intermediate_symlinks();
         }
+        $this->apply_pull_index_wal();
 
+        $this->ensure_local_index_exists();
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->save_state();
         $this->remove_pull_index_wal();
@@ -2893,6 +3011,21 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    /** Creates an empty local index when files-pull recorded no local paths. */
+    private function ensure_local_index_exists(): void
+    {
+        if (is_file($this->local_index_file)) {
+            return;
+        }
+        if (file_put_contents($this->local_index_file, "") === false) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI filesystem path, never HTML output.
+            throw new RuntimeException(
+                "Failed to create the empty local index: {$this->local_index_file}."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
     }
 
     /**
@@ -3363,6 +3496,13 @@ class ImportClient
 
             if (@symlink($symlink_target, $local_absolute_path)) {
                 $created++;
+                $this->record_pulled_path(
+                    $remote_absolute_path,
+                    $local_absolute_path,
+                    (int) ($next_remote_index_entry["ctime"] ?? 0),
+                    (int) ($next_remote_index_entry["size"] ?? 0),
+                    "link"
+                );
                 $this->audit_log(
                     "INTERMEDIATE SYMLINK: {$remote_absolute_path} -> {$symlink_target}",
                     false,
@@ -6334,7 +6474,8 @@ class ImportClient
                         );
                     } else {
                         $this->wal_append_successful_deletion(
-                            $missing_remote_index_entry_path
+                            $missing_remote_index_entry_path,
+                            $local_absolute_path
                         );
                     }
                 }
@@ -6426,7 +6567,8 @@ class ImportClient
                     );
                 } else {
                     $this->wal_append_successful_deletion(
-                        $missing_remote_index_entry_path
+                        $missing_remote_index_entry_path,
+                        $local_absolute_path
                     );
                 }
             }
@@ -6968,7 +7110,7 @@ class ImportClient
         }
     }
 
-    /** Applies the current pull index WAL to the remote index. */
+    /** Applies the pull index WAL to the remote index and then the local index. */
     private function apply_pull_index_wal(): void
     {
         if ($this->pull_index_wal_handle) {
@@ -6999,7 +7141,7 @@ class ImportClient
         $remote_index_replacement_file_handle = fopen($remote_index_replacement_file, "w");
 
         if (!$pull_index_wal_file_handle || !$remote_index_replacement_file_handle) {
-            throw new RuntimeException("Failed to merge pull index WAL records");
+            throw new RuntimeException("Failed to merge remote index updates.");
         }
 
         $write_remote_index_entry = function ($remote_index_destination_file_handle, array $remote_index_entry_to_write): void {
@@ -7018,15 +7160,15 @@ class ImportClient
         };
 
         $remote_index_entry = $this->read_remote_index_entry($remote_index_file_handle);
-        $pull_index_wal_lookahead_record = null;
-        $pull_index_wal_record = $this->read_pull_index_wal_record(
+        $remote_index_update_lookahead = null;
+        $remote_index_update = $this->read_remote_index_update(
             $pull_index_wal_file_handle,
-            $pull_index_wal_lookahead_record
+            $remote_index_update_lookahead
         );
         $last_written_remote_index_entry_path = null;
 
-        while ($remote_index_entry !== null || $pull_index_wal_record !== null) {
-            if ($pull_index_wal_record === null) {
+        while ($remote_index_entry !== null || $remote_index_update !== null) {
+            if ($remote_index_update === null) {
                 if ($last_written_remote_index_entry_path !== $remote_index_entry["path"]) {
                     $write_remote_index_entry($remote_index_replacement_file_handle, $remote_index_entry);
                     $last_written_remote_index_entry_path = $remote_index_entry["path"];
@@ -7037,32 +7179,32 @@ class ImportClient
 
             if ($remote_index_entry === null) {
                 if (
-                    !$pull_index_wal_record["delete"] &&
-                    $last_written_remote_index_entry_path !== $pull_index_wal_record["path"]
+                    !$remote_index_update["delete"] &&
+                    $last_written_remote_index_entry_path !== $remote_index_update["path"]
                 ) {
-                    $write_remote_index_entry($remote_index_replacement_file_handle, $pull_index_wal_record);
-                    $last_written_remote_index_entry_path = $pull_index_wal_record["path"];
+                    $write_remote_index_entry($remote_index_replacement_file_handle, $remote_index_update);
+                    $last_written_remote_index_entry_path = $remote_index_update["path"];
                 }
-                $pull_index_wal_record = $this->read_pull_index_wal_record(
+                $remote_index_update = $this->read_remote_index_update(
                     $pull_index_wal_file_handle,
-                    $pull_index_wal_lookahead_record
+                    $remote_index_update_lookahead
                 );
                 continue;
             }
 
-            $remote_index_entry_path_comparison = strcmp($remote_index_entry["path"], $pull_index_wal_record["path"]);
+            $remote_index_entry_path_comparison = strcmp($remote_index_entry["path"], $remote_index_update["path"]);
             if ($remote_index_entry_path_comparison === 0) {
                 if (
-                    !$pull_index_wal_record["delete"] &&
-                    $last_written_remote_index_entry_path !== $pull_index_wal_record["path"]
+                    !$remote_index_update["delete"] &&
+                    $last_written_remote_index_entry_path !== $remote_index_update["path"]
                 ) {
-                    $write_remote_index_entry($remote_index_replacement_file_handle, $pull_index_wal_record);
-                    $last_written_remote_index_entry_path = $pull_index_wal_record["path"];
+                    $write_remote_index_entry($remote_index_replacement_file_handle, $remote_index_update);
+                    $last_written_remote_index_entry_path = $remote_index_update["path"];
                 }
                 $remote_index_entry = $this->read_remote_index_entry($remote_index_file_handle);
-                $pull_index_wal_record = $this->read_pull_index_wal_record(
+                $remote_index_update = $this->read_remote_index_update(
                     $pull_index_wal_file_handle,
-                    $pull_index_wal_lookahead_record
+                    $remote_index_update_lookahead
                 );
             } elseif ($remote_index_entry_path_comparison < 0) {
                 if ($last_written_remote_index_entry_path !== $remote_index_entry["path"]) {
@@ -7072,15 +7214,15 @@ class ImportClient
                 $remote_index_entry = $this->read_remote_index_entry($remote_index_file_handle);
             } else {
                 if (
-                    !$pull_index_wal_record["delete"] &&
-                    $last_written_remote_index_entry_path !== $pull_index_wal_record["path"]
+                    !$remote_index_update["delete"] &&
+                    $last_written_remote_index_entry_path !== $remote_index_update["path"]
                 ) {
-                    $write_remote_index_entry($remote_index_replacement_file_handle, $pull_index_wal_record);
-                    $last_written_remote_index_entry_path = $pull_index_wal_record["path"];
+                    $write_remote_index_entry($remote_index_replacement_file_handle, $remote_index_update);
+                    $last_written_remote_index_entry_path = $remote_index_update["path"];
                 }
-                $pull_index_wal_record = $this->read_pull_index_wal_record(
+                $remote_index_update = $this->read_remote_index_update(
                     $pull_index_wal_file_handle,
-                    $pull_index_wal_lookahead_record
+                    $remote_index_update_lookahead
                 );
             }
         }
@@ -7092,12 +7234,75 @@ class ImportClient
         fclose($remote_index_replacement_file_handle);
 
         if (!rename($remote_index_replacement_file, $this->remote_index_file)) {
-            throw new RuntimeException("Failed to replace the remote index file");
+            throw new RuntimeException("Failed to replace the remote index file.");
         }
         $this->audit_log("INDEX MERGE COMPLETE | {$this->remote_index_file} updated");
 
-        if (file_put_contents($this->pull_index_wal_path, '') === false) {
-            throw new RuntimeException("Failed to clear the applied pull index WAL.");
+        /*
+         * Rebuild the sorted local index updates from the pull index WAL. This
+         * temporary file is disposable: the WAL remains until both index
+         * replacements finish, so resume can discard a partial file and replay
+         * the batch. The WAL is in completion order, while the local index
+         * merge requires local relative path byte order. Records without a
+         * local relative path update only the remote index. An unterminated
+         * final record is repeated from the preceding durable cursor when
+         * files-pull resumes.
+         */
+        $local_index_updates_path = $this->pull_index_wal_path . ".local";
+        $pull_index_wal_file_handle = fopen($this->pull_index_wal_path, "r");
+        $local_index_updates_handle = fopen($local_index_updates_path, "w");
+        if (!$pull_index_wal_file_handle || !$local_index_updates_handle) {
+            throw new RuntimeException("Failed to prepare the local index updates.");
+        }
+
+        $local_index_updates_written = 0;
+        while (( $pull_index_wal_json_line = fgets($pull_index_wal_file_handle) ) !== false) {
+            if (
+                substr($pull_index_wal_json_line, -1) !== "\n"
+                && feof($pull_index_wal_file_handle)
+            ) {
+                break;
+            }
+            $pull_index_wal_record = json_decode($pull_index_wal_json_line, true);
+            if (!is_array($pull_index_wal_record)) {
+                throw new RuntimeException("Invalid pull index WAL line format.");
+            }
+            if (!array_key_exists("local_relative_path_b64", $pull_index_wal_record)) {
+                continue;
+            }
+            $local_index_update = [
+                "op" => $pull_index_wal_record["op"],
+                "path" => $pull_index_wal_record["local_relative_path_b64"],
+            ];
+            if ($pull_index_wal_record["op"] === "+") {
+                $local_index_update += [
+                    "ctime" => $pull_index_wal_record["local_path_ctime"],
+                    "size" => $pull_index_wal_record["local_path_size"],
+                    "type" => $pull_index_wal_record["local_path_type"],
+                ];
+            }
+            write_local_index_update(
+                $local_index_updates_handle,
+                $local_index_update
+            );
+            ++$local_index_updates_written;
+        }
+        fclose($pull_index_wal_file_handle);
+        fclose($local_index_updates_handle);
+
+        if ($local_index_updates_written > 0) {
+            sort_index_file($local_index_updates_path);
+            merge_local_index_mutations(
+                $this->local_index_file,
+                $local_index_updates_path
+            );
+        }
+        @unlink($local_index_updates_path);
+
+        if (file_put_contents($this->pull_index_wal_path, "") === false) {
+            throw new RuntimeException(
+                "Failed to clear the applied pull index WAL."
+            );
         }
         $this->audit_log(
             "FILE TRUNCATE | {$this->pull_index_wal_path} | pull index WAL batch applied"
@@ -7118,7 +7323,9 @@ class ImportClient
             is_file($this->pull_index_wal_path)
             && filesize($this->pull_index_wal_path) > 0
         ) {
-            throw new RuntimeException("Cannot remove an unapplied pull index WAL.");
+            throw new RuntimeException(
+                "Cannot remove an unapplied pull index WAL."
+            );
         }
         if (
             is_file($this->pull_index_wal_path)
@@ -7128,9 +7335,7 @@ class ImportClient
         }
     }
 
-    /**
-     * Read one JSON record from the on-disk index.
-     */
+    /** Reads one entry from the remote index. */
     private function read_remote_index_entry($remote_index_file_handle): ?array
     {
         if (!$remote_index_file_handle) {
@@ -7145,15 +7350,14 @@ class ImportClient
         return null;
     }
 
-    /**
-     * Read one raw pull index WAL record (`+` upsert or `-` deletion).
-     */
-    private function read_raw_pull_index_wal_record($pull_index_wal_file_handle): ?array
-    {
+    /** Reads one raw remote index projection from the pull index WAL. */
+    private function read_raw_remote_index_update(
+        $pull_index_wal_file_handle
+    ): ?array {
         if (!$pull_index_wal_file_handle) {
             return null;
         }
-        while (($pull_index_wal_json_line = fgets($pull_index_wal_file_handle)) !== false) {
+        while (( $pull_index_wal_json_line = fgets($pull_index_wal_file_handle) ) !== false) {
             if (substr($pull_index_wal_json_line, -1) !== "\n" && feof($pull_index_wal_file_handle)) {
                 return null;
             }
@@ -7163,17 +7367,24 @@ class ImportClient
             }
             $pull_index_wal_record = json_decode($pull_index_wal_json_line, true);
             if (!is_array($pull_index_wal_record)) {
-                throw new RuntimeException("Invalid pull index WAL line format");
+                throw new RuntimeException("Invalid pull index WAL line format.");
             }
             $pull_index_wal_operation = $pull_index_wal_record["op"] ?? null;
             $remote_absolute_path_base64 =
                 $pull_index_wal_record["remote_absolute_path_b64"] ?? null;
-            if (!is_string($remote_absolute_path_base64) || $remote_absolute_path_base64 === "") {
-                throw new RuntimeException("Invalid pull index WAL path");
+            if (
+                !is_string($remote_absolute_path_base64)
+                || $remote_absolute_path_base64 === ""
+            ) {
+                throw new RuntimeException(
+                    "Invalid pull index WAL remote absolute path."
+                );
             }
-            $remote_absolute_path = base64_decode($remote_absolute_path_base64);
+            $remote_absolute_path = base64_decode($remote_absolute_path_base64, true);
             if ($remote_absolute_path === false || $remote_absolute_path === "") {
-                throw new RuntimeException("Invalid pull index WAL path (base64 decode failed)");
+                throw new RuntimeException(
+                    "Invalid pull index WAL remote absolute path (base64 decode failed)."
+                );
             }
             if ($pull_index_wal_operation === "-") {
                 return [
@@ -7198,35 +7409,48 @@ class ImportClient
     }
 
     /**
-     * Read one pull index WAL record, coalescing consecutive records for the same path.
+     * Reads one remote index update, keeping the last consecutive update for
+     * the same remote absolute path.
      *
-     * @param mixed $pull_index_wal_file_handle Pull index WAL file handle.
-     * @param array|null $pull_index_wal_lookahead_record Pull index WAL lookahead record.
+     * @param mixed      $pull_index_wal_file_handle Open WAL handle.
+     * @param array|null $remote_index_update_lookahead Retained lookahead.
      */
-    private function read_pull_index_wal_record($pull_index_wal_file_handle, ?array &$pull_index_wal_lookahead_record = null): ?array
-    {
+    private function read_remote_index_update(
+        $pull_index_wal_file_handle,
+        ?array &$remote_index_update_lookahead = null
+    ): ?array {
         if (!$pull_index_wal_file_handle) {
             return null;
         }
-        $current_pull_index_wal_record = $pull_index_wal_lookahead_record ?? $this->read_raw_pull_index_wal_record($pull_index_wal_file_handle);
-        $pull_index_wal_lookahead_record = null;
-        if ($current_pull_index_wal_record === null) {
+        $current_remote_index_update =
+            $remote_index_update_lookahead
+            ?? $this->read_raw_remote_index_update(
+                $pull_index_wal_file_handle
+            );
+        $remote_index_update_lookahead = null;
+        if ($current_remote_index_update === null) {
             return null;
         }
 
         while (true) {
-            $next_pull_index_wal_record = $this->read_raw_pull_index_wal_record($pull_index_wal_file_handle);
-            if ($next_pull_index_wal_record === null) {
-                return $current_pull_index_wal_record;
+            $next_remote_index_update = $this->read_raw_remote_index_update(
+                $pull_index_wal_file_handle
+            );
+            if ($next_remote_index_update === null) {
+                return $current_remote_index_update;
             }
-            if ($next_pull_index_wal_record["path"] !== $current_pull_index_wal_record["path"]) {
-                $pull_index_wal_lookahead_record = $next_pull_index_wal_record;
-                return $current_pull_index_wal_record;
+            if (
+                $next_remote_index_update["path"]
+                !== $current_remote_index_update["path"]
+            ) {
+                $remote_index_update_lookahead =
+                    $next_remote_index_update;
+                return $current_remote_index_update;
             }
-            // Same path: keep the latest pull index WAL record.
-            $current_pull_index_wal_record = $next_pull_index_wal_record;
+            $current_remote_index_update = $next_remote_index_update;
         }
     }
+
     /**
      * Download SQL from remote.
      */
@@ -8970,8 +9194,9 @@ class ImportClient
             $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
 
             if ($context->file_ctime && !$file_changed) {
-                $this->upsert_remote_index_entry(
+                $this->record_pulled_path(
                     $path,
+                    $context->file_path,
                     $context->file_ctime,
                     $file_size,
                     "file",
@@ -9286,7 +9511,13 @@ class ImportClient
         $this->audit_log("Directory: {$remote_absolute_path}", false);
 
         if ($ctime > 0) {
-            $this->upsert_remote_index_entry($remote_absolute_path, $ctime, 0, "dir");
+            $this->record_pulled_path(
+                $remote_absolute_path,
+                $local_absolute_path,
+                $ctime,
+                0,
+                "dir"
+            );
         }
     }
 
@@ -9438,7 +9669,13 @@ class ImportClient
         $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
 
         if ($ctime > 0) {
-            $this->upsert_remote_index_entry($path, $ctime, 0, "link");
+            $this->record_pulled_path(
+                $path,
+                $local_absolute_path,
+                $ctime,
+                0,
+                "link"
+            );
         }
 
         $this->output_progress([
@@ -12113,6 +12350,8 @@ if (
                 "\n" .
                 "Output files:\n" .
                 "  (filesystem root)/                       Downloaded files\n" .
+                "  remotes/<md5-of-trimmed-remote-reprint-api-url>/local_index.jsonl\n" .
+                "                                           Local index advanced by completed pull mutations\n" .
                 "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/remote-index.jsonl\n" .
                 "                                           Remote index\n" .
                 "  remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/remote-index.next.jsonl\n" .
@@ -12130,9 +12369,10 @@ if (
             "description" =>
                 "Shows which local paths a files-push would send or delete, comparing\n" .
                 "the filesystem root at --fs-root with the local index for this remote\n" .
-                "Reprint API URL. files-push writes that index after the target confirms\n" .
-                "commit. Use the same remote Reprint API URL, state directory, and\n" .
-                "filesystem root for both commands.\n" .
+                "Reprint API URL. files-pull advances that index after completed local\n" .
+                "mutations, and files-push writes it after the target confirms commit.\n" .
+                "Use the same remote Reprint API URL, state directory, and filesystem\n" .
+                "root for these commands.\n" .
                 "The output is a local minimized push operation plan before target\n" .
                 "exclusions, not a path-for-path filesystem log. Like files-push, its\n" .
                 "default-skipped paths include generated wp-content caches, version-\n" .

--- a/packages/reprint-importer/src/lib/sort-index-file.php
+++ b/packages/reprint-importer/src/lib/sort-index-file.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/external-merge-sort.php';
  * `sort(1)`, then strips the keys. This handles arbitrarily large files with
  * no PHP memory pressure. When exec() is unavailable or the command fails,
  * the fallback uses an external merge sort with bounded memory.
+ * Paths may be remote absolute paths or local relative paths.
  *
  * Duplicates arise from overlapping symlink targets that index the same
  * files; they are removed during the final write pass.
@@ -53,7 +54,10 @@ function sort_index_file(string $path): bool
             throw new RuntimeException('Invalid index path (base64 decode failed)');
         }
 
-        assert_valid_path($path, 'index path');
+        assert_valid_path(
+            $path[0] === '/' ? $path : '/' . $path,
+            'index path'
+        );
         return $path;
     };
 

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -37,6 +37,11 @@ class CliHelpTest extends TestCase
 
         $this->assertStringContainsString('pull/remote-index.jsonl', $output);
         $this->assertStringContainsString('pull/remote-index.next.jsonl', $output);
+        $this->assertStringContainsString('local_index.jsonl', $output);
+        $this->assertStringContainsString(
+            'completed pull mutations',
+            $output
+        );
         $this->assertStringContainsString('Remote index', $output);
         $this->assertStringContainsString('Next remote index', $output);
     }
@@ -132,6 +137,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('local index', $output);
+        $this->assertStringContainsString('files-pull advances', $output);
         $this->assertStringContainsString('target confirms', $output);
         $this->assertStringContainsString('push operation plan', $output);
         $this->assertStringContainsString('default-skipped paths', $output);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -232,7 +232,8 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertIsArray($errorRecord);
         $this->assertSame(
             'files-diff requires <remote-state-directory>/local_index.jsonl. '
-            . 'files-push writes it after the target confirms commit for the same '
+            . 'files-pull writes it from completed local mutations; files-push '
+            . 'writes it after the target finishes applying the push. Use the same '
             . 'remote Reprint API URL and state directory.',
             $errorRecord['error'] ?? null
         );
@@ -251,7 +252,8 @@ final class FilesDiffCommandTest extends TestCase
         $this->assertIsArray($errorRecord);
         $this->assertSame(
             'files-diff requires <remote-state-directory>/local_index.jsonl. '
-            . 'files-push writes it after the target confirms commit for the same '
+            . 'files-pull writes it from completed local mutations; files-push '
+            . 'writes it after the target finishes applying the push. Use the same '
             . 'remote Reprint API URL and state directory.',
             $errorRecord['error'] ?? null
         );

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -1,0 +1,971 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * The local index used by files-pull, files-push, and files-diff.
+ *
+ * Files-pull records each non-skipped local path it changes. A later files-diff
+ * therefore ignores pulled changes while still reporting unrelated local changes.
+ */
+final class FilesPullLocalIndexTest extends TestCase
+{
+    private const REMOTE_CTIME = 41;
+    private const PULLED_PATH = 'selected/written-by-files-pull.txt';
+    private const PULLED_CONTENTS = 'contents delivered by file_fetch';
+
+    private string $root;
+    private string $stateDirectory;
+    private string $remoteStateDirectory;
+    private string $pullStateDirectory;
+    private string $rawFileRoot;
+    private string $localTree;
+    private string $targetUrl;
+
+    /** @var resource|null */
+    private $serverProcess = null;
+
+    /** @var array<int,resource> */
+    private array $serverPipes = [];
+
+    /** @var array<string,string> */
+    private array $remoteFiles = [
+        'deleted.txt' => 'delete me',
+        'edited.txt' => 'old',
+        'folder/remote-deleted.txt' => 'remote child',
+        'unchanged.txt' => 'same',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/files-pull-local-index-' . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->rawFileRoot = $this->root . '/files';
+        $this->localTree = $this->rawFileRoot . '/var/www/html';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->rawFileRoot, 0700, true);
+        $this->targetUrl = $this->startIndexServer();
+        $this->remoteStateDirectory = $this->stateDirectory
+            . '/remotes/'
+            . md5(rtrim($this->targetUrl, '?&'));
+        $this->pullStateDirectory = $this->remoteStateDirectory . '/pull';
+        $this->writePullState();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testInitialPullCreatesTheLocalIndex(): void
+    {
+        $this->completeFilesPull();
+
+        $this->assertSame(
+            self::PULLED_CONTENTS,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $this->assertSame(
+            [
+                $this->localIndexEntryPath('deleted.txt'),
+                $this->localIndexEntryPath('edited.txt'),
+                $this->localIndexEntryPath('folder/remote-deleted.txt'),
+                $this->localIndexEntryPath(self::PULLED_PATH),
+                $this->localIndexEntryPath('unchanged.txt'),
+            ],
+            array_keys($this->readIndex($this->localIndexPath()))
+        );
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testEmptyInitialPullCreatesAnEmptyLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'removed_paths' => array_merge(
+                array_keys($this->remoteFiles),
+                [self::PULLED_PATH]
+            ),
+        ]);
+
+        $this->completeFilesPull();
+
+        $localIndexes = glob($this->remoteStateDirectory . '/local_index.jsonl');
+        $this->assertIsArray($localIndexes);
+        $this->assertCount(1, $localIndexes);
+        $this->assertSame([], $this->readIndex($localIndexes[0]));
+        $this->assertSame(
+            realpath($localIndexes[0]),
+            realpath($this->localIndexPath())
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testPullDoesNotAddDefaultSkippedPathsToTheLocalIndex(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'node_modules/pulled-package.js' => 'pulled dependency',
+            ],
+        ]);
+
+        $this->completeFilesPull();
+
+        $this->assertSame(
+            'pulled dependency',
+            file_get_contents(
+                $this->localTree . '/node_modules/pulled-package.js'
+            )
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('node_modules'),
+            $index
+        );
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('node_modules/pulled-package.js'),
+            $index
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(
+            0,
+            $this->filesDiffRecords($diff['stdout'])[0][
+                'local_paths_to_push'
+            ]
+        );
+    }
+
+    public function testFilesPullRejectsAnUnfinishedFilesPush(): void
+    {
+        if (PHP_VERSION_ID < 80100 || !function_exists('curl_init')) {
+            $this->markTestSkipped(
+                'Starting files-push requires PHP 8.1+ with curl.'
+            );
+        }
+        $remoteReprintApiUrl = $this->targetUrl;
+        mkdir($this->localTree, 0700, true);
+        $pushStateDirectory = \ImportClient::resolve_push_state_directory(
+            $remoteReprintApiUrl,
+            $this->stateDirectory,
+            $this->rawFileRoot,
+            'files-push'
+        );
+        $processLock = new \ReprintProcessLock($this->stateDirectory);
+        try {
+            $sender = \PushFilesSender::start([
+                'filesystem_root' => $this->rawFileRoot,
+                'push_state_directory' => $pushStateDirectory,
+                'remote_reprint_api_url' =>
+                    $remoteReprintApiUrl,
+                'hmac_client' => new \Site_Export_HMAC_Client('secret'),
+                'allow_http' => true,
+            ], $processLock);
+            $sender->close();
+        } finally {
+            $processLock->close();
+        }
+
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(1, $pull['exit'], $pull['output']);
+        $this->assertStringContainsString(
+            'Finish the unfinished files-push before running files-pull.',
+            $pull['output']
+        );
+    }
+
+    public function testDeltaPullUpdatesOnlyThePathsItChanges(): void
+    {
+        $this->completeFilesPull();
+        file_put_contents($this->localTree . '/edited.txt', 'longer local edit');
+        unlink($this->localTree . '/deleted.txt');
+        $pulledContents = 'remote change delivered by the second pull';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+            'removed_paths' => ['unchanged.txt'],
+        ]);
+
+        $this->abortFilesPull();
+        $delta = $this->runFilesPull();
+
+        $this->assertSame(0, $delta['exit'], $delta['output']);
+        $this->assertSame('longer local edit', file_get_contents($this->localTree . '/edited.txt'));
+        $this->assertSame($pulledContents, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertFileDoesNotExist($this->localTree . '/unchanged.txt');
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $records = $this->filesDiffRecords($diff['stdout']);
+        $complete = array_pop($records);
+        $this->assertSame([
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 1,
+            'local_paths_to_delete' => 1,
+        ], $complete);
+        $this->assertSame([
+            $this->expectedPushRecord('edited.txt'),
+            [
+                'command' => 'files-diff',
+                'action' => 'delete',
+                'path_b64' => base64_encode(
+                    $this->localIndexEntryPath('deleted.txt')
+                ),
+            ],
+        ], $records);
+    }
+
+    public function testResumeReplaysTheWALIntoTheLocalIndex(): void
+    {
+        $this->completeFilesPull();
+        $pulledContents = 'complete file retained in the WAL before interruption';
+        $this->interruptPullAfterFile($pulledContents);
+        $walPath = $this->pullStateDirectory . '/index.wal';
+
+        $this->assertFileExists($walPath);
+        $blockedDiff = $this->runFilesDiff();
+        $this->assertSame(1, $blockedDiff['exit'], $blockedDiff['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull',
+            $blockedDiff['output']
+        );
+        $blockedPush = $this->runCli([
+            'files-push',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+            '--secret=secret',
+            '--force-http',
+        ]);
+        $this->assertSame(1, $blockedPush['exit'], $blockedPush['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull',
+            $blockedPush['output']
+        );
+
+        $resumed = $this->runFilesPull();
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0]['local_paths_to_push']);
+    }
+
+    public function testAbortReplaysTheWALAndKeepsTheLocalIndexUsable(): void
+    {
+        $this->completeFilesPull();
+        $this->interruptPullAfterFile('complete file retained before abort');
+        $walPath = $this->pullStateDirectory . '/index.wal';
+        $this->assertFileExists($walPath);
+
+        $abort = $this->runFilesPull(['--abort']);
+
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $this->assertFileDoesNotExist($walPath);
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    /**
+     * @dataProvider partialPullProvider
+     * @param list<string> $arguments
+     */
+    public function testFilesPullKeepsLocalIndexEntriesForPathsItDoesNotChange(
+        array $arguments
+    ): void {
+        $this->completeFilesPull();
+        $before = $this->readIndex($this->localIndexPath());
+        $pulledContents = 'partial pull change';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $after = $this->readIndex($this->localIndexPath());
+        $this->assertSame(
+            $before[$this->localIndexEntryPath('unchanged.txt')],
+            $after[$this->localIndexEntryPath('unchanged.txt')]
+        );
+        $this->assertSame(
+            $pulledContents,
+            file_get_contents(
+                $this->localTree . '/' . self::PULLED_PATH
+            )
+        );
+        $this->assertLocalIndexMatches(self::PULLED_PATH);
+    }
+
+    /** @return iterable<string,array{list<string>}> */
+    public static function partialPullProvider(): iterable
+    {
+        yield 'selected directory' => [[
+            '--only=/var/www/html/selected',
+        ]];
+        yield 'filtered files' => [[
+            '--filter=essential-files',
+        ]];
+        yield 'preserve local files' => [[
+            '--on-fs-root-nonempty=preserve-local',
+        ]];
+    }
+
+    public function testRemappedPullKeepsUnrelatedLocalIndexEntries(): void
+    {
+        $arguments = [
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/var/www/html/remapped',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $remappedUnchangedPath = $this->localIndexEntryPath(
+            'remapped/unchanged.txt'
+        );
+        $before = $this->readIndex(
+            $this->localIndexPath()
+        )[$remappedUnchangedPath];
+        $pulledContents = 'remapped pull change';
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame(
+            $pulledContents,
+            file_get_contents($this->localTree . '/remapped/' . self::PULLED_PATH)
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertSame($before, $index[$remappedUnchangedPath]);
+        $this->assertArrayHasKey(
+            $this->localIndexEntryPath('remapped/' . self::PULLED_PATH),
+            $index
+        );
+    }
+
+    public function testPulledDeletionRemovesTheDerivedDirectoryRoot(): void
+    {
+        $this->completeFilesPull();
+        file_put_contents($this->localTree . '/folder/local-added.txt', 'local addition');
+        $this->writeRemoteOverrides([
+            'removed_paths' => ['folder/remote-deleted.txt'],
+        ]);
+
+        $this->abortFilesPull();
+        $pull = $this->runFilesPull([
+            '--only=/var/www/html/folder',
+        ]);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree . '/folder');
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('folder'),
+            $index
+        );
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('folder/remote-deleted.txt'),
+            $index
+        );
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('folder/local-added.txt'),
+            $index
+        );
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testPulledDirectoryDeletionRemovesItsLocalIndexSubtree(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_directories' => ['removed-tree'],
+            'added_files' => [
+                'removed-tree/child.txt' => 'remote child',
+            ],
+        ]);
+        $this->completeFilesPull();
+        $this->assertFileExists($this->localTree . '/removed-tree/child.txt');
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([]);
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree . '/removed-tree');
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('removed-tree'),
+            $index
+        );
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('removed-tree/child.txt'),
+            $index
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0]['local_paths_to_push']);
+    }
+
+    private function completeFilesPull(): void
+    {
+        $result = $this->runFilesPull();
+        $this->assertSame(0, $result['exit'], $result['output']);
+    }
+
+    private function abortFilesPull(): void
+    {
+        $result = $this->runFilesPull(['--abort']);
+        $this->assertSame(0, $result['exit'], $result['output']);
+    }
+
+    private function interruptPullAfterFile(string $contents): void
+    {
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($contents),
+            'pause_before_response_end' => true,
+        ]);
+        [$process, $pipes] = $this->startCliProcess([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+        $readyPath = $this->root . '/remote-overrides.json.pause-ready';
+        $walPath = $this->pullStateDirectory . '/index.wal';
+        $deadline = microtime(true) + 10;
+        while (
+            ( !is_file($readyPath) || !is_file($walPath) || filesize($walPath) === 0 )
+            && microtime(true) < $deadline
+        ) {
+            clearstatcache(true, $walPath);
+            usleep(20000);
+        }
+        $this->assertFileExists($readyPath);
+        $this->assertFileExists($walPath);
+        $this->assertGreaterThan(0, filesize($walPath));
+
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+        file_put_contents($this->root . '/remote-overrides.json.pause-release', '');
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($contents),
+        ]);
+    }
+
+    private function assertLocalIndexMatches(string $path): void
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        $entry = $this->readIndex($this->localIndexPath())[
+            $this->localIndexEntryPath($path)
+        ];
+        $this->assertSame( (int) $stat['ctime'], $entry['ctime']);
+        $this->assertSame( (int) $stat['size'], $entry['size']);
+    }
+
+    /** @return array{command:string,action:string,path_b64:string,type:string,size:int,ctime:int} */
+    private function expectedPushRecord(string $path): array
+    {
+        $stat = lstat($this->localTree . '/' . $path);
+        $this->assertIsArray($stat);
+        return [
+            'command' => 'files-diff',
+            'action' => 'push',
+            'path_b64' => base64_encode(
+                $this->localIndexEntryPath($path)
+            ),
+            'type' => 'file',
+            'size' => (int) $stat['size'],
+            'ctime' => (int) $stat['ctime'],
+        ];
+    }
+
+    /** @param array<string,mixed> $overrides */
+    private function writeRemoteOverrides(array $overrides): void
+    {
+        file_put_contents(
+            $this->root . '/remote-overrides.json',
+            json_encode($overrides, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+    }
+
+    /** @param list<string> $extraArguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runFilesPull(array $extraArguments = []): array
+    {
+        return $this->runCli(array_merge([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ], $extraArguments));
+    }
+
+    /** @return array{exit:int,stdout:string,stderr:string,output:string} */
+    private function runFilesDiff(): array
+    {
+        return $this->runCli([
+            'files-diff',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+        ]);
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        [$process, $pipes] = $this->startCliProcess($arguments);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{0:resource,1:array<int,resource>}
+     */
+    private function startCliProcess(array $arguments): array
+    {
+        $process = proc_open(
+            array_merge([PHP_BINARY, __DIR__ . '/../../importer/import.php'], $arguments),
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function filesDiffRecords(string $output): array
+    {
+        $records = [];
+        foreach (preg_split('/\R/', trim($output)) ?: [] as $line) {
+            $record = json_decode($line, true);
+            if (is_array($record) && ( $record['command'] ?? null ) === 'files-diff') {
+                $records[] = $record;
+            }
+        }
+        return $records;
+    }
+
+    /** @return array<string,array{path:string,type:string,size:int,ctime:int,empty?:bool}> */
+    private function readIndex(string $path): array
+    {
+        $entries = [];
+        $lines = file(
+            $path,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        foreach ($lines as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $decodedPath = base64_decode($entry['path']);
+            $entries[$decodedPath] = [
+                'path' => $decodedPath,
+                'type' => $entry['type'],
+                'size' => $entry['size'],
+                'ctime' => $entry['ctime'],
+            ];
+            if (array_key_exists('empty', $entry)) {
+                $entries[$decodedPath]['empty'] = $entry['empty'];
+            }
+        }
+        return $entries;
+    }
+
+    private function localIndexPath(): string
+    {
+        return $this->remoteStateDirectory . '/local_index.jsonl';
+    }
+
+    private function localIndexEntryPath(string $siteRelativePath = ''): string
+    {
+        return 'var/www/html'
+            . ( $siteRelativePath === ''
+                ? ''
+                : '/' . ltrim($siteRelativePath, '/') );
+    }
+
+    private function writePullState(): void
+    {
+        mkdir($this->pullStateDirectory, 0700, true);
+        $state = new \PullState();
+        $state->preflight = [
+            'http_code' => 200,
+            'data' => [
+                'ok' => true,
+                'runtime' => [
+                    'document_root' =>
+                        'base64:'
+                        . base64_encode('/var/www/html'),
+                ],
+                'wp_detect' => [
+                    'roots' => [[
+                        'path' =>
+                            'base64:'
+                            . base64_encode('/var/www/html'),
+                    ]],
+                ],
+                'database' => [
+                    'wp' => [
+                        'paths_urls' => [
+                            'content_dir' => '/var/www/html/wp-content',
+                            'uploads' => [
+                                'basedir' => '/var/www/html/wp-content/uploads',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        file_put_contents(
+            $this->pullStateDirectory . '/state.json',
+            json_encode(
+                $state->to_array(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            )
+        );
+        file_put_contents(
+            $this->pullStateDirectory . '/remote-index.jsonl',
+            ''
+        );
+    }
+
+    private function startIndexServer(): string
+    {
+        $remoteFiles = $this->remoteFiles;
+        $remoteFiles[self::PULLED_PATH] = self::PULLED_CONTENTS;
+        $router = $this->root . '/index-server.php';
+        file_put_contents($router, sprintf(<<<'PHP'
+<?php
+$base_remote_files = json_decode(base64_decode('%s'), true);
+$pulled_path = base64_decode('%s');
+$overrides_path = base64_decode('%s');
+$overrides = is_file($overrides_path)
+    ? json_decode((string) file_get_contents($overrides_path), true)
+    : array();
+$remote_files = $base_remote_files;
+$pulled_ctime = 41;
+if (isset($overrides['pulled_contents_b64'])) {
+    $remote_files[$pulled_path] = base64_decode($overrides['pulled_contents_b64']);
+}
+if (isset($overrides['pulled_ctime'])) {
+    $pulled_ctime = (int) $overrides['pulled_ctime'];
+}
+foreach (($overrides['removed_paths'] ?? array()) as $removed_path) {
+    unset($remote_files[$removed_path]);
+}
+foreach (($overrides['added_files'] ?? array()) as $path => $contents) {
+    $remote_files[$path] = $contents;
+}
+$added_directories = array_fill_keys(
+    $overrides['added_directories'] ?? array(),
+    true
+);
+$added_files = array_fill_keys(
+    array_keys($overrides['added_files'] ?? array()),
+    true
+);
+$remote_index = array();
+foreach ($remote_files as $path => $contents) {
+    $remote_index['/var/www/html/' . $path] = array(
+        'path' => base64_encode('/var/www/html/' . $path),
+        'ctime' => $path === $pulled_path
+            ? $pulled_ctime
+            : (isset($added_files[$path]) ? 43 : 41),
+        'size' => strlen($contents),
+        'type' => 'file',
+    );
+}
+foreach ($added_directories as $path => $_) {
+    $remote_index['/var/www/html/' . $path] = array(
+        'path' => base64_encode('/var/www/html/' . $path),
+        'ctime' => 43,
+        'size' => 0,
+        'type' => 'dir',
+    );
+}
+uksort($remote_index, static function (string $left, string $right): int {
+    return strcmp(
+        str_replace('/', "\0", $left),
+        str_replace('/', "\0", $right)
+    );
+});
+
+$endpoint = $_GET['endpoint'] ?? null;
+$request_cursor = $_GET['cursor'] ?? null;
+$selected_directories = $_GET['directory'] ?? array();
+if ($endpoint === 'file_index' && count($selected_directories) > 0) {
+    $remote_index = array_filter(
+        $remote_index,
+        static function (array $entry) use ($selected_directories): bool {
+            $path = base64_decode($entry['path']);
+            foreach ($selected_directories as $directory) {
+                $directory = rtrim($directory, '/');
+                if ($path === $directory || strpos($path, $directory . '/') === 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    );
+}
+
+if ($endpoint === 'preflight') {
+    header('Content-Type: application/json');
+    echo json_encode(array(
+        'ok' => true,
+        'runtime' => array(
+            'document_root' => '/var/www/html',
+            'ini_get_all' => array(),
+        ),
+        'wp_detect' => array(
+            'roots' => array(array('path' => '/var/www/html')),
+        ),
+        'database' => array(
+            'wp' => array(
+                'wp_version' => '6.0-test',
+                'table_prefix' => 'wp_',
+                'paths_urls' => array(
+                    'abspath' => '/var/www/html',
+                    'content_dir' => '/var/www/html/wp-content',
+                    'uploads' => array(
+                        'basedir' => '/var/www/html/wp-content/uploads',
+                    ),
+                ),
+            ),
+        ),
+        'limits' => array('max_request_bytes' => 4194304),
+    ), JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$boundary = 'reprint-files-pull-local-index-test';
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+$write_part = static function (array $headers, string $body = '') use ($boundary): void {
+    echo "--{$boundary}\r\n";
+    foreach ($headers as $name => $value) {
+        echo $name . ': ' . $value . "\r\n";
+    }
+    echo 'Content-Length: ' . strlen($body) . "\r\n\r\n";
+    echo $body . "\r\n";
+};
+
+if ($endpoint === 'file_index') {
+    $write_part(
+        array('X-Chunk-Type' => 'index_batch'),
+        json_encode(array_values($remote_index), JSON_UNESCAPED_SLASHES)
+    );
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Total-Entries' => count($remote_index),
+    ));
+} elseif ($endpoint === 'file_fetch') {
+    $requested_paths = null;
+    if (
+        isset($_FILES['file_list']['tmp_name'])
+        && is_file($_FILES['file_list']['tmp_name'])
+    ) {
+        $requested_paths = array_fill_keys(
+            json_decode((string) file_get_contents($_FILES['file_list']['tmp_name']), true),
+            true
+        );
+    }
+    $parts = array();
+    foreach ($remote_index as $path => $entry) {
+        if ($requested_paths !== null && !isset($requested_paths[$path])) {
+            continue;
+        }
+        $relative_path = substr($path, strlen('/var/www/html/'));
+        $parts[] = array(
+            'path' => $path,
+            'entry' => $entry,
+            'contents' => $entry['type'] === 'file' ? $remote_files[$relative_path] : '',
+            'cursor' => 'path-' . sha1($path),
+        );
+    }
+    $cursor_reached = $request_cursor === null;
+    $files_completed = 0;
+    $bytes_processed = 0;
+    foreach ($parts as $part) {
+        if (!$cursor_reached) {
+            if ($part['cursor'] === $request_cursor) {
+                $cursor_reached = true;
+            }
+            continue;
+        }
+        if ($part['entry']['type'] === 'dir') {
+            $write_part(array(
+                'X-Chunk-Type' => 'directory',
+                'X-Directory-Path' => $part['entry']['path'],
+                'X-Directory-Ctime' => $part['entry']['ctime'],
+                'X-Cursor' => $part['cursor'],
+            ));
+        } else {
+            $write_part(array(
+                'X-Chunk-Type' => 'file',
+                'X-File-Path' => $part['entry']['path'],
+                'X-File-Ctime' => $part['entry']['ctime'],
+                'X-File-Size' => strlen($part['contents']),
+                'X-First-Chunk' => 1,
+                'X-Last-Chunk' => 1,
+                'X-Cursor' => $part['cursor'],
+            ), $part['contents']);
+            $bytes_processed += strlen($part['contents']);
+        }
+        ++$files_completed;
+    }
+    $completion_body = !empty($overrides['pause_before_response_end'])
+        ? str_repeat(' ', 65536)
+        : '';
+    $write_part(array(
+        'X-Chunk-Type' => 'completion',
+        'X-Status' => 'complete',
+        'X-Files-Completed' => $files_completed,
+        'X-Bytes-Processed' => $bytes_processed,
+    ), $completion_body);
+    if (!empty($overrides['pause_before_response_end'])) {
+        if (ob_get_level() > 0) {
+            ob_flush();
+        }
+        flush();
+        file_put_contents($overrides_path . '.pause-ready', '');
+        while (!is_file($overrides_path . '.pause-release')) {
+            usleep(20000);
+        }
+    }
+} else {
+    $write_part(array(
+        'X-Chunk-Type' => 'error',
+        'X-Status' => 'failed',
+    ), json_encode(array('message' => 'Unexpected endpoint')));
+}
+echo "--{$boundary}--\r\n";
+PHP,
+            base64_encode( (string) json_encode($remoteFiles)),
+            base64_encode(self::PULLED_PATH),
+            base64_encode($this->root . '/remote-overrides.json')
+        ));
+
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $this->serverPipes,
+            $this->root
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen('127.0.0.1', $port, $errorNumber, $errorMessage, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Local index server did not start.');
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/LocalIndexUpdateFunctionsTest.php
+++ b/tests/Import/LocalIndexUpdateFunctionsTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\TestCase;
 use function Reprint\Importer\merge_local_index_mutations;
 
 require_once __DIR__ . '/../../importer/import.php';
-require_once __DIR__
-    . '/../../packages/reprint-importer/src/lib/local-index-update-functions.php';
 
 final class LocalIndexUpdateFunctionsTest extends TestCase
 {

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -38,13 +38,16 @@ final class PullIndexWalTest extends TestCase
         $this->removeTree($this->root);
     }
 
-    public function testAppliedBatchLeavesThePullIndexWalMarkerUntilCompletion(): void
+    public function testAppliedBatchAdvancesBothIndexesAndLeavesTheMarker(): void
     {
+        mkdir($this->fileRoot . '/site');
+        file_put_contents($this->fileRoot . '/site/file.txt', 'hello');
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('upsert_remote_index_entry')->invoke(
+        $reflection->getMethod('record_pulled_path')->invoke(
             $client,
             '/site/file.txt',
+            (string) realpath($this->fileRoot . '/site/file.txt'),
             42,
             5,
             'file'
@@ -58,6 +61,15 @@ final class PullIndexWalTest extends TestCase
             '/site/file.txt',
             $this->firstRemoteIndexEntryPath()
         );
+        $localIndexEntries = $this->readLocalIndex();
+        $this->assertSame(['site/file.txt'], array_keys($localIndexEntries));
+        $localStat = lstat($this->fileRoot . '/site/file.txt');
+        $this->assertIsArray($localStat);
+        $this->assertSame(
+            (int) $localStat['ctime'],
+            $localIndexEntries['site/file.txt']['ctime']
+        );
+        $this->assertSame(5, $localIndexEntries['site/file.txt']['size']);
 
         $reflection->getMethod('remove_pull_index_wal')->invoke($client);
         $this->assertFileDoesNotExist($pullIndexWalPath);
@@ -74,9 +86,12 @@ final class PullIndexWalTest extends TestCase
             5,
             'file'
         );
+        $filesystemRoot = realpath($this->fileRoot);
+        $this->assertIsString($filesystemRoot);
         $reflection->getMethod('wal_append_successful_deletion')->invoke(
             $client,
-            '/site/file.txt'
+            '/site/file.txt',
+            $filesystemRoot . '/site/file.txt'
         );
         $reflection->getMethod('wal_append_remote_index_invalidation')->invoke(
             $client,
@@ -90,6 +105,8 @@ final class PullIndexWalTest extends TestCase
             . "\n"
             . '{"op":"-","remote_absolute_path_b64":"'
             . base64_encode('/site/file.txt')
+            . '","local_relative_path_b64":"'
+            . base64_encode('site/file.txt')
             . '"}'
             . "\n"
             . '{"op":"-","remote_absolute_path_b64":"'
@@ -260,6 +277,24 @@ final class PullIndexWalTest extends TestCase
             },
             $lines
         );
+    }
+
+    /** @return array<string,array<string,mixed>> */
+    private function readLocalIndex(): array
+    {
+        $lines = file(
+            dirname($this->pullStateDirectory) . '/local_index.jsonl',
+            FILE_IGNORE_NEW_LINES
+        );
+        $this->assertIsArray($lines);
+        $entries = [];
+        foreach ($lines as $line) {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $path = base64_decode( (string) $entry['path']);
+            $this->assertIsString($path);
+            $entries[$path] = $entry;
+        }
+        return $entries;
     }
 
     private function removeTree(string $path): void

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -57,6 +57,7 @@ final class ReprintProcessLockTest extends TestCase
         $expected_paths = [
             'state_dir' => $this->root . '/state',
             'pull_state_directory' => $pull_state_directory,
+            'local_index_file' => $remote_state_directory . '/local_index.jsonl',
             'pull_state_file' => $pull_state_directory . '/state.json',
             'remote_index_file' => $pull_state_directory . '/remote-index.jsonl',
             'pull_index_wal_path' => $pull_state_directory . '/index.wal',

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -131,6 +131,19 @@ final class SortIndexFileTest extends TestCase
         $this->assertFalse(sort_index_file($this->temporary_directory . '/missing.jsonl'));
     }
 
+    public function testSortsLocalIndexRelativePaths(): void
+    {
+        $path = $this->temporary_directory . '/local-index.jsonl';
+        file_put_contents($path, implode("\n", [
+            $this->index_line('zebra', 3),
+            $this->index_line('apple', 2),
+            $this->index_line('banana', 4),
+        ]));
+
+        $this->assertTrue(sort_index_file($path));
+        $this->assertSame(['apple', 'banana', 'zebra'], $this->index_paths($path));
+    }
+
     public function testImporterRejectsAMissingNextRemoteIndex(): void
     {
         $client = new \ImportClient(


### PR DESCRIPTION
`files-pull` now advances the local index for every completed local mutation. The next `files-diff` or PushPlan no longer selects a pulled change as a local change to push.

## Why this is needed

Before this PR, files-pull changed the filesystem and updated only the remote index. That was enough for the next files-pull: the remote index records which remote state was already accounted for.

Files-push does not use that remote index. PushPlan compares the filesystem root with the local index, which previously changed only after a target-confirmed files-push commit. Files-pull could therefore download a file while leaving the local index on its older version:

```text
before files-pull:
    local index:      file.txt  file, size 1, ctime 10
    filesystem root:  file.txt  file, size 1, ctime 10

files-pull downloads a newer file:
    local index:      file.txt  file, size 1, ctime 10
    filesystem root:  file.txt  file, size 4, ctime 12

next files-diff:
    push file.txt
```

The pull itself did not need a local index update, but the next push did. Without it, PushPlan treated the downloaded file as a local edit and selected it for upload.

## This change

After files-pull completes a non-skipped file, symlink, empty directory, or deletion mutation beneath the filesystem root, its pull index WAL record also describes the resulting local index update. Applying the WAL advances both indexes:

```text
after files-pull:
    remote index:     /srv/site/file.txt  file, size 4, ctime 12
    local index:      file.txt            file, size 4, ctime 12
    filesystem root:  file.txt            file, size 4, ctime 12

next files-diff:
    no change
```

Only paths actually changed by files-pull advance in the local index. There is no filesystem-root scan, so unrelated local additions, edits, and deletions remain available to `files-diff` and PushPlan. A failed download, rejected pull mapping, or failed local deletion updates only the remote index because no local mutation completed.

The pull index WAL is applied to the remote index first and the local index second. It is cleared only after both replacements finish, so resume and abort can apply the same completed mutations.

## Testing

The importer suite covers initial and delta pulls, resume, abort, selected and filtered paths, preserve-local behavior, pull mappings, files, symlinks, empty directories, and deletions.

