### PR TITLE
Encode pull index WAL upserts as + and deletions as -

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6956,7 +6956,7 @@ class ImportClient
         }
         $pull_index_wal_json_line = json_encode(
             [
-                "op" => "F",
+                "op" => "+",
                 "path" => base64_encode($remote_absolute_path),
                 "ctime" => $remote_path_ctime,
                 "size" => $remote_path_size,
@@ -6995,7 +6995,7 @@ class ImportClient
         }
         $pull_index_wal_json_line = json_encode(
             [
-                "op" => "D",
+                "op" => "-",
                 "path" => base64_encode($remote_absolute_path),
             ],
             JSON_UNESCAPED_SLASHES,
@@ -7203,7 +7203,7 @@ class ImportClient
     }
 
     /**
-     * Read one raw pull index WAL record (F/D).
+     * Read one raw pull index WAL record (`+` upsert or `-` deletion).
      */
     private function read_raw_pull_index_wal_record($pull_index_wal_file_handle): ?array
     {
@@ -7231,7 +7231,7 @@ class ImportClient
             if ($remote_absolute_path === false || $remote_absolute_path === "") {
                 throw new RuntimeException("Invalid pull index WAL path (base64 decode failed)");
             }
-            if ($pull_index_wal_operation === "D") {
+            if ($pull_index_wal_operation === "-") {
                 return [
                     "path" => $remote_absolute_path,
                     "delete" => true,
@@ -7240,7 +7240,7 @@ class ImportClient
                     "type" => null,
                 ];
             }
-            if ($pull_index_wal_operation === "F") {
+            if ($pull_index_wal_operation === "+") {
                 return [
                     "path" => $remote_absolute_path,
                     "delete" => false,

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -63,6 +63,41 @@ final class PullIndexWalTest extends TestCase
         $this->assertFileDoesNotExist($pullIndexWalPath);
     }
 
+    public function testRecordedMutationsUsePlusAndMinusOperations(): void
+    {
+        $client = $this->client();
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getMethod('record_pull_index_wal_upsert')->invoke(
+            $client,
+            '/site/file.txt',
+            42,
+            5,
+            'file'
+        );
+        $reflection->getMethod('record_pull_index_wal_deletion')->invoke(
+            $client,
+            '/site/file.txt'
+        );
+
+        $expectedPullIndexWal =
+            '{"op":"+","path":"'
+            . base64_encode('/site/file.txt')
+            . '","ctime":42,"size":5,"type":"file"}'
+            . "\n"
+            . '{"op":"-","path":"'
+            . base64_encode('/site/file.txt')
+            . '"}'
+            . "\n";
+        $this->assertSame(
+            $expectedPullIndexWal,
+            file_get_contents($this->pullStateDirectory . '/index.wal')
+        );
+
+        $reflection->getMethod('apply_pull_index_wal')->invoke($client);
+        $this->assertSame([], $this->remoteIndexEntryPaths());
+        $reflection->getMethod('remove_pull_index_wal')->invoke($client);
+    }
+
     public function testUpsertingFileDoesNotCreateParentDirectoryEntries(): void
     {
         $client = $this->client();
@@ -115,7 +150,7 @@ final class PullIndexWalTest extends TestCase
     public function testReplayDiscardsAnUnterminatedFinalRecord(): void
     {
         $completeRecord = json_encode([
-            'op' => 'F',
+            'op' => '+',
             'path' => base64_encode('/site/complete.txt'),
             'ctime' => 42,
             'size' => 5,
@@ -123,7 +158,7 @@ final class PullIndexWalTest extends TestCase
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         file_put_contents(
             $this->pullStateDirectory . '/index.wal',
-            $completeRecord . '{"op":"F","path":"'
+            $completeRecord . '{"op":"+","path":"'
         );
 
         $client = $this->client();
@@ -147,7 +182,7 @@ final class PullIndexWalTest extends TestCase
         file_put_contents(
             $this->pullStateDirectory . '/index.wal',
             json_encode([
-                'op' => 'F',
+                'op' => '+',
                 'path' => base64_encode('/site/aborted.txt'),
                 'ctime' => 42,
                 'size' => 5,


### PR DESCRIPTION
Pull index WAL records now use `+` for upserts and `-` for deletions, matching the local-index mutation format introduced in #448.

The focused test asserts the serialized operations and applies an upsert followed by a deletion of the same path.

## Testing

The pull index WAL suite passes 8 tests with 25 assertions. PHPStan, PHP 7.4 compatibility, PHP syntax, and `git diff --check` pass. PHPCS per-file counts are unchanged.
