### PR TITLE
Extract reusable index-file sorting function

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -28,6 +28,7 @@ use function Reprint\Importer\apply_curl_proxy_from_environment;
 use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
+use function Reprint\Importer\sort_index_file;
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
@@ -70,8 +71,7 @@ require_once __DIR__ . '/lib/host/load.php';
 // Load target runtime appliers (consume a manifest, write server config)
 require_once __DIR__ . '/lib/target-runtime/load.php';
 
-// External merge sort for large index files when exec() is unavailable
-require_once __DIR__ . '/lib/external-merge-sort.php';
+require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
@@ -2766,7 +2766,7 @@ class ImportClient
                     return;
                 }
             }
-            $this->sort_index_file($this->next_remote_index_file);
+            $this->sort_next_remote_index_file();
             $this->get_state()->active_resumable_command->current_stage = "diff";
             $this->get_state()->diff = new FileDiffProgressState();
             if (file_exists($this->fetch_list_file)) {
@@ -2967,7 +2967,7 @@ class ImportClient
             $this->discover_symlink_targets();
         }
 
-        $this->sort_index_file($this->next_remote_index_file);
+        $this->sort_next_remote_index_file();
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->get_state()->active_resumable_command->current_stage = null;
         $this->save_state();
@@ -9644,190 +9644,17 @@ class ImportClient
     }
 
     /**
-     * Check if a function is available (not disabled).
+     * Sort the next remote index before a command reads it.
      */
