### PR TITLE
[Push] Require preflight to map filesystem-root paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,8 +150,13 @@ jobs:
             PUSH_PROBE="files-push-version-${{ matrix.importer_php }}"
             rm -rf "$PUSH_STATE_DIR" "$PUSH_FS_ROOT"
             mkdir -p "$PUSH_FS_ROOT"
+            PUSH_REMOTE_URL="${BASE}&directory=${DIR}&version_gate_probe=${PUSH_PROBE}"
+            # Seed the mandatory preflight, then clear that setup request so the
+            # access-log assertion below covers only files-push.
+            "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" >/dev/null
+            sudo truncate -s 0 /var/log/nginx/access.log
             set +e
-            files_push_version_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "${BASE}&directory=${DIR}&version_gate_probe=${PUSH_PROBE}" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" --force-http 2>&1)"
+            files_push_version_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" --force-http 2>&1)"
             files_push_version_status=$?
             set -e
             if [ "$files_push_version_status" -ne 1 ]; then

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -125,9 +125,11 @@ the push plan.
 
 A push plan is an internal part of the sender lifecycle:
 
-1. `PushFilesSender::start()` enters `creating`. `push_create` returns at most
-   100 target exclusions, which the sender stores once in
-   `excluded_paths.json` after creating the active `plan/` directory.
+1. Before `PushFilesSender::start()`, `files-push` loads the mandatory
+   preflight document root as the push root. The sender enters `creating`,
+   stores the push root's local relative path in `sender.json`, and requests
+   at most 100 target exclusions from `push_create`. It stores the exclusions
+   in `excluded_paths.json` after creating the active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
@@ -140,9 +142,9 @@ A push plan is an internal part of the sender lifecycle:
 4. Each later `next_step()` compares at most one path represented by either
    index. It returns true while another planning step remains and false when
    both indexes reach EOF. It
-   writes files, symlinks, and empty directories with their planned type, size,
-   and ctime to
-   `plan/local_paths_to_push.jsonl`, and writes raw NUL-delimited paths to
+   writes files, symlinks, and empty directories with their local relative
+   path, planned type, size, and ctime to `plan/local_paths_to_push.jsonl`,
+   and writes raw NUL-delimited push-root-relative paths to
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
 6. After the target confirms commit, the sender saves the retained fresh local
@@ -168,11 +170,11 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, filesystem root, local index file, and
-current planning position. During indexing, that
-position contains the `FileIndexProcessor` cursor and committed fresh-index byte
-offset. During diffing, each step flushes only the path list or append-only
-deleted-directory stack changed by that step before updating the two index
+The cursor contains the plan directory, filesystem root, local index file,
+push root's local relative path, and current planning position. During
+indexing, that position contains the `FileIndexProcessor` cursor and committed
+fresh-index byte offset. During diffing, each step flushes only the path list or
+append-only deleted-directory stack changed by that step before updating the two index
 offsets, two output byte offsets, and active stack byte offset. Each stack entry
 links to the preceding active directory, so continuation reads only the top
 entry. A later process passes the stored cursor to `PushPlan::resume()`. The
@@ -316,7 +318,7 @@ state:
       excluded_paths.json               target exclusions for the active push
       fresh_local_index.jsonl           plan-owned fresh local index
       local_paths_to_push.jsonl         local paths to push
-      local_paths_to_delete             raw NUL-delimited local paths to delete
+      local_paths_to_delete             raw NUL-delimited push-root-relative paths
       deleted_directories_stack.jsonl   append-only planning stack
 ```
 
@@ -346,8 +348,9 @@ with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
 remaining handles before `close()` returns.
 
-The sender creates the push session and stores its exclusion policy before it
-starts PushPlan. Each internal `indexing` step completes one traversal event,
+The sender stores the mandatory preflight push root, creates the push session,
+and stores its exclusion policy before it starts PushPlan. Each internal
+`indexing` step completes one traversal event,
 and `starting_diff` initializes the index diff. Each internal `diffing` step
 compares at most one path and updates the path lists. PushPlan owns the
 meaning of its file-index cursor, index offsets, output lengths, and
@@ -356,10 +359,10 @@ upload begins until both indexes have been consumed and the two path lists are
 stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the PushPlan cursor, the next byte offset in
-`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
-sizing state. Its phases are `creating`, `starting_plan`, `planning`,
-`pushing_paths`, `pushing_deletes`, `committing`,
+and phase, the push root's local relative path, the PushPlan cursor, the next
+byte offset in `local_paths_to_push.jsonl`, the receiver part limit, and
+learned request-body sizing state. Its phases are `creating`, `starting_plan`,
+`planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`, `removing`, and
 `discarding_plan`.
 The separate start, local-index-save, completion, removal, and discard phases ensure
