### PR TITLE
[Push] Serve push requests without loading WordPress

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -274,8 +274,9 @@ resets, empty responses, and malformed responses end the current sender run
 without changing request sizing. A later push command reconciles the receiver
 cursor before continuing.
 
-The WordPress plugin passes the platform-supplied `docroot` to push endpoints,
-defaulting to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
+The WordPress plugin copies the platform-supplied `docroot` and the rest of the
+push path policy into private standalone-route configuration, defaulting
+`docroot` to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
 trusted API-options array through the early `site_export_api_options` filter; a
 direct embedder passes the same array to `_site_export_handle_api_request()`.
 The document-root path must resolve to an existing directory. `ABSPATH` remains
@@ -435,9 +436,13 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 ## Low-level files-push command
 
 `reprint files-push <remote-reprint-api-url>` is the production CLI caller for one
-`PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
-It requires `--state-dir`, `--fs-root`, `--secret`, and saved preflight
-data for the remote document root; HTTPS is required unless the operator passes
+`PushFilesSender`. The positional URL selects the shared remote state directory;
+`--push-url` may send push requests to a separate route without changing that
+state. It defaults to the positional URL. The sender records the push URL in
+`sender.json` and rejects a different URL while that push is active. Files-push
+sends only the resolved filesystem root named by `--fs-root`. It requires
+`--state-dir`, `--fs-root`, `--secret`, and saved preflight data for the
+remote document root; HTTPS is required unless the operator passes
 `--force-http`. It reads but never writes
 `<remote-state-directory>/pull/state.json`. It does not run preflight itself,
 show a plan, ask for confirmation, transfer a database, retry a failed request,
@@ -454,7 +459,7 @@ md5(rtrim(<remote-reprint-api-url>, "?&"))
 A different remote query therefore selects a different retained local index. A
 different filesystem root requires a different state directory and does not
 participate in the directory name. Fragments, URL user-info, and `SECRET_KEY`
-target parameters are rejected. The local push state directory must be outside
+parameters are rejected in either URL. The local push state directory must be outside
 the filesystem root so planning cannot index its own changing files.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
@@ -537,9 +542,10 @@ Order:
 1. **Receive work, outside maintenance:** multipart requests write one bounded
    chunk at a time into `work/inflight.data` and move complete values into
    `work/files`. The site runs normally throughout receipt.
-2. **Maintenance on.** Commit writes the `.maintenance` file itself, and since
-   WordPress executes that file, ours whitelists reprint API requests
-   (`$upgrading = 0` for us, `time()` for everyone else). WordPress's own
+2. **Maintenance on.** Commit writes the `.maintenance` file itself. The
+   standalone push route does not load WordPress, and the WordPress route is
+   whitelisted by the marker (`$upgrading = 0` for it, `time()` for everyone
+   else). WordPress's own
    rule that a `.maintenance` file older than 10 minutes is ignored stays
    intact, so an interrupted commit can never leave the site down for good.
 3. **Commit:** consume `work/deletes`, then `work/files`, with the durable
@@ -557,16 +563,26 @@ file after 10 minutes on its own, and the next commit request resumes from
 excluded from installs and deletes and reported as excluded in the summary.
 Updating reprint itself is a separate concern, never part of a sync.
 
-## Escape hatch: commit without booting WordPress
+## Push without booting WordPress
 
-Normally the endpoint runs through the WordPress boot because it is
-convenient. But a commit step can break that boot — a fatal in a partially
-committed plugin — so the same endpoint is also reachable as a standalone PHP file that
-never loads WordPress: it reads database credentials from `wp-config.php`
-directly and operates on the filesystem and database with reprint's own code.
-The driver falls back to it automatically when the normal route stops
-answering sensibly. This is what makes commit failures recoverable from the
-outside instead of requiring SSH.
+The WordPress plugin exposes `push.php` as the files-push URL. It authenticates
+and dispatches every push operation without loading WordPress, so a pushed
+plugin which breaks WordPress startup cannot block the next files-push.
+
+While WordPress is healthy, the plugin writes the current connection token,
+authorization state, document root, reprint directory, exclusions, and limits
+to the mode-0600 private `push-config.json`. The route adds its own installed
+directory to the exclusions. Disabling push blocks every operation except
+continuing `push_commit` after its durable checkpoint; the retained token lets
+that recovery request use the same authentication contract as before
+revocation.
+
+The WordPress-front-controller URL remains the positional remote Reprint API
+URL because it selects the remote state directory and shared local index.
+Files-push receives the standalone URL shown by the plugin settings through
+`--push-url`; that option changes only where push requests are sent. There is
+no automatic fallback between URLs. Hosts which block direct plugin PHP must
+allow this file or provide another no-WordPress route.
 
 ## Database diff (phase two)
 
@@ -632,7 +648,8 @@ Files first, database second, each PR small and stacked in this order:
 8. **Commit engine, files** — delete `work/deletes`, then rename values from
    `work/files` into the document root with the whitelisted maintenance file
    and resumable `commit.json` cursor.
-9. **Standalone escape hatch** — the no-boot endpoint and driver fallback.
+9. **Standalone push route** — the no-WordPress endpoint and its private path
+   policy and authorization configuration.
 10. **Row index and database diff** — the local row index, previously pushed
     rows, diff generation and URL rewrite, the commit batch.
 11. **`reprint files-push`** — the low-level, files-only caller that retains

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -14,8 +14,13 @@ is absolute or relative to a named root.
 - The **filesystem root** is the local directory under which a pulled remote
   filesystem is reconstructed and whose contents are compared, pulled, and
   pushed. Use `$filesystem_root`.
-- The **remote Reprint API URL** is the configured URL used for Reprint
-  requests. Use `$remote_reprint_api_url`.
+- The **remote Reprint API URL** identifies one remote state directory and
+  receives pull requests. Files-push keeps this URL as its positional argument
+  so pull, diff, and push share one local index. Use
+  `$remote_reprint_api_url`.
+- The **push URL** receives push requests. It defaults to the remote Reprint
+  API URL, but `--push-url` may select a standalone route without changing the
+  remote state directory. Use `$push_url`.
 - The **push root** is the remote root selected by the receiving push session.
   Use `$push_root`.
 
@@ -277,6 +282,7 @@ Use these names verbatim:
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
+| Push URL | `push_url`, `$push_url` |
 | PushPlan cursor | `push_plan_cursor`, `$push_plan_cursor`, `get_cursor()` |
 | Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
@@ -287,7 +293,9 @@ Use these names verbatim:
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
 `sender.json` and `excluded_paths.json` live directly under the local push
-state directory. The sender creates `plan/` for one active plan. PushPlan
+state directory. `sender.json` records the push URL so a later process cannot
+resume the active push through a different route. The sender creates `plan/`
+for one active plan. PushPlan
 copies the sender-owned exclusions to `plan/excluded_paths.json` when it starts.
 `fresh_local_index.jsonl`, `local_paths_to_push.jsonl`,
 `local_paths_to_delete`, and `deleted_directories_stack.jsonl` live inside it.
@@ -311,12 +319,13 @@ links to the preceding active directory. The exclusions have a maximum of 100
 paths. The `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`,
-`removing`, and `discarding_plan`. It stores the push session ID, selected
-path-list cursor, selected local-path count, target-confirmed local-path count,
-receiver part limit, and request-sizing state. The index diff cursor retains
-the selected local-path count as it builds the path list, and its complete
-cursor retains the final count. The index diff completes before local paths
-are sent. The index copy after a target-confirmed commit
+`removing`, and `discarding_plan`. It stores the push URL, push session ID,
+push root, selected path-list cursor, selected local-path count,
+target-confirmed local-path count, receiver part limit, and request-sizing
+state. The index diff cursor retains the selected local-path count as it builds
+the path list, and its complete cursor retains the final count. The index diff
+completes before local paths are sent. The index copy after a target-confirmed
+commit
 has no separate copy cursor and is repeated after interruption. After the index
 is saved or the remote confirms removal, the sender clears the PushPlan
 cursor, then removes the entire plan directory and its exclusions file. It
@@ -352,8 +361,9 @@ reports `complete`, `restart`, or `failed`.
 
 ## Files-diff CLI names
 
-The local-only command is `files-diff`. Its `remote Reprint API URL` and
-`filesystem root` have the same meanings as for `files-push`. It reads
+The local-only command is `files-diff`. Its `remote Reprint API URL` selects
+the same remote state directory as files-push, and its `filesystem root` has
+the same meaning. It reads
 `<remote-state-directory>/local_index.jsonl`, which files-pull advances after
 completed local mutations and files-push writes after the target confirms
 commit. Files-diff never changes it.
@@ -375,11 +385,14 @@ running the command again prints the complete report.
 
 ## Files-push CLI names
 
-The low-level, files-only command is `files-push`. Its `remote Reprint API URL` is the
-exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
-`--fs-root`. It requires saved preflight data and uses its remote document
-root as the push root. It also requires `--secret=TOKEN`; `--force-http` is
-the explicit plain-HTTP opt-in.
+The low-level, files-only command is `files-push`. Its positional `remote
+Reprint API URL` selects the remote state directory shared with files-pull and
+files-diff. Its `push URL` receives push requests and defaults to that remote
+Reprint API URL; `--push-url=URL` selects a different route without selecting
+different state. Its `filesystem root` is the resolved absolute directory
+supplied by `--fs-root`. It requires saved preflight data and uses its remote
+document root as the push root. It also requires `--secret=TOKEN`;
+`--force-http` is the explicit plain-HTTP opt-in.
 
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash
@@ -392,7 +405,8 @@ md5(rtrim(<remote-reprint-api-url>, "?&"))
 The state directory belongs to one filesystem root. Use a different state
 directory for a different filesystem root; the filesystem root does not
 participate in the directory name. `files-push` chooses `start` or `resume`
-only from whether `sender.json` exists there. The receiver-confirmed upload
+only from whether `sender.json` exists there. An active `sender.json` records
+the push URL, and resume rejects another push URL. The receiver-confirmed upload
 positions remain receiver-owned; they are not a files-push cursor and are not
 copied into `<remote-state-directory>/pull/state.json` or the state-directory-wide
 `progress.json`.
@@ -426,6 +440,7 @@ Use these names verbatim inside `PushFilesSender`:
 | Local path to delete | `LocalPathToDelete`, `$local_path_to_delete`, `read_next_local_path_to_delete()` |
 | Push stream client | `$push_stream_client`, `create_push_stream_client()` |
 | Push stream client options | `$push_stream_client_options` |
+| Push URL | `$push_url` |
 | Request sizer options | `request_sizer_options`, `$request_sizer_options` |
 | Push request | `send_push_request()` |
 | Open upload request stage | `$upload_request_stage`: `closed`, `sending_parts`, or `finishing` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1563,6 +1563,7 @@ class ImportClient
      *     Parsed files-push options and context.
      *
      *     @type string $secret             HMAC shared secret.
+     *     @type string $push_url           URL receiving push requests. Defaults to the remote Reprint API URL.
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
@@ -1609,7 +1610,7 @@ class ImportClient
             'filesystem_root' => $context['filesystem_root'],
             'push_root' => $push_root,
             'push_state_directory' => $context['push_state_directory'],
-            'remote_reprint_api_url' => $context['remote_reprint_api_url'],
+            'push_url' => $context['push_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
             'chunk_bytes' => $chunk_bytes,
@@ -1911,6 +1912,7 @@ class ImportClient
      *     Parsed files-push options.
      *
      *     @type string $secret     HMAC shared secret.
+     *     @type string $push_url   URL receiving push requests. Defaults to the remote Reprint API URL.
      *     @type bool   $force_http Whether the operator allowed a plain-HTTP target.
      * }
      * @phpstan-param array<string,mixed> $options
@@ -1918,10 +1920,11 @@ class ImportClient
      *     Validated files-push command context.
      *
      *     @type string $remote_reprint_api_url Remote Reprint API URL.
+     *     @type string $push_url              URL receiving push requests.
      *     @type string $filesystem_root  Resolved filesystem root being sent.
      *     @type string $push_state_directory Local push state directory.
      * }
-     * @phpstan-return array{remote_reprint_api_url:string,filesystem_root:string,push_state_directory:string}
+     * @phpstan-return array{remote_reprint_api_url:string,push_url:string,filesystem_root:string,push_state_directory:string}
      */
     public static function prepare_files_push_context(
         string $remote_reprint_api_url,
@@ -1933,9 +1936,18 @@ class ImportClient
         if (!is_string($secret) || $secret === '') {
             throw new InvalidArgumentException('files-push requires --secret=TOKEN.');
         }
+        $push_url = $options['push_url'] ?? $remote_reprint_api_url;
+        if (!is_string($push_url) || $push_url === '') {
+            throw new InvalidArgumentException('files-push requires --push-url to be a non-empty URL.');
+        }
         if (preg_match('/(?:\?|&)SECRET_KEY(?:=|&|$)/', $remote_reprint_api_url) === 1) {
             throw new InvalidArgumentException(
                 'files-push does not accept SECRET_KEY in the remote Reprint API URL; pass --secret=TOKEN.'
+            );
+        }
+        if (preg_match('/(?:\?|&)SECRET_KEY(?:=|&|$)/', $push_url) === 1) {
+            throw new InvalidArgumentException(
+                'files-push does not accept SECRET_KEY in the push URL; pass --secret=TOKEN.'
             );
         }
 
@@ -1945,14 +1957,25 @@ class ImportClient
             $filesystem_root,
             'files-push'
         );
-        $masked_remote_reprint_api_url =
-            self::mask_url_credentials($remote_reprint_api_url);
+        $masked_push_url = self::mask_url_credentials($push_url);
+        if (strpos($push_url, '#') !== false) {
+            throw new InvalidArgumentException(
+                'The files-push push URL must not contain a fragment: ' . $masked_push_url . '.'
+            );
+        }
+        $push_url_user = parse_url($push_url, PHP_URL_USER);
+        $push_url_password = parse_url($push_url, PHP_URL_PASS);
+        if (is_string($push_url_user) || is_string($push_url_password)) {
+            throw new InvalidArgumentException(
+                'The files-push push URL must not contain URL user-info: ' . $masked_push_url . '.'
+            );
+        }
         $force_http = $options['force_http'] ?? false;
-        $scheme = strtolower( (string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME) );
+        $scheme = strtolower( (string) parse_url($push_url, PHP_URL_SCHEME) );
         if ($scheme !== 'https' && !( $scheme === 'http' && $force_http === true )) {
             throw new InvalidArgumentException(
-                'The files-push remote Reprint API URL must use HTTPS: ' . $masked_remote_reprint_api_url
-                . '. Pass --force-http only for a remote Reprint API URL you trust.'
+                'The files-push push URL must use HTTPS: ' . $masked_push_url
+                . '. Pass --force-http only for a push URL you trust.'
             );
         }
         $resolved_local_filesystem_root = realpath($filesystem_root);
@@ -1963,6 +1986,7 @@ class ImportClient
         }
         return [
             'remote_reprint_api_url' => rtrim($remote_reprint_api_url, '?&'),
+            'push_url' => rtrim($push_url, '?&'),
             'filesystem_root' => rtrim($resolved_local_filesystem_root, '/') ?: '/',
             'push_state_directory' => $push_state_directory,
         ];
@@ -11546,6 +11570,14 @@ if (
             'commands' => ['files-push'],
         ],
         [
+            'name' => 'push-url',
+            'type' => 'value',
+            'target' => 'push_url',
+            'placeholder' => 'URL',
+            'help' => 'URL receiving push requests; defaults to the remote Reprint API URL',
+            'commands' => ['files-push'],
+        ],
+        [
             'name' => 'abort',
             'type' => 'flag',
             'target' => 'abort',
@@ -12496,9 +12528,11 @@ if (
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
-            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
+            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--push-url=URL] [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing filesystem root at --fs-root to the remote Reprint API.\n" .
+                "Sends the existing filesystem root at --fs-root to --push-url. The\n" .
+                "remote Reprint API URL selects the same retained local index used by\n" .
+                "files-pull and files-diff. --push-url defaults to that URL.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
                 "It requires saved preflight data for the remote document root.\n" .
@@ -12756,7 +12790,8 @@ if (
             )
                 || strpos($reprint_files_push_command_argument, '--state-dir=') === 0
                 || strpos($reprint_files_push_command_argument, '--fs-root=') === 0
-                || strpos($reprint_files_push_command_argument, '--secret=') === 0;
+                || strpos($reprint_files_push_command_argument, '--secret=') === 0
+                || strpos($reprint_files_push_command_argument, '--push-url=') === 0;
             if (!$reprint_files_push_option_allowed) {
                 $reprint_files_push_option_name = explode('=', $reprint_files_push_command_argument, 2)[0];
                 fwrite(STDERR, "Error: files-push does not accept {$reprint_files_push_option_name}.\n");

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -70,9 +70,11 @@
  * durable phase. A stopped process therefore repeats only an idempotent
  * boundary action rather than a group of unrelated transitions.
  *
- * sender.json owns the top-level phase and the cursor returned by
- * PushPlan. PushFilesSender stores that cursor after every completed planning
- * step but never interprets its internal phase or offsets. The sender creates
+ * sender.json owns the top-level phase, the push URL, and the cursor returned
+ * by PushPlan. Recording the push URL prevents a later process from resuming
+ * an active push through another route. PushFilesSender stores the plan cursor
+ * after every completed planning step but never interprets its internal phase
+ * or offsets. The sender creates
  * the active plan directory before planning and removes the whole directory
  * only after success or target-session removal. The local index for this remote
  * Reprint API URL remains in the remote state directory. Once the plan result
@@ -125,7 +127,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{local_relative_path:string,push_root_relative_path:string,push_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,push_url:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -137,6 +139,9 @@ final class PushFilesSender
 
     /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
+
+    /** @var string URL receiving this sender's push requests. */
+    private string $push_url;
 
     /** @var string Sender-owned active plan directory. */
     private string $plan_directory;
@@ -240,7 +245,7 @@ final class PushFilesSender
      *     @type string                  $filesystem_root         Required filesystem root directory.
      *     @type string                  $push_root               Required remote absolute push root.
      *     @type string                  $push_state_directory    Required local push state directory.
-     *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
+     *     @type string                  $push_url                Required URL receiving push requests.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
      *     @type int|float|string        $chunk_bytes             Maximum bytes read from one local file. Default 4 MiB.
@@ -272,6 +277,7 @@ final class PushFilesSender
             $sender->push_stream_client = $sender->create_push_stream_client(null);
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
+                'push_url' => $sender->push_url,
                 'phase' => 'creating',
                 'push_root_local_relative_path' => $sender->push_root_local_relative_path,
                 'push_plan_cursor' => null,
@@ -318,6 +324,11 @@ final class PushFilesSender
                 );
             }
             $sender->state = $state;
+            if ($state['push_url'] !== $sender->push_url) {
+                throw new InvalidArgumentException(
+                    'files-push must resume with the same push URL recorded by its active sender.'
+                );
+            }
             $sender->push_stream_client = $sender->create_push_stream_client($state);
             if ($state['push_plan_cursor'] !== null) {
                 $sender->plan = PushPlan::resume($state['push_plan_cursor']);
@@ -343,11 +354,15 @@ final class PushFilesSender
         /** @var string $push_root */
         $push_root = $options['push_root'];
         $push_state_directory = $options['push_state_directory'] ?? null;
+        $push_url = $options['push_url'] ?? null;
         if (!is_string($filesystem_root) || !is_dir($filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
         if (!is_string($push_state_directory) || $push_state_directory === '') {
             throw new InvalidArgumentException('PushFilesSender requires a push_state_directory.');
+        }
+        if (!is_string($push_url) || $push_url === '') {
+            throw new InvalidArgumentException('PushFilesSender requires a push_url.');
         }
         if (!$process_lock->is_held()) {
             throw new InvalidArgumentException('PushFilesSender requires a held Reprint process lock.');
@@ -358,7 +373,7 @@ final class PushFilesSender
         }
 
         $push_stream_client_options = [
-            'remote_reprint_api_url' => $options['remote_reprint_api_url'] ?? null,
+            'push_url' => $push_url,
             'hmac_client' => $options['hmac_client'] ?? null,
             'allow_http' => $options['allow_http'] ?? false,
         ];
@@ -376,6 +391,7 @@ final class PushFilesSender
         $this->push_root_local_relative_path = trim($push_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
+        $this->push_url = rtrim($push_url, '?&');
         $this->plan_directory = $this->push_state_directory . '/plan';
         $remote_state_directory = dirname($this->push_state_directory);
         $this->local_index_file = $remote_state_directory . '/local_index.jsonl';

--- a/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-importer/src/lib/upload/class-multipart-push-stream-client.php
@@ -64,8 +64,8 @@ class MultipartPushStreamClient
     /** Maximum JSON response bytes retained from the target. */
     private const MAX_RESPONSE_BYTES = 1024 * 1024;
 
-    /** @var string Remote Reprint API URL used for every signed request target. */
-    private string $remote_reprint_api_url;
+    /** @var string Push URL used for every signed request target. */
+    private string $push_url;
 
     /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
     private Site_Export_HMAC_Client $hmac_client;
@@ -167,11 +167,11 @@ class MultipartPushStreamClient
      * @param array<string,mixed> $options {
      *     Transport, authentication, and limit options.
      *
-     *     @type string $remote_reprint_api_url Required remote Reprint API URL. Must use HTTPS
+     *     @type string $push_url Required URL receiving push requests. Must use HTTPS
      *         unless `allow_http` is true.
      *     @type Site_Export_HMAC_Client $hmac_client Required signer for the
      *         exact method and request URL.
-     *     @type bool $allow_http Whether to permit an explicit HTTP remote Reprint API URL.
+     *     @type bool $allow_http Whether to permit an explicit HTTP push URL.
      *         Default false.
      *     @type PushRequestSizer $request_sizer Request-body sizing state to
      *         reuse. Defaults to a new sizer.
@@ -199,22 +199,22 @@ class MultipartPushStreamClient
                 . 'which older PHP curl bindings interpret as end-of-body. See https://github.com/WordPress/reprint/issues/327.'
             );
         }
-        $remote_reprint_api_url = $options['remote_reprint_api_url'] ?? null;
-        if (!is_string($remote_reprint_api_url) || $remote_reprint_api_url === '') {
-            throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty remote_reprint_api_url option.');
+        $push_url = $options['push_url'] ?? null;
+        if (!is_string($push_url) || $push_url === '') {
+            throw new InvalidArgumentException('MultipartPushStreamClient requires a non-empty push_url option.');
         }
-        $scheme = strtolower((string) parse_url($remote_reprint_api_url, PHP_URL_SCHEME));
+        $scheme = strtolower((string) parse_url($push_url, PHP_URL_SCHEME));
         $allow_http = $options['allow_http'] ?? false;
         if (!is_bool($allow_http) || ($scheme !== 'https' && $scheme !== 'http') || ($scheme === 'http' && !$allow_http)) {
             throw new InvalidArgumentException(
-                'Push remote Reprint API URL must be https://, unless allow_http is true for an explicit http:// remote Reprint API URL.'
+                'Push URL must be https://, unless allow_http is true for an explicit http:// push URL.'
             );
         }
         $hmac_client = $options['hmac_client'] ?? null;
         if (!$hmac_client instanceof Site_Export_HMAC_Client) {
             throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
         }
-        $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
+        $this->push_url = rtrim($push_url, '?&');
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
         if (!$this->request_sizer instanceof PushRequestSizer) {
@@ -1112,7 +1112,7 @@ class MultipartPushStreamClient
     private function endpoint_url(string $endpoint, array $parameters): string
     {
         $parameters = array_merge(['endpoint' => $endpoint], $parameters);
-        return $this->remote_reprint_api_url . (strpos($this->remote_reprint_api_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+        return $this->push_url . (strpos($this->push_url, '?') === false ? '?' : '&') . http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -4,9 +4,13 @@ When working from this monorepo checkout, run `composer install` in
 `reprint-exporter-wp/` to populate the bundled `vendor/` directory used by the
 plugin runtime. GitHub release ZIPs already include that vendor tree.
 
-## API Routing
+## API routing
 
-Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside `wp-content/plugins/` at the web server level, returning a 403 before the request ever reaches PHP. To work around this, export API requests are routed through WordPress's front controller (`index.php` at the site root), which hosts never block.
+### Pull route
+
+Many shared hosts block direct PHP execution inside `wp-content/plugins/` at
+the web server level. Pull requests therefore use WordPress's front controller
+at `https://example.com/?reprint-api`.
 
 ### How it works
 
