### PR TITLE
Emit file-index directory entries only for empty directories

### DIFF
--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -47,9 +47,6 @@ final class FileIndexProcessor {
     /** @var bool Whether generated caches and development files are included. */
     private $include_caches;
 
-    /** @var bool Whether a caller needs non-empty directory rows for a transient plan. */
-    private $include_non_empty_directories;
-
     /** @var string Canonical Reprint storage path omitted from the index, or an empty string. */
     private $storage_path;
 
@@ -90,8 +87,7 @@ final class FileIndexProcessor {
      * @param string   $index_directory Directory where traversal begins.
      * @param bool     $follow_symlinks  Whether directory symlinks may lead outside the allowed directories.
      * @param bool     $include_caches   Whether generated caches and development files are included.
-     * @param string   $storage_path                    Reprint storage path omitted from the index, or an empty string.
-     * @param bool     $include_non_empty_directories   Whether to retain non-empty directory rows for a transient plan.
+     * @param string   $storage_path     Reprint storage path omitted from the index, or an empty string.
      * @return self New file-index processor.
      */
     public static function start(
@@ -99,8 +95,7 @@ final class FileIndexProcessor {
         string $index_directory,
         bool $follow_symlinks,
         bool $include_caches,
-        string $storage_path,
-        bool $include_non_empty_directories = false
+        string $storage_path
     ): self {
         // Anchor traversal to a real directory. All later comparisons use
         // canonical paths so configured roots and followed links share one
@@ -173,7 +168,6 @@ final class FileIndexProcessor {
             $follow_symlinks,
             $include_caches,
             $storage_path,
-            $include_non_empty_directories,
             $directory_stack,
             $canonical_index_directory,
             $initial_index_entries
@@ -187,8 +181,7 @@ final class FileIndexProcessor {
      * @param string   $cursor_json     JSON cursor returned by the preceding request.
      * @param bool     $follow_symlinks Whether directory symlinks may lead outside the allowed directories.
      * @param bool     $include_caches  Whether generated caches and development files are included.
-     * @param string   $storage_path                   Reprint storage path omitted from the index, or an empty string.
-     * @param bool     $include_non_empty_directories Whether to retain non-empty directory rows for a transient plan.
+     * @param string   $storage_path    Reprint storage path omitted from the index, or an empty string.
      * @return self Resumed file-index processor.
      */
     public static function resume(
@@ -196,8 +189,7 @@ final class FileIndexProcessor {
         string $cursor_json,
         bool $follow_symlinks,
         bool $include_caches,
-        string $storage_path,
-        bool $include_non_empty_directories = false
+        string $storage_path
     ): self {
         // A cursor is caller-held continuation state. Reject malformed JSON or
         // a missing stack before any filesystem work begins.
@@ -256,7 +248,6 @@ final class FileIndexProcessor {
             $follow_symlinks,
             $include_caches,
             $storage_path,
-            $include_non_empty_directories,
             $directory_stack,
             $index_directory,
             []
@@ -407,8 +398,7 @@ final class FileIndexProcessor {
         // A descendant implies its non-empty ancestors. Keep explicit rows
         // only for empty directories, which have no descendant to imply them.
         if (
-            $this->include_non_empty_directories
-            || $type !== "dir"
+            $type !== "dir"
             || !isset($item["empty"])
             || $item["empty"]
         ) {
@@ -599,8 +589,7 @@ final class FileIndexProcessor {
      * @param string[] $directories          Canonical directories allowed during traversal.
      * @param bool     $follow_symlinks      Whether directory symlinks may leave the allowed directories.
      * @param bool     $include_caches       Whether generated caches and development files are included.
-     * @param string   $storage_path                    Reprint storage path omitted from the index, or an empty string.
-     * @param bool     $include_non_empty_directories   Whether to retain non-empty directory rows for a transient plan.
+     * @param string   $storage_path         Reprint storage path omitted from the index, or an empty string.
      * @param array[]  $directory_stack      Active directory stack.
      * @param string   $index_directory      Directory reported by the endpoint.
      * @param array[]  $initial_index_entries Intermediate symlinks emitted before traversal.
@@ -610,7 +599,6 @@ final class FileIndexProcessor {
         bool $follow_symlinks,
         bool $include_caches,
         string $storage_path,
-        bool $include_non_empty_directories,
         array $directory_stack,
         string $index_directory,
         array $initial_index_entries
@@ -619,7 +607,6 @@ final class FileIndexProcessor {
         $this->follow_symlinks = $follow_symlinks;
         $this->include_caches = $include_caches;
         $this->storage_path = self::canonical_storage_path($storage_path);
-        $this->include_non_empty_directories = $include_non_empty_directories;
         $this->directory_stack = $directory_stack;
         $this->index_directory = $index_directory;
         $this->initial_index_entries = $initial_index_entries;

--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -15,7 +15,7 @@
  * directories and continues after those names. Directory names remain sorted
  * exactly as they were in endpoint_file_index() before this extraction.
  *
- * One step either produces one or more index entries for one filesystem path,
+ * One step either produces zero or more index entries for one filesystem path,
  * skips one path, reports one directory failure, or finishes one directory.
  * Following a symlink may produce additional intermediate-symlink entries in
  * the same step because they share the path's cursor boundary.
@@ -46,6 +46,9 @@ final class FileIndexProcessor {
 
     /** @var bool Whether generated caches and development files are included. */
     private $include_caches;
+
+    /** @var bool Whether a caller needs non-empty directory rows for a transient plan. */
+    private $include_non_empty_directories;
 
     /** @var string Canonical Reprint storage path omitted from the index, or an empty string. */
     private $storage_path;
@@ -87,7 +90,8 @@ final class FileIndexProcessor {
      * @param string   $index_directory Directory where traversal begins.
      * @param bool     $follow_symlinks  Whether directory symlinks may lead outside the allowed directories.
      * @param bool     $include_caches   Whether generated caches and development files are included.
-     * @param string   $storage_path     Reprint storage path omitted from the index, or an empty string.
+     * @param string   $storage_path                    Reprint storage path omitted from the index, or an empty string.
+     * @param bool     $include_non_empty_directories   Whether to retain non-empty directory rows for a transient plan.
      * @return self New file-index processor.
      */
     public static function start(
@@ -95,7 +99,8 @@ final class FileIndexProcessor {
         string $index_directory,
         bool $follow_symlinks,
         bool $include_caches,
-        string $storage_path
+        string $storage_path,
+        bool $include_non_empty_directories = false
     ): self {
         // Anchor traversal to a real directory. All later comparisons use
         // canonical paths so configured roots and followed links share one
@@ -168,6 +173,7 @@ final class FileIndexProcessor {
             $follow_symlinks,
             $include_caches,
             $storage_path,
+            $include_non_empty_directories,
             $directory_stack,
             $canonical_index_directory,
             $initial_index_entries
@@ -181,7 +187,8 @@ final class FileIndexProcessor {
      * @param string   $cursor_json     JSON cursor returned by the preceding request.
      * @param bool     $follow_symlinks Whether directory symlinks may lead outside the allowed directories.
      * @param bool     $include_caches  Whether generated caches and development files are included.
-     * @param string   $storage_path    Reprint storage path omitted from the index, or an empty string.
+     * @param string   $storage_path                   Reprint storage path omitted from the index, or an empty string.
+     * @param bool     $include_non_empty_directories Whether to retain non-empty directory rows for a transient plan.
      * @return self Resumed file-index processor.
      */
     public static function resume(
@@ -189,7 +196,8 @@ final class FileIndexProcessor {
         string $cursor_json,
         bool $follow_symlinks,
         bool $include_caches,
-        string $storage_path
+        string $storage_path,
+        bool $include_non_empty_directories = false
     ): self {
         // A cursor is caller-held continuation state. Reject malformed JSON or
         // a missing stack before any filesystem work begins.
@@ -248,6 +256,7 @@ final class FileIndexProcessor {
             $follow_symlinks,
             $include_caches,
             $storage_path,
+            $include_non_empty_directories,
             $directory_stack,
             $index_directory,
             []
@@ -395,7 +404,16 @@ final class FileIndexProcessor {
         // Intermediate links and the inspected path belong to the same step
         // because the cursor cannot stop between them without losing one.
         $this->index_entries = $intermediate_symlinks;
-        $this->index_entries[] = $item;
+        // A descendant implies its non-empty ancestors. Keep explicit rows
+        // only for empty directories, which have no descendant to imply them.
+        if (
+            $this->include_non_empty_directories
+            || $type !== "dir"
+            || !isset($item["empty"])
+            || $item["empty"]
+        ) {
+            $this->index_entries[] = $item;
+        }
         $this->step_status = self::STATUS_INDEXED;
 
         // Depth-first traversal enters a new directory before returning to the
@@ -581,7 +599,8 @@ final class FileIndexProcessor {
      * @param string[] $directories          Canonical directories allowed during traversal.
      * @param bool     $follow_symlinks      Whether directory symlinks may leave the allowed directories.
      * @param bool     $include_caches       Whether generated caches and development files are included.
-     * @param string   $storage_path         Reprint storage path omitted from the index, or an empty string.
+     * @param string   $storage_path                    Reprint storage path omitted from the index, or an empty string.
+     * @param bool     $include_non_empty_directories   Whether to retain non-empty directory rows for a transient plan.
      * @param array[]  $directory_stack      Active directory stack.
      * @param string   $index_directory      Directory reported by the endpoint.
      * @param array[]  $initial_index_entries Intermediate symlinks emitted before traversal.
@@ -591,6 +610,7 @@ final class FileIndexProcessor {
         bool $follow_symlinks,
         bool $include_caches,
         string $storage_path,
+        bool $include_non_empty_directories,
         array $directory_stack,
         string $index_directory,
         array $initial_index_entries
@@ -599,6 +619,7 @@ final class FileIndexProcessor {
         $this->follow_symlinks = $follow_symlinks;
         $this->include_caches = $include_caches;
         $this->storage_path = self::canonical_storage_path($storage_path);
+        $this->include_non_empty_directories = $include_non_empty_directories;
         $this->directory_stack = $directory_stack;
         $this->index_directory = $index_directory;
         $this->initial_index_entries = $initial_index_entries;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -506,6 +506,25 @@ class ImportClient
         int $remote_path_size,
         string $remote_path_type
     ): void {
+        if ($remote_path_type !== "dir") {
+            // The remote index WAL stays path-sorted. Record every ancestor
+            // before its file or symlink so its streaming merger can apply the
+            // batch without reordering records.
+            $remote_parent_directories = [];
+            $remote_parent_directory = dirname($remote_absolute_path);
+            while ($remote_parent_directory !== "/" && $remote_parent_directory !== ".") {
+                $remote_parent_directories[] = $remote_parent_directory;
+                $remote_parent_directory = dirname($remote_parent_directory);
+            }
+            foreach (array_reverse($remote_parent_directories) as $remote_parent_directory) {
+                $this->record_remote_index_wal_upsert(
+                    $remote_parent_directory,
+                    $remote_path_ctime,
+                    0,
+                    "dir",
+                );
+            }
+        }
         $this->record_remote_index_wal_upsert(
             $remote_absolute_path,
             $remote_path_ctime,
@@ -6295,7 +6314,15 @@ class ImportClient
             ) {
                 // The remote index is a union across files-pull path selections.
                 // Keep entries outside this run's selection.
-                if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
+                if (
+                    $this->is_selected_for_pulling($remote_index_entry["path"], false)
+                    && !(
+                        $remote_index_entry["type"] === "dir"
+                        && $this->next_remote_index_contains_remote_absolute_path_prefix(
+                            $remote_index_entry["path"]
+                        )
+                    )
+                ) {
                     $remote_absolute_path = $remote_index_entry["path"];
                     $this->apply_remote_deletion_locally($remote_absolute_path);
                     $this->delete_remote_index_entry($remote_absolute_path);

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6227,6 +6227,8 @@ class ImportClient
             $file_diff_progress_state->next_remote_index_byte_offset;
         $last_consumed_remote_index_entry_path =
             $file_diff_progress_state->last_consumed_remote_index_entry_path;
+        $previous_next_remote_index_entry_path =
+            $file_diff_progress_state->previous_next_remote_index_entry_path;
         $fetch_list_file_mode = $next_remote_index_byte_offset > 0 ? "a" : "w";
         if ($fetch_list_file_mode === "w") {
             $this->audit_log(
@@ -6306,7 +6308,13 @@ class ImportClient
                             $remote_absolute_path
                         )
                     )) {
-                        $this->apply_remote_deletion_locally($remote_absolute_path);
+                        $this->apply_remote_deletion_locally(
+                            $this->remote_absolute_path_to_delete(
+                                $remote_absolute_path,
+                                $previous_next_remote_index_entry_path,
+                                $next_remote_index_entry["path"],
+                            )
+                        );
                     }
                     $this->delete_remote_index_entry($remote_absolute_path);
                 }
@@ -6361,11 +6369,15 @@ class ImportClient
                 }
             }
 
+            $previous_next_remote_index_entry_path =
+                $next_remote_index_entry["path"];
             $next_remote_index_entries_processed++;
             if ($next_remote_index_entries_processed % 200 === 0) {
                 $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
                 $this->get_state()->diff->last_consumed_remote_index_entry_path =
                     $last_consumed_remote_index_entry_path;
+                $this->get_state()->diff->previous_next_remote_index_entry_path =
+                    $previous_next_remote_index_entry_path;
                 if (
                     $this->remote_index_wal_handle
                     && !fflush($this->remote_index_wal_handle)
@@ -6380,7 +6392,13 @@ class ImportClient
         while ($remote_index_entry !== null) {
             if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                 $remote_absolute_path = $remote_index_entry["path"];
-                $this->apply_remote_deletion_locally($remote_absolute_path);
+                $this->apply_remote_deletion_locally(
+                    $this->remote_absolute_path_to_delete(
+                        $remote_absolute_path,
+                        $previous_next_remote_index_entry_path,
+                        null,
+                    )
+                );
                 $this->delete_remote_index_entry($remote_absolute_path);
             }
             $last_consumed_remote_index_entry_path =
@@ -6398,6 +6416,8 @@ class ImportClient
         $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
         $this->get_state()->diff->last_consumed_remote_index_entry_path =
             $last_consumed_remote_index_entry_path;
+        $this->get_state()->diff->previous_next_remote_index_entry_path =
+            $previous_next_remote_index_entry_path;
         $this->apply_remote_index_wal();
         $this->save_state();
 
@@ -6744,6 +6764,51 @@ class ImportClient
         }
 
         $this->audit_log("Failed to delete: {$remote_absolute_path}", true);
+    }
+
+    /**
+     * Returns the highest absent remote directory containing a deleted entry.
+     *
+     * The previous and current next-index entries bracket every path in the
+     * sorted stream. A path or descendant beside an ancestor means that
+     * ancestor still exists and deletion must continue below it.
+     */
+    private function remote_absolute_path_to_delete(
+        string $remote_absolute_path,
+        ?string $previous_next_remote_index_entry_path,
+        ?string $next_remote_index_entry_path,
+    ): string {
+        $remote_path_components = explode("/", trim($remote_absolute_path, "/"));
+        $remote_directory_components = [];
+        $remote_path_component_count = count($remote_path_components) - 1;
+        for ($index = 0; $index < $remote_path_component_count; ++$index) {
+            $remote_directory_components[] = $remote_path_components[$index];
+            $remote_absolute_directory = "/" . implode("/", $remote_directory_components);
+            $remote_absolute_directory_prefix = $remote_absolute_directory . "/";
+            $directory_has_next_index_descendant = false;
+            foreach ([
+                $previous_next_remote_index_entry_path,
+                $next_remote_index_entry_path,
+            ] as $adjacent_next_remote_index_entry_path) {
+                if (
+                    $adjacent_next_remote_index_entry_path === $remote_absolute_directory
+                    || (
+                        is_string($adjacent_next_remote_index_entry_path)
+                        && str_starts_with(
+                            $adjacent_next_remote_index_entry_path,
+                            $remote_absolute_directory_prefix,
+                        )
+                    )
+                ) {
+                    $directory_has_next_index_descendant = true;
+                    break;
+                }
+            }
+            if (!$directory_has_next_index_descendant) {
+                return $remote_absolute_directory;
+            }
+        }
+        return $remote_absolute_path;
     }
 
     /**
@@ -10571,6 +10636,9 @@ class ImportClient
         $state["diff"]["last_consumed_remote_index_entry_path"] = $this->encode_state_path_value(
             $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
         );
+        $state["diff"]["previous_next_remote_index_entry_path"] = $this->encode_state_path_value(
+            $state["diff"]["previous_next_remote_index_entry_path"] ?? null,
+        );
         $state["fetch"]["batch_file"] = $this->encode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
         );
@@ -10602,6 +10670,9 @@ class ImportClient
     {
         $state["diff"]["last_consumed_remote_index_entry_path"] = $this->decode_state_path_value(
             $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
+        );
+        $state["diff"]["previous_next_remote_index_entry_path"] = $this->decode_state_path_value(
+            $state["diff"]["previous_next_remote_index_entry_path"] ?? null,
         );
         $state["fetch"]["batch_file"] = $this->decode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6776,7 +6776,7 @@ class ImportClient
     private function remote_absolute_path_to_delete(
         string $remote_absolute_path,
         ?string $previous_next_remote_index_entry_path,
-        ?string $next_remote_index_entry_path,
+        ?string $next_remote_index_entry_path
     ): string {
         $remote_path_components = explode("/", trim($remote_absolute_path, "/"));
         $remote_directory_components = [];

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10,7 +10,6 @@
  * - Three-phase pull: files, SQL, then file deltas
  */
 
-use function WordPress\Filesystem\wp_join_unix_paths;
 use Reprint\Importer\CurlTimeoutException;
 use Reprint\Importer\PreserveLocalSkipException;
 use Reprint\Importer\Pull\PullFailureReportedException;
@@ -23,12 +22,15 @@ use Reprint\Importer\State\RemoteFileIndexCursorState;
 use Reprint\Importer\StreamingContext;
 use Reprint\Importer\TransientInterruptionException;
 use Reprint\Importer\Tuning\AdaptiveTuner;
+
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
 use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
 use function Reprint\Importer\sort_index_file;
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
@@ -6300,7 +6302,7 @@ class ImportClient
                 if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                     $remote_absolute_path = $remote_index_entry["path"];
                     $this->apply_remote_deletion_locally(
-                        $this->remote_absolute_path_to_delete(
+                        $this->derive_remote_deletion_root_from_sparse_index(
                             $remote_absolute_path,
                             $last_processed_next_remote_index_entry_path,
                             $next_remote_index_entry["path"],
@@ -6383,7 +6385,7 @@ class ImportClient
             if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                 $remote_absolute_path = $remote_index_entry["path"];
                 $this->apply_remote_deletion_locally(
-                    $this->remote_absolute_path_to_delete(
+                    $this->derive_remote_deletion_root_from_sparse_index(
                         $remote_absolute_path,
                         $last_processed_next_remote_index_entry_path,
                         null,
@@ -6757,48 +6759,84 @@ class ImportClient
     }
 
     /**
-     * Returns the highest absent remote directory containing a deleted entry.
+     * Derives the shallowest missing remote path that can be deleted locally.
      *
-     * The previous and current next-index entries bracket every path in the
-     * sorted stream. A path or descendant beside an ancestor means that
-     * ancestor still exists and deletion must continue below it.
+     * Whenever a path stored in the locally saved remote index is missing from the
+     * currently downloaded remote index, we must figure out the blast radius. What
+     * exactly was deleted on the remote server? This function answers that
+     * question based on the:
+     *
+     * * original missing path
+     * * the nearest path before it in the new index, if any
+     * * the nearest path after it in the new index, if any
+     *
+     * For example:
+     *
+     *     Saved index:
+     *         /srv/site/wp-config.php
+     *         /srv/site/wp-content/index.php
+     *         /srv/site/wp-content/test.php
+     *         /srv/site/wp-settings.php
+     *
+     *     Newly downloaded index:
+     *         /srv/site/wp-config.php
+     *         /srv/site/wp-settings.php
+     *
+     * When we notice `/srv/site/wp-content/index.php` is not in the new index,
+     * this function is called with:
+     *
+     *     derive_remote_deletion_root_from_sparse_index(
+     *         missing_remote_path: "/srv/site/wp-content/index.php",
+     *         nearest_existing_path_before: "/srv/site/wp-config.php",
+     *         nearest_existing_path_after: "/srv/site/wp-settings.php"
+     *     )
+     *     // returns "/srv/site/wp-content"
+     *
+     * The neighboring paths show that `/srv` and `/srv/site` still contain files,
+     * but neither path is within `/srv/site/wp-content`.
+     *
+     * @param string      $missing_remote_path           Previously recorded path that is now missing.
+     * @param string|null $nearest_existing_path_before  Nearest existing path before the missing path, if any.
+     * @param string|null $nearest_existing_path_after   Nearest existing path after the missing path, if any.
+     *
+     * @return string The shallowest missing parent, or the original path when every parent still contains an entry.
      */
-    private function remote_absolute_path_to_delete(
-        string $remote_absolute_path,
-        ?string $last_processed_next_remote_index_entry_path,
-        ?string $next_remote_index_entry_path
+    private function derive_remote_deletion_root_from_sparse_index(
+        string $missing_remote_path,
+        ?string $nearest_existing_path_before,
+        ?string $nearest_existing_path_after
     ): string {
-        $remote_path_components = explode("/", trim($remote_absolute_path, "/"));
-        $remote_directory_components = [];
-        $remote_path_component_count = count($remote_path_components) - 1;
-        for ($index = 0; $index < $remote_path_component_count; ++$index) {
-            $remote_directory_components[] = $remote_path_components[$index];
-            $remote_absolute_directory = "/" . implode("/", $remote_directory_components);
-            $remote_absolute_directory_prefix = $remote_absolute_directory . "/";
-            $directory_has_next_index_descendant = false;
-            foreach ([
-                $last_processed_next_remote_index_entry_path,
-                $next_remote_index_entry_path,
-            ] as $adjacent_next_remote_index_entry_path) {
-                if (
-                    $adjacent_next_remote_index_entry_path === $remote_absolute_directory
-                    || (
-                        is_string($adjacent_next_remote_index_entry_path)
-                        && str_starts_with(
-                            $adjacent_next_remote_index_entry_path,
-                            $remote_absolute_directory_prefix,
-                        )
-                    )
-                ) {
-                    $directory_has_next_index_descendant = true;
-                    break;
-                }
-            }
-            if (!$directory_has_next_index_descendant) {
-                return $remote_absolute_directory;
+        // Use an invalid path that cannot match any validated remote path so
+        // both comparisons below always receive strings.
+        if (null === $nearest_existing_path_before) {
+            $nearest_existing_path_before = "/\0/";
+        }
+        if (null === $nearest_existing_path_after) {
+            $nearest_existing_path_after = "/\0/";
+        }
+        $missing_remote_path_components = wp_unix_path_segments($missing_remote_path);
+        $remote_parent_components = [];
+        $remote_parent_component_count = count($missing_remote_path_components) - 1;
+        // Find the shallowest parent absent from both neighboring entries.
+        for ($component_index = 0; $component_index < $remote_parent_component_count; ++$component_index) {
+            $remote_parent_components[] = $missing_remote_path_components[$component_index];
+            $path_prefix = wp_join_unix_paths("/", ...$remote_parent_components);
+            if (
+                !path_is_within_root(
+                    $nearest_existing_path_before,
+                    $path_prefix,
+                )
+                && !path_is_within_root(
+                    $nearest_existing_path_after,
+                    $path_prefix,
+                )
+            ) {
+                return $path_prefix;
             }
         }
-        return $remote_absolute_path;
+        // Every parent still has an entry in the new index, so only the
+        // original missing entry should be deleted.
+        return $missing_remote_path;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -506,25 +506,6 @@ class ImportClient
         int $remote_path_size,
         string $remote_path_type
     ): void {
-        if ($remote_path_type !== "dir") {
-            // The remote index WAL stays path-sorted. Record every ancestor
-            // before its file or symlink so its streaming merger can apply the
-            // batch without reordering records.
-            $remote_parent_directories = [];
-            $remote_parent_directory = dirname($remote_absolute_path);
-            while ($remote_parent_directory !== "/" && $remote_parent_directory !== ".") {
-                $remote_parent_directories[] = $remote_parent_directory;
-                $remote_parent_directory = dirname($remote_parent_directory);
-            }
-            foreach (array_reverse($remote_parent_directories) as $remote_parent_directory) {
-                $this->record_remote_index_wal_upsert(
-                    $remote_parent_directory,
-                    $remote_path_ctime,
-                    0,
-                    "dir",
-                );
-            }
-        }
         $this->record_remote_index_wal_upsert(
             $remote_absolute_path,
             $remote_path_ctime,
@@ -6314,17 +6295,19 @@ class ImportClient
             ) {
                 // The remote index is a union across files-pull path selections.
                 // Keep entries outside this run's selection.
-                if (
-                    $this->is_selected_for_pulling($remote_index_entry["path"], false)
-                    && !(
+                if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
+                    $remote_absolute_path = $remote_index_entry["path"];
+                    // Old indexes recorded non-empty directories. A descendant
+                    // in the next index means this directory still exists, so
+                    // remove only its obsolete index record.
+                    if (!(
                         $remote_index_entry["type"] === "dir"
                         && $this->next_remote_index_contains_remote_absolute_path_prefix(
-                            $remote_index_entry["path"]
+                            $remote_absolute_path
                         )
-                    )
-                ) {
-                    $remote_absolute_path = $remote_index_entry["path"];
-                    $this->apply_remote_deletion_locally($remote_absolute_path);
+                    )) {
+                        $this->apply_remote_deletion_locally($remote_absolute_path);
+                    }
                     $this->delete_remote_index_entry($remote_absolute_path);
                 }
                 $last_consumed_remote_index_entry_path =

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6299,23 +6299,13 @@ class ImportClient
                 // Keep entries outside this run's selection.
                 if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
                     $remote_absolute_path = $remote_index_entry["path"];
-                    // Old indexes recorded non-empty directories. A descendant
-                    // in the next index means this directory still exists, so
-                    // remove only its obsolete index record.
-                    if (!(
-                        $remote_index_entry["type"] === "dir"
-                        && $this->next_remote_index_contains_remote_absolute_path_prefix(
-                            $remote_absolute_path
+                    $this->apply_remote_deletion_locally(
+                        $this->remote_absolute_path_to_delete(
+                            $remote_absolute_path,
+                            $previous_next_remote_index_entry_path,
+                            $next_remote_index_entry["path"],
                         )
-                    )) {
-                        $this->apply_remote_deletion_locally(
-                            $this->remote_absolute_path_to_delete(
-                                $remote_absolute_path,
-                                $previous_next_remote_index_entry_path,
-                                $next_remote_index_entry["path"],
-                            )
-                        );
-                    }
+                    );
                     $this->delete_remote_index_entry($remote_absolute_path);
                 }
                 $last_consumed_remote_index_entry_path =

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6227,8 +6227,8 @@ class ImportClient
             $file_diff_progress_state->next_remote_index_byte_offset;
         $last_consumed_remote_index_entry_path =
             $file_diff_progress_state->last_consumed_remote_index_entry_path;
-        $previous_next_remote_index_entry_path =
-            $file_diff_progress_state->previous_next_remote_index_entry_path;
+        $last_processed_next_remote_index_entry_path =
+            $file_diff_progress_state->last_processed_next_remote_index_entry_path;
         $fetch_list_file_mode = $next_remote_index_byte_offset > 0 ? "a" : "w";
         if ($fetch_list_file_mode === "w") {
             $this->audit_log(
@@ -6302,7 +6302,7 @@ class ImportClient
                     $this->apply_remote_deletion_locally(
                         $this->remote_absolute_path_to_delete(
                             $remote_absolute_path,
-                            $previous_next_remote_index_entry_path,
+                            $last_processed_next_remote_index_entry_path,
                             $next_remote_index_entry["path"],
                         )
                     );
@@ -6359,15 +6359,15 @@ class ImportClient
                 }
             }
 
-            $previous_next_remote_index_entry_path =
+            $last_processed_next_remote_index_entry_path =
                 $next_remote_index_entry["path"];
             $next_remote_index_entries_processed++;
             if ($next_remote_index_entries_processed % 200 === 0) {
                 $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
                 $this->get_state()->diff->last_consumed_remote_index_entry_path =
                     $last_consumed_remote_index_entry_path;
-                $this->get_state()->diff->previous_next_remote_index_entry_path =
-                    $previous_next_remote_index_entry_path;
+                $this->get_state()->diff->last_processed_next_remote_index_entry_path =
+                    $last_processed_next_remote_index_entry_path;
                 if (
                     $this->remote_index_wal_handle
                     && !fflush($this->remote_index_wal_handle)
@@ -6385,7 +6385,7 @@ class ImportClient
                 $this->apply_remote_deletion_locally(
                     $this->remote_absolute_path_to_delete(
                         $remote_absolute_path,
-                        $previous_next_remote_index_entry_path,
+                        $last_processed_next_remote_index_entry_path,
                         null,
                     )
                 );
@@ -6406,8 +6406,8 @@ class ImportClient
         $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
         $this->get_state()->diff->last_consumed_remote_index_entry_path =
             $last_consumed_remote_index_entry_path;
-        $this->get_state()->diff->previous_next_remote_index_entry_path =
-            $previous_next_remote_index_entry_path;
+        $this->get_state()->diff->last_processed_next_remote_index_entry_path =
+            $last_processed_next_remote_index_entry_path;
         $this->apply_remote_index_wal();
         $this->save_state();
 
@@ -6765,7 +6765,7 @@ class ImportClient
      */
     private function remote_absolute_path_to_delete(
         string $remote_absolute_path,
-        ?string $previous_next_remote_index_entry_path,
+        ?string $last_processed_next_remote_index_entry_path,
         ?string $next_remote_index_entry_path
     ): string {
         $remote_path_components = explode("/", trim($remote_absolute_path, "/"));
@@ -6777,7 +6777,7 @@ class ImportClient
             $remote_absolute_directory_prefix = $remote_absolute_directory . "/";
             $directory_has_next_index_descendant = false;
             foreach ([
-                $previous_next_remote_index_entry_path,
+                $last_processed_next_remote_index_entry_path,
                 $next_remote_index_entry_path,
             ] as $adjacent_next_remote_index_entry_path) {
                 if (
@@ -10626,8 +10626,8 @@ class ImportClient
         $state["diff"]["last_consumed_remote_index_entry_path"] = $this->encode_state_path_value(
             $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
         );
-        $state["diff"]["previous_next_remote_index_entry_path"] = $this->encode_state_path_value(
-            $state["diff"]["previous_next_remote_index_entry_path"] ?? null,
+        $state["diff"]["last_processed_next_remote_index_entry_path"] = $this->encode_state_path_value(
+            $state["diff"]["last_processed_next_remote_index_entry_path"] ?? null,
         );
         $state["fetch"]["batch_file"] = $this->encode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
@@ -10661,8 +10661,8 @@ class ImportClient
         $state["diff"]["last_consumed_remote_index_entry_path"] = $this->decode_state_path_value(
             $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
         );
-        $state["diff"]["previous_next_remote_index_entry_path"] = $this->decode_state_path_value(
-            $state["diff"]["previous_next_remote_index_entry_path"] ?? null,
+        $state["diff"]["last_processed_next_remote_index_entry_path"] = $this->decode_state_path_value(
+            $state["diff"]["last_processed_next_remote_index_entry_path"] ?? null,
         );
         $state["fetch"]["batch_file"] = $this->decode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -57,7 +57,7 @@
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete'}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
@@ -106,6 +106,9 @@ class PushPlan
 
     /** @var bool Whether $fresh_local_index_entry has been read, including EOF. */
     private bool $fresh_local_index_entry_loaded = false;
+
+    /** @var string|null Path of the fresh entry consumed before the lookahead entry. */
+    private ?string $previous_fresh_local_index_entry_path = null;
 
     /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
     private ?array $local_index_lookahead_entry = null;
@@ -320,6 +323,8 @@ class PushPlan
         $cursor = $this->cursor["position"];
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
+        $this->previous_fresh_local_index_entry_path =
+            $cursor["previous_fresh_local_index_entry_path"];
         $this->local_index_lookahead_entry = null;
         $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
@@ -460,6 +465,7 @@ class PushPlan
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
+            "previous_fresh_local_index_entry_path" => null,
         ];
         $this->open_plan_files();
     }
@@ -550,14 +556,17 @@ class PushPlan
 
         if ($fresh_local_index_entry !== null || $local_index_entry !== null) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
-            // in ASCII but encodes a higher value), so ordering uses the
-            // decoded path bytes.
+            // in ASCII but encodes a higher value). Component order keeps
+            // every descendant next to its parent before the next sibling.
             if ($local_index_entry === null) {
                 $path_comparison = -1;
             } elseif ($fresh_local_index_entry === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = strcmp($fresh_local_index_entry["path"], $local_index_entry["path"]);
+                $path_comparison = $this->compare_local_relative_paths(
+                    $fresh_local_index_entry["path"],
+                    $local_index_entry["path"]
+                );
             }
 
             $fresh_local_index_entry_shape = null;
@@ -577,7 +586,10 @@ class PushPlan
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
                         strpos($local_index_entry["path"], $descendant_prefix) !== 0
-                        && strcmp($local_index_entry["path"], $descendant_prefix) > 0
+                        && $this->compare_local_relative_paths(
+                            $local_index_entry["path"],
+                            $descendant_prefix
+                        ) > 0
                     ) {
                         $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
                         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
@@ -591,6 +603,28 @@ class PushPlan
                 // New files, symlinks, and empty directories need to be
                 // pushed. A new non-empty directory is represented by its
                 // descendants.
+                $fresh_local_index_entry_replaces_local_subtree = $local_index_entry !== null
+                    && strpos(
+                        $local_index_entry["path"],
+                        $fresh_local_index_entry["path"] . "/"
+                    ) === 0;
+                if (
+                    $fresh_local_index_entry_replaces_local_subtree
+                    && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
+                    && !$this->deleted_directory_stack_covers_path(
+                        $fresh_local_index_entry["path"],
+                        $this->deleted_directory_stack_entry
+                    )
+                ) {
+                    $this->append_local_path_to_delete($fresh_local_index_entry["path"]);
+                    $local_paths_to_delete_changed = true;
+                    $deleted_directory_stack_top_byte_offset =
+                        $this->append_deleted_directory_stack_entry(
+                            $fresh_local_index_entry["path"],
+                            $deleted_directory_stack_top_byte_offset
+                        );
+                    $deleted_directories_stack_changed = true;
+                }
                 if (
                     $fresh_local_index_entry_shape !== "non_empty_directory"
                     && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
@@ -599,20 +633,29 @@ class PushPlan
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
+                $local_directory_is_implied_by_fresh_descendant =
+                    $local_index_entry["type"] === "dir"
+                    && $this->fresh_index_contains_path_or_descendant(
+                        $local_index_entry["path"]
+                    );
+                $local_path_to_delete = $this->local_path_to_delete(
+                    $local_index_entry["path"]
+                );
                 // A deleted non-empty directory emits one root. Its later
                 // descendant entries are already covered by that path.
                 if (
-                    !$this->path_conflicts_with_excluded_paths($local_index_entry["path"])
+                    !$local_directory_is_implied_by_fresh_descendant
+                    && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
                     && !$this->deleted_directory_stack_covers_path(
                         $local_index_entry["path"],
                         $this->deleted_directory_stack_entry
                     )
                 ) {
-                    $this->append_local_path_to_delete($local_index_entry["path"]);
+                    $this->append_local_path_to_delete($local_path_to_delete);
                     $local_paths_to_delete_changed = true;
-                    if ($local_index_entry_shape === "non_empty_directory") {
+                    if ($local_path_to_delete !== $local_index_entry["path"] || $local_index_entry_shape === "non_empty_directory") {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $local_index_entry["path"],
+                            $local_path_to_delete,
                             $deleted_directory_stack_top_byte_offset
                         );
                         $deleted_directories_stack_changed = true;
@@ -668,6 +711,8 @@ class PushPlan
 
             if ($path_comparison <= 0) {
                 $byte_offset_in_fresh_local_index = ftell($this->fresh_local_index_handle);
+                $this->previous_fresh_local_index_entry_path =
+                    $fresh_local_index_entry["path"];
                 $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
             }
             if ($path_comparison >= 0) {
@@ -701,6 +746,8 @@ class PushPlan
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
+                "previous_fresh_local_index_entry_path" =>
+                    $this->previous_fresh_local_index_entry_path,
             ];
         $this->cursor["position"] = $cursor_after_step;
         return !$complete;
@@ -737,6 +784,7 @@ class PushPlan
         $this->deleted_directories_stack_handle = null;
         $this->fresh_local_index_entry = null;
         $this->fresh_local_index_entry_loaded = false;
+        $this->previous_fresh_local_index_entry_path = null;
         $this->local_index_lookahead_entry = null;
         $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
@@ -807,6 +855,72 @@ class PushPlan
         if (fseek($index_file_handle, $byte_offset) !== 0) {
             throw new RuntimeException("Failed to seek the {$index_description} to byte {$byte_offset}.");
         }
+    }
+
+    /**
+     * Compares local relative paths by components instead of raw bytes.
+     *
+     * This keeps a directory and all of its descendants together before a
+     * sibling such as `directory-other`.
+     */
+    private function compare_local_relative_paths(string $left_path, string $right_path): int
+    {
+        $left_components = explode("/", $left_path);
+        $right_components = explode("/", $right_path);
+        $shared_component_count = min(count($left_components), count($right_components));
+        for ($index = 0; $index < $shared_component_count; ++$index) {
+            $component_comparison = strcmp($left_components[$index], $right_components[$index]);
+            if ($component_comparison !== 0) {
+                return $component_comparison;
+            }
+        }
+        return count($left_components) <=> count($right_components);
+    }
+
+    /**
+     * Returns the highest deleted directory without a fresh entry below it.
+     *
+     * Only the previous fresh entry and the current lookahead can neighbor a
+     * path in component order, so this derives one subtree root without
+     * retaining the tree.
+     */
+    private function local_path_to_delete(string $local_relative_path): string
+    {
+        $components = explode("/", $local_relative_path);
+        $candidate_components = [];
+        for ($index = 0, $component_count = count($components) - 1; $index < $component_count; ++$index) {
+            $candidate_components[] = $components[$index];
+            $candidate_path = implode("/", $candidate_components);
+            if (!$this->fresh_index_contains_path_or_descendant($candidate_path)) {
+                return $candidate_path;
+            }
+        }
+        return $local_relative_path;
+    }
+
+    /**
+     * Checks the adjacent fresh entries for a path or one of its descendants.
+     */
+    private function fresh_index_contains_path_or_descendant(string $local_relative_path): bool
+    {
+        $local_relative_path_prefix = $local_relative_path . "/";
+        foreach ([
+            $this->previous_fresh_local_index_entry_path,
+            $this->fresh_local_index_entry === null
+                ? null
+                : $this->fresh_local_index_entry["path"],
+        ] as $fresh_local_index_entry_path) {
+            if (
+                $fresh_local_index_entry_path === $local_relative_path
+                || (
+                    is_string($fresh_local_index_entry_path)
+                    && strpos($fresh_local_index_entry_path, $local_relative_path_prefix) === 0
+                )
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -160,7 +160,8 @@ class PushPlan
             $plan->filesystem_root,
             false,
             false,
-            $plan->plan_directory
+            $plan->plan_directory,
+            true
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
@@ -304,7 +305,8 @@ class PushPlan
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             false,
             false,
-            $this->plan_directory
+            $this->plan_directory,
+            true
         );
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -556,17 +556,14 @@ class PushPlan
 
         if ($fresh_local_index_entry !== null || $local_index_entry !== null) {
             // Base64 does not preserve byte order ('0' sorts before 'A'
-            // in ASCII but encodes a higher value). Component order keeps
-            // every descendant next to its parent before the next sibling.
+            // in ASCII but encodes a higher value), so ordering uses the
+            // decoded path bytes.
             if ($local_index_entry === null) {
                 $path_comparison = -1;
             } elseif ($fresh_local_index_entry === null) {
                 $path_comparison = 1;
             } else {
-                $path_comparison = $this->compare_local_relative_paths(
-                    $fresh_local_index_entry["path"],
-                    $local_index_entry["path"]
-                );
+                $path_comparison = strcmp($fresh_local_index_entry["path"], $local_index_entry["path"]);
             }
 
             $fresh_local_index_entry_shape = null;
@@ -579,17 +576,13 @@ class PushPlan
                 $local_index_entry_shape = $this->index_entry_shape($local_index_entry);
 
                 // Byte sorting can put a sibling such as `a-other` before
-                // `a/child`. Every retained non-empty directory has a later
-                // descendant, so adjacent local index entries can pass at
-                // most the top sibling range.
+                // `a/child`. Keep a deleted root while local index entries
+                // remain within that root's descendants.
                 if ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
                         strpos($local_index_entry["path"], $descendant_prefix) !== 0
-                        && $this->compare_local_relative_paths(
-                            $local_index_entry["path"],
-                            $descendant_prefix
-                        ) > 0
+                        && strcmp($local_index_entry["path"], $descendant_prefix) > 0
                     ) {
                         $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
                         $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
@@ -600,9 +593,7 @@ class PushPlan
             }
 
             if ($path_comparison < 0) {
-                // New files, symlinks, and empty directories need to be
-                // pushed. A new non-empty directory is represented by its
-                // descendants.
+                // New files, symlinks, and empty directories need to be pushed.
                 $fresh_local_index_entry_replaces_local_subtree = $local_index_entry !== null
                     && strpos(
                         $local_index_entry["path"],
@@ -625,26 +616,23 @@ class PushPlan
                         );
                     $deleted_directories_stack_changed = true;
                 }
-                if (
-                    $fresh_local_index_entry_shape !== "non_empty_directory"
-                    && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
-                ) {
+                if (!$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
-                $local_directory_is_implied_by_fresh_descendant =
-                    $local_index_entry["type"] === "dir"
+                $local_empty_directory_is_implied_by_fresh_descendant =
+                    $local_index_entry_shape === "empty_directory"
                     && $this->fresh_index_contains_path_or_descendant(
                         $local_index_entry["path"]
                     );
                 $local_path_to_delete = $this->local_path_to_delete(
                     $local_index_entry["path"]
                 );
-                // A deleted non-empty directory emits one root. Its later
-                // descendant entries are already covered by that path.
+                // A sparse index entry derives one deleted root, covering its
+                // later descendant entries.
                 if (
-                    !$local_directory_is_implied_by_fresh_descendant
+                    !$local_empty_directory_is_implied_by_fresh_descendant
                     && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
                     && !$this->deleted_directory_stack_covers_path(
                         $local_index_entry["path"],
@@ -653,7 +641,7 @@ class PushPlan
                 ) {
                     $this->append_local_path_to_delete($local_path_to_delete);
                     $local_paths_to_delete_changed = true;
-                    if ($local_path_to_delete !== $local_index_entry["path"] || $local_index_entry_shape === "non_empty_directory") {
+                    if ($local_path_to_delete !== $local_index_entry["path"]) {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
                             $local_path_to_delete,
                             $deleted_directory_stack_top_byte_offset
@@ -666,8 +654,6 @@ class PushPlan
                     || $fresh_local_index_entry_shape === "symlink";
                 $local_index_entry_is_file_or_symlink = $local_index_entry_shape === "file"
                     || $local_index_entry_shape === "symlink";
-                $non_empty_directory_becomes_empty = $fresh_local_index_entry_shape === "empty_directory"
-                    && $local_index_entry_shape === "non_empty_directory";
                 $empty_directory_needs_push = $fresh_local_index_entry_shape === "empty_directory"
                     && $local_index_entry_shape !== "empty_directory";
                 // File and symlink changes are defined by type, ctime, and
@@ -679,8 +665,7 @@ class PushPlan
                         || $fresh_local_index_entry["type"] !== $local_index_entry["type"]
                     );
                 $needs_delete =
-                    $fresh_local_index_entry_is_file_or_symlink !== $local_index_entry_is_file_or_symlink
-                    || $non_empty_directory_becomes_empty;
+                    $fresh_local_index_entry_is_file_or_symlink !== $local_index_entry_is_file_or_symlink;
                 $needs_push = $empty_directory_needs_push
                     || $changed_file_or_symlink_needs_push;
                 $path_is_excluded = $this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"]);
@@ -695,13 +680,6 @@ class PushPlan
                 ) {
                     $this->append_local_path_to_delete($local_index_entry["path"]);
                     $local_paths_to_delete_changed = true;
-                    if ($local_index_entry_shape === "non_empty_directory") {
-                        $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $local_index_entry["path"],
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                        $deleted_directories_stack_changed = true;
-                    }
                 }
                 if ($needs_push && !$path_is_excluded) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
@@ -858,31 +836,11 @@ class PushPlan
     }
 
     /**
-     * Compares local relative paths by components instead of raw bytes.
-     *
-     * This keeps a directory and all of its descendants together before a
-     * sibling such as `directory-other`.
-     */
-    private function compare_local_relative_paths(string $left_path, string $right_path): int
-    {
-        $left_components = explode("/", $left_path);
-        $right_components = explode("/", $right_path);
-        $shared_component_count = min(count($left_components), count($right_components));
-        for ($index = 0; $index < $shared_component_count; ++$index) {
-            $component_comparison = strcmp($left_components[$index], $right_components[$index]);
-            if ($component_comparison !== 0) {
-                return $component_comparison;
-            }
-        }
-        return count($left_components) <=> count($right_components);
-    }
-
-    /**
      * Returns the highest deleted directory without a fresh entry below it.
      *
      * Only the previous fresh entry and the current lookahead can neighbor a
-     * path in component order, so this derives one subtree root without
-     * retaining the tree.
+     * path in byte order, so this derives one subtree root without retaining
+     * the tree.
      */
     private function local_path_to_delete(string $local_relative_path): string
     {
@@ -936,7 +894,7 @@ class PushPlan
      *     @type bool   $empty Whether a directory is empty. Present for directory entries.
      * }
      * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $index_entry
-     * @return 'file'|'symlink'|'empty_directory'|'non_empty_directory'
+     * @return 'file'|'symlink'|'empty_directory'
      */
     private function index_entry_shape(array $index_entry): string
     {
@@ -946,7 +904,7 @@ class PushPlan
         if ($index_entry["type"] === "link") {
             return "symlink";
         }
-        return $index_entry["empty"] ? "empty_directory" : "non_empty_directory";
+        return "empty_directory";
     }
 
     /**

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -160,8 +160,7 @@ class PushPlan
             $plan->filesystem_root,
             false,
             false,
-            $plan->plan_directory,
-            true
+            $plan->plan_directory
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
@@ -305,8 +304,7 @@ class PushPlan
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
             false,
             false,
-            $this->plan_directory,
-            true
+            $this->plan_directory
         );
     }
 

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,5 +1,9 @@
 <?php
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Filesystem\wp_unix_path_segments;
+use function WordPress\Reprint\Exporter\path_is_within_root;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
 /**
@@ -581,7 +585,10 @@ class PushPlan
                 if ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
-                        strpos($local_index_entry["path"], $descendant_prefix) !== 0
+                        !path_is_within_root(
+                            $local_index_entry["path"],
+                            $this->deleted_directory_stack_entry["path"]
+                        )
                         && strcmp($local_index_entry["path"], $descendant_prefix) > 0
                     ) {
                         $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
@@ -595,10 +602,11 @@ class PushPlan
             if ($path_comparison < 0) {
                 // New files, symlinks, and empty directories need to be pushed.
                 $fresh_local_index_entry_replaces_local_subtree = $local_index_entry !== null
-                    && strpos(
+                    && $local_index_entry["path"] !== $fresh_local_index_entry["path"]
+                    && path_is_within_root(
                         $local_index_entry["path"],
-                        $fresh_local_index_entry["path"] . "/"
-                    ) === 0;
+                        $fresh_local_index_entry["path"]
+                    );
                 if (
                     $fresh_local_index_entry_replaces_local_subtree
                     && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
@@ -844,13 +852,15 @@ class PushPlan
      */
     private function local_path_to_delete(string $local_relative_path): string
     {
-        $components = explode("/", $local_relative_path);
-        $candidate_components = [];
-        for ($index = 0, $component_count = count($components) - 1; $index < $component_count; ++$index) {
-            $candidate_components[] = $components[$index];
-            $candidate_path = implode("/", $candidate_components);
-            if (!$this->fresh_index_contains_path_or_descendant($candidate_path)) {
-                return $candidate_path;
+        $local_relative_path_components = wp_unix_path_segments($local_relative_path);
+        $candidate_local_relative_path_components = [];
+        for ($index = 0, $component_count = count($local_relative_path_components) - 1; $index < $component_count; ++$index) {
+            $candidate_local_relative_path_components[] = $local_relative_path_components[$index];
+            $candidate_local_relative_path = wp_join_unix_paths(
+                ...$candidate_local_relative_path_components
+            );
+            if (!$this->fresh_index_contains_path_or_descendant($candidate_local_relative_path)) {
+                return $candidate_local_relative_path;
             }
         }
         return $local_relative_path;
@@ -861,7 +871,6 @@ class PushPlan
      */
     private function fresh_index_contains_path_or_descendant(string $local_relative_path): bool
     {
-        $local_relative_path_prefix = $local_relative_path . "/";
         foreach ([
             $this->previous_fresh_local_index_entry_path,
             $this->fresh_local_index_entry === null
@@ -869,10 +878,10 @@ class PushPlan
                 : $this->fresh_local_index_entry["path"],
         ] as $fresh_local_index_entry_path) {
             if (
-                $fresh_local_index_entry_path === $local_relative_path
-                || (
-                    is_string($fresh_local_index_entry_path)
-                    && strpos($fresh_local_index_entry_path, $local_relative_path_prefix) === 0
+                is_string($fresh_local_index_entry_path)
+                && path_is_within_root(
+                    $fresh_local_index_entry_path,
+                    $local_relative_path
                 )
             ) {
                 return true;
@@ -1031,7 +1040,9 @@ class PushPlan
      */
     private function deleted_directory_stack_covers_path(string $path, ?array $entry): bool
     {
-        return $entry !== null && strpos($path, $entry["path"] . "/") === 0;
+        return $entry !== null
+            && $path !== $entry["path"]
+            && path_is_within_root($path, $entry["path"]);
     }
 
     /**
@@ -1049,9 +1060,8 @@ class PushPlan
     {
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                $path === $excluded_path
-                || strpos($path, $excluded_path . "/") === 0
-                || strpos($excluded_path, $path . "/") === 0
+                path_is_within_root($path, $excluded_path)
+                || path_is_within_root($excluded_path, $path)
             ) {
                 return true;
             }

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -871,23 +871,20 @@ class PushPlan
      */
     private function fresh_index_contains_path_or_descendant(string $local_relative_path): bool
     {
-        foreach ([
-            $this->previous_fresh_local_index_entry_path,
-            $this->fresh_local_index_entry === null
-                ? null
-                : $this->fresh_local_index_entry["path"],
-        ] as $fresh_local_index_entry_path) {
-            if (
-                is_string($fresh_local_index_entry_path)
-                && path_is_within_root(
-                    $fresh_local_index_entry_path,
-                    $local_relative_path
-                )
-            ) {
-                return true;
-            }
-        }
-        return false;
+        // Use an invalid path that cannot match an indexed local relative path
+        // so both comparisons below always receive strings.
+        $previous_fresh_local_index_entry_path =
+            $this->previous_fresh_local_index_entry_path ?? "\0";
+        $next_fresh_local_index_entry_path =
+            $this->fresh_local_index_entry["path"] ?? "\0";
+
+        return path_is_within_root(
+            $previous_fresh_local_index_entry_path,
+            $local_relative_path
+        ) || path_is_within_root(
+            $next_fresh_local_index_entry_path,
+            $local_relative_path
+        );
     }
 
     /**

--- a/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
+++ b/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
@@ -16,9 +16,6 @@ class FileDiffProgressState {
 
     public static function from_array(array $data): self
     {
-        if (!array_key_exists('previous_next_remote_index_entry_path', $data)) {
-            $data['previous_next_remote_index_entry_path'] = null;
-        }
         $state = new self();
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->next_remote_index_byte_offset =

--- a/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
+++ b/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
@@ -11,8 +11,8 @@ class FileDiffProgressState {
     /** @var string|null Last remote index entry path consumed at the current next remote index byte offset. */
     public ?string $last_consumed_remote_index_entry_path = null;
 
-    /** @var string|null Next remote index path consumed immediately before the current byte offset. */
-    public ?string $previous_next_remote_index_entry_path = null;
+    /** @var string|null Last next remote index entry processed before the current byte offset. */
+    public ?string $last_processed_next_remote_index_entry_path = null;
 
     public static function from_array(array $data): self
     {
@@ -22,8 +22,8 @@ class FileDiffProgressState {
             $data['next_remote_index_byte_offset'];
         $state->last_consumed_remote_index_entry_path =
             $data['last_consumed_remote_index_entry_path'];
-        $state->previous_next_remote_index_entry_path =
-            $data['previous_next_remote_index_entry_path'];
+        $state->last_processed_next_remote_index_entry_path =
+            $data['last_processed_next_remote_index_entry_path'];
         return $state;
     }
 
@@ -34,8 +34,8 @@ class FileDiffProgressState {
                 $this->next_remote_index_byte_offset,
             'last_consumed_remote_index_entry_path' =>
                 $this->last_consumed_remote_index_entry_path,
-            'previous_next_remote_index_entry_path' =>
-                $this->previous_next_remote_index_entry_path,
+            'last_processed_next_remote_index_entry_path' =>
+                $this->last_processed_next_remote_index_entry_path,
         ];
     }
 }

--- a/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
+++ b/packages/reprint-importer/src/lib/state/class-file-diff-progress-state.php
@@ -11,14 +11,22 @@ class FileDiffProgressState {
     /** @var string|null Last remote index entry path consumed at the current next remote index byte offset. */
     public ?string $last_consumed_remote_index_entry_path = null;
 
+    /** @var string|null Next remote index path consumed immediately before the current byte offset. */
+    public ?string $previous_next_remote_index_entry_path = null;
+
     public static function from_array(array $data): self
     {
+        if (!array_key_exists('previous_next_remote_index_entry_path', $data)) {
+            $data['previous_next_remote_index_entry_path'] = null;
+        }
         $state = new self();
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->next_remote_index_byte_offset =
             $data['next_remote_index_byte_offset'];
         $state->last_consumed_remote_index_entry_path =
             $data['last_consumed_remote_index_entry_path'];
+        $state->previous_next_remote_index_entry_path =
+            $data['previous_next_remote_index_entry_path'];
         return $state;
     }
 
@@ -29,6 +37,8 @@ class FileDiffProgressState {
                 $this->next_remote_index_byte_offset,
             'last_consumed_remote_index_entry_path' =>
                 $this->last_consumed_remote_index_entry_path,
+            'previous_next_remote_index_entry_path' =>
+                $this->previous_next_remote_index_entry_path,
         ];
     }
 }

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -41,6 +41,8 @@ final class FileIndexProcessorTest extends TestCase {
         $this->assertContains('empty', $this->relativePaths($resumed['entries'], $docroot));
         $this->assertContains('a-link', $this->relativePaths($resumed['entries'], $docroot));
         $this->assertContains('nested/b.txt', $this->relativePaths($resumed['entries'], $docroot));
+        $this->assertNotContains('nested', $this->relativePaths($resumed['entries'], $docroot));
+        $this->assertNotContains('wp-content', $this->relativePaths($resumed['entries'], $docroot));
         $link_stat = lstat($docroot . '/a-link');
         $this->assertIsArray($link_stat);
         foreach ($resumed['entries'] as $index_entry) {

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -245,7 +245,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
         $this->assertNotContains('wp-content/reprint-storage/state.json', $withCaches);
     }
 
-    public function testFileIndexRecordsPhysicalDirectoryEmptiness(): void
+    public function testFileIndexKeepsOnlyPhysicalEmptyDirectories(): void
     {
         $siteDir = $this->tempDir . '/site';
         mkdir($siteDir . '/empty', 0755, true);
@@ -271,9 +271,9 @@ final class FileIndexSkipDefaultsTest extends TestCase
             $this->assertIsBool($entry['empty'], $path);
         }
         $this->assertTrue($entries['empty']['empty']);
-        $this->assertFalse($entries['full']['empty']);
-        $this->assertFalse($entries['skipped-only']['empty']);
-        $this->assertFalse($entries['storage-parent']['empty']);
+        $this->assertArrayNotHasKey('full', $entries);
+        $this->assertArrayNotHasKey('skipped-only', $entries);
+        $this->assertArrayNotHasKey('storage-parent', $entries);
         $this->assertArrayNotHasKey('empty', $entries['file.txt']);
         $this->assertArrayNotHasKey('skipped-only/.git', $entries);
         $this->assertArrayNotHasKey('storage-parent/reprint-storage', $entries);

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -60,16 +60,6 @@ class PullStateTest extends TestCase
         $this->assertSame(99, $array['sql_statements_counted']);
     }
 
-    public function testStateAcceptsDiffProgressFromBeforeThePreviousNextPath(): void
-    {
-        $data = (new \PullState())->to_array();
-        unset($data['diff']['previous_next_remote_index_entry_path']);
-
-        $state = \PullState::from_array($data);
-
-        $this->assertNull($state->diff->previous_next_remote_index_entry_path);
-    }
-
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
         $state = new \PullState();

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -43,7 +43,7 @@ class PullStateTest extends TestCase
         $state->pull_pipeline->started_by_command = 'pull';
         $state->diff->next_remote_index_byte_offset = 123;
         $state->diff->last_consumed_remote_index_entry_path = '/wp-content/index.php';
-        $state->diff->previous_next_remote_index_entry_path = '/wp-content/themes/twentytwenty/style.css';
+        $state->diff->last_processed_next_remote_index_entry_path = '/wp-content/themes/twentytwenty/style.css';
         $state->sql_statements_counted = 99;
 
         $array = $state->to_array();
@@ -55,7 +55,7 @@ class PullStateTest extends TestCase
         $this->assertSame('/wp-content/index.php', $array['diff']['last_consumed_remote_index_entry_path']);
         $this->assertSame(
             '/wp-content/themes/twentytwenty/style.css',
-            $array['diff']['previous_next_remote_index_entry_path']
+            $array['diff']['last_processed_next_remote_index_entry_path']
         );
         $this->assertSame(99, $array['sql_statements_counted']);
     }

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -43,6 +43,7 @@ class PullStateTest extends TestCase
         $state->pull_pipeline->started_by_command = 'pull';
         $state->diff->next_remote_index_byte_offset = 123;
         $state->diff->last_consumed_remote_index_entry_path = '/wp-content/index.php';
+        $state->diff->previous_next_remote_index_entry_path = '/wp-content/themes/twentytwenty/style.css';
         $state->sql_statements_counted = 99;
 
         $array = $state->to_array();
@@ -52,7 +53,21 @@ class PullStateTest extends TestCase
         $this->assertSame('pull', $array['pull_pipeline']['started_by_command']);
         $this->assertSame(123, $array['diff']['next_remote_index_byte_offset']);
         $this->assertSame('/wp-content/index.php', $array['diff']['last_consumed_remote_index_entry_path']);
+        $this->assertSame(
+            '/wp-content/themes/twentytwenty/style.css',
+            $array['diff']['previous_next_remote_index_entry_path']
+        );
         $this->assertSame(99, $array['sql_statements_counted']);
+    }
+
+    public function testStateAcceptsDiffProgressFromBeforeThePreviousNextPath(): void
+    {
+        $data = (new \PullState())->to_array();
+        unset($data['diff']['previous_next_remote_index_entry_path']);
+
+        $state = \PullState::from_array($data);
+
+        $this->assertNull($state->diff->previous_next_remote_index_entry_path);
     }
 
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push
  * `empty` boolean from the indexer, against the local index.
  * The tests pin the resulting local_paths_to_push JSONL, raw NUL-delimited
  * local paths to delete, cursor replay, and every transition among files,
- * symlinks, empty directories, and non-empty directories.
+ * symlinks, and empty directories.
  */
 final class PushPlanTest extends TestCase
 {
@@ -110,7 +110,6 @@ final class PushPlanTest extends TestCase
     {
         $index = $this->writeIndex([
             'index.php' => [100, 5, 'file'],
-            'wp-content' => [100, 0, 'dir', false],
             'wp-content/themes/foo/style.css' => [150, 5, 'file'],
         ]);
 
@@ -139,14 +138,11 @@ final class PushPlanTest extends TestCase
     {
         $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
-            'private' => [1, 0, 'dir', false],
             'private/gone.txt' => [1, 1, 'file'],
         ]));
         $current = $this->writeIndex([
             'empty' => [2, 0, 'dir', true],
-            'full' => [2, 0, 'dir', false],
             'full/child.txt' => [2, 5, 'file'],
-            'private' => [2, 0, 'dir', false],
             'private/current.txt' => [2, 7, 'file'],
             'public.txt' => [2, 6, 'file'],
         ]);
@@ -167,29 +163,6 @@ final class PushPlanTest extends TestCase
         $this->assertArrayNotHasKey('full', $freshLocalIndexEntries);
         $this->assertArrayNotHasKey('private', $freshLocalIndexEntries);
         $this->assertArrayNotHasKey('empty', $freshLocalIndexEntries['public.txt']);
-    }
-
-    public function testFullExistingLocalIndexProducesCompactFreshLocalIndex(): void
-    {
-        $current = $this->writeIndex([
-            'full/child.txt' => [2, 5, 'file'],
-        ]);
-        $this->saveLocalIndex($current);
-        $existingLocalIndex = file_get_contents($this->localIndexFile());
-        $this->assertIsString($existingLocalIndex);
-        file_put_contents(
-            $this->localIndexFile(),
-            $this->indexLine('full', 1, 0, 'dir', false) . "\n" . $existingLocalIndex
-        );
-
-        $plan = $this->startPlan($current);
-        $this->planToCompletion($plan);
-
-        $this->assertPathCounts(0, 0);
-        $this->assertSame(
-            ['full/child.txt'],
-            array_keys($this->indexEntries($this->planPath('fresh_local_index.jsonl')))
-        );
     }
 
     public function testUnchangedIndexProducesEmptyPlans(): void
@@ -246,25 +219,16 @@ final class PushPlanTest extends TestCase
                 'file' => [['value'], []],
                 'symlink' => [['value'], []],
                 'empty_directory' => [['value'], ['value']],
-                'non_empty_directory' => [['value/child.txt'], ['value']],
             ],
             'symlink' => [
                 'file' => [['value'], []],
                 'symlink' => [['value'], []],
                 'empty_directory' => [['value'], ['value']],
-                'non_empty_directory' => [['value/child.txt'], ['value']],
             ],
             'empty_directory' => [
                 'file' => [['value'], ['value']],
                 'symlink' => [['value'], ['value']],
                 'empty_directory' => [[], []],
-                'non_empty_directory' => [['value/child.txt'], []],
-            ],
-            'non_empty_directory' => [
-                'file' => [['value'], ['value']],
-                'symlink' => [['value'], ['value']],
-                'empty_directory' => [['value'], ['value']],
-                'non_empty_directory' => [['value/child.txt'], []],
             ],
         ];
 
@@ -288,9 +252,7 @@ final class PushPlanTest extends TestCase
     public function testDeletedSubtreeEmitsOnlyItsRootAsALocalPathToDelete(): void
     {
         $this->saveLocalIndex($this->writeIndex([
-            'gone' => [1, 0, 'dir', false],
             'gone/child.txt' => [1, 1, 'file'],
-            'gone/nested' => [1, 0, 'dir', false],
             'gone/nested/leaf.txt' => [1, 1, 'file'],
             'stays.txt' => [1, 1, 'file'],
         ]));
@@ -307,7 +269,6 @@ final class PushPlanTest extends TestCase
     public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
     {
         $this->saveLocalIndex($this->writeIndex([
-            'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
             'b.txt' => [1, 1, 'file'],
         ]));
@@ -332,7 +293,6 @@ final class PushPlanTest extends TestCase
     public function testSeenDeletedDirectorySurvivesAnInterleavedSiblingCursor(): void
     {
         $this->saveLocalIndex($this->writeIndex([
-            'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
         $entries = [];
@@ -356,7 +316,6 @@ final class PushPlanTest extends TestCase
     public function testReplacementRootSurvivesLexicallyInterleavedSiblingPaths(): void
     {
         $this->saveLocalIndex($this->writeIndex([
-            'a' => [1, 0, 'dir', false],
             'a/child.txt' => [1, 1, 'file'],
         ]));
         $current = $this->writeIndex([
@@ -894,10 +853,7 @@ final class PushPlanTest extends TestCase
         if ($logicalType === 'empty_directory') {
             return $this->writeIndex(['value' => [$version, 0, 'dir', true]]);
         }
-        return $this->writeIndex([
-            'value' => [$version, 0, 'dir', false],
-            'value/child.txt' => [$version, $version, 'file'],
-        ]);
+        throw new InvalidArgumentException("Unknown logical index type: {$logicalType}");
     }
 
     /** @return array<string,array{0:int,1:int,2:string}> */

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -135,7 +135,7 @@ final class PushPlanTest extends TestCase
         $this->assertIsInt($firstPath['ctime']);
     }
 
-    public function testPlanCopiesEveryFreshLocalIndexEntryAndExcludesOnlyPushAndDeletePaths(): void
+    public function testPlanRetainsACompactFreshLocalIndexAndExcludesOnlyPushAndDeletePaths(): void
     {
         $this->saveLocalIndex($this->writeIndex([
             'gone.txt' => [1, 1, 'file'],
@@ -160,13 +160,36 @@ final class PushPlanTest extends TestCase
 
         $freshLocalIndexEntries = $this->indexEntries($this->planPath('fresh_local_index.jsonl'));
         $this->assertSame(
-            ['empty', 'full', 'full/child.txt', 'private', 'private/current.txt', 'public.txt'],
+            ['empty', 'full/child.txt', 'private/current.txt', 'public.txt'],
             array_keys($freshLocalIndexEntries)
         );
         $this->assertTrue($freshLocalIndexEntries['empty']['empty']);
-        $this->assertFalse($freshLocalIndexEntries['full']['empty']);
-        $this->assertFalse($freshLocalIndexEntries['private']['empty']);
+        $this->assertArrayNotHasKey('full', $freshLocalIndexEntries);
+        $this->assertArrayNotHasKey('private', $freshLocalIndexEntries);
         $this->assertArrayNotHasKey('empty', $freshLocalIndexEntries['public.txt']);
+    }
+
+    public function testFullExistingLocalIndexProducesCompactFreshLocalIndex(): void
+    {
+        $current = $this->writeIndex([
+            'full/child.txt' => [2, 5, 'file'],
+        ]);
+        $this->saveLocalIndex($current);
+        $existingLocalIndex = file_get_contents($this->localIndexFile());
+        $this->assertIsString($existingLocalIndex);
+        file_put_contents(
+            $this->localIndexFile(),
+            $this->indexLine('full', 1, 0, 'dir', false) . "\n" . $existingLocalIndex
+        );
+
+        $plan = $this->startPlan($current);
+        $this->planToCompletion($plan);
+
+        $this->assertPathCounts(0, 0);
+        $this->assertSame(
+            ['full/child.txt'],
+            array_keys($this->indexEntries($this->planPath('fresh_local_index.jsonl')))
+        );
     }
 
     public function testUnchangedIndexProducesEmptyPlans(): void
@@ -297,7 +320,6 @@ final class PushPlanTest extends TestCase
         $first_cursor = $this->planCursor();
         $this->assertSame(0, $first_cursor['deleted_directory_stack_top_byte_offset']);
 
-        $this->assertTrue($this->nextPlanStep($plan));
         $this->assertFalse($this->nextPlanStep($plan));
         $complete_cursor = $this->planCursor();
         $this->assertSame(['phase' => 'complete'], $complete_cursor);
@@ -539,6 +561,7 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'deleted_directory_stack_top_byte_offset',
+            'previous_fresh_local_index_entry_path',
         ], array_keys($cursor['position']));
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),

--- a/tests/Import/RemoteIndexWalTest.php
+++ b/tests/Import/RemoteIndexWalTest.php
@@ -86,7 +86,7 @@ final class RemoteIndexWalTest extends TestCase
     {
         $reflection = new \ReflectionClass(\ImportClient::class);
         $remoteAbsolutePathToDelete = $reflection
-            ->getMethod('remote_absolute_path_to_delete')
+            ->getMethod('derive_remote_deletion_root_from_sparse_index')
             ->invoke(
                 $this->client(),
                 '/srv/site/gone/nested/file.txt',
@@ -101,7 +101,7 @@ final class RemoteIndexWalTest extends TestCase
     {
         $reflection = new \ReflectionClass(\ImportClient::class);
         $remoteAbsolutePathToDelete = $reflection
-            ->getMethod('remote_absolute_path_to_delete')
+            ->getMethod('derive_remote_deletion_root_from_sparse_index')
             ->invoke(
                 $this->client(),
                 '/srv/site/kept/old.txt',

--- a/tests/Import/RemoteIndexWalTest.php
+++ b/tests/Import/RemoteIndexWalTest.php
@@ -82,6 +82,36 @@ final class RemoteIndexWalTest extends TestCase
         );
     }
 
+    public function testDeletedFileDerivesTheAbsentDirectoryRoot(): void
+    {
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $remoteAbsolutePathToDelete = $reflection
+            ->getMethod('remote_absolute_path_to_delete')
+            ->invoke(
+                $this->client(),
+                '/srv/site/gone/nested/file.txt',
+                '/srv/site/kept.txt',
+                null
+            );
+
+        $this->assertSame('/srv/site/gone', $remoteAbsolutePathToDelete);
+    }
+
+    public function testDeletedFileKeepsAParentWithAnotherNextIndexEntry(): void
+    {
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $remoteAbsolutePathToDelete = $reflection
+            ->getMethod('remote_absolute_path_to_delete')
+            ->invoke(
+                $this->client(),
+                '/srv/site/kept/old.txt',
+                '/srv/site/kept/current.txt',
+                null
+            );
+
+        $this->assertSame('/srv/site/kept/old.txt', $remoteAbsolutePathToDelete);
+    }
+
     public function testReplayDiscardsAnUnterminatedFinalRecord(): void
     {
         $completeRecord = json_encode([

--- a/tests/Import/RemoteIndexWalTest.php
+++ b/tests/Import/RemoteIndexWalTest.php
@@ -63,6 +63,25 @@ final class RemoteIndexWalTest extends TestCase
         $this->assertFileDoesNotExist($remoteIndexWalPath);
     }
 
+    public function testUpsertingFileDoesNotCreateParentDirectoryEntries(): void
+    {
+        $client = $this->client();
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getMethod('upsert_remote_index_entry')->invoke(
+            $client,
+            '/site/nested/file.txt',
+            42,
+            5,
+            'file'
+        );
+        $reflection->getMethod('apply_remote_index_wal')->invoke($client);
+
+        $this->assertSame(
+            ['/site/nested/file.txt'],
+            $this->remoteIndexEntryPaths()
+        );
+    }
+
     public function testReplayDiscardsAnUnterminatedFinalRecord(): void
     {
         $completeRecord = json_encode([
@@ -143,17 +162,31 @@ final class RemoteIndexWalTest extends TestCase
 
     private function firstRemoteIndexEntryPath(): string
     {
+        $paths = $this->remoteIndexEntryPaths();
+        $path = $paths[0] ?? null;
+        $this->assertIsString($path);
+        return $path;
+    }
+
+    /** @return list<string> */
+    private function remoteIndexEntryPaths(): array
+    {
         $lines = file(
             $this->pullStateDirectory . '/remote-index.jsonl',
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($lines);
-        $line = $lines[0] ?? null;
-        $this->assertIsString($line);
-        $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        $path = base64_decode((string) $entry['path']);
-        $this->assertIsString($path);
-        return $path;
+        return array_map(
+            static function (string $line): string {
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                $path = base64_decode((string) $entry['path']);
+                if (!is_string($path)) {
+                    throw new \RuntimeException('Failed to decode remote index path.');
+                }
+                return $path;
+            },
+            $lines
+        );
     }
 
     private function removeTree(string $path): void


### PR DESCRIPTION
File indexes now emit directory entries only for empty directories. Descendants already represent every non-empty directory.

For example:

```text
wp-content/
├── cache/                  (empty)
└── plugins/
    └── akismet.php
```

becomes:

```text
wp-content/cache
wp-content/plugins/akismet.php
```

There are no separate `wp-content` or `wp-content/plugins` rows.

Push and pull derive deleted subtree roots from neighboring sorted entries, so removing a non-empty directory still removes the correct local subtree.

Tests cover file-index output, push planning, pull deletion roots, and resumed diff state.

Closes #452.
