### PR TITLE
[Push] Report target-confirmed files-push progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,8 @@ When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the i
 
 During the file fetch phase, progress and heartbeat records include `files_done` (cumulative across restarts, derived from fetch list byte offset + current batch count) and `files_total` (total fetch list entries, fixed after the diff phase). Both are emitted together only when the fetch list exists.
 
+During files-push, progress records include `files_done` and `files_total` together after planning. The completed count advances only at target-confirmed request boundaries and survives resume.
+
 ## File Organization
 
 - packages/reprint-exporter/: Packagist exporter package

--- a/README.md
+++ b/README.md
@@ -605,6 +605,15 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
+During `files-push`, terminal output refreshes as the command changes phase and
+shows `Uploading — N / T files` while local paths are sent. Non-interactive
+output emits `push_progress` JSONL records. After planning completes, those
+records, the final result, and `progress.json` include `files_done` and
+`files_total` together. `files_total` is the number of local paths selected by
+the plan; `files_done` advances only after the target confirms the request
+containing each path, and both counts survive exit-code-2 restarts. The fields
+are absent while the plan is still being built.
+
 #### `<remote-state-directory>/pull/state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it

--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -471,8 +471,14 @@ The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
 state-directory-wide audit log records opening mode, phase changes, planned pauses, handled
-interruptions, and terminal outcomes. The flat progress file records only
-`command`, `status`, `phase`, `reason`, `detail`, and `ts`; neither file copies
+interruptions, and terminal outcomes. Terminal output names the active phase
+and shows `Uploading — N / T files` while local paths are sent.
+Non-interactive output emits throttled `push_progress` JSONL records.
+After planning, those records, the final result, and the flat progress file
+include `files_done` and `files_total` together. The total comes from the
+completed plan; the completed count advances only when the target confirms the
+request containing a local path, and both counts survive resume. They are
+absent while planning. Neither the audit log nor the progress file copies
 receiver cursors or tentative upload positions.
 
 ## Local files-diff command

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -282,6 +282,8 @@ Use these names verbatim:
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
+| Selected local-path count | `local_paths_to_push_count`, `$local_paths_to_push_count`, `get_local_paths_to_push_count()` |
+| Target-confirmed local-path count | `local_paths_pushed`, `$local_paths_pushed` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
 `sender.json` and `excluded_paths.json` live directly under the local push
@@ -310,8 +312,11 @@ paths. The `sender.json` phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`,
 `removing`, and `discarding_plan`. It stores the push session ID, selected
-path-list cursor, receiver part limit, and request-sizing state. The index diff
-completes before local paths are sent. The index copy after a target-confirmed commit
+path-list cursor, selected local-path count, target-confirmed local-path count,
+receiver part limit, and request-sizing state. The index diff cursor retains
+the selected local-path count as it builds the path list, and its complete
+cursor retains the final count. The index diff completes before local paths
+are sent. The index copy after a target-confirmed commit
 has no separate copy cursor and is repeated after interruption. After the index
 is saved or the remote confirms removal, the sender clears the PushPlan
 cursor, then removes the entire plan directory and its exclusions file. It
@@ -391,6 +396,14 @@ positions remain receiver-owned; they are not a files-push cursor and are not
 copied into `<remote-state-directory>/pull/state.json` or the state-directory-wide
 `progress.json`.
 
+Terminal output names the active phase and uses `Uploading — N / T files`
+while local paths are sent. Non-interactive output emits `push_progress` JSONL
+records. `files_done` and `files_total` appear together after planning in those
+records, the final result, and `progress.json`; they are absent while the plan
+is still being built. `files_total` is the selected local-path count.
+`files_done` is the target-confirmed local-path count, so an open, failed, or
+canceled request does not advance it. Both counts survive resume.
+
 Files-push lifecycle lines use these command-first names verbatim: `START
 files-push`, `RESUME files-push`, `PHASE files-push`, `PARTIAL files-push`,
 `INTERRUPTED files-push`, `COMPLETE files-push`, `RESTART files-push`, `FAILED