@@ -384,7 +387,8 @@ After all local paths are pushed, a newly opened sender reads
 `work_deletes_bytes` and `work_deletes_complete` from `push_status`. Successful
 uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
-duplicate it. Each uploaded deletion-list part contains one complete local path.
+duplicate it. Each uploaded deletion-list part contains one complete
+push-root-relative path.
 The sender trusts this completed, immutable plan without consulting the fresh
 local index or live filesystem root again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
@@ -432,11 +436,12 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 
 `reprint files-push <remote-reprint-api-url>` is the production CLI caller for one
 `PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
-It requires `--state-dir`, `--fs-root`, and `--secret`; HTTPS is required unless
-the operator passes `--force-http`. It does not run pull preflight, read or
-write `<remote-state-directory>/pull/state.json`, show a plan, ask for
-confirmation, transfer a database, retry a failed request, or start a
-replacement sender after a `restart` outcome.
+It requires `--state-dir`, `--fs-root`, `--secret`, and saved preflight
+data for the remote document root; HTTPS is required unless the operator passes
+`--force-http`. It reads but never writes
+`<remote-state-directory>/pull/state.json`. It does not run preflight itself,
+show a plan, ask for confirmation, transfer a database, retry a failed request,
+or start a replacement sender after a `restart` outcome.
 
 The local push state directory is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -377,8 +377,9 @@ running the command again prints the complete report.
 
 The low-level, files-only command is `files-push`. Its `remote Reprint API URL` is the
 exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
-`--fs-root`. It requires `--secret=TOKEN`; `--force-http` is the explicit
-plain-HTTP opt-in.
+`--fs-root`. It requires saved preflight data and uses its remote document
+root as the push root. It also requires `--secret=TOKEN`; `--force-http` is
+the explicit plain-HTTP opt-in.
 
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -248,6 +248,28 @@ function path_is_within_root(string $path, string $root): bool
 }
 
 /**
+ * Returns the remainder of $path underneath $prefix.
+ *
+ * An exact match returns an empty string. A descendant returns the remainder
+ * beginning with "/". A path outside $prefix returns null.
+ */
+function path_remainder_under(string $path, string $prefix): ?string
+{
+    $path = rtrim($path, "/");
+    $prefix = rtrim($prefix, "/");
+
+    if ($path === $prefix) {
+        return "";
+    }
+
+    if (str_starts_with($path, $prefix . "/")) {
+        return substr($path, strlen($prefix));
+    }
+
+    return null;
+}
+
+/**
  * Validates that a path is a non-empty absolute string without NUL bytes
  * or dot-segments (. or ..).
  *

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -35,6 +35,7 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 use function Reprint\Importer\merge_local_index_mutations;
 use function Reprint\Importer\write_local_index_update;
 
@@ -602,7 +603,7 @@ class ImportClient
     private function local_relative_path_from_local_absolute_path(
         string $local_absolute_path
     ): ?string {
-        $local_relative_path = self::path_remainder_under(
+        $local_relative_path = path_remainder_under(
             $local_absolute_path,
             $this->get_filesystem_root_path()
         );
@@ -983,8 +984,8 @@ class ImportClient
             );
         }
 
-        // files-diff and files-push use local push state and must not load
-        // or write the pull command's pull/state.json file.
+        // files-diff uses local push state and must not load or write the
+        // pull command's pull/state.json file.
         if ($command === "files-diff") {
             if (is_file($this->pull_index_wal_path)) {
                 throw new RuntimeException(
@@ -1000,6 +1001,10 @@ class ImportClient
                     "Finish or abort the interrupted files-pull before running files-push."
                 );
             }
+            // files-push reads preflight to locate the remote document root,
+            // but its lifecycle never writes pull state.
+            $this->state = $this->load_state();
+            $this->require_preflight();
             $this->run_files_push($options, $process_lock);
             return;
         }
@@ -1579,6 +1584,12 @@ class ImportClient
         if (!is_array($context)) {
             throw new InvalidArgumentException('files-push requires its validated command context.');
         }
+        $push_root = $this->get_state()->preflight["data"]["runtime"]["document_root"] ?? null;
+        if (!is_string($push_root) || $push_root === '' || $push_root[0] !== '/') {
+            throw new RuntimeException(
+                "Preflight did not report an absolute document root. Run 'preflight' or 'preflight-assert' again."
+            );
+        }
 
         $this->enable_files_push_signal_handling();
 
@@ -1596,6 +1607,7 @@ class ImportClient
             : parse_size($memory_limit_value);
         $sender_options = [
             'filesystem_root' => $context['filesystem_root'],
+            'push_root' => $push_root,
             'push_state_directory' => $context['push_state_directory'],
             'remote_reprint_api_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
@@ -8963,7 +8975,7 @@ class ImportClient
             $selected = empty($this->pull_only_files_with_path_prefixes);
 
             foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-                $remainder = self::path_remainder_under($path, $prefix);
+                $remainder = path_remainder_under($path, $prefix);
                 if ($remainder === "") {
                     return false;
                 }
@@ -8979,7 +8991,7 @@ class ImportClient
         }
 
         foreach ($this->pull_excluded_files_with_path_prefixes as $prefix) {
-            if (self::path_remainder_under($path, $prefix) !== null) {
+            if (path_remainder_under($path, $prefix) !== null) {
                 return false;
             }
         }
@@ -9089,7 +9101,7 @@ class ImportClient
         $local_absolute_path = null;
         $longest_remote_prefix_length = -1;
         foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
-            $remainder = self::path_remainder_under($remote_absolute_path, $remote_prefix);
+            $remainder = path_remainder_under($remote_absolute_path, $remote_prefix);
             if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
                 $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
                 $longest_remote_prefix_length = strlen($remote_prefix);
@@ -9109,27 +9121,6 @@ class ImportClient
         return $this->get_filesystem_root_path() . $remote_absolute_path;
     }
 
-
-    /**
-     * Returns the remainder of $path underneath $prefix,
-     * empty string if $path === $prefix,
-     * or null if $path is not under $prefix.
-     */
-    private static function path_remainder_under(string $path, string $prefix): ?string
-    {
-        $path = rtrim($path, "/");
-        $prefix = rtrim($prefix, "/");
-
-        if ($path === $prefix) {
-            return "";
-        }
-
-        if (str_starts_with($path, $prefix . "/")) {
-            return substr($path, strlen($prefix));
-        }
-
-        return null;
-    }
 
     /**
      * Handle a metadata chunk from multipart response.
@@ -12510,7 +12501,7 @@ if (
                 "Sends the existing filesystem root at --fs-root to the remote Reprint API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
-                "It does not require pull preflight.\n" .
+                "It requires saved preflight data for the remote document root.\n" .
                 "\n" .
                 "Each process runs one sender until it completes, reaches a caller time or\n" .
                 "memory boundary, or receives a signal handled by this PHP runtime.\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -123,14 +123,17 @@
  *
  * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'directory'|'symlink',size:int,ctime:int}
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
- * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
+ * @phpstan-type LocalPathToPush array{local_relative_path:string,push_root_relative_path:string,push_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
     /** @var string Filesystem root whose local paths to push are sent. */
     private string $filesystem_root;
+
+    /** @var string Push root relative to the local filesystem root. */
+    private string $push_root_local_relative_path;
 
     /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
@@ -234,7 +237,8 @@ final class PushFilesSender
      * @param array $options {
      *     Push, push stream client, and local-file options.
      *
-     *     @type string                  $filesystem_root                Required filesystem root directory.
+     *     @type string                  $filesystem_root         Required filesystem root directory.
+     *     @type string                  $push_root               Required remote absolute push root.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
@@ -269,6 +273,7 @@ final class PushFilesSender
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
+                'push_root_local_relative_path' => $sender->push_root_local_relative_path,
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
@@ -335,6 +340,8 @@ final class PushFilesSender
     private function __construct(array $options, ReprintProcessLock $process_lock)
     {
         $filesystem_root = $options['filesystem_root'] ?? null;
+        /** @var string $push_root */
+        $push_root = $options['push_root'];
         $push_state_directory = $options['push_state_directory'] ?? null;
         if (!is_string($filesystem_root) || !is_dir($filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
@@ -366,6 +373,7 @@ final class PushFilesSender
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
         $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/');
+        $this->push_root_local_relative_path = trim($push_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
@@ -620,7 +628,8 @@ final class PushFilesSender
             $this->plan_directory,
             $this->filesystem_root,
             $this->local_index_file,
-            $this->excluded_paths_path
+            $this->excluded_paths_path,
+            $this->state['push_root_local_relative_path']
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
@@ -710,7 +719,7 @@ final class PushFilesSender
         }
 
         $planned_local_path_type_size_and_ctime = $local_path_to_push['planned_local_path_type_size_and_ctime'];
-        $local_path_type_size_and_ctime = $this->stat_local_path($local_path_to_push['path']);
+        $local_path_type_size_and_ctime = $this->stat_local_path($local_path_to_push['local_relative_path']);
 
         // A path which disappeared belongs in a newly generated plan, not this upload-only session.
         if ($local_path_type_size_and_ctime === null) {
@@ -748,7 +757,7 @@ final class PushFilesSender
         } else {
             $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
-                'path_b64' => $local_path_to_push['path_b64'],
+                'path_b64' => $local_path_to_push['push_root_relative_path_b64'],
             ], ['accepted']);
             if ($this->handle_request_failure($request_result)) {
                 return;
@@ -784,12 +793,12 @@ final class PushFilesSender
 
         // Directory and symlink values each fit in one MIME part and need no byte cursor.
         if ($local_path_type_size_and_ctime['type'] === 'directory') {
-            $directory_is_empty = $this->directory_is_empty($local_path_to_push['path']);
+            $directory_is_empty = $this->directory_is_empty($local_path_to_push['local_relative_path']);
             if ($directory_is_empty === null) {
-                $this->fail('local_io_error', 'Could not read the local directory to push: ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('local_io_error', 'Could not read the local directory to push: ' . base64_encode($local_path_to_push['local_relative_path']) . '.');
                 return;
             }
-            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['local_relative_path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
                 $this->start_removing_push_session_after_local_change();
@@ -807,13 +816,13 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => 'directory',
-                'path' => $local_path_to_push['path'],
+                'path' => $local_path_to_push['push_root_relative_path'],
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
         } elseif ($local_path_type_size_and_ctime['type'] === 'symlink') {
-            $symlink_target = @readlink($this->filesystem_root . '/' . $local_path_to_push['path']);
-            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+            $symlink_target = @readlink($this->filesystem_root . '/' . $local_path_to_push['local_relative_path']);
+            $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['local_relative_path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
                 $this->start_removing_push_session_after_local_change();
@@ -825,12 +834,12 @@ final class PushFilesSender
                 return;
             }
             if ($symlink_target === false) {
-                $this->fail('local_io_error', 'Could not read the local symlink target to push: ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('local_io_error', 'Could not read the local symlink target to push: ' . base64_encode($local_path_to_push['local_relative_path']) . '.');
                 return;
             }
             $upload_part = [
                 'type' => 'symlink',
-                'path' => $local_path_to_push['path'],
+                'path' => $local_path_to_push['push_root_relative_path'],
                 'target' => $symlink_target,
                 'payload' => '',
             ];
@@ -840,7 +849,7 @@ final class PushFilesSender
         // A file contributes at most one bounded chunk during this call and remains open for the next.
         if ($local_path_type_size_and_ctime['type'] === 'file') {
             $maximum_file_payload_bytes = $this->push_stream_client->next_file_body_bytes(
-                $local_path_to_push['path'],
+                $local_path_to_push['push_root_relative_path'],
                 $local_path_type_size_and_ctime['size'],
                 $file_byte_offset
             );
@@ -849,7 +858,7 @@ final class PushFilesSender
                     $this->upload_request_stage = 'finishing';
                     return;
                 }
-                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['path']) . '.');
+                $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['local_relative_path']) . '.');
                 return;
             }
 
@@ -858,18 +867,18 @@ final class PushFilesSender
                 $local_io_failure_detail = null;
                 if (!is_resource($this->local_file_handle)) {
                     $this->local_file_handle = fopen(
-                        $this->filesystem_root . '/' . $local_path_to_push['path'],
+                        $this->filesystem_root . '/' . $local_path_to_push['local_relative_path'],
                         'rb'
                     );
                 }
 
                 if (!is_resource($this->local_file_handle)) {
-                    $local_io_failure_detail = 'Could not open the local file to push: ' . base64_encode($local_path_to_push['path']) . '.';
+                    $local_io_failure_detail = 'Could not open the local file to push: ' . base64_encode($local_path_to_push['local_relative_path']) . '.';
                 } else {
                     if ($this->local_file_byte_offset !== $file_byte_offset) {
                         if (fseek($this->local_file_handle, $file_byte_offset) !== 0) {
                             $this->close_local_file_handle();
-                            $local_io_failure_detail = 'Could not seek to the receiver-confirmed cursor in the local file to push: ' . base64_encode($local_path_to_push['path']) . '.';
+                            $local_io_failure_detail = 'Could not seek to the receiver-confirmed cursor in the local file to push: ' . base64_encode($local_path_to_push['local_relative_path']) . '.';
                         } else {
                             $this->local_file_byte_offset = $file_byte_offset;
                         }
@@ -882,7 +891,7 @@ final class PushFilesSender
                     }
                 }
 
-                $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['path']);
+                $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['local_relative_path']);
                 if ($local_path_type_size_and_ctime_after_read === null) {
                     $this->close_local_file_handle();
                     $this->close_local_paths_to_push_handle();
@@ -901,14 +910,14 @@ final class PushFilesSender
                 }
                 if (!is_string($payload) || ( $payload === '' && $file_byte_offset < $local_path_type_size_and_ctime['size'] )) {
                     $this->close_local_file_handle();
-                    $this->fail('local_io_error', 'Could not read the local file to push at its receiver-confirmed cursor: ' . base64_encode($local_path_to_push['path']) . '.');
+                    $this->fail('local_io_error', 'Could not read the local file to push at its receiver-confirmed cursor: ' . base64_encode($local_path_to_push['local_relative_path']) . '.');
                     return;
                 }
             }
 
             $upload_part = [
                 'type' => 'file',
-                'path' => $local_path_to_push['path'],
+                'path' => $local_path_to_push['push_root_relative_path'],
                 'total_bytes' => $local_path_type_size_and_ctime['size'],
                 'offset' => $file_byte_offset,
                 'payload' => $payload,
@@ -942,7 +951,7 @@ final class PushFilesSender
             if ($this->status !== 'continue') {
                 return;
             }
-            $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['path']) . '.');
+            $this->fail('request_size_exhausted', 'The current request-body budget cannot fit one MIME part for path ' . base64_encode($local_path_to_push['local_relative_path']) . '.');
             return;
         }
 
@@ -1397,14 +1406,22 @@ final class PushFilesSender
             throw new RuntimeException('Failed to decode a local path to push.', 0, $exception);
         }
         /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $decoded_local_path */
-        $path_b64 = $decoded_local_path['path'];
-        $path = base64_decode($path_b64, true);
-        if ($path === false) {
+        $local_relative_path = base64_decode($decoded_local_path['path'], true);
+        if ($local_relative_path === false) {
             throw new RuntimeException('Failed to decode a path in the local paths-to-push file.');
         }
+        $push_root_local_relative_path = $this->state['push_root_local_relative_path'];
+        if ($push_root_local_relative_path === '') {
+            $push_root_relative_path = $local_relative_path;
+        } else {
+            $push_root_relative_path = $local_relative_path === $push_root_local_relative_path
+                ? ''
+                : substr($local_relative_path, strlen($push_root_local_relative_path) + 1);
+        }
         return [
-            'path' => $path,
-            'path_b64' => $path_b64,
+            'local_relative_path' => $local_relative_path,
+            'push_root_relative_path' => $push_root_relative_path,
+            'push_root_relative_path_b64' => base64_encode($push_root_relative_path),
             'next_local_paths_to_push_byte_offset' => $next_local_paths_to_push_byte_offset,
             'planned_local_path_type_size_and_ctime' => [
                 'type' => $decoded_local_path['type'],

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -3,6 +3,7 @@
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -64,13 +65,16 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
  * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,push_root_local_relative_path:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
 {
     /** @var string Resolved filesystem root inspected while building the fresh local index. */
     private string $filesystem_root;
+
+    /** @var string Push root relative to the local filesystem root. */
+    private string $push_root_local_relative_path;
 
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
@@ -145,15 +149,22 @@ class PushPlan
      * @param string $filesystem_root     Resolved filesystem root.
      * @param string $local_index_file    Local index file this plan diffs against.
      * @param string $excluded_paths_path Caller-owned target exclusions file.
+     * @param string $push_root_local_relative_path Push root relative to the local filesystem root.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $filesystem_root,
         string $local_index_file,
-        string $excluded_paths_path
+        string $excluded_paths_path,
+        string $push_root_local_relative_path = ""
     ): self {
-        $plan = new self($plan_directory, $filesystem_root, $local_index_file);
+        $plan = new self(
+            $plan_directory,
+            $filesystem_root,
+            $local_index_file,
+            $push_root_local_relative_path
+        );
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -173,6 +184,7 @@ class PushPlan
             "plan_directory" => $plan->plan_directory,
             "filesystem_root" => $plan->filesystem_root,
             "local_index_file" => $plan->local_index_file,
+            "push_root_local_relative_path" => $plan->push_root_local_relative_path,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -196,7 +208,8 @@ class PushPlan
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["filesystem_root"],
-            $cursor["local_index_file"]
+            $cursor["local_index_file"],
+            $cursor["push_root_local_relative_path"]
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
@@ -263,11 +276,13 @@ class PushPlan
      * @param string $plan_directory   Caller-owned active plan directory.
      * @param string $filesystem_root  Resolved filesystem root.
      * @param string $local_index_file Local index file this plan diffs against.
+     * @param string $push_root_local_relative_path Push root relative to the local filesystem root.
      */
     private function __construct(
         string $plan_directory,
         string $filesystem_root,
-        string $local_index_file
+        string $local_index_file,
+        string $push_root_local_relative_path
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -276,6 +291,8 @@ class PushPlan
         $this->plan_directory = $plan_directory;
         $this->set_filesystem_root($filesystem_root);
         $this->local_index_file = $local_index_file;
+        $this->push_root_local_relative_path =
+            rtrim($push_root_local_relative_path, "/");
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index_file = $plan_directory . "/fresh_local_index.jsonl";
@@ -976,8 +993,9 @@ class PushPlan
      */
     private function append_local_path_to_delete(string $path): void
     {
-        $path_with_nul = $path . "\0";
-        if (fwrite($this->local_paths_to_delete_handle, $path_with_nul) !== strlen($path_with_nul)) {
+        $push_root_relative_path_with_nul =
+            $this->local_relative_path_to_push_root_relative_path($path) . "\0";
+        if (fwrite($this->local_paths_to_delete_handle, $push_root_relative_path_with_nul) !== strlen($push_root_relative_path_with_nul)) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
         }
     }
@@ -1075,15 +1093,44 @@ class PushPlan
      */
     private function path_conflicts_with_excluded_paths(string $path): bool
     {
+        $push_root_relative_path =
+            $this->local_relative_path_to_push_root_relative_path($path);
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                path_is_within_root($path, $excluded_path)
-                || path_is_within_root($excluded_path, $path)
+                path_is_within_root($push_root_relative_path, $excluded_path)
+                || path_is_within_root($excluded_path, $push_root_relative_path)
             ) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Maps a local relative path to its push-root-relative path.
+     */
+    private function local_relative_path_to_push_root_relative_path(
+        string $local_relative_path
+    ): string {
+        if ($this->push_root_local_relative_path === "") {
+            return $local_relative_path;
+        }
+        $path_remainder = path_remainder_under(
+            $local_relative_path,
+            $this->push_root_local_relative_path
+        );
+        if ($path_remainder === null) {
+            throw new RuntimeException(
+                "Local relative path "
+                . base64_encode($local_relative_path)
+                . " is not below the push root's local relative path "
+                . base64_encode($this->push_root_local_relative_path)
+                . "."
+            );
+        }
+        return $path_remainder === ""
+            ? ""
+            : substr($path_remainder, 1);
     }
 
     /**

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -122,6 +122,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
         $this->assertStringContainsString('existing filesystem root at --fs-root', $output);
+        $this->assertStringContainsString('requires saved preflight data', $output);
         $this->assertStringContainsString('read or modify', $output);
         $this->assertStringNotContainsString('--abort', $output);
         $this->assertStringNotContainsString('--filter', $output);

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -187,6 +187,7 @@ final class FilesPullLocalIndexTest extends TestCase
         try {
             $sender = \PushFilesSender::start([
                 'filesystem_root' => $this->rawFileRoot,
+                'push_root' => '/',
                 'push_state_directory' => $pushStateDirectory,
                 'remote_reprint_api_url' =>
                     $remoteReprintApiUrl,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -234,10 +234,22 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushRequiresPreflightBeforeStartingSender(): void
+    {
+        $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
+
+        $result = $this->runFilesPush($remoteReprintApiUrl, ['--secret=token']);
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertStringContainsString('No preflight data found', $result['output']);
+        $this->assertNoSenderState($remoteReprintApiUrl);
+    }
+
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
     {
         $secret = 'shared-secret-' . bin2hex(random_bytes(6));
         $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $this->writePreflightState($remoteReprintApiUrl);
         $result = $this->runFilesPush($remoteReprintApiUrl, ['--secret=' . $secret]);
 
         $this->assertSame(1, $result['exit'], $result['output']);
@@ -248,7 +260,7 @@ final class FilesPushCommandTest extends TestCase
         $this->assertSame('files-push', $finalLine['command'] ?? null);
         $this->assertSame('failed', $finalLine['status'] ?? null);
         $this->assertSame(1, $result['exit']);
-        $this->assertFileDoesNotExist(
+        $this->assertFileExists(
             $this->pullStateFileForRemoteReprintApiUrl($remoteReprintApiUrl)
         );
     }
@@ -256,6 +268,7 @@ final class FilesPushCommandTest extends TestCase
     public function testCorruptSenderStateUsesTheStructuredWorkflowErrorResult(): void
     {
         $remoteReprintApiUrl = 'https://127.0.0.1:1/?reprint-api=1';
+        $this->writePreflightState($remoteReprintApiUrl);
         $context = ImportClient::prepare_files_push_context(
             $remoteReprintApiUrl,
             $this->stateDirectory,
@@ -268,6 +281,7 @@ final class FilesPushCommandTest extends TestCase
             json_encode([
                 'push_session_id' => str_repeat('1', 32),
                 'phase' => 'starting_plan',
+                'push_root_local_relative_path' => '',
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
@@ -319,6 +333,30 @@ final class FilesPushCommandTest extends TestCase
             '--state-dir=' . $this->stateDirectory,
             '--fs-root=' . $this->localTree,
         ], $extraOptions));
+    }
+
+    private function writePreflightState(
+        string $remoteReprintApiUrl,
+        string $pushRoot = '/'
+    ): void {
+        $pullStateFile = $this->pullStateFileForRemoteReprintApiUrl($remoteReprintApiUrl);
+        $pullStateDirectory = dirname($pullStateFile);
+        if (!is_dir($pullStateDirectory)) {
+            mkdir($pullStateDirectory, 0700, true);
+        }
+        $pullState = new \PullState();
+        $pullState->preflight = [
+            'http_code' => 200,
+            'data' => [
+                'runtime' => [
+                    'document_root' => 'base64:' . base64_encode($pushRoot),
+                ],
+            ],
+        ];
+        file_put_contents(
+            $pullStateFile,
+            json_encode($pullState->to_array(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)
+        );
     }
 
     /** @param list<string> $arguments

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -515,11 +515,13 @@ final class PushPlanTest extends TestCase
             'plan_directory',
             'filesystem_root',
             'local_index_file',
+            'push_root_local_relative_path',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
         $this->assertSame(realpath($this->filesystemRoot()), $cursor['filesystem_root']);
         $this->assertSame($this->localIndexFile(), $cursor['local_index_file']);
+        $this->assertSame('', $cursor['push_root_local_relative_path']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_local_index',
@@ -631,13 +633,45 @@ final class PushPlanTest extends TestCase
         );
     }
 
+    public function testPlanAppliesPushRootToDeletionPathsAndTargetExclusions(): void
+    {
+        $this->saveLocalIndex($this->writeIndex([
+            'var/www/html/deleted.txt' => [100, 5, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            'var/www/html/added.txt' => [300, 3, 'file'],
+            'var/www/html/preserved/value.txt' => [300, 3, 'file'],
+        ]);
+
+        $plan = $this->startPlan(
+            $current,
+            ['preserved'],
+            'var/www/html'
+        );
+        $plan->close();
+        $plan = $this->resumePlan();
+        $this->planToCompletion($plan);
+
+        $this->assertSame(
+            ['var/www/html/added.txt'],
+            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+        );
+        $this->assertSame(
+            "deleted.txt\0",
+            file_get_contents($this->planPath('local_paths_to_delete'))
+        );
+    }
+
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------
 
     /** @param list<string> $excludedPaths */
-    private function startPlan(?string $filesystemRootDescriptionFile = null, array $excludedPaths = []): PushPlan
-    {
+    private function startPlan(
+        ?string $filesystemRootDescriptionFile = null,
+        array $excludedPaths = [],
+        string $pushRootLocalRelativePath = ''
+    ): PushPlan {
         if ($filesystemRootDescriptionFile === null) {
             $filesystemRootDescriptionFile = $this->tempDir . '/empty-filesystem-root.jsonl';
             if (!is_file($filesystemRootDescriptionFile)) {
@@ -659,7 +693,8 @@ final class PushPlanTest extends TestCase
             $this->planDirectory(),
             $this->filesystemRoot(),
             $this->localIndexFile(),
-            $this->excludedPathsPath()
+            $this->excludedPathsPath(),
+            $pushRootLocalRelativePath
         );
         $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -3,6 +3,7 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 
 require_once __DIR__ . '/../../importer/import.php';
 
@@ -133,8 +134,7 @@ class RemapSeamTest extends TestCase
      */
     public function testPathRemainderUnder(?string $expected, string $path, string $prefix): void
     {
-        $c = $this->clientWithRules(array());
-        $this->assertSame($expected, $this->call($c, 'path_remainder_under', array($path, $prefix)));
+        $this->assertSame($expected, path_remainder_under($path, $prefix));
     }
 
     public static function providePathRemainderCases(): array

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2509,6 +2509,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         $sender = $this->startSender([
             'filesystem_root' => $local_docroot,
+            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
@@ -2695,6 +2696,51 @@ final class PushEndpointsTest extends TestCase {
         ];
     }
 
+    public function testFilesPushCliPushesFromPushRootBelowFilesystemRoot(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
+        ]);
+        $filesystem_root = $this->root . '/cli-filesystem-root';
+        $state_directory = $this->root . '/cli-filesystem-root-state';
+        $push_root = (string) realpath($this->docroot);
+        $local_absolute_push_root = $filesystem_root . $push_root;
+        mkdir($local_absolute_push_root, 0700, true);
+        file_put_contents($local_absolute_push_root . '/newfile.php', "<?php echo 'from filesystem root';");
+
+        $created = $this->runFilesPushCli($filesystem_root, $state_directory, [], $push_root);
+
+        $this->assertSame(0, $created['exit'], $created['output']);
+        $this->assertSame(
+            'complete',
+            $this->lastCliJsonLine($created['stdout'])['status'] ?? null
+        );
+        $this->assertSame(
+            "<?php echo 'from filesystem root';",
+            file_get_contents($this->docroot . '/newfile.php')
+        );
+        $this->assertFileDoesNotExist(
+            $this->docroot . $push_root . '/newfile.php'
+        );
+
+        unlink($local_absolute_push_root . '/newfile.php');
+        file_put_contents($local_absolute_push_root . '/replacement.php', "<?php echo 'replacement';");
+
+        $updated = $this->runFilesPushCli($filesystem_root, $state_directory, [], $push_root);
+
+        $this->assertSame(0, $updated['exit'], $updated['output']);
+        $this->assertSame(
+            'complete',
+            $this->lastCliJsonLine($updated['stdout'])['status'] ?? null
+        );
+        $this->assertFileDoesNotExist($this->docroot . '/newfile.php');
+        $this->assertSame(
+            "<?php echo 'replacement';",
+            file_get_contents($this->docroot . '/replacement.php')
+        );
+    }
+
     public function testFilesPushCliPushesAndUpdatesACompleteLocalTree(): void
     {
         $this->writeDocrootConfiguration([
@@ -2746,7 +2792,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($this->localIndexFile(dirname($push_state_directory)));
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
-        $this->assertFileDoesNotExist(
+        $this->assertFileExists(
             dirname($push_state_directory) . '/pull/state.json'
         );
 
@@ -3040,12 +3086,14 @@ final class PushEndpointsTest extends TestCase {
     private function runFilesPushCli(
         string $filesystem_root,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        string $push_root = '/'
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $filesystem_root,
             $state_directory,
-            $ini_settings
+            $ini_settings,
+            $push_root
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3057,10 +3105,13 @@ final class PushEndpointsTest extends TestCase {
      * @return array{0:resource,1:array<int,resource>}
      */
     private function startFilesPushCli(
-        string $local_docroot,
+        string $filesystem_root,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        string $push_root = '/'
     ): array {
+        $this->writeFilesPushPreflight($state_directory, $push_root);
+
         $command = [PHP_BINARY];
         foreach ($ini_settings as $name => $value) {
             $command[] = '-d';
@@ -3071,7 +3122,7 @@ final class PushEndpointsTest extends TestCase {
             'files-push',
             $this->remote_reprint_api_url,
             '--state-dir=' . $state_directory,
-            '--fs-root=' . $local_docroot,
+            '--fs-root=' . $filesystem_root,
             '--secret=' . self::SECRET,
             '--force-http',
         ]);
@@ -3085,6 +3136,35 @@ final class PushEndpointsTest extends TestCase {
         fclose($pipes[0]);
         unset($pipes[0]);
         return [$process, $pipes];
+    }
+
+    private function writeFilesPushPreflight(
+        string $state_directory,
+        string $push_root
+    ): void {
+        $pull_state_file = dirname($this->filesPushStateDirectory($state_directory))
+            . '/pull/state.json';
+        if (is_file($pull_state_file)) {
+            return;
+        }
+
+        $pull_state_directory = dirname($pull_state_file);
+        if (!is_dir($pull_state_directory)) {
+            mkdir($pull_state_directory, 0700, true);
+        }
+        $pull_state = new PullState();
+        $pull_state->preflight = [
+            'http_code' => 200,
+            'data' => [
+                'runtime' => [
+                    'document_root' => 'base64:' . base64_encode($push_root),
+                ],
+            ],
+        ];
+        file_put_contents(
+            $pull_state_file,
+            json_encode($pull_state->to_array(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)
+        );
     }
 
     /**
@@ -3149,6 +3229,7 @@ final class PushEndpointsTest extends TestCase {
     ): array {
         return [
             'filesystem_root' => $filesystem_root,
+            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
@@ -3402,6 +3483,7 @@ final class PushEndpointsTest extends TestCase {
         ]);
         return [
             'filesystem_root' => $filesystem_root,
+            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,


### PR DESCRIPTION
`files-push --fs-root=<pulled-filesystem-root>` now maps paths beneath the saved preflight document root to target document-root-relative paths. A local `var/www/html/newfile.php` is pushed as `newfile.php`, not `var/www/html/newfile.php`.

Saved preflight data is mandatory for `files-push`. Local relative paths still address the filesystem and local index; push-root-relative paths are used for target status, exclusions, uploads, and deletions. The shared `path_remainder_under()` helper now owns the prefix-to-remainder mapping used by pull and push.

## Testing

The endpoint regression pushes a file from a pull-shaped filesystem root, then deletes it and pushes a replacement. The focused push, diff, preflight, remapping, PHP 7.4 parsing, and endpoint suites pass: 138 tests and 4,513 assertions. PHPStan passes, and PHPCS reports no new violations.
