### PR TITLE
Reject file commands which cross unfinished pull and push lifecycles

### DIFF
--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -248,7 +248,9 @@ Call the single pull-side write-ahead log the **remote index WAL**. It lives at
 Applied batch records are cleared, but the empty WAL remains as a marker until
 files-pull completes. A retained WAL is consumed only while resuming or
 aborting the interrupted files-pull, including through a high-level pull
-command; unrelated commands do not consume it.
+command. Files-diff and files-push reject the unfinished files-pull instead of
+consuming its WAL. Files-pull rejects an unfinished files-push while
+`<remote-state-directory>/push/sender.json` exists.
 
 ## Local index and push state
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -847,10 +847,20 @@ class ImportClient
         // files-diff and files-push use local push state and must not load
         // or write the pull command's pull/state.json file.
         if ($command === "files-diff") {
+            if (is_file($this->remote_index_wal_path)) {
+                throw new RuntimeException(
+                    "Finish or abort the interrupted files-pull before running files-diff."
+                );
+            }
             $this->run_files_diff($options);
             return;
         }
         if ($command === "files-push") {
+            if (is_file($this->remote_index_wal_path)) {
+                throw new RuntimeException(
+                    "Finish or abort the interrupted files-pull before running files-push."
+                );
+            }
             $this->run_files_push($options, $process_lock);
             return;
         }
@@ -2582,6 +2592,14 @@ class ImportClient
      */
     public function run_files_pull(): void
     {
+        $sender_state_path = dirname($this->pull_state_directory)
+            . "/push/sender.json";
+        if (is_file($sender_state_path)) {
+            throw new RuntimeException(
+                "Finish the unfinished files-push before running files-pull."
+            );
+        }
+
         $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
 
         $current_status =
@@ -2676,6 +2694,9 @@ class ImportClient
                 );
             }
 
+            // The marker blocks files-diff and files-push before the first
+            // pull checkpoint can make this lifecycle resumable.
+            $this->open_remote_index_wal();
             $this->get_state()->active_resumable_command->command_name = "files-pull";
             $this->get_state()->active_resumable_command->completion_state = "in_progress";
             $this->get_state()->active_resumable_command->current_stage = "index";

--- a/tests/Import/IndexLifecycleOwnershipTest.php
+++ b/tests/Import/IndexLifecycleOwnershipTest.php
@@ -1,0 +1,162 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+final class IndexLifecycleOwnershipTest extends TestCase
+{
+    private string $root;
+    private string $stateDirectory;
+    private string $filesystemRoot;
+    private string $remoteReprintApiUrl =
+        'https://example.test/export.php?site-export-api';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir()
+            . '/index-lifecycle-ownership-'
+            . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->filesystemRoot = $this->root . '/filesystem-root';
+        mkdir($this->stateDirectory, 0700, true);
+        mkdir($this->filesystemRoot, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider commandBlockedByFilesPullProvider
+     * @param list<string> $extraArguments
+     */
+    public function testUnfinishedFilesPullBlocksLocalIndexCommands(
+        string $command,
+        array $extraArguments
+    ): void {
+        mkdir($this->pullStateDirectory(), 0700, true);
+        file_put_contents(
+            $this->pullStateDirectory() . '/remote-index.wal',
+            ''
+        );
+
+        $result = $this->runCli(array_merge([
+            $command,
+            $this->remoteReprintApiUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->filesystemRoot,
+        ], $extraArguments));
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertStringContainsString(
+            'Finish or abort the interrupted files-pull before running '
+                . $command,
+            $result['output']
+        );
+    }
+
+    /**
+     * @return array<string,array{string,list<string>}>
+     */
+    public static function commandBlockedByFilesPullProvider(): array
+    {
+        return [
+            'files-diff' => ['files-diff', []],
+            'files-push' => [
+                'files-push',
+                ['--secret=secret', '--force-http'],
+            ],
+        ];
+    }
+
+    public function testUnfinishedFilesPushBlocksFilesPull(): void
+    {
+        $pushStateDirectory = $this->remoteStateDirectory() . '/push';
+        mkdir($pushStateDirectory, 0700, true);
+        file_put_contents($pushStateDirectory . '/sender.json', "{}\n");
+
+        $client = new \ImportClient(
+            $this->remoteReprintApiUrl,
+            $this->stateDirectory,
+            $this->filesystemRoot
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Finish the unfinished files-push before running files-pull.'
+        );
+        $client->run_files_pull();
+    }
+
+    private function pullStateDirectory(): string
+    {
+        return $this->remoteStateDirectory() . '/pull';
+    }
+
+    private function remoteStateDirectory(): string
+    {
+        return realpath($this->stateDirectory)
+            . '/remotes/'
+            . md5(rtrim($this->remoteReprintApiUrl, '?&'));
+    }
+
+    /**
+     * @param list<string> $arguments
+     * @return array{exit:int,stdout:string,stderr:string,output:string}
+     */
+    private function runCli(array $arguments): array
+    {
+        $process = proc_open(
+            array_merge([
+                PHP_BINARY,
+                __DIR__ . '/../../importer/import.php',
+            ], $arguments),
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $child = $path . '/' . $entry;
+            if (is_dir($child) && !is_link($child)) {
+                $this->removeTree($child);
+            } else {
+                @unlink($child);
+            }
+        }
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
File commands now reject index state owned by another unfinished file lifecycle.

An empty `pull/remote-index.wal` marks an unfinished `files-pull`. `files-diff` and `files-push` reject that marker instead of reading or replacing index state while the pull is open. A fresh pull creates the marker before its first resumable checkpoint.

`files-pull` also rejects `push/sender.json`, which means an unfinished `files-push` still owns the retained local index.

This follows #434 and is the base of #448 and #446.

## Testing

The focused importer suite passes 20 tests with 1,135 assertions and one skipped test. PHPStan, PHP 7.4 compatibility, PHP syntax, PHPCS violation-count checks, and `git diff --check` pass.
