### PR TITLE
Write pull index WAL records through one method

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -484,12 +484,13 @@ class ImportClient
         int $remote_path_size,
         string $remote_path_type
     ): void {
-        $this->record_pull_index_wal_upsert(
-            $remote_absolute_path,
-            $remote_path_ctime,
-            $remote_path_size,
-            $remote_path_type,
-        );
+        $this->write_pull_index_wal_record([
+            "op" => "+",
+            "remote_absolute_path_b64" => base64_encode($remote_absolute_path),
+            "remote_path_ctime" => $remote_path_ctime,
+            "remote_path_size" => $remote_path_size,
+            "remote_path_type" => $remote_path_type,
+        ]);
     }
 
     /**
@@ -497,7 +498,43 @@ class ImportClient
      */
     private function delete_remote_index_entry(string $remote_absolute_path): void
     {
-        $this->record_pull_index_wal_deletion($remote_absolute_path);
+        $this->write_pull_index_wal_record([
+            "op" => "-",
+            "remote_absolute_path_b64" => base64_encode($remote_absolute_path),
+        ]);
+    }
+
+    /**
+     * Appends one complete record to the pull index WAL.
+     *
+     * @param array $pull_index_wal_record {
+     *     One completed remote-index mutation.
+     *
+     *     @type string $op                       `+` upsert or `-` deletion.
+     *     @type string $remote_absolute_path_b64 Base64 remote absolute path.
+     *     @type int    $remote_path_ctime        Remote ctime for `+`.
+     *     @type int    $remote_path_size         Remote size for `+`.
+     *     @type string $remote_path_type         Remote type for `+`.
+     * }
+     */
+    private function write_pull_index_wal_record(
+        array $pull_index_wal_record
+    ): void {
+        if (!$this->pull_index_wal_handle) {
+            $this->open_pull_index_wal();
+        }
+        $pull_index_wal_json_line = json_encode(
+            $pull_index_wal_record,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (
+            fwrite($this->pull_index_wal_handle, $pull_index_wal_json_line)
+            !== strlen($pull_index_wal_json_line)
+        ) {
+            throw new RuntimeException(
+                "Failed to write to the pull index WAL (disk full?)."
+            );
+        }
     }
 
     /** Replays a pull index WAL left by an interrupted batch. */
@@ -6902,61 +6939,6 @@ class ImportClient
         }
     }
 
-    /**
-     * Record an upsert in the pull index WAL.
-     */
-    private function record_pull_index_wal_upsert(
-        string $remote_absolute_path,
-        int $remote_path_ctime,
-        int $remote_path_size,
-        string $remote_path_type
-    ): void {
-        if (!$this->pull_index_wal_handle) {
-            $this->open_pull_index_wal();
-        }
-        $pull_index_wal_json_line = json_encode(
-            [
-                "op" => "+",
-                "path" => base64_encode($remote_absolute_path),
-                "ctime" => $remote_path_ctime,
-                "size" => $remote_path_size,
-                "type" => $remote_path_type,
-            ],
-            JSON_UNESCAPED_SLASHES,
-        );
-        if ($pull_index_wal_json_line !== false) {
-            $pull_index_wal_json_line .= "\n";
-            $pull_index_wal_bytes_written = fwrite($this->pull_index_wal_handle, $pull_index_wal_json_line);
-            if ($pull_index_wal_bytes_written !== strlen($pull_index_wal_json_line)) {
-                throw new RuntimeException("Failed to write to the pull index WAL (disk full?).");
-            }
-        }
-    }
-
-    /**
-     * Record a deletion in the pull index WAL.
-     */
-    private function record_pull_index_wal_deletion(string $remote_absolute_path): void
-    {
-        if (!$this->pull_index_wal_handle) {
-            $this->open_pull_index_wal();
-        }
-        $pull_index_wal_json_line = json_encode(
-            [
-                "op" => "-",
-                "path" => base64_encode($remote_absolute_path),
-            ],
-            JSON_UNESCAPED_SLASHES,
-        );
-        if ($pull_index_wal_json_line !== false) {
-            $pull_index_wal_json_line .= "\n";
-            $pull_index_wal_bytes_written = fwrite($this->pull_index_wal_handle, $pull_index_wal_json_line);
-            if ($pull_index_wal_bytes_written !== strlen($pull_index_wal_json_line)) {
-                throw new RuntimeException("Failed to write to the pull index WAL (disk full?).");
-            }
-        }
-    }
-
     /** Applies the current pull index WAL to the remote index. */
     private function apply_pull_index_wal(): void
     {
@@ -7155,7 +7137,8 @@ class ImportClient
                 throw new RuntimeException("Invalid pull index WAL line format");
             }
             $pull_index_wal_operation = $pull_index_wal_record["op"] ?? null;