@@ -424,6 +437,7 @@ Use these names verbatim inside `PushFilesSender`:
 | Plan result | `$plan_result` |
 | Sender status | `$status`, `get_status()` |
 | Sender phase | `get_phase()` |
+| Sender progress | `get_progress()` |
 | Sender outcome classification | `$reason`, `get_reason()` |
 | Sender outcome explanation | `$detail`, `get_detail()` |
 | Receiver path status | `$receiver_path_status` |

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1612,6 +1612,7 @@ class ImportClient
         $detail = null;
         $phase = $sender->get_phase();
         $previous_phase = $phase;
+        $reported_progress = $sender->get_progress();
 
         try {
             $this->audit_log(
@@ -1619,6 +1620,7 @@ class ImportClient
                     . " files-push | phase={$phase}",
                 false
             );
+            $this->report_files_push_progress($reported_progress, true);
 
             while ($sender->get_status() === 'continue') {
                 if ($this->files_push_stop_signal !== null) {
@@ -1643,12 +1645,18 @@ class ImportClient
 
                 $has_next_sender_step = $sender->next_step();
                 $phase = $sender->get_phase();
-                if ($phase !== $previous_phase) {
+                $phase_changed = $phase !== $previous_phase;
+                if ($phase_changed) {
                     $this->audit_log(
                         "PHASE files-push | from={$previous_phase} | to={$phase}",
                         false
                     );
                     $previous_phase = $phase;
+                }
+                $sender_progress = $sender->get_progress();
+                if ($sender_progress !== $reported_progress) {
+                    $this->report_files_push_progress($sender_progress, $phase_changed);
+                    $reported_progress = $sender_progress;
                 }
                 if (!$has_next_sender_step) {
                     break;
@@ -1677,6 +1685,7 @@ class ImportClient
                 }
             }
             $phase = $sender->get_phase();
+            $sender_progress = $sender->get_progress();
             try {
                 $sender->close();
             } catch (\Throwable $throwable) {
@@ -1741,6 +1750,11 @@ class ImportClient
         if ($detail !== null) {
             $result['detail'] = $detail;
         }
+        foreach (['files_done', 'files_total'] as $progress_field) {
+            if (isset($sender_progress[$progress_field])) {
+                $result[$progress_field] = $sender_progress[$progress_field];
+            }
+        }
         // Write the flat progress snapshot without consulting pull state.
         $progress_payload = [
             'command' => 'files-push',
@@ -1748,21 +1762,18 @@ class ImportClient
             'phase' => $phase,
             'reason' => $reason,
             'detail' => $detail,
-            'ts' => microtime(true),
         ];
-        $progress_json = json_encode(
-            $progress_payload,
-            JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE
-        );
-        if ($progress_json !== false) {
-            $temporary_progress_path = $this->progress_file . '.tmp';
-            if (file_put_contents($temporary_progress_path, $progress_json) !== false) {
-                rename($temporary_progress_path, $this->progress_file);
+        foreach (['files_done', 'files_total'] as $progress_field) {
+            if (isset($sender_progress[$progress_field])) {
+                $progress_payload[$progress_field] = $sender_progress[$progress_field];
             }
         }
+        $progress_payload['ts'] = microtime(true);
+        $this->write_files_push_progress_file($progress_payload);
 
-        // Emit the sole final JSON line for non-interactive callers.
+        // Emit the final JSON line after any preceding progress records.
         if ($this->is_tty && !$this->verbose_mode) {
+            $this->progress->clear_progress_line();
             $this->progress->show_lifecycle_line($result['message'] . "\n");
             return;
         }
@@ -1772,6 +1783,112 @@ class ImportClient
         }
         @fwrite($this->progress_fd, $result_json . "\n");
         @flush();
+    }
+
+    /**
+     * Reports one files-push progress snapshot.
+     *
+     * @param array $sender_progress {
+     *     Target-confirmed sender progress.
+     *
+     *     @type string $phase       Current sender phase.
+     *     @type int    $files_done  Target-confirmed local paths. Present after planning.
+     *     @type int    $files_total Total local paths selected by the plan. Present after planning.
+     * }
+     * @param bool $force_output Whether to bypass the JSONL progress throttle.
+     * @phpstan-param array{phase:string,files_done?:int,files_total?:int} $sender_progress
+     */
+    private function report_files_push_progress(
+        array $sender_progress,
+        bool $force_output
+    ): void {
+        $phase = $sender_progress['phase'];
+        $fraction = null;
+        switch ($phase) {
+            case 'creating':
+                $message = 'Starting files push';
+                break;
+            case 'starting_plan':
+            case 'planning':
+                $message = 'Planning file changes';
+                break;
+            case 'pushing_paths':
+                $files_done = $sender_progress['files_done'];
+                $files_total = $sender_progress['files_total'];
+                $fraction = $files_total > 0 ? $files_done / $files_total : null;
+                $message = sprintf(
+                    'Uploading — %s / %s files',
+                    number_format($files_done),
+                    number_format($files_total)
+                );
+                break;
+            case 'pushing_deletes':
+                $message = 'Uploading deleted paths';
+                break;
+            case 'committing':
+                $message = 'Applying file changes';
+                break;
+            case 'saving_local_index':
+                $message = 'Saving local index';
+                break;
+            case 'completing':
+                $message = 'Finishing files push';
+                break;
+            case 'removing':
+                $message = 'Removing changed push session';
+                break;
+            case 'discarding_plan':
+                $message = 'Discarding changed push plan';
+                break;
+            default:
+                $message = 'Running files push';
+                break;
+        }
+
+        $this->progress->show_progress_line($message, $fraction);
+        $progress_record = [
+            'type' => 'push_progress',
+            'command' => 'files-push',
+            'status' => 'in_progress',
+            'phase' => $phase,
+            'message' => $message,
+        ];
+        $progress_payload = [
+            'command' => 'files-push',
+            'status' => 'in_progress',
+            'phase' => $phase,
+            'reason' => null,
+            'detail' => null,
+        ];
+        foreach (['files_done', 'files_total'] as $progress_field) {
+            if (isset($sender_progress[$progress_field])) {
+                $progress_record[$progress_field] = $sender_progress[$progress_field];
+                $progress_payload[$progress_field] = $sender_progress[$progress_field];
+            }
+        }
+        $this->output_progress($progress_record, $force_output);
+        $progress_payload['ts'] = microtime(true);
+        $this->write_files_push_progress_file($progress_payload);
+    }
+
+    /**
+     * Atomically writes the flat files-push progress snapshot.
+     *
+     * @param array<string,mixed> $progress_payload Complete progress-file payload.
+     */
+    private function write_files_push_progress_file(array $progress_payload): void
+    {
+        $progress_json = json_encode(
+            $progress_payload,
+            JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        if ($progress_json === false) {
+            return;
+        }
+        $temporary_progress_path = $this->progress_file . '.tmp';
+        if (file_put_contents($temporary_progress_path, $progress_json) !== false) {
+            rename($temporary_progress_path, $this->progress_file);
+        }
     }
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions are CLI text, not HTML.

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -13,8 +13,9 @@
  * push, and saves the completed fresh local index as the local index for this
  * remote Reprint API URL. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
- * retains the top-level phase, the selected path-list cursor, and learned
- * request limits and the PushPlan cursor needed after a process restart.
+ * retains the top-level phase, the selected path-list cursor, the planned and
+ * target-confirmed local-path counts, learned request limits, and the PushPlan
+ * cursor needed after a process restart.
  *
  * ## Usage
  *
@@ -124,7 +125,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{path:string,path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -270,6 +271,8 @@ final class PushFilesSender
                 'phase' => 'creating',
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
+                'local_paths_to_push_count' => null,
+                'local_paths_pushed' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => $sender->push_stream_client->get_request_sizer_state(),
             ];
@@ -457,6 +460,32 @@ final class PushFilesSender
     }
 
     /**
+     * Returns target-confirmed local-path progress for the open sender.
+     *
+     * @return array {
+     *     Current files-push progress.
+     *
+     *     @type string $phase       Current sender phase.
+     *     @type int    $files_done  Target-confirmed local paths. Present after planning.
+     *     @type int    $files_total Total local paths selected by the plan. Present after planning.
+     * }
+     * @phpstan-return array{phase:string,files_done?:int,files_total?:int}
+     */
+    public function get_progress(): array
+    {
+        $progress_state = $this->upload_request_stage === 'closed'
+            ? $this->state
+            : $this->state_before_upload_request;
+        /** @var State $progress_state */
+        $progress = ['phase' => $progress_state['phase']];
+        if ($progress_state['local_paths_to_push_count'] !== null) {
+            $progress['files_done'] = $progress_state['local_paths_pushed'];
+            $progress['files_total'] = $progress_state['local_paths_to_push_count'];
+        }
+        return $progress;
+    }
+
+    /**
      * Returns the machine-readable classification for the current outcome.
      *
      * @return string|null Current classification, or null when none applies.
@@ -613,6 +642,7 @@ final class PushFilesSender
         }
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         if (!$has_next_step) {
+            $this->state['local_paths_to_push_count'] = $this->plan->get_local_paths_to_push_count();
             $this->plan->close();
             $this->state['phase'] = 'pushing_paths';
         }
@@ -735,6 +765,7 @@ final class PushFilesSender
             ) {
                 $this->close_local_file_handle();
                 $this->state['local_paths_to_push_byte_offset'] = $local_path_to_push['next_local_paths_to_push_byte_offset'];
+                ++$this->state['local_paths_pushed'];
                 $this->local_path_to_push = null;
                 $this->store_state($this->state);
                 return;
@@ -920,6 +951,7 @@ final class PushFilesSender
         if ($upload_completes_local_path) {
             $this->close_local_file_handle();
             $this->state['local_paths_to_push_byte_offset'] = $local_path_to_push['next_local_paths_to_push_byte_offset'];
+            ++$this->state['local_paths_pushed'];
             $this->next_file_byte_offset = null;
             $this->local_path_to_push = null;
         } else {

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -61,8 +61,8 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
- * @phpstan-type CompleteCursor array{phase:'complete'}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
+ * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
@@ -227,6 +227,18 @@ class PushPlan
     public function get_local_paths_to_push_path(): string
     {
         return $this->local_paths_to_push;
+    }
+
+    /**
+     * Returns the number of local paths in the completed push plan.
+     */
+    public function get_local_paths_to_push_count(): int
+    {
+        $position = $this->cursor["position"];
+        if ($position["phase"] !== "complete") {
+            throw new LogicException("Cannot count local paths to push before the push plan is complete.");
+        }
+        return $position["local_paths_to_push_count"];
     }
 
     /**
@@ -468,6 +480,7 @@ class PushPlan
             "byte_offset_in_local_index" => 0,
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
+            "local_paths_to_push_count" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
             "previous_fresh_local_index_entry_path" => null,
         ];
@@ -540,6 +553,7 @@ class PushPlan
 
         $byte_offset_in_fresh_local_index = $cursor["byte_offset_in_fresh_local_index"];
         $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
+        $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
         $local_paths_to_push_changed = false;
         $local_paths_to_delete_changed = false;
@@ -626,6 +640,7 @@ class PushPlan
                 }
                 if (!$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
+                    ++$local_paths_to_push_count;
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
@@ -691,6 +706,7 @@ class PushPlan
                 }
                 if ($needs_push && !$path_is_excluded) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
+                    ++$local_paths_to_push_count;
                     $local_paths_to_push_changed = true;
                 }
             }
@@ -724,13 +740,17 @@ class PushPlan
             $this->deleted_directory_stack_entry = null;
         }
         $cursor_after_step = $complete
-            ? ["phase" => "complete"]
+            ? [
+                "phase" => "complete",
+                "local_paths_to_push_count" => $local_paths_to_push_count,
+            ]
             : [
                 "phase" => "diffing",
                 "byte_offset_in_fresh_local_index" => $byte_offset_in_fresh_local_index,
                 "byte_offset_in_local_index" => $byte_offset_in_local_index,
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
+                "local_paths_to_push_count" => $local_paths_to_push_count,
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
                 "previous_fresh_local_index_entry_path" =>
                     $this->previous_fresh_local_index_entry_path,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -270,6 +270,8 @@ final class FilesPushCommandTest extends TestCase
                 'phase' => 'starting_plan',
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
+                'local_paths_to_push_count' => null,
+                'local_paths_pushed' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => [
                     'request_body_bytes' => 32 * 1024 * 1024,

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -117,6 +117,7 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(2, 0);
+        $this->assertSame(2, $plan->get_local_paths_to_push_count());
         $this->assertSame(
             ['index.php', 'wp-content/themes/foo/style.css'],
             $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
@@ -283,7 +284,13 @@ final class PushPlanTest extends TestCase
 
         $this->assertFalse($this->nextPlanStep($plan));
         $complete_cursor = $this->planCursor();
-        $this->assertSame(['phase' => 'complete'], $complete_cursor);
+        $this->assertSame(
+            [
+                'phase' => 'complete',
+                'local_paths_to_push_count' => 0,
+            ],
+            $complete_cursor
+        );
         $this->assertSame($stack_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
         $plan->close();
 
@@ -519,9 +526,11 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_index',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
+            'local_paths_to_push_count',
             'deleted_directory_stack_top_byte_offset',
             'previous_fresh_local_index_entry_path',
         ], array_keys($cursor['position']));
+        $this->assertSame(1, $cursor['position']['local_paths_to_push_count']);
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
             $cursor['position']['byte_offset_in_local_paths_to_push']
@@ -567,6 +576,7 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($reopened);
 
         $this->assertPathCounts(3, 3);
+        $this->assertSame(3, $reopened->get_local_paths_to_push_count());
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1454,6 +1454,69 @@ final class PushEndpointsTest extends TestCase {
     }
 
     /**
+     * Reports completed local paths only after the target confirms their request.
+     */
+    public function testHighLevelSenderReportsTargetConfirmedPathProgress(): void
+    {
+        $local_docroot = $this->root . '/progress-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/first.txt', 'first');
+        file_put_contents($local_docroot . '/second.txt', 'second');
+        $push_state_directory = $this->root . '/progress-state';
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
+
+        $sender = $this->startSender($options);
+        try {
+            $this->takeSenderStepsUntilPhase($sender, 'pushing_paths');
+            $this->assertSame(
+                [
+                    'phase' => 'pushing_paths',
+                    'files_done' => 0,
+                    'files_total' => 2,
+                ],
+                $sender->get_progress()
+            );
+
+            $this->assertTrue($sender->next_step());
+            $this->assertSame(0, $sender->get_progress()['files_done']);
+            $sender->cancel();
+            $this->assertSame(0, $sender->get_progress()['files_done']);
+
+            $files_done = $sender->get_progress()['files_done'];
+            for ($step = 0; $step < 20 && $files_done === 0; ++$step) {
+                $this->assertTrue($sender->next_step());
+                $files_done = $sender->get_progress()['files_done'];
+            }
+            $confirmed_progress = $sender->get_progress();
+            $this->assertGreaterThan(0, $confirmed_progress['files_done']);
+            $this->assertLessThanOrEqual(2, $confirmed_progress['files_done']);
+        } finally {
+            if ($sender->get_status() === 'continue') {
+                $sender->cancel();
+            }
+            $this->closeSender($sender);
+        }
+
+        $sender = $this->resumeSender($options);
+        try {
+            $this->assertSame($confirmed_progress, $sender->get_progress());
+            while ($sender->next_step()) {
+                continue;
+            }
+            $this->assertSame(
+                [
+                    'phase' => 'completing',
+                    'files_done' => 2,
+                    'files_total' => 2,
+                ],
+                $sender->get_progress()
+            );
+        } finally {
+            $this->closeSender($sender);
+        }
+    }
+
+    /**
      * Continues deleted paths and their completion from successful upload responses.
      */
     public function testHighLevelSenderRetainsReceiverConfirmedDeletedPathsWhileOpen(): void
@@ -2654,6 +2717,25 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(0, $initial['exit'], $initial['output']);
         $initial_result = $this->lastCliJsonLine($initial['stdout']);
         $this->assertSame('complete', $initial_result['status'] ?? null);
+        $this->assertSame(4, $initial_result['files_done'] ?? null);
+        $this->assertSame(4, $initial_result['files_total'] ?? null);
+        $push_progress_records = array_values(array_filter(
+            $this->cliJsonLines($initial['stdout']),
+            static function (array $record): bool {
+                return ( $record['type'] ?? null ) === 'push_progress';
+            }
+        ));
+        $this->assertNotEmpty($push_progress_records);
+        $upload_progress_records = array_values(array_filter(
+            $push_progress_records,
+            static function (array $record): bool {
+                return ( $record['phase'] ?? null ) === 'pushing_paths';
+            }
+        ));
+        $this->assertNotEmpty($upload_progress_records);
+        $this->assertSame(0, $upload_progress_records[0]['files_done'] ?? null);
+        $this->assertSame(4, $upload_progress_records[0]['files_total'] ?? null);
+        $this->assertSame('Uploading — 0 / 4 files', $upload_progress_records[0]['message'] ?? null);
         $push_state_directory = $this->filesPushStateDirectory($state_directory);
         $this->assertSame($initial_contents, file_get_contents($this->docroot . '/nested/multi-chunk.bin'));
         $this->assertSame('delete me later', file_get_contents($this->docroot . '/delete-later.txt'));
@@ -2675,10 +2757,12 @@ final class PushEndpointsTest extends TestCase {
             JSON_THROW_ON_ERROR
         );
         $this->assertSame(
-            ['command', 'status', 'phase', 'reason', 'detail', 'ts'],
+            ['command', 'status', 'phase', 'reason', 'detail', 'files_done', 'files_total', 'ts'],
             array_keys($progress)
         );
         $this->assertSame('complete', $progress['status']);
+        $this->assertSame(4, $progress['files_done']);
+        $this->assertSame(4, $progress['files_total']);
         $audit = (string) file_get_contents($state_directory . '/audit.log');
         $this->assertStringNotContainsString(self::SECRET, $audit . $initial['output']);
         $this->assertStringNotContainsString('cursor', $audit . json_encode($progress));
@@ -3030,13 +3114,24 @@ final class PushEndpointsTest extends TestCase {
     /** @return array<string,mixed> */
     private function lastCliJsonLine(string $output): array
     {
-        foreach (array_reverse(preg_split('/\R/', trim($output)) ?: []) as $line) {
-            $decoded = json_decode($line, true);
-            if (is_array($decoded)) {
-                return $decoded;
-            }
+        $records = $this->cliJsonLines($output);
+        if ($records !== []) {
+            return $records[count($records) - 1];
         }
         $this->fail('No JSON line was found in CLI output: ' . $output);
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function cliJsonLines(string $output): array
+    {
+        $records = [];
+        foreach (preg_split('/\R/', trim($output)) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                $records[] = $decoded;
+            }
+        }
+        return $records;
     }
 
     private function filesPushStateDirectory(string $state_directory): string


### PR DESCRIPTION
`files-push` now refreshes terminal phase output, emits `push_progress` JSONL records, and updates `progress.json` with `files_done` and `files_total` after planning.

The plan persists its selected-local-path count as it is built. The sender advances the completed count only at a target-confirmed boundary, so an open, canceled, or failed request reports the preceding durable count and a resumed process continues from it. Final command results carry the same counters.

The focused push, plan, command, PHP 7.4 parsing, and endpoint suites pass (91 tests, 2,992 assertions); PHPStan, the PHP 7.4 compatibility scan, the PHAR build, and `git diff --check` pass. PHPCS counts do not increase in any changed file. The complete suite's 159 remaining results are MySQL connection failures because no local server is running.

Part of #276.
