### PR TITLE
Reject pull state with removed skipped-file fields

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10983,19 +10983,6 @@ class ImportClient
             return new PullState();
         }
 
-        if (
-            array_key_exists("fetch_skipped", $state) &&
-            isset($state["pull_pipeline"]) &&
-            is_array($state["pull_pipeline"]) &&
-            array_key_exists("files_filter", $state["pull_pipeline"]) &&
-            array_key_exists("skipped_pending", $state["pull_pipeline"])
-        ) {
-            unset(
-                $state["fetch_skipped"],
-                $state["pull_pipeline"]["files_filter"],
-                $state["pull_pipeline"]["skipped_pending"]
-            );
-        }
         $state = $this->decode_state_paths($state);
 
         return PullState::from_array($state);

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -368,7 +368,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->runFilesPull(array('exclude' => array(':wp-uploads:')));
     }
 
-    public function testRunDropsSkippedFieldsWithoutChangingPathSelectionState(): void
+    public function testRunRejectsSkippedFieldsFromThePreviousStateSchema(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
         $fingerprint = $this->pathSelectionFingerprint(
@@ -388,16 +388,9 @@ class OnlyFilesPathPrefixTest extends TestCase
             json_encode($state, JSON_PRETTY_PRINT)
         );
 
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('unexpected fetch_skipped');
         $this->runFilesPull(array('filter' => 'essential-files'));
-
-        $state = $this->readState();
-        $this->assertSame(
-            $fingerprint,
-            $state['files_pull_path_selection_fingerprint'] ?? null
-        );
-        $this->assertArrayNotHasKey('fetch_skipped', $state);
-        $this->assertArrayNotHasKey('files_filter', $state['pull_pipeline']);
-        $this->assertArrayNotHasKey('skipped_pending', $state['pull_pipeline']);
     }
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void


### PR DESCRIPTION
Pull state files containing the removed skipped-file fields now fail exact-schema validation instead of being silently rewritten during load.

This removes the old-state migration for `fetch_skipped`, `files_filter`, and `skipped_pending`. The existing schema error names the unexpected field, and callers must start with current pull state.

## Testing

The path-selection, pull-state, and pull-pipeline test suites pass. PHPStan reports no errors.