-    private function function_available(string $name): bool
+    private function sort_next_remote_index_file(): void
     {
-        if (!function_exists($name)) {
-            return false;
-        }
-        $disabled = ini_get("disable_functions");
-        if ($disabled === false || trim($disabled) === "") {
-            return true;
-        }
-        $list = array_map("trim", explode(",", $disabled));
-        return !in_array($name, $list, true);
-    }
-
-
-    /**
-     * Fast-path index sort via shell exec.
-     *
-     * Prepends a hex-encoded sort key to each line, shells out to `sort(1)`,
-     * strips the keys, and deduplicates.  This handles arbitrarily large
-     * files with no PHP memory pressure.
-     *
-     * @param string $path         The JSONL index file to sort.
-     * @param string $tmp          Temporary output path for the sorted result.
-     * @return bool True if the exec-based sort succeeded (and $path was replaced).
-     */
-    private function try_exec_sort(string $path, string $tmp): bool
-    {
-        if (!$this->function_available("exec")) {
-            return false;
-        }
-
-        $keyed = $path . ".keyed";
-        $sorted_keyed = $path . ".keyed.sorted";
-        $in = fopen($path, "r");
-        $out = fopen($keyed, "w");
-        if (!$in || !$out) {
-            if ($in) {
-                fclose($in);
-            }
-            if ($out) {
-                fclose($out);
-            }
-            $this->audit_log("Failed to prepare keyed index file, falling back to PHP sort");
-            return false;
-        }
-        $lines_read = 0;
-        while (($line = fgets($in)) !== false) {
-            $line = rtrim($line, "\r\n");
-            if ($line === "") {
-                continue;
-            }
-            $entry = $this->parse_index_line($line);
-            if ($entry === null) {
-                continue;
-            }
-            $key = bin2hex($entry["path"]);
-            fwrite($out, $key . "\t" . $line . "\n");
-            if (++$lines_read % 500 === 0) {
-                $this->progress->tick_spinner();
-            }
-        }
-        fclose($in);
-        fclose($out);
-
-        $cmd =
-            "LC_ALL=C sort -t '\t' -k1,1 " .
-            escapeshellarg($keyed) .
-            " > " .
-            escapeshellarg($sorted_keyed);
-        $output = [];
-        $code = 0;
-        exec($cmd, $output, $code);
-        if ($code !== 0) {
-            @unlink($keyed);
-            @unlink($sorted_keyed);
-            $this->audit_log("exec() sort failed (exit code {$code}), falling back to PHP sort");
-            return false;
-        }
-
-        $sorted_in = fopen($sorted_keyed, "r");
-        $sorted_out = fopen($tmp, "w");
-        if (!$sorted_in || !$sorted_out) {
-            if ($sorted_in) {
-                fclose($sorted_in);
-            }
-            if ($sorted_out) {
-                fclose($sorted_out);
-            }
-            @unlink($keyed);
-            @unlink($sorted_keyed);
-            $this->audit_log("Failed to open sorted index files, falling back to PHP sort");
-            return false;
-        }
-
-        $prev_key = null;
-        $lines_stripped = 0;
-        while (($line = fgets($sorted_in)) !== false) {
-            $pos = strpos($line, "\t");
-            if ($pos === false) {
-                continue;
-            }
-            $key = substr($line, 0, $pos);
-            $data = substr($line, $pos + 1);
-            if ($data === "") {
-                continue;
-            }
-            // Deduplicate: skip entries with the same path as the previous one.
-            // This handles overlapping symlink targets that index the same files.
-            if ($key === $prev_key) {
-                continue;
-            }
-            $prev_key = $key;
-            fwrite($sorted_out, $data);
-            if (++$lines_stripped % 500 === 0) {
-                $this->progress->tick_spinner();
-            }
-        }
-        fclose($sorted_in);
-        fclose($sorted_out);
-        @unlink($keyed);
-        @unlink($sorted_keyed);
-        if (!rename($tmp, $path)) {
-            throw new RuntimeException("Failed to replace sorted index file");
-        }
-        return true;
-    }
-
-    /**
-     * Sorts an index file by path and removes duplicate entries.
-     *
-     * Tries the fast path first: prepends a hex-encoded sort key to each line,
-     * shells out to `sort(1)`, then strips the keys.  This handles arbitrarily
-     * large files with no PHP memory pressure.  If exec() is unavailable or
-     * the sort command fails, falls back to an in-memory usort() — which
-     * requires roughly 5x the file size in available memory.
-     *
-     * Duplicates arise from overlapping symlink targets that index the same
-     * files; they are removed during the final write pass.
-     *
-     * @param string $path The JSONL index file to sort in place.
-     */
-    private function sort_index_file(string $path): void
-    {
-        if (!file_exists($path)) {
-            return;
-        }
-        if (filesize($path) === 0) {
+        if (sort_index_file($this->next_remote_index_file)) {
             return;
         }
 
-        $tmp = $path . ".sorted";
-
-        // Fast path: shell out to `sort` for O(n log n) with no memory
-        // pressure.  If anything goes wrong, fall through to the pure-PHP
-        // external merge sort below.
-        if ($this->try_exec_sort($path, $tmp)) {
-            return;
-        }
-
-        // Pure-PHP fallback: external merge sort.  Splits the file into
-        // memory-sized chunks, sorts each in memory, then streams a k-way
-        // merge.  Handles files of any size without exec().
-        $mem_limit_raw = ini_get("memory_limit");
-        $mem_limit = ($mem_limit_raw === "-1" || $mem_limit_raw === "" || $mem_limit_raw === "0")
-            ? 0
-            : parse_size($mem_limit_raw);
-        $mem_used = memory_get_usage(true);
-        $available = $mem_limit > 0
-            ? (int) (($mem_limit - $mem_used) * 0.6)
-            : 256 * 1024 * 1024;
-
-        $key_extractor = function (string $line): ?string {
-            $entry = $this->parse_index_line($line);
-            return $entry !== null ? $entry['path'] : null;
-        };
-        $sorter = new ExternalMergeSort(
-            $key_extractor,
-            max(1024, (int) ($available * 0.8)),
-            true,
-            dirname($path),
+        throw new RuntimeException(
+            "Cannot sort the next remote index because it does not exist: {$this->next_remote_index_file}",
         );
-        $sorter->sort($path);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/sort-index-file.php
+++ b/packages/reprint-importer/src/lib/sort-index-file.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Reprint\Importer;
+
+use RuntimeException;
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\parse_size;
+
+require_once __DIR__ . '/external-merge-sort.php';
+
+/**
+ * Sort an index file by path and remove duplicate entries.
+ *
+ * The fast path prepends a hex-encoded sort key to each line, shells out to
+ * `sort(1)`, then strips the keys. This handles arbitrarily large files with
+ * no PHP memory pressure. When exec() is unavailable or the command fails,
+ * the fallback uses an external merge sort with bounded memory.
+ *
+ * Duplicates arise from overlapping symlink targets that index the same
+ * files; they are removed during the final write pass.
+ *
+ * @param string $path The JSONL index file to sort in place.
+ * @return bool True when the index file was sorted or was empty, false when
+ *              the index file does not exist.
+ */
+function sort_index_file(string $path): bool
+{
+    if (!file_exists($path)) {
+        return false;
+    }
+    if (filesize($path) === 0) {
+        return true;
+    }
+
+    $parse_index_path = static function (string $line): ?string {
+        $line = trim($line);
+        if ($line === '') {
+            return null;
+        }
+
+        $data = json_decode($line, true);
+        if (!is_array($data)) {
+            throw new RuntimeException('Invalid index line format');
+        }
+
+        $path_encoded = $data['path'] ?? '';
+        if (!is_string($path_encoded) || $path_encoded === '') {
+            throw new RuntimeException('Invalid index path');
+        }
+
+        $path = base64_decode($path_encoded, true);
+        if ($path === '' || $path === false) {
+            throw new RuntimeException('Invalid index path (base64 decode failed)');
+        }
+
+        assert_valid_path($path, 'index path');
+        return $path;
+    };
+
+    $tmp = $path . '.sorted';
+
+    // Fast path: shell out to `sort` for O(n log n) with no memory pressure.
+    // If anything goes wrong, fall through to the pure-PHP external merge
+    // sort below.
+    if (try_exec_sort_index_file($path, $tmp, $parse_index_path)) {
+        return true;
+    }
+
+    // Pure-PHP fallback: external merge sort. Splits the file into
+    // memory-sized chunks, sorts each in memory, then streams a k-way merge.
+    // Handles files of any size without exec().
+    $memory_limit_raw = ini_get('memory_limit');
+    $memory_limit = ($memory_limit_raw === '-1' || $memory_limit_raw === '' || $memory_limit_raw === '0')
+        ? 0
+        : parse_size($memory_limit_raw);
+    $memory_used = memory_get_usage(true);
+    $available_memory = $memory_limit > 0
+        ? (int) (($memory_limit - $memory_used) * 0.6)
+        : 256 * 1024 * 1024;
+
+    $sorter = new \ExternalMergeSort(
+        $parse_index_path,
+        max(1024, (int) ($available_memory * 0.8)),
+        true,
+        dirname($path),
+    );
+    $sorter->sort($path);
+    return true;
+}
+
+/**
+ * Attempt to sort an index file with the system `sort(1)` command.
+ *
+ * @param string                   $path             The JSONL index file to sort.
+ * @param string                   $temporary_output Path to write before replacing $path.
+ * @param callable(string):?string $parse_index_path Returns an index path for a JSONL line.
+ * @return bool True when the system command sorted and replaced the file.
+ */
+function try_exec_sort_index_file(
+    string $path,
+    string $temporary_output,
+    callable $parse_index_path
+): bool {
+    $exec_is_available = function_exists('exec') && !in_array(
+        'exec',
+        array_map('trim', explode(',', (string) ini_get('disable_functions'))),
+        true
+    );
+    if (!$exec_is_available) {
+        return false;
+    }
+
+    $keyed = $path . '.keyed';
+    $sorted_keyed = $path . '.keyed.sorted';
+    $input = fopen($path, 'r');
+    $output = fopen($keyed, 'w');
+    if (!$input || !$output) {
+        if ($input) {
+            fclose($input);
+        }
+        if ($output) {
+            fclose($output);
+        }
+        return false;
+    }
+
+    while (($line = fgets($input)) !== false) {
+        $line = rtrim($line, "\r\n");
+        $index_path = $parse_index_path($line);
+        if ($index_path === null) {
+            continue;
+        }
+        fwrite($output, bin2hex($index_path) . "\t" . $line . "\n");
+    }
+    fclose($input);
+    fclose($output);
+
+    $command =
+        "LC_ALL=C sort -t '\t' -k1,1 " .
+        escapeshellarg($keyed) .
+        ' > ' .
+        escapeshellarg($sorted_keyed);
+    $command_output = [];
+    $command_exit_code = 0;
+    exec($command, $command_output, $command_exit_code);
+    if ($command_exit_code !== 0) {
+        @unlink($keyed);
+        @unlink($sorted_keyed);
+        return false;
+    }
+
+    $sorted_input = fopen($sorted_keyed, 'r');
+    $sorted_output = fopen($temporary_output, 'w');
+    if (!$sorted_input || !$sorted_output) {
+        if ($sorted_input) {
+            fclose($sorted_input);
+        }
+        if ($sorted_output) {
+            fclose($sorted_output);
+        }
+        @unlink($keyed);
+        @unlink($sorted_keyed);
+        return false;
+    }
+
+    $previous_key = null;
+    while (($line = fgets($sorted_input)) !== false) {
+        $tab_position = strpos($line, "\t");
+        if ($tab_position === false) {
+            continue;
+        }
+        $key = substr($line, 0, $tab_position);
+        $data = substr($line, $tab_position + 1);
+        if ($data === '' || $key === $previous_key) {
+            continue;
+        }
+        $previous_key = $key;
+        fwrite($sorted_output, $data);
+    }
+    fclose($sorted_input);
+    fclose($sorted_output);
+    @unlink($keyed);
+    @unlink($sorted_keyed);
+    if (!rename($temporary_output, $path)) {
+        throw new RuntimeException('Failed to replace sorted index file');
+    }
+    return true;
+}

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\try_exec_sort_index_file;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/sort-index-file.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+final class SortIndexFileTest extends TestCase
+{
+    private string $temporary_directory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporary_directory = sys_get_temp_dir() . '/sort-index-file-test-' . uniqid();
+        mkdir($this->temporary_directory, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->temporary_directory . '/*') ?: [] as $path) {
+            $this->remove_path($path);
+        }
+        rmdir($this->temporary_directory);
+        parent::tearDown();
+    }
+
+    public function testSystemSortMatchesExternalMergeSortWhenAvailable(): void
+    {
+        if (!function_exists('exec') || !is_executable('/usr/bin/sort')) {
+            $this->markTestSkipped('The system sort command is unavailable.');
+        }
+
+        $system_sort_path = $this->write_unsorted_index('system-sort.jsonl', false);
+        $external_sort_path = $this->write_unsorted_index('external-sort.jsonl', false);
+        $parse_index_path = fn(string $line): ?string => $this->index_path_from_line($line);
+        $sort_directory = $this->temporary_directory . '/sort-bin';
+        $attempt_file = $this->temporary_directory . '/system-sort-attempted';
+        mkdir($sort_directory);
+        file_put_contents(
+            $sort_directory . '/sort',
+            "#!/bin/sh\nprintf attempted > " . escapeshellarg($attempt_file)
+                . "\nexec /usr/bin/sort \"$@\"\n"
+        );
+        chmod($sort_directory . '/sort', 0755);
+
+        $original_path = getenv('PATH');
+        putenv('PATH=' . $sort_directory . ':' . $original_path);
+        try {
+            $this->assertTrue(
+                try_exec_sort_index_file(
+                    $system_sort_path,
+                    $system_sort_path . '.sorted',
+                    $parse_index_path
+                )
+            );
+        } finally {
+            putenv('PATH=' . $original_path);
+        }
+
+        $sorter = new \ExternalMergeSort(
+            $parse_index_path,
+            1024,
+            true,
+            $this->temporary_directory,
+        );
+        $sorter->sort($external_sort_path);
+
+        $this->assertFileExists($attempt_file);
+        $this->assertSame(
+            file_get_contents($external_sort_path),
+            file_get_contents($system_sort_path)
+        );
+    }
+
+    public function testFallsBackToExternalSortWhenSystemSortFails(): void
+    {
+        $path = $this->write_unsorted_index();
+        $sort_directory = $this->temporary_directory . '/sort-bin';
+        $attempt_file = $this->temporary_directory . '/system-sort-attempted';
+        mkdir($sort_directory);
+        file_put_contents(
+            $sort_directory . '/sort',
+            "#!/bin/sh\nprintf attempted > " . escapeshellarg($attempt_file) . "\nexit 1\n"
+        );
+        chmod($sort_directory . '/sort', 0755);
+
+        $original_path = getenv('PATH');
+        putenv('PATH=' . $sort_directory . ':' . $original_path);
+        try {
+            $this->assertTrue(sort_index_file($path));
+        } finally {
+            putenv('PATH=' . $original_path);
+        }
+
+        $this->assertFileExists($attempt_file);
+        $this->assertSame(['/apple', '/banana', '/zebra'], $this->index_paths($path));
+    }
+
+    public function testUsesExternalSortWhenExecIsDisabled(): void
+    {
+        $path = $this->write_unsorted_index();
+        $script = $this->temporary_directory . '/sort-without-exec.php';
+        file_put_contents($script, '<?php' . "\n"
+            . 'require ' . var_export(dirname(__DIR__, 2) . '/packages/reprint-exporter/src/utils.php', true) . ';' . "\n"
+            . 'require ' . var_export(dirname(__DIR__, 2) . '/packages/reprint-importer/src/lib/sort-index-file.php', true) . ';' . "\n"
+            . '\\Reprint\\Importer\\sort_index_file($argv[1]);' . "\n");
+
+        $process = proc_open(
+            [PHP_BINARY, '-d', 'disable_functions=exec', $script, $path],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->assertSame(0, proc_close($process), $stdout . $stderr);
+        $this->assertSame(['/apple', '/banana', '/zebra'], $this->index_paths($path));
+    }
+
+    public function testReturnsFalseForAMissingIndexFile(): void
+    {
+        $this->assertFalse(sort_index_file($this->temporary_directory . '/missing.jsonl'));
+    }
+
+    public function testImporterRejectsAMissingNextRemoteIndex(): void
+    {
+        $client = new \ImportClient(
+            'https://example.test/?site-export-api',
+            $this->temporary_directory . '/state',
+            $this->temporary_directory . '/files'
+        );
+        $sort_next_remote_index_file = (new \ReflectionClass($client))
+            ->getMethod('sort_next_remote_index_file');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot sort the next remote index because it does not exist');
+        $sort_next_remote_index_file->invoke($client);
+    }
+
+    public function testRejectsMalformedIndexLines(): void
+    {
+        $path = $this->temporary_directory . '/index.jsonl';
+        file_put_contents($path, "not json\n");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid index line format');
+        sort_index_file($path);
+    }
+
+    private function write_unsorted_index(string $filename = 'index.jsonl', bool $with_duplicate = true): string
+    {
+        $lines = [
+            $this->index_line('/zebra', 3),
+            $this->index_line('/apple', 2),
+            $this->index_line('/banana', 4),
+        ];
+        if ($with_duplicate) {
+            $lines[] = $this->index_line('/zebra', 1);
+        }
+        $lines[] = '';
+
+        $path = $this->temporary_directory . '/' . $filename;
+        file_put_contents($path, implode("\n", $lines));
+        return $path;
+    }
+
+    private function index_path_from_line(string $line): ?string
+    {
+        $entry = json_decode($line, true);
+        if (!is_array($entry) || !isset($entry['path'])) {
+            return null;
+        }
+        return base64_decode($entry['path'], true) ?: null;
+    }
+
+    /** @return string[] */
+    private function index_paths(string $path): array
+    {
+        $paths = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $entry = json_decode($line, true);
+            $paths[] = base64_decode($entry['path'], true);
+        }
+        return $paths;
+    }
+
+    private function remove_path(string $path): void
+    {
+        if (!is_dir($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (glob($path . '/*') ?: [] as $child) {
+            $this->remove_path($child);
+        }
+        rmdir($path);
+    }
+
+    private function index_line(string $path, int $ctime): string
+    {
+        return json_encode([
+            'path' => base64_encode($path),
+            'ctime' => $ctime,
+            'size' => 0,
+            'type' => 'file',
+        ]);
+    }
+}


### PR DESCRIPTION
The importer now calls a standalone `sort_index_file()` function, so index ordering and duplicate removal can be reused outside `ImportClient`.

The utility keeps the shell-sort path and bounded-memory merge-sort fallback.

Tests: PHP syntax checks and a direct sorting run passed. PHPUnit could not start because this workspace has no `vendor/autoload.php`.