-            $remote_absolute_path_base64 = $pull_index_wal_record["path"] ?? null;
+            $remote_absolute_path_base64 =
+                $pull_index_wal_record["remote_absolute_path_b64"] ?? null;
             if (!is_string($remote_absolute_path_base64) || $remote_absolute_path_base64 === "") {
                 throw new RuntimeException("Invalid pull index WAL path");
             }
@@ -7176,9 +7159,9 @@ class ImportClient
                 return [
                     "path" => $remote_absolute_path,
                     "delete" => false,
-                    "ctime" => (int) ($pull_index_wal_record["ctime"] ?? 0),
-                    "size" => (int) ($pull_index_wal_record["size"] ?? 0),
-                    "type" => (string) ($pull_index_wal_record["type"] ?? "file"),
+                    "ctime" => (int) ($pull_index_wal_record["remote_path_ctime"] ?? 0),
+                    "size" => (int) ($pull_index_wal_record["remote_path_size"] ?? 0),
+                    "type" => (string) ($pull_index_wal_record["remote_path_type"] ?? "file"),
                 ];
             }
         }

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -42,7 +42,7 @@ final class PullIndexWalTest extends TestCase
     {
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('record_pull_index_wal_upsert')->invoke(
+        $reflection->getMethod('upsert_remote_index_entry')->invoke(
             $client,
             '/site/file.txt',
             42,
@@ -67,24 +67,24 @@ final class PullIndexWalTest extends TestCase
     {
         $client = $this->client();
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getMethod('record_pull_index_wal_upsert')->invoke(
+        $reflection->getMethod('upsert_remote_index_entry')->invoke(
             $client,
             '/site/file.txt',
             42,
             5,
             'file'
         );
-        $reflection->getMethod('record_pull_index_wal_deletion')->invoke(
+        $reflection->getMethod('delete_remote_index_entry')->invoke(
             $client,
             '/site/file.txt'
         );
 
         $expectedPullIndexWal =
-            '{"op":"+","path":"'
+            '{"op":"+","remote_absolute_path_b64":"'
             . base64_encode('/site/file.txt')
-            . '","ctime":42,"size":5,"type":"file"}'
+            . '","remote_path_ctime":42,"remote_path_size":5,"remote_path_type":"file"}'
             . "\n"
-            . '{"op":"-","path":"'
+            . '{"op":"-","remote_absolute_path_b64":"'
             . base64_encode('/site/file.txt')
             . '"}'
             . "\n";
@@ -151,14 +151,14 @@ final class PullIndexWalTest extends TestCase
     {
         $completeRecord = json_encode([
             'op' => '+',
-            'path' => base64_encode('/site/complete.txt'),
-            'ctime' => 42,
-            'size' => 5,
-            'type' => 'file',
+            'remote_absolute_path_b64' => base64_encode('/site/complete.txt'),
+            'remote_path_ctime' => 42,
+            'remote_path_size' => 5,
+            'remote_path_type' => 'file',
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
         file_put_contents(
             $this->pullStateDirectory . '/index.wal',
-            $completeRecord . '{"op":"+","path":"'
+            $completeRecord . '{"op":"+","remote_absolute_path_b64":"'
         );
 
         $client = $this->client();
@@ -183,10 +183,10 @@ final class PullIndexWalTest extends TestCase
             $this->pullStateDirectory . '/index.wal',
             json_encode([
                 'op' => '+',
-                'path' => base64_encode('/site/aborted.txt'),
-                'ctime' => 42,
-                'size' => 5,
-                'type' => 'file',
+                'remote_absolute_path_b64' => base64_encode('/site/aborted.txt'),
+                'remote_path_ctime' => 42,
+                'remote_path_size' => 5,
+                'remote_path_type' => 'file',
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
         \write_current_pull_state($this->client(), [


### PR DESCRIPTION
Pull index WAL upserts and deletions now go through one record writer.

The two old helpers repeated the same open, JSON encode, and append sequence. This PR moves record construction to `upsert_remote_index_entry()` and `delete_remote_index_entry()`, names the serialized fields by their remote-path meaning, and leaves `write_pull_index_wal_record()` responsible only for writing a complete record.

The operations remain `+` and `-`, and applying or replaying the WAL produces the same remote index. This is split from #446 so that its next PR can add the local-index projection without carrying this mechanical change.

## Testing

```
cd tests && ../vendor/bin/phpunit Import
php vendor/bin/phpstan analyze --memory-limit=1G
php vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -q packages/reprint-importer/src
php -l packages/reprint-importer/src/import.php
git diff --check
```