@@ -21,6 +25,45 @@ When a request arrives at `https://example.com/?reprint-api` (or the legacy `?si
 5. Calls `exit` — WordPress never finishes booting
 
 This gives us a clean execution environment while using WordPress's front controller as the entry point.
+
+### Standalone push route
+
+Use the separate URL shown as **Push endpoint** in the plugin settings with
+`files-push`. It normally ends in:
+
+```text
+https://example.com/wp-content/plugins/reprint-exporter/push.php
+```
+
+```bash
+php reprint.phar files-push \
+  "https://example.com/?reprint-api" \
+  --state-dir=/path/to/reprint-state \
+  --fs-root=/path/to/local-tree \
+  --secret=the-connection-token \
+  --push-url="https://example.com/wp-content/plugins/reprint-exporter/push.php"
+```
+
+`push.php` does not load WordPress. A pushed plugin can therefore prevent
+WordPress from starting without preventing the next `files-push` from replacing
+that plugin. Every push operation still uses the same connection token and
+push-authorization rules as the WordPress route.
+
+The positional remote Reprint API URL still selects the remote state directory
+and shared local index used by `files-pull`, `files-diff`, and `files-push`.
+`--push-url` changes only where `files-push` sends its requests.
+
+While WordPress is healthy, the plugin copies the current token, authorization
+state, document root, reprint directory, exclusions, and push limits to the
+mode-0600 private file
+`<default-reprint-directory>/.reprint/push-config.json`. The standalone route
+reads that file and always adds its own installed directory to the excluded
+paths. Revoking push access keeps a disabled copy only so an authenticated
+`push_commit` can finish work which already has a durable checkpoint.
+
+A host which blocks direct execution of `push.php` cannot use the bundled
+recovery route until it allows that file or exposes another PHP route which does
+not load WordPress.
 
 ### Platform configuration
 
@@ -56,13 +99,21 @@ The supported options are:
 - `maximum_commit_entries` — the maximum number of bounded entries processed
   by one `push_commit` request. It defaults to 256.
 
+The plugin copies the path policy and numeric limits into the standalone push
+configuration. A callable `authenticate` option cannot be persisted. Platforms
+using custom authentication must expose their own push route outside WordPress
+instead of the bundled `push.php`; the plugin removes the bundled route's
+private configuration when that callback is present.
+
 ## Push access
 
 Connection tokens authorize downloads only by default. This also applies to
 tokens that already existed when the plugin was upgraded; no migration enables
 push access. A site administrator can grant push access from the plugin settings
 page. The grant stores a fingerprint of the current connection token, so rotating
-that token revokes the grant and requires fresh consent.
+that token revokes the grant and requires fresh consent. Enabling push also
+writes the private configuration required by the standalone push route; a
+failure to write it makes the settings update fail.
 
 Hosts can manage push access before active plugins load with an immutable boolean:
 

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -179,6 +179,214 @@ function _site_export_update_shared_secret(string $secret): bool {
     return (bool) update_option(SITE_EXPORT_SECRET_OPTION, $secret, false);
 }
 
+/** Copies push authentication, authorization, and path policy outside WordPress. */
+function _site_export_sync_standalone_push_configuration(): bool {
+    $configuration_path = _site_export_get_standalone_push_configuration_path();
+    if ($configuration_path === null) {
+        return false;
+    }
+
+    $connection_secret = _site_export_get_shared_secret();
+    clearstatcache(true, $configuration_path);
+    $configuration_exists = file_exists($configuration_path) || is_link($configuration_path);
+    if ($connection_secret === null) {
+        return !$configuration_exists || @unlink($configuration_path);
+    }
+
+    $push_authorization_error = _site_export_get_push_authorization_error();
+    if ($push_authorization_error !== null && !$configuration_exists) {
+        // A download-only connection needs no second copy of its token. Once
+        // push has been enabled, retain the token so an interrupted commit can
+        // still authenticate after push access is revoked.
+        return true;
+    }
+
+    return _site_export_write_standalone_push_configuration(
+        $connection_secret,
+        $push_authorization_error
+    );
+}
+
+/** Returns the private configuration read by the standalone push route. */
+function _site_export_get_standalone_push_configuration_path(): ?string {
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
+    $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+    if (!is_string($configured_docroot) || $configured_docroot === '') {
+        return null;
+    }
+
+    $docroot = realpath($configured_docroot);
+    if ($docroot === false || !is_dir($docroot)) {
+        return null;
+    }
+    $docroot = $docroot === '/' ? '/' : rtrim($docroot, '/\\');
+    $reprint_directory = dirname($docroot)
+        . '/.reprint-'
+        . substr(hash('sha256', $docroot), 0, 12);
+
+    return $reprint_directory . '/.reprint/push-config.json';
+}
+
+/** Atomically writes the private configuration read without WordPress. */
+function _site_export_write_standalone_push_configuration(
+    string $connection_secret,
+    ?string $push_authorization_error
+): bool {
+    if ($connection_secret === '') {
+        return false;
+    }
+    $configuration_path = _site_export_get_standalone_push_configuration_path();
+    if ($configuration_path === null) {
+        return false;
+    }
+    $push_server_configuration = _site_export_get_standalone_push_server_configuration();
+    if ($push_server_configuration === null) {
+        // A stale default-authentication file must not remain usable after the
+        // site switches to policy which cannot run without WordPress.
+        clearstatcache(true, $configuration_path);
+        if (file_exists($configuration_path) || is_link($configuration_path)) {
+            @unlink($configuration_path);
+        }
+        return false;
+    }
+    $configuration_directory = dirname($configuration_path);
+    if (
+        !is_dir($configuration_directory)
+        && !@mkdir($configuration_directory, 0700, true)
+        && !is_dir($configuration_directory)
+    ) {
+        return false;
+    }
+
+    $configuration = [
+        'connection_secret_b64' => base64_encode($connection_secret),
+        'push_authorization_error' => $push_authorization_error,
+        'docroot_b64' => base64_encode($push_server_configuration['docroot']),
+        'reprint_directory_b64' => base64_encode($push_server_configuration['reprint_directory']),
+        'excluded_paths_b64' => array_map('base64_encode', $push_server_configuration['excluded_paths']),
+    ];
+    foreach (['maximum_part_bytes', 'maximum_commit_entries'] as $option_name) {
+        if (array_key_exists($option_name, $push_server_configuration)) {
+            $configuration[$option_name] = $push_server_configuration[$option_name];
+        }
+    }
+    $contents = json_encode($configuration, JSON_UNESCAPED_SLASHES);
+    if ($contents === false) {
+        return false;
+    }
+    $contents .= "\n";
+    if (
+        is_file($configuration_path)
+        && !is_link($configuration_path)
+        && file_get_contents($configuration_path) === $contents
+    ) {
+        return true;
+    }
+
+    try {
+        $temporary_path = $configuration_path . '.' . bin2hex(random_bytes(8)) . '.tmp';
+    } catch (Throwable $throwable) {
+        return false;
+    }
+    $temporary_handle = @fopen($temporary_path, 'x+b');
+    if ($temporary_handle === false) {
+        return false;
+    }
+    $written_bytes = 0;
+    $temporary_file_complete = false;
+    try {
+        if (!@chmod($temporary_path, 0600)) {
+            return false;
+        }
+        $contents_bytes = strlen($contents);
+        while ($written_bytes < $contents_bytes) {
+            $written = fwrite($temporary_handle, substr($contents, $written_bytes));
+            if ($written === false || $written === 0) {
+                return false;
+            }
+            $written_bytes += $written;
+        }
+        if (!fflush($temporary_handle)) {
+            return false;
+        }
+        $temporary_file_complete = true;
+    } finally {
+        fclose($temporary_handle);
+        if (!$temporary_file_complete) {
+            @unlink($temporary_path);
+        }
+    }
+    if (!@rename($temporary_path, $configuration_path)) {
+        @unlink($temporary_path);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Returns the trusted path policy persisted for requests which skip WordPress.
+ *
+ * @return array|null {
+ *     Standalone push-server options, or null when they cannot be persisted.
+ *
+ *     @type string   $docroot                  Resolved document root changed by push.
+ *     @type string   $reprint_directory        Private push storage directory.
+ *     @type string[] $excluded_paths           Document-root-relative paths push must preserve.
+ *     @type int      $maximum_part_bytes       Optional maximum upload-part bytes.
+ *     @type int      $maximum_commit_entries   Optional maximum entries processed by one commit request.
+ * }
+ */
+function _site_export_get_standalone_push_server_configuration(): ?array {
+    $options = [];
+    if (function_exists('apply_filters')) {
+        $options = apply_filters('site_export_api_options', []);
+    }
+    if (!is_array($options) || ( $options['authenticate'] ?? null ) !== null) {
+        return null;
+    }
+
+    if (array_key_exists('docroot', $options)) {
+        $configured_docroot = $options['docroot'];
+    } else {
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted server configuration and must retain exact filesystem bytes.
+        $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
+    }
+    if (!is_string($configured_docroot) || $configured_docroot === '') {
+        return null;
+    }
+    $docroot = realpath($configured_docroot);
+    if ($docroot === false || !is_dir($docroot)) {
+        return null;
+    }
+    $docroot = $docroot === '/' ? '/' : rtrim($docroot, '/\\');
+
+    $reprint_directory = $options['reprint_directory'] ?? (
+        dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
+    );
+    $excluded_paths = $options['excluded_paths'] ?? [];
+    if (!is_string($reprint_directory) || $reprint_directory === '' || !is_array($excluded_paths)) {
+        return null;
+    }
+    foreach ($excluded_paths as $excluded_path) {
+        if (!is_string($excluded_path)) {
+            return null;
+        }
+    }
+
+    $configuration = [
+        'docroot' => $docroot,
+        'reprint_directory' => $reprint_directory,
+        'excluded_paths' => array_values($excluded_paths),
+    ];
+    foreach (['maximum_part_bytes', 'maximum_commit_entries'] as $option_name) {
+        if (array_key_exists($option_name, $options)) {
+            $configuration[$option_name] = $options[$option_name];
+        }
+    }
+    return $configuration;
+}
+
 /**
  * Returns the hosting provider's push policy, or null when the site controls it.
  *
@@ -241,15 +449,40 @@ function _site_export_update_push_authorization(bool $enabled): bool {
         return false;
     }
 
-    $fingerprint = '';
-    if ($enabled) {
-        $fingerprint = hash('sha256', $secret);
+    $fingerprint = $enabled ? hash('sha256', $secret) : '';
+    $previous_fingerprint = function_exists('get_option')
+        ? get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '')
+        : '';
+    if ($previous_fingerprint === $fingerprint) {
+        return _site_export_sync_standalone_push_configuration();
     }
-    if (function_exists('get_option') && get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint) {
+
+    if (!$enabled) {
+        $configuration_updated = $secret === null
+            ? _site_export_sync_standalone_push_configuration()
+            : _site_export_write_standalone_push_configuration(
+                $secret,
+                'Push access is disabled for the current connection token.'
+            );
+        if (!$configuration_updated) {
+            return false;
+        }
+    }
+
+    if (! (bool) update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $fingerprint, false)) {
+        _site_export_sync_standalone_push_configuration();
+        return false;
+    }
+    if (_site_export_sync_standalone_push_configuration()) {
         return true;
     }
 
-    return (bool) update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $fingerprint, false);
+    // The standalone route is the recovery path. Do not leave its grant and
+    // WordPress's authorization record disagreeing when its file cannot be
+    // updated.
+    update_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, $previous_fingerprint, false);
+    _site_export_sync_standalone_push_configuration();
+    return false;
 }
 
 /**

--- a/reprint-exporter-wp/push.php
+++ b/reprint-exporter-wp/push.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Standalone push route for the web server's document root.
+ *
+ * This file deliberately does not load WordPress. The private configuration
+ * written while WordPress is healthy lets files-push repair code which later
+ * prevents WordPress from starting.
+ */
+
+@ini_set('display_errors', '0');
+@ini_set('html_errors', '0');
+while (ob_get_level()) {
+    ob_end_clean();
+}
+clearstatcache(true);
+
+$site_export_plugin_directory = __DIR__ . '/';
+$site_export_repo_root = dirname(__DIR__);
+$site_export_runtime = null;
+foreach ([
+    [
+        'autoload' => $site_export_plugin_directory . 'vendor/autoload.php',
+        'http_server' => $site_export_plugin_directory . 'vendor/wp-php-toolkit/reprint-exporter/src/class-http-server.php',
+    ],
+    [
+        'autoload' => $site_export_repo_root . '/vendor/autoload.php',
+        'http_server' => $site_export_repo_root . '/vendor/wp-php-toolkit/reprint-exporter/src/class-http-server.php',
+    ],
+] as $site_export_candidate) {
+    if (is_file($site_export_candidate['autoload']) && is_file($site_export_candidate['http_server'])) {
+        $site_export_runtime = $site_export_candidate;
+        break;
+    }
+}
+if ($site_export_runtime === null) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
+    );
+}
+require_once $site_export_runtime['autoload'];
+require_once $site_export_runtime['http_server'];
+
+Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('*');
+
+// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput -- Push authenticates the exact signed request target below.
+$site_export_endpoint = $_GET['endpoint'] ?? null;
+if (!is_string($site_export_endpoint) || strpos($site_export_endpoint, 'push_') !== 0) {
+    _site_export_standalone_push_error(
+        404,
+        'invalid_request',
+        'The standalone push route accepts only push endpoints.'
+    );
+}
+
+$site_export_server_docroot_configuration = $_SERVER['DOCUMENT_ROOT'] ?? null;
+if (!is_string($site_export_server_docroot_configuration) || $site_export_server_docroot_configuration === '') {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The standalone push route requires DOCUMENT_ROOT to name an existing directory.'
+    );
+}
+$site_export_server_docroot = realpath($site_export_server_docroot_configuration);
+if ($site_export_server_docroot === false || !is_dir($site_export_server_docroot)) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The standalone push route requires DOCUMENT_ROOT to name an existing directory; observed '
+            . json_encode($site_export_server_docroot_configuration)
+            . '.'
+    );
+}
+$site_export_server_docroot = $site_export_server_docroot === '/'
+    ? '/'
+    : rtrim($site_export_server_docroot, '/\\');
+$site_export_configuration_reprint_directory = dirname($site_export_server_docroot)
+    . '/.reprint-'
+    . substr(hash('sha256', $site_export_server_docroot), 0, 12);
+$site_export_configuration_path = $site_export_configuration_reprint_directory
+    . '/.reprint/push-config.json';
+if (!is_file($site_export_configuration_path) || is_link($site_export_configuration_path)) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'Enable push access in WordPress before using the standalone push route.'
+    );
+}
+$site_export_configuration_json = file_get_contents($site_export_configuration_path);
+$site_export_configuration = is_string($site_export_configuration_json)
+    ? json_decode($site_export_configuration_json, true)
+    : null;
+$site_export_configuration_has_required_fields = is_array($site_export_configuration)
+    && array_key_exists('push_authorization_error', $site_export_configuration)
+    && array_key_exists('excluded_paths_b64', $site_export_configuration);
+$site_export_connection_secret_b64 = is_array($site_export_configuration)
+    ? ( $site_export_configuration['connection_secret_b64'] ?? null )
+    : null;
+$site_export_docroot_b64 = is_array($site_export_configuration)
+    ? ( $site_export_configuration['docroot_b64'] ?? null )
+    : null;
+$site_export_reprint_directory_b64 = is_array($site_export_configuration)
+    ? ( $site_export_configuration['reprint_directory_b64'] ?? null )
+    : null;
+$site_export_excluded_paths_b64 = is_array($site_export_configuration)
+    ? ( $site_export_configuration['excluded_paths_b64'] ?? null )
+    : null;
+$site_export_push_authorization_error = is_array($site_export_configuration)
+    ? ( $site_export_configuration['push_authorization_error'] ?? null )
+    : null;
+$site_export_connection_secret = is_string($site_export_connection_secret_b64)
+    ? base64_decode($site_export_connection_secret_b64, true)
+    : false;
+$site_export_configured_docroot = is_string($site_export_docroot_b64)
+    ? base64_decode($site_export_docroot_b64, true)
+    : false;
+$site_export_reprint_directory = is_string($site_export_reprint_directory_b64)
+    ? base64_decode($site_export_reprint_directory_b64, true)
+    : false;
+if (
+    !$site_export_configuration_has_required_fields
+    || $site_export_connection_secret === false
+    || $site_export_connection_secret === ''
+    || $site_export_configured_docroot === false
+    || $site_export_configured_docroot === ''
+    || $site_export_reprint_directory === false
+    || $site_export_reprint_directory === ''
+    || !is_array($site_export_excluded_paths_b64)
+    || (
+        $site_export_push_authorization_error !== null
+        && (
+            !is_string($site_export_push_authorization_error)
+            || $site_export_push_authorization_error === ''
+        )
+    )
+) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The private standalone push configuration is invalid.'
+    );
+}
+$site_export_docroot = realpath($site_export_configured_docroot);
+if ($site_export_docroot === false || !is_dir($site_export_docroot)) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The private standalone push configuration names a document root which is not an existing directory.'
+    );
+}
+$site_export_docroot = $site_export_docroot === '/' ? '/' : rtrim($site_export_docroot, '/\\');
+$site_export_excluded_paths = [];
+foreach ($site_export_excluded_paths_b64 as $site_export_excluded_path_b64) {
+    $site_export_excluded_path = is_string($site_export_excluded_path_b64)
+        ? base64_decode($site_export_excluded_path_b64, true)
+        : false;
+    if ($site_export_excluded_path === false) {
+        _site_export_standalone_push_error(
+            503,
+            'not_configured',
+            'The private standalone push configuration contains an invalid excluded path.'
+        );
+    }
+    $site_export_excluded_paths[] = $site_export_excluded_path;
+}
+
+$site_export_script_filename = $_SERVER['SCRIPT_FILENAME'] ?? null;
+if (!is_string($site_export_script_filename) || $site_export_script_filename === '') {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The standalone push route requires SCRIPT_FILENAME to identify its installed directory.'
+    );
+}
+$site_export_route_directory = \WordPress\Reprint\Exporter\normalize_path(
+    str_replace('\\', '/', dirname($site_export_script_filename))
+);
+$site_export_canonical_route_directory = realpath($site_export_route_directory);
+$site_export_canonical_plugin_directory = realpath(__DIR__);
+if (
+    $site_export_canonical_route_directory === false
+    || $site_export_canonical_plugin_directory === false
+    || rtrim($site_export_canonical_route_directory, '/\\') !== rtrim($site_export_canonical_plugin_directory, '/\\')
+) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'SCRIPT_FILENAME does not identify the installed Reprint Exporter directory.'
+    );
+}
+
+// Keep the served path lexical until its document-root-relative name is known.
+// realpath() could follow a symlinked plugin outside the document root and omit
+// the installed route from push exclusions.
+$site_export_route_relative_path = null;
+$site_export_route_docroots = [str_replace('\\', '/', $site_export_docroot)];
+if ($site_export_server_docroot === $site_export_docroot) {
+    $site_export_lexical_server_docroot = rtrim(
+        \WordPress\Reprint\Exporter\normalize_path(
+            str_replace('\\', '/', $site_export_server_docroot_configuration)
+        ),
+        '/'
+    );
+    $site_export_route_docroots[] = $site_export_lexical_server_docroot === ''
+        ? '/'
+        : $site_export_lexical_server_docroot;
+}
+foreach (array_unique($site_export_route_docroots) as $site_export_route_docroot) {
+    $site_export_docroot_prefix = $site_export_route_docroot === '/'
+        ? '/'
+        : $site_export_route_docroot . '/';
+    if (strpos($site_export_route_directory . '/', $site_export_docroot_prefix) === 0) {
+        $site_export_docroot_relative_offset = $site_export_route_docroot === '/'
+            ? 1
+            : strlen($site_export_route_docroot) + 1;
+        $site_export_route_relative_path = substr(
+            $site_export_route_directory,
+            $site_export_docroot_relative_offset
+        );
+        break;
+    }
+}
+if ($site_export_route_relative_path === '') {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'The Reprint Exporter directory must not be the configured document root.'
+    );
+}
+if (
+    $site_export_route_relative_path === null
+    && $site_export_server_docroot === $site_export_docroot
+) {
+    _site_export_standalone_push_error(
+        503,
+        'not_configured',
+        'SCRIPT_FILENAME must locate the Reprint Exporter directory below the configured document root.'
+    );
+}
+if ($site_export_route_relative_path !== null) {
+    $site_export_excluded_paths[] = $site_export_route_relative_path;
+}
+
+$site_export_request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
+$site_export_request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
+$site_export_authentication_error = (
+    new Site_Export_HMAC_Server($site_export_connection_secret, 300)
+)->verify_envelope($_SERVER, $site_export_request_method, $site_export_request_target);
+if ($site_export_authentication_error !== null) {
+    _site_export_standalone_push_error(403, 'auth_failed', $site_export_authentication_error);
+}
+
+$site_export_managed_push_enabled = getenv('SITE_EXPORT_PUSH_ENABLED');
+if ($site_export_managed_push_enabled !== false) {
+    $site_export_push_authorization_error = filter_var(
+        $site_export_managed_push_enabled,
+        FILTER_VALIDATE_BOOLEAN,
+        FILTER_NULL_ON_FAILURE
+    ) === true
+        ? null
+        : 'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.';
+}
+if ($site_export_push_authorization_error !== null && $site_export_endpoint !== 'push_commit') {
+    _site_export_standalone_push_error(
+        403,
+        'push_disabled',
+        $site_export_push_authorization_error
+    );
+}
+// phpcs:enable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput
+
+$site_export_push_options = [
+    'reprint_directory' => $site_export_reprint_directory,
+    'docroot' => $site_export_docroot,
+    'excluded_paths' => $site_export_excluded_paths,
+];
+foreach (['maximum_part_bytes', 'maximum_commit_entries'] as $site_export_option_name) {
+    if (array_key_exists($site_export_option_name, $site_export_configuration)) {
+        $site_export_push_options[$site_export_option_name] = $site_export_configuration[$site_export_option_name];
+    }
+}
+if ($site_export_push_authorization_error !== null) {
+    $site_export_push_options['commit_start_denial_detail'] = $site_export_push_authorization_error;
+}
+
+try {
+    Site_Export_HTTP_Server::serve(['push' => $site_export_push_options]);
+} catch (Site_Export_Push_Configuration_Exception $exception) {
+    _site_export_standalone_push_error(503, 'not_configured', $exception->getMessage());
+} catch (InvalidArgumentException $exception) {
+    _site_export_standalone_push_error(400, 'invalid_request', $exception->getMessage());
+} catch (Throwable $throwable) {
+    _site_export_standalone_push_error(
+        500,
+        'filesystem_error',
+        'The standalone push route failed while processing the request.'
+    );
+}
+
+/** Sends one push-protocol failure without loading WordPress. */
+function _site_export_standalone_push_error(int $http_code, string $reason, string $detail): void {
+    http_response_code($http_code);
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Expires: 0');
+    header('Content-Type: application/json');
+    echo json_encode([
+        'status' => 'rejected',
+        'reason' => $reason,
+        'detail' => $detail,
+    ]);
+    exit;
+}

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -3,10 +3,10 @@
  * Admin interface for Reprint Exporter plugin.
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
- * The export API is triggered via `?reprint-api` (or the legacy
- * `?site-export-api` alias) during plugin load,
- * before WordPress finishes booting. It reads the secret from a site option,
- * with secret.php supported only as an override when present.
+ * Pull requests use `?reprint-api` (or the legacy `?site-export-api` alias)
+ * during plugin load. Push requests can use push.php without loading WordPress.
+ * Both routes read the connection token configured here, with secret.php
+ * supported only as an override when present.
  *
  * Authentication uses HMAC signatures: the importing side generates a secret,
  * the user enters it here, and all requests must include a valid signature
@@ -24,6 +24,7 @@ class Site_Export_Plugin {
     }
 
     private function __construct() {
+        _site_export_sync_standalone_push_configuration();
         add_action('init', [$this, 'register_settings']);
         add_action(
             'update_option_' . SITE_EXPORT_SECRET_OPTION,
@@ -197,6 +198,7 @@ class Site_Export_Plugin {
         $stored_secret = _site_export_get_option_secret();
         $effective_secret = _site_export_get_shared_secret() ?? '';
         $api_url = home_url('?reprint-api');
+        $push_url = plugin_dir_url(SITE_EXPORT_PLUGIN_DIR . 'index.php') . 'push.php';
         $is_configured = $effective_secret !== '';
         $has_file_override = _site_export_has_secret_file();
         $managed_push_enabled = _site_export_get_managed_push_enabled();
@@ -432,13 +434,26 @@ class Site_Export_Plugin {
 
             <?php if ($is_configured): ?>
             <div class="site-export-card">
-                <h2>API Endpoint</h2>
+                <h2>Download endpoint</h2>
                 <p class="card-desc">
-                    If your import tool asks for an endpoint URL, copy this:
+                    Use this as the remote Reprint API URL for pull, diff, and push commands:
                 </p>
                 <div class="site-export-endpoint">
                     <code id="site-export-api-url"><?php echo esc_html($api_url); ?></code>
-                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl()">Copy</button>
+                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl('site-export-api-url', this)">Copy</button>
+                </div>
+            </div>
+            <?php endif; ?>
+
+            <?php if ($is_configured && $push_enabled): ?>
+            <div class="site-export-card">
+                <h2>Push endpoint</h2>
+                <p class="card-desc">
+                    Pass this URL to <code>files-push</code> as <code>--push-url</code>. It remains available when WordPress cannot start.
+                </p>
+                <div class="site-export-endpoint">
+                    <code id="site-export-push-url"><?php echo esc_html($push_url); ?></code>
+                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl('site-export-push-url', this)">Copy</button>
                 </div>
             </div>
             <?php endif; ?>
@@ -449,13 +464,12 @@ class Site_Export_Plugin {
             var input = document.getElementById('site_export_secret');
             input.type = input.type === 'password' ? 'text' : 'password';
         }
-        function siteExportCopyUrl() {
-            var url = document.getElementById('site-export-api-url').textContent.trim();
+        function siteExportCopyUrl(elementId, button) {
+            var url = document.getElementById(elementId).textContent.trim();
             navigator.clipboard.writeText(url).then(function() {
-                var btn = document.querySelector('.site-export-copy-btn');
-                var original = btn.textContent;
-                btn.textContent = 'Copied!';
-                setTimeout(function() { btn.textContent = original; }, 1500);
+                var original = button.textContent;
+                button.textContent = 'Copied!';
+                setTimeout(function() { button.textContent = original; }, 1500);
             });
         }
         </script>

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -118,11 +118,13 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('--secret=TOKEN', $output);
+        $this->assertStringContainsString('--push-url=URL', $output);
         $this->assertStringContainsString('--force-http', $output);
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
         $this->assertStringContainsString('existing filesystem root at --fs-root', $output);
         $this->assertStringContainsString('requires saved preflight data', $output);
+        $this->assertStringContainsString('same retained local index used by', $output);
         $this->assertStringContainsString('read or modify', $output);
         $this->assertStringNotContainsString('--abort', $output);
         $this->assertStringNotContainsString('--filter', $output);

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -189,7 +189,7 @@ final class FilesPullLocalIndexTest extends TestCase
                 'filesystem_root' => $this->rawFileRoot,
                 'push_root' => '/',
                 'push_state_directory' => $pushStateDirectory,
-                'remote_reprint_api_url' =>
+                'push_url' =>
                     $remoteReprintApiUrl,
                 'hmac_client' => new \Site_Export_HMAC_Client('secret'),
                 'allow_http' => true,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -60,6 +60,7 @@ final class FilesPushCommandTest extends TestCase
             . '/push';
 
         $this->assertSame($trimmedRemoteReprintApiUrl, $context['remote_reprint_api_url']);
+        $this->assertSame($trimmedRemoteReprintApiUrl, $context['push_url']);
         $this->assertSame(realpath($this->localTree), $context['filesystem_root']);
         $this->assertSame($expectedPushStateDirectory, $context['push_state_directory']);
 
@@ -90,6 +91,23 @@ final class FilesPushCommandTest extends TestCase
                 . md5($trimmedRemoteReprintApiUrl)
                 . '/push',
             $differentFilesystemRootContext['push_state_directory']
+        );
+
+        $standalonePushUrl = 'https://example.test/wp-content/plugins/reprint-exporter/push.php';
+        $standaloneContext = ImportClient::prepare_files_push_context(
+            $remoteReprintApiUrl,
+            $this->stateDirectory,
+            $this->localTree,
+            [
+                'secret' => 'token',
+                'force_http' => false,
+                'push_url' => $standalonePushUrl,
+            ]
+        );
+        $this->assertSame($standalonePushUrl, $standaloneContext['push_url']);
+        $this->assertSame(
+            $context['push_state_directory'],
+            $standaloneContext['push_state_directory']
         );
     }
 
@@ -181,6 +199,30 @@ final class FilesPushCommandTest extends TestCase
         $this->assertStringContainsString('must use HTTPS', $plainHttp['output']);
         $this->assertStringContainsString('--force-http', $plainHttp['output']);
 
+        $pushUrlQuerySecret = $this->runFilesPush(
+            'https://example.test/?reprint-api=1',
+            [
+                '--secret=token',
+                '--push-url=https://example.test/push.php?SECRET_KEY=push-query-secret',
+            ]
+        );
+        $this->assertSame(1, $pushUrlQuerySecret['exit']);
+        $this->assertStringContainsString(
+            'files-push does not accept SECRET_KEY in the push URL; pass --secret=TOKEN.',
+            $pushUrlQuerySecret['output']
+        );
+        $this->assertStringNotContainsString('push-query-secret', $pushUrlQuerySecret['output']);
+
+        $plainHttpPushUrl = $this->runFilesPush(
+            'https://example.test/?reprint-api=1',
+            ['--secret=token', '--push-url=http://example.test/push.php']
+        );
+        $this->assertSame(1, $plainHttpPushUrl['exit']);
+        $this->assertStringContainsString(
+            'The files-push push URL must use HTTPS',
+            $plainHttpPushUrl['output']
+        );
+
         $missingTree = $this->root . '/missing-tree';
         $missingTreeResult = $this->runCli([
             'files-push',
@@ -265,6 +307,29 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushResumesOnlyThroughItsRecordedPushUrl(): void
+    {
+        $remoteReprintApiUrl = 'https://example.test/?reprint-api=1';
+        $this->writePreflightState($remoteReprintApiUrl);
+
+        $first = $this->runFilesPush($remoteReprintApiUrl, [
+            '--secret=token',
+            '--push-url=https://127.0.0.1:1/push.php',
+        ]);
+        $this->assertSame(1, $first['exit'], $first['output']);
+
+        $changed = $this->runFilesPush($remoteReprintApiUrl, [
+            '--secret=token',
+            '--push-url=https://127.0.0.1:2/push.php',
+        ]);
+
+        $this->assertSame(1, $changed['exit'], $changed['output']);
+        $this->assertStringContainsString(
+            'files-push must resume with the same push URL recorded by its active sender.',
+            $changed['output']
+        );
+    }
+
     public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
     {
         $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
@@ -280,6 +345,7 @@ final class FilesPushCommandTest extends TestCase
             $context['push_state_directory'] . '/sender.json',
             json_encode([
                 'push_session_id' => str_repeat('1', 32),
+                'push_url' => $context['push_url'],
                 'phase' => 'starting_plan',
                 'push_root_local_relative_path' => '',
                 'push_plan_cursor' => null,

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -22,7 +22,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4,
@@ -156,7 +156,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -190,7 +190,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 64,
@@ -222,7 +222,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'max_bytes' => 512,
         ]);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'request_sizer' => $request_sizer,
@@ -257,7 +257,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('allow_http is true');
         new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://example.test/?reprint-api=1',
+            'push_url' => 'http://example.test/?reprint-api=1',
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
         ]);
     }
@@ -270,7 +270,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -319,7 +319,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'max_bytes' => 2048,
         ]);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'request_sizer' => $request_sizer,
@@ -353,7 +353,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -398,7 +398,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -470,7 +470,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -541,7 +541,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -626,7 +626,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             }
 
             $client = new MultipartPushStreamClient([
-                'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+                'push_url' => 'http://' . $address . '/?reprint-api=1',
                 'allow_http' => true,
                 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
                 'connect_timeout' => 2,
@@ -665,7 +665,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 16 * 1024 * 1024,
@@ -708,7 +708,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -791,7 +791,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -872,7 +872,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
 
         $client = new MultipartPushStreamClient([
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 8 * 1024 * 1024,

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -147,6 +147,39 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
     }
 
+    public function testStandalonePushRouteUsesTheConfiguredAuthenticationAndAuthorization(): void
+    {
+        $standalone_push_url = $this->enableStandalonePushRoute();
+        $push_session_id = str_repeat('a', 32);
+
+        $authentication = $this->requestPushEndpoint(
+            'not-the-server-secret',
+            'POST',
+            'push_create',
+            $push_session_id,
+            null,
+            null,
+            $standalone_push_url
+        );
+        $this->assertSame(403, $authentication['http_code']);
+        $this->assertSame('auth_failed', $authentication['response']['reason']);
+
+        $this->writeStandalonePushConfiguration(
+            'Push access is disabled for the current connection token.'
+        );
+        $authorization = $this->requestPushEndpoint(
+            self::SECRET,
+            'POST',
+            'push_create',
+            $push_session_id,
+            null,
+            null,
+            $standalone_push_url
+        );
+        $this->assertSame(403, $authorization['http_code']);
+        $this->assertSame('push_disabled', $authorization['response']['reason']);
+    }
+
     public function testAuthorizedFuturePushEndpointUsesPushErrorContract(): void
     {
         $response = $this->requestPushEndpoint(
@@ -2511,7 +2544,7 @@ final class PushEndpointsTest extends TestCase {
             'filesystem_root' => $local_docroot,
             'push_root' => '/',
             'push_state_directory' => $push_state_directory,
-            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'push_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -2848,6 +2881,76 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
     }
 
+    public function testFilesPushCliRepairsAPluginWhichPreventsWordPressFromStarting(): void
+    {
+        $wordpress_reprint_api_url = $this->remote_reprint_api_url;
+        $standalone_push_url = $this->enableStandalonePushRoute();
+        $local_docroot = $this->root . '/cli-broken-wordpress-local-docroot';
+        $state_directory = $this->root . '/cli-broken-wordpress-state';
+        $plugin_directory = $local_docroot . '/wp-content/plugins/defunct';
+        mkdir($plugin_directory, 0700, true);
+        mkdir($local_docroot . '/preserved', 0700, true);
+        file_put_contents($local_docroot . '/preserved/value.txt', 'must not replace');
+        file_put_contents(
+            $plugin_directory . '/defunct.php',
+            "<?php\nthrow new RuntimeException('The pushed plugin broke WordPress boot.');\n"
+        );
+
+        $break_site = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            '/',
+            $standalone_push_url
+        );
+
+        $this->assertSame(0, $break_site['exit'], $break_site['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($break_site['stdout'])['status'] ?? null);
+        $this->assertFileExists($this->docroot . '/wp-content/plugins/defunct/defunct.php');
+        $this->assertSame('keep', file_get_contents($this->docroot . '/preserved/value.txt'));
+
+        $handle = curl_init($wordpress_reprint_api_url);
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        $body = curl_exec($handle);
+        $this->assertIsString($body);
+        $this->assertSame(500, curl_getinfo($handle, CURLINFO_HTTP_CODE));
+        curl_close($handle);
+        $this->assertStringContainsString('WordPress could not boot', $body);
+
+        $push_create_requests = $this->countEndpointRequests('push_create');
+        file_put_contents(
+            $plugin_directory . '/defunct.php',
+            "<?php\n// WordPress can start again.\n"
+        );
+
+        $repair_site = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            '/',
+            $standalone_push_url
+        );
+
+        $this->assertSame(0, $repair_site['exit'], $repair_site['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($repair_site['stdout'])['status'] ?? null);
+        $this->assertSame(
+            "<?php\n// WordPress can start again.\n",
+            file_get_contents($this->docroot . '/wp-content/plugins/defunct/defunct.php')
+        );
+        $this->assertSame($push_create_requests + 1, $this->countEndpointRequests('push_create'));
+        $this->assertFileExists(
+            $state_directory
+                . '/remotes/'
+                . md5(rtrim($wordpress_reprint_api_url, '?&'))
+                . '/local_index.jsonl'
+        );
+        $this->assertDirectoryDoesNotExist(
+            $state_directory
+                . '/remotes/'
+                . md5(rtrim($standalone_push_url, '?&'))
+        );
+    }
+
     public function testFilesPushCliStopsAtTheCallerDeadlineAndAnotherProcessCompletes(): void
     {
         $local_docroot = $this->root . '/cli-partial-local-docroot';
@@ -3081,19 +3184,23 @@ final class PushEndpointsTest extends TestCase {
      * Runs the production CLI against the production endpoint router.
      *
      * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @param string $push_root Remote absolute push root written to preflight state.
+     * @param string|null $push_url Separate URL receiving push requests.
      * @return array{exit:int,stdout:string,stderr:string,output:string}
      */
     private function runFilesPushCli(
         string $filesystem_root,
         string $state_directory,
         array $ini_settings = [],
-        string $push_root = '/'
+        string $push_root = '/',
+        ?string $push_url = null
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $filesystem_root,
             $state_directory,
             $ini_settings,
-            $push_root
+            $push_root,
+            $push_url
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3102,13 +3209,16 @@ final class PushEndpointsTest extends TestCase {
      * Starts a production files-push CLI subprocess.
      *
      * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @param string $push_root Remote absolute push root written to preflight state.
+     * @param string|null $push_url Separate URL receiving push requests.
      * @return array{0:resource,1:array<int,resource>}
      */
     private function startFilesPushCli(
         string $filesystem_root,
         string $state_directory,
         array $ini_settings = [],
-        string $push_root = '/'
+        string $push_root = '/',
+        ?string $push_url = null
     ): array {
         $this->writeFilesPushPreflight($state_directory, $push_root);
 
@@ -3126,6 +3236,9 @@ final class PushEndpointsTest extends TestCase {
             '--secret=' . self::SECRET,
             '--force-http',
         ]);
+        if ($push_url !== null) {
+            $command[] = '--push-url=' . $push_url;
+        }
         $process = proc_open(
             $command,
             [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
@@ -3231,7 +3344,7 @@ final class PushEndpointsTest extends TestCase {
             'filesystem_root' => $filesystem_root,
             'push_root' => '/',
             'push_state_directory' => $push_state_directory,
-            'remote_reprint_api_url' => $this->remote_reprint_api_url,
+            'push_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4 * 1024 * 1024,
@@ -3467,6 +3580,51 @@ final class PushEndpointsTest extends TestCase {
         $this->fail('Push endpoint test server did not start: ' . $server_log);
     }
 
+    /** Installs and authorizes the bundled route without loading WordPress. */
+    private function enableStandalonePushRoute(): string
+    {
+        $canonical_docroot = realpath($this->docroot);
+        $canonical_plugin_directory = realpath(__DIR__ . '/../reprint-exporter-wp');
+        $this->assertIsString($canonical_docroot);
+        $this->assertIsString($canonical_plugin_directory);
+        symlink($canonical_plugin_directory, $canonical_docroot . '/reprint-exporter-wp');
+
+        $this->writeStandalonePushConfiguration(null);
+
+        $url = parse_url($this->remote_reprint_api_url);
+        $this->assertIsArray($url);
+        return (string) $url['scheme']
+            . '://'
+            . (string) $url['host']
+            . ( isset($url['port']) ? ':' . $url['port'] : '' )
+            . '/reprint-exporter-wp/push.php';
+    }
+
+    /** Writes the private configuration read by the production push route. */
+    private function writeStandalonePushConfiguration(?string $push_authorization_error): void
+    {
+        $canonical_docroot = realpath($this->docroot);
+        $this->assertIsString($canonical_docroot);
+
+        $reprint_directory = dirname($canonical_docroot)
+            . '/.reprint-'
+            . substr(hash('sha256', $canonical_docroot), 0, 12);
+        $configuration_directory = $reprint_directory . '/.reprint';
+        if (!is_dir($configuration_directory)) {
+            mkdir($configuration_directory, 0700, true);
+        }
+        $configuration_path = $configuration_directory . '/push-config.json';
+        $configuration = json_encode([
+            'connection_secret_b64' => base64_encode(self::SECRET),
+            'push_authorization_error' => $push_authorization_error,
+            'docroot_b64' => base64_encode($canonical_docroot),
+            'reprint_directory_b64' => base64_encode($reprint_directory),
+            'excluded_paths_b64' => [base64_encode('preserved')],
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        file_put_contents($configuration_path, $configuration . "\n");
+        chmod($configuration_path, 0600);
+    }
+
     /**
      * Builds the production sender options used at each lifecycle boundary.
      *
@@ -3485,7 +3643,7 @@ final class PushEndpointsTest extends TestCase {
             'filesystem_root' => $filesystem_root,
             'push_root' => '/',
             'push_state_directory' => $push_state_directory,
-            'remote_reprint_api_url' => $this->remote_reprint_api_url,
+            'push_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 64,
@@ -3767,10 +3925,10 @@ final class PushEndpointsTest extends TestCase {
         proc_close($process);
     }
 
-    private function newClient(string $secret, ?string $remote_reprint_api_url = null): MultipartPushStreamClient
+    private function newClient(string $secret, ?string $push_url = null): MultipartPushStreamClient
     {
         return new MultipartPushStreamClient([
-            'remote_reprint_api_url' => $remote_reprint_api_url ?? $this->remote_reprint_api_url,
+            'push_url' => $push_url ?? $this->remote_reprint_api_url,
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client($secret),
             'chunk_bytes' => 4,
@@ -3868,6 +4026,7 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
+     * @param string|null $push_url URL receiving the request, or the test WordPress route by default.
      * @return array{http_code:int,body:string,response:array<string,mixed>}
      */
     private function requestPushEndpoint(
@@ -3876,10 +4035,13 @@ final class PushEndpointsTest extends TestCase {
         string $endpoint,
         string $push_session_id,
         ?string $body = null,
-        ?string $content_type = null
+        ?string $content_type = null,
+        ?string $push_url = null
     ): array {
-        $url = $this->remote_reprint_api_url
-            . '&endpoint=' . rawurlencode($endpoint)
+        $push_url = $push_url ?? $this->remote_reprint_api_url;
+        $url = $push_url
+            . ( strpos($push_url, '?') === false ? '?' : '&' )
+            . 'endpoint=' . rawurlencode($endpoint)
             . '&push_session_id=' . rawurlencode($push_session_id);
         $curl_headers = [];
         if ($content_type !== null) {

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -166,6 +166,12 @@ if (!function_exists('home_url')) {
     }
 }
 
+if (!function_exists('plugin_dir_url')) {
+    function plugin_dir_url(string $file): string {
+        return $file === '' ? '' : 'https://example.test/wp-content/plugins/reprint-exporter/';
+    }
+}
+
 if (!function_exists('wp_nonce_field')) {
     function wp_nonce_field(string $action): void {
         echo '<input type="hidden" name="_wpnonce" value="' . esc_attr($action) . '" />';
@@ -202,6 +208,14 @@ final class SiteExportSecretTest extends TestCase
     /** @var string|false */
     private $original_push_enabled_environment;
 
+    private string $standalone_push_root;
+
+    private string $standalone_docroot;
+
+    private string $standalone_reprint_directory;
+
+    private string $standalone_push_configuration_path;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -225,6 +239,21 @@ final class SiteExportSecretTest extends TestCase
         $_POST = [];
         putenv('SITE_EXPORT_PUSH_ENABLED');
 
+        $this->standalone_push_root = sys_get_temp_dir()
+            . '/site-export-standalone-push-test-'
+            . bin2hex(random_bytes(6));
+        $docroot = $this->standalone_push_root . '/site';
+        mkdir($docroot, 0700, true);
+        $_SERVER['DOCUMENT_ROOT'] = $docroot;
+        $canonical_docroot = realpath($docroot);
+        $this->assertIsString($canonical_docroot);
+        $this->standalone_docroot = $canonical_docroot;
+        $this->standalone_reprint_directory = dirname($canonical_docroot)
+            . '/.reprint-'
+            . substr(hash('sha256', $canonical_docroot), 0, 12);
+        $this->standalone_push_configuration_path = $this->standalone_reprint_directory
+            . '/.reprint/push-config.json';
+
         if (file_exists(SITE_EXPORT_SECRET_FILE)) {
             unlink(SITE_EXPORT_SECRET_FILE);
         }
@@ -238,6 +267,9 @@ final class SiteExportSecretTest extends TestCase
 
         if (is_dir(SITE_EXPORT_PLUGIN_DIR)) {
             rmdir(SITE_EXPORT_PLUGIN_DIR);
+        }
+        if (isset($this->standalone_push_root)) {
+            $this->removeTree($this->standalone_push_root);
         }
 
         $_SERVER = $this->original_server;
@@ -416,6 +448,45 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
+    public function testPushAccessWritesPrivateStandaloneConfiguration(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $this->assertFileExists($this->standalone_push_configuration_path);
+        $this->assertSame(0600, fileperms($this->standalone_push_configuration_path) & 0777);
+        $this->assertSame(
+            [
+                'connection_secret_b64' => base64_encode('current-token'),
+                'push_authorization_error' => null,
+                'docroot_b64' => base64_encode($this->standalone_docroot),
+                'reprint_directory_b64' => base64_encode($this->standalone_reprint_directory),
+                'excluded_paths_b64' => [],
+            ],
+            $this->readStandalonePushConfiguration()
+        );
+    }
+
+    public function testRevokingPushAccessKeepsOnlyDurableCommitRecovery(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertTrue(_site_export_update_push_authorization(true));
+
+        $this->assertTrue(_site_export_update_push_authorization(false));
+
+        $this->assertSame(
+            [
+                'connection_secret_b64' => base64_encode('current-token'),
+                'push_authorization_error' => 'Push access is disabled for the current connection token.',
+                'docroot_b64' => base64_encode($this->standalone_docroot),
+                'reprint_directory_b64' => base64_encode($this->standalone_reprint_directory),
+                'excluded_paths_b64' => [],
+            ],
+            $this->readStandalonePushConfiguration()
+        );
+    }
+
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
@@ -439,6 +510,11 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertStringContainsString('<strong>Connected for downloads and push.</strong>', $html);
         $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked', $html);
+        $this->assertStringContainsString('<h2>Push endpoint</h2>', $html);
+        $this->assertStringContainsString(
+            'https://example.test/wp-content/plugins/reprint-exporter/push.php',
+            $html
+        );
     }
 
     public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
@@ -458,5 +534,35 @@ final class SiteExportSecretTest extends TestCase
         ob_start();
         Site_Export_Plugin::get_instance()->render_admin_page();
         return (string) ob_get_clean();
+    }
+
+    /** @return array<string,mixed> */
+    private function readStandalonePushConfiguration(): array
+    {
+        $configuration = json_decode(
+            (string) file_get_contents($this->standalone_push_configuration_path),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($configuration);
+        return $configuration;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (!is_dir($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
     }
 }

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -1,13 +1,16 @@
 <?php
 
-// This fixture supplies the WordPress functions and values the production
-// plugin entry point reads. API routing, authentication, and dispatch all run
-// through index.php and its site_export_api_options filter.
+// This fixture serves the production standalone push route directly. Other
+// requests receive the WordPress functions and values read by index.php and
+// its site_export_api_options filter.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 
 $reprint_push_test_request_log = (string) getenv('REPRINT_PUSH_TEST_REQUEST_LOG');
 $reprint_push_test_endpoint = filter_input(INPUT_GET, 'endpoint', FILTER_UNSAFE_RAW);
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- The router needs the raw path to select the production route under test.
+$reprint_push_test_request_path = parse_url( (string) ( $_SERVER['REQUEST_URI'] ?? '' ), PHP_URL_PATH );
+$reprint_push_test_is_standalone_push_request = $reprint_push_test_request_path === '/reprint-exporter-wp/push.php';
 if ($reprint_push_test_request_log !== '' && is_string($reprint_push_test_endpoint)) {
     register_shutdown_function(
         static function () use ($reprint_push_test_request_log, $reprint_push_test_endpoint): void {
@@ -50,12 +53,35 @@ if (!is_array($reprint_push_test_docroot_configuration)) {
     $reprint_push_test_docroot_configuration = [];
 }
 
-define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_ABSPATH'), '/\\') . '/');
 if (is_string($reprint_push_test_docroot_configuration['document_root'] ?? null)) {
     $_SERVER['DOCUMENT_ROOT'] = $reprint_push_test_docroot_configuration['document_root'];
 } else {
     unset($_SERVER['DOCUMENT_ROOT']);
 }
+
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- DOCUMENT_ROOT is trusted test server configuration and must retain exact filesystem bytes.
+$reprint_push_test_document_root = $_SERVER['DOCUMENT_ROOT'] ?? null;
+$reprint_push_test_defunct_plugin_path = is_string($reprint_push_test_document_root)
+    ? rtrim($reprint_push_test_document_root, '/\\') . '/wp-content/plugins/defunct/defunct.php'
+    : '';
+if (!$reprint_push_test_is_standalone_push_request && is_file($reprint_push_test_defunct_plugin_path)) {
+    try {
+        require $reprint_push_test_defunct_plugin_path;
+    } catch (Throwable $throwable) {
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo 'WordPress could not boot after loading the pushed plugin.';
+        return;
+    }
+}
+if ($reprint_push_test_is_standalone_push_request) {
+    $_SERVER['SCRIPT_FILENAME'] = rtrim( (string) $reprint_push_test_document_root, '/\\')
+        . '/reprint-exporter-wp/push.php';
+    require dirname(__DIR__, 2) . '/reprint-exporter-wp/push.php';
+    return;
+}
+
+define('ABSPATH', rtrim( (string) getenv('REPRINT_PUSH_TEST_ABSPATH'), '/\\') . '/');
 if (is_string($reprint_push_test_docroot_configuration['wp_plugin_dir'] ?? null)) {
     define('WP_PLUGIN_DIR', $reprint_push_test_docroot_configuration['wp_plugin_dir']);
 }


### PR DESCRIPTION
Files-push can now use a standalone PHP route that remains reachable when pushed code prevents WordPress from starting.

## Background

Before this PR, every push request used the WordPress front controller. A push could install a plugin which throws during WordPress startup, and the next push could not reach `push_create` to replace it.

## This change

The exporter plugin now exposes `push.php`, which authenticates and dispatches every push operation without loading WordPress. While WordPress is healthy, it writes the current connection token, push authorization, document root, reprint directory, exclusions, and request limits to a mode-0600 private configuration file. Revoking push blocks new work while retaining the existing durable-commit recovery rule.

`files-push` accepts that route through `--push-url`. The positional remote Reprint API URL still selects the remote state directory and shared local index used by pull, diff, and push. An active sender records its push URL and refuses to resume through another route.

The existing WordPress push route remains available for compatibility. Hosts which block direct plugin PHP execution must allow `push.php` or provide another route which does not load WordPress.

## Testing

The endpoint test pushes a plugin which breaks WordPress startup, confirms the WordPress route returns 500, then runs another files-push through `push.php` and confirms the safe plugin replaces it. It also covers connection-token authentication, revoked authorization, excluded paths, and shared local-index ownership.

Supersedes #378.
