### PR TITLE
[Push] Keep files-push paths relative to filesystem root

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -125,11 +125,10 @@ the push plan.
 
 A push plan is an internal part of the sender lifecycle:
 
-1. Before `PushFilesSender::start()`, `files-push` loads the mandatory
-   preflight document root as the push root. The sender enters `creating`,
-   stores the push root's local relative path in `sender.json`, and requests
-   at most 100 target exclusions from `push_create`. It stores the exclusions
-   in `excluded_paths.json` after creating the active `plan/` directory.
+1. Before `PushFilesSender::start()`, `files-push` requires saved preflight
+   data. The sender enters `creating` and requests at most 100 target
+   exclusions from `push_create`. It stores the exclusions in
+   `excluded_paths.json` after creating the active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
@@ -144,7 +143,7 @@ A push plan is an internal part of the sender lifecycle:
    both indexes reach EOF. It
    writes files, symlinks, and empty directories with their local relative
    path, planned type, size, and ctime to `plan/local_paths_to_push.jsonl`,
-   and writes raw NUL-delimited push-root-relative paths to
+   and writes raw NUL-delimited local relative paths to
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
 6. After the target confirms commit, the sender saves the retained fresh local
@@ -170,8 +169,8 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, filesystem root, local index file,
-push root's local relative path, and current planning position. During
+The cursor contains the plan directory, filesystem root, local index file, and
+current planning position. During
 indexing, that position contains the `FileIndexProcessor` cursor and committed
 fresh-index byte offset. During diffing, each step flushes only the path list or
 append-only deleted-directory stack changed by that step before updating the two index
@@ -318,7 +317,7 @@ state:
       excluded_paths.json               target exclusions for the active push
       fresh_local_index.jsonl           plan-owned fresh local index
       local_paths_to_push.jsonl         local paths to push
-      local_paths_to_delete             raw NUL-delimited push-root-relative paths
+      local_paths_to_delete             raw NUL-delimited local relative paths
       deleted_directories_stack.jsonl   append-only planning stack
 ```
 
@@ -348,8 +347,9 @@ with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
 remaining handles before `close()` returns.
 
-The sender stores the mandatory preflight push root, creates the push session,
-and stores its exclusion policy before it starts PushPlan. Each internal
+The CLI requires saved preflight data before it creates the sender. The sender
+creates the push session and stores its exclusion policy before it starts
+PushPlan. Each internal
 `indexing` step completes one traversal event,
 and `starting_diff` initializes the index diff. Each internal `diffing` step
 compares at most one path and updates the path lists. PushPlan owns the
@@ -359,9 +359,9 @@ upload begins until both indexes have been consumed and the two path lists are
 stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the push root's local relative path, the PushPlan cursor, the next
-byte offset in `local_paths_to_push.jsonl`, the receiver part limit, and
-learned request-body sizing state. Its phases are `creating`, `starting_plan`,
+and phase, the PushPlan cursor, the next byte offset in
+`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
+sizing state. Its phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`, `removing`, and
 `discarding_plan`.
@@ -387,8 +387,8 @@ After all local paths are pushed, a newly opened sender reads
 `work_deletes_bytes` and `work_deletes_complete` from `push_status`. Successful
 uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
-duplicate it. Each uploaded deletion-list part contains one complete
-push-root-relative path.
+duplicate it. Each uploaded deletion-list part contains one complete local
+relative path, sent unchanged as a push-root-relative path.
 The sender trusts this completed, immutable plan without consulting the fresh
 local index or live filesystem root again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
@@ -435,10 +435,12 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 ## Low-level files-push command
 
 `reprint files-push <remote-reprint-api-url>` is the production CLI caller for one
-`PushFilesSender`. It sends only the resolved filesystem root named by `--fs-root`.
-It requires `--state-dir`, `--fs-root`, `--secret`, and saved preflight
-data for the remote document root; HTTPS is required unless the operator passes
-`--force-http`. It reads but never writes
+`PushFilesSender`. The resolved filesystem root named by `--fs-root` represents
+the target push root locally. Every local relative path is sent unchanged as a
+push-root-relative path; the target's absolute document root is not a prefix
+within the local filesystem root. It requires `--state-dir`, `--fs-root`,
+`--secret`, and saved preflight data; HTTPS is required unless the operator
+passes `--force-http`. It reads but never writes
 `<remote-state-directory>/pull/state.json`. It does not run preflight itself,
 show a plan, ask for confirmation, transfer a database, retry a failed request,
 or start a replacement sender after a `restart` outcome.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -377,9 +377,10 @@ running the command again prints the complete report.
 
 The low-level, files-only command is `files-push`. Its `remote Reprint API URL` is the
 exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
-`--fs-root`. It requires saved preflight data and uses its remote document
-root as the push root. It also requires `--secret=TOKEN`; `--force-http` is
-the explicit plain-HTTP opt-in.
+`--fs-root` and represents the push root locally. Every local relative path is
+also its push-root-relative path; the target's absolute document root is not a
+local path prefix. It requires saved preflight data and `--secret=TOKEN`;
+`--force-http` is the explicit plain-HTTP opt-in.
 
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1001,8 +1001,8 @@ class ImportClient
                     "Finish or abort the interrupted files-pull before running files-push."
                 );
             }
-            // files-push reads preflight to locate the remote document root,
-            // but its lifecycle never writes pull state.
+            // files-push requires saved preflight data, but its lifecycle never
+            // writes pull state.
             $this->state = $this->load_state();
             $this->require_preflight();
             $this->run_files_push($options, $process_lock);
@@ -1584,13 +1584,6 @@ class ImportClient
         if (!is_array($context)) {
             throw new InvalidArgumentException('files-push requires its validated command context.');
         }
-        $push_root = $this->get_state()->preflight["data"]["runtime"]["document_root"] ?? null;
-        if (!is_string($push_root) || $push_root === '' || $push_root[0] !== '/') {
-            throw new RuntimeException(
-                "Preflight did not report an absolute document root. Run 'preflight' or 'preflight-assert' again."
-            );
-        }
-
         $this->enable_files_push_signal_handling();
 
         if (!class_exists('Site_Export_HMAC_Client')) {
@@ -1607,7 +1600,6 @@ class ImportClient
             : parse_size($memory_limit_value);
         $sender_options = [
             'filesystem_root' => $context['filesystem_root'],
-            'push_root' => $push_root,
             'push_state_directory' => $context['push_state_directory'],
             'remote_reprint_api_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
@@ -12501,7 +12493,7 @@ if (
                 "Sends the existing filesystem root at --fs-root to the remote Reprint API.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
-                "It requires saved preflight data for the remote document root.\n" .
+                "It requires saved preflight data.\n" .
                 "\n" .
                 "Each process runs one sender until it completes, reaches a caller time or\n" .
                 "memory boundary, or receives a signal handled by this PHP runtime.\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -123,17 +123,14 @@
  *
  * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'directory'|'symlink',size:int,ctime:int}
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
- * @phpstan-type LocalPathToPush array{local_relative_path:string,push_root_relative_path:string,push_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
+ * @phpstan-type LocalPathToPush array{local_relative_path:string,local_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
     /** @var string Filesystem root whose local paths to push are sent. */
     private string $filesystem_root;
-
-    /** @var string Push root relative to the local filesystem root. */
-    private string $push_root_local_relative_path;
 
     /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
@@ -238,7 +235,6 @@ final class PushFilesSender
      *     Push, push stream client, and local-file options.
      *
      *     @type string                  $filesystem_root         Required filesystem root directory.
-     *     @type string                  $push_root               Required remote absolute push root.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
@@ -273,7 +269,6 @@ final class PushFilesSender
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
-                'push_root_local_relative_path' => $sender->push_root_local_relative_path,
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
@@ -340,8 +335,6 @@ final class PushFilesSender
     private function __construct(array $options, ReprintProcessLock $process_lock)
     {
         $filesystem_root = $options['filesystem_root'] ?? null;
-        /** @var string $push_root */
-        $push_root = $options['push_root'];
         $push_state_directory = $options['push_state_directory'] ?? null;
         if (!is_string($filesystem_root) || !is_dir($filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
@@ -373,7 +366,6 @@ final class PushFilesSender
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
         $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/');
-        $this->push_root_local_relative_path = trim($push_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
@@ -628,8 +620,7 @@ final class PushFilesSender
             $this->plan_directory,
             $this->filesystem_root,
             $this->local_index_file,
-            $this->excluded_paths_path,
-            $this->state['push_root_local_relative_path']
+            $this->excluded_paths_path
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
@@ -757,7 +748,7 @@ final class PushFilesSender
         } else {
             $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
-                'path_b64' => $local_path_to_push['push_root_relative_path_b64'],
+                'path_b64' => $local_path_to_push['local_relative_path_b64'],
             ], ['accepted']);
             if ($this->handle_request_failure($request_result)) {
                 return;
@@ -816,7 +807,7 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => 'directory',
-                'path' => $local_path_to_push['push_root_relative_path'],
+                'path' => $local_path_to_push['local_relative_path'],
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
@@ -839,7 +830,7 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => 'symlink',
-                'path' => $local_path_to_push['push_root_relative_path'],
+                'path' => $local_path_to_push['local_relative_path'],
                 'target' => $symlink_target,
                 'payload' => '',
             ];
@@ -849,7 +840,7 @@ final class PushFilesSender
         // A file contributes at most one bounded chunk during this call and remains open for the next.
         if ($local_path_type_size_and_ctime['type'] === 'file') {
             $maximum_file_payload_bytes = $this->push_stream_client->next_file_body_bytes(
-                $local_path_to_push['push_root_relative_path'],
+                $local_path_to_push['local_relative_path'],
                 $local_path_type_size_and_ctime['size'],
                 $file_byte_offset
             );
@@ -917,7 +908,7 @@ final class PushFilesSender
 
             $upload_part = [
                 'type' => 'file',
-                'path' => $local_path_to_push['push_root_relative_path'],
+                'path' => $local_path_to_push['local_relative_path'],
                 'total_bytes' => $local_path_type_size_and_ctime['size'],
                 'offset' => $file_byte_offset,
                 'payload' => $payload,
@@ -1406,22 +1397,14 @@ final class PushFilesSender
             throw new RuntimeException('Failed to decode a local path to push.', 0, $exception);
         }
         /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $decoded_local_path */
-        $local_relative_path = base64_decode($decoded_local_path['path'], true);
+        $local_relative_path_b64 = $decoded_local_path['path'];
+        $local_relative_path = base64_decode($local_relative_path_b64, true);
         if ($local_relative_path === false) {
             throw new RuntimeException('Failed to decode a path in the local paths-to-push file.');
         }
-        $push_root_local_relative_path = $this->state['push_root_local_relative_path'];
-        if ($push_root_local_relative_path === '') {
-            $push_root_relative_path = $local_relative_path;
-        } else {
-            $push_root_relative_path = $local_relative_path === $push_root_local_relative_path
-                ? ''
-                : substr($local_relative_path, strlen($push_root_local_relative_path) + 1);
-        }
         return [
             'local_relative_path' => $local_relative_path,
-            'push_root_relative_path' => $push_root_relative_path,
-            'push_root_relative_path_b64' => base64_encode($push_root_relative_path),
+            'local_relative_path_b64' => $local_relative_path_b64,
             'next_local_paths_to_push_byte_offset' => $next_local_paths_to_push_byte_offset,
             'planned_local_path_type_size_and_ctime' => [
                 'type' => $decoded_local_path['type'],
@@ -1577,10 +1560,6 @@ final class PushFilesSender
         }
 
         /** @var array<string,mixed> $state */
-        if (!array_key_exists('push_root_local_relative_path', $state)) {
-            // Older state used local relative paths as push-root-relative paths.
-            $state['push_root_local_relative_path'] = '';
-        }
         if (!array_key_exists('local_paths_to_push_count', $state)) {
             // Keep the sender single-pass when older state has no path progress.
             $state['local_paths_to_push_count'] = null;

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -1575,6 +1575,18 @@ final class PushFilesSender
         } catch (JsonException $exception) {
             throw new RuntimeException('Failed to decode active state: ' . $this->state_path, 0, $exception);
         }
+
+        /** @var array<string,mixed> $state */
+        if (!array_key_exists('push_root_local_relative_path', $state)) {
+            // Older state used local relative paths as push-root-relative paths.
+            $state['push_root_local_relative_path'] = '';
+        }
+        if (!array_key_exists('local_paths_to_push_count', $state)) {
+            // Keep the sender single-pass when older state has no path progress.
+            $state['local_paths_to_push_count'] = null;
+            $state['local_paths_pushed'] = 0;
+        }
+
         /** @var State $state */
         return $state;
     }

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -62,8 +62,8 @@ use function WordPress\Reprint\Exporter\path_remainder_under;
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
- * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
+ * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,push_root_local_relative_path:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
@@ -205,6 +205,20 @@ class PushPlan
      */
     public static function resume(array $cursor): self
     {
+        if (!array_key_exists("push_root_local_relative_path", $cursor)) {
+            // Older cursors used local relative paths as push-root-relative paths.
+            $cursor["push_root_local_relative_path"] = "";
+        }
+        $position = $cursor["position"];
+        if (
+            ($position["phase"] === "diffing" || $position["phase"] === "complete")
+            && !array_key_exists("local_paths_to_push_count", $position)
+        ) {
+            // Keep the plan single-pass when an older cursor has no path count.
+            $position["local_paths_to_push_count"] = null;
+            $cursor["position"] = $position;
+        }
+
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["filesystem_root"],
@@ -244,8 +258,10 @@ class PushPlan
 
     /**
      * Returns the number of local paths in the completed push plan.
+     *
+     * Null means the plan resumed from an older cursor without a saved count.
      */
-    public function get_local_paths_to_push_count(): int
+    public function get_local_paths_to_push_count(): ?int
     {
         $position = $this->cursor["position"];
         if ($position["phase"] !== "complete") {
@@ -657,7 +673,9 @@ class PushPlan
                 }
                 if (!$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
-                    ++$local_paths_to_push_count;
+                    if ($local_paths_to_push_count !== null) {
+                        ++$local_paths_to_push_count;
+                    }
                     $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
@@ -723,7 +741,9 @@ class PushPlan
                 }
                 if ($needs_push && !$path_is_excluded) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
-                    ++$local_paths_to_push_count;
+                    if ($local_paths_to_push_count !== null) {
+                        ++$local_paths_to_push_count;
+                    }
                     $local_paths_to_push_changed = true;
                 }
             }

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -3,7 +3,6 @@
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
-use function WordPress\Reprint\Exporter\path_remainder_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -65,16 +64,13 @@ use function WordPress\Reprint\Exporter\path_remainder_under;
  * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,push_root_local_relative_path:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
 {
     /** @var string Resolved filesystem root inspected while building the fresh local index. */
     private string $filesystem_root;
-
-    /** @var string Push root relative to the local filesystem root. */
-    private string $push_root_local_relative_path;
 
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
@@ -149,22 +145,15 @@ class PushPlan
      * @param string $filesystem_root     Resolved filesystem root.
      * @param string $local_index_file    Local index file this plan diffs against.
      * @param string $excluded_paths_path Caller-owned target exclusions file.
-     * @param string $push_root_local_relative_path Push root relative to the local filesystem root.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $filesystem_root,
         string $local_index_file,
-        string $excluded_paths_path,
-        string $push_root_local_relative_path = ""
+        string $excluded_paths_path
     ): self {
-        $plan = new self(
-            $plan_directory,
-            $filesystem_root,
-            $local_index_file,
-            $push_root_local_relative_path
-        );
+        $plan = new self($plan_directory, $filesystem_root, $local_index_file);
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -184,7 +173,6 @@ class PushPlan
             "plan_directory" => $plan->plan_directory,
             "filesystem_root" => $plan->filesystem_root,
             "local_index_file" => $plan->local_index_file,
-            "push_root_local_relative_path" => $plan->push_root_local_relative_path,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -205,10 +193,6 @@ class PushPlan
      */
     public static function resume(array $cursor): self
     {
-        if (!array_key_exists("push_root_local_relative_path", $cursor)) {
-            // Older cursors used local relative paths as push-root-relative paths.
-            $cursor["push_root_local_relative_path"] = "";
-        }
         $position = $cursor["position"];
         if (
             ($position["phase"] === "diffing" || $position["phase"] === "complete")
@@ -222,8 +206,7 @@ class PushPlan
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["filesystem_root"],
-            $cursor["local_index_file"],
-            $cursor["push_root_local_relative_path"]
+            $cursor["local_index_file"]
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
@@ -292,13 +275,11 @@ class PushPlan
      * @param string $plan_directory   Caller-owned active plan directory.
      * @param string $filesystem_root  Resolved filesystem root.
      * @param string $local_index_file Local index file this plan diffs against.
-     * @param string $push_root_local_relative_path Push root relative to the local filesystem root.
      */
     private function __construct(
         string $plan_directory,
         string $filesystem_root,
-        string $local_index_file,
-        string $push_root_local_relative_path
+        string $local_index_file
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -307,8 +288,6 @@ class PushPlan
         $this->plan_directory = $plan_directory;
         $this->set_filesystem_root($filesystem_root);
         $this->local_index_file = $local_index_file;
-        $this->push_root_local_relative_path =
-            rtrim($push_root_local_relative_path, "/");
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index_file = $plan_directory . "/fresh_local_index.jsonl";
@@ -1013,9 +992,8 @@ class PushPlan
      */
     private function append_local_path_to_delete(string $path): void
     {
-        $push_root_relative_path_with_nul =
-            $this->local_relative_path_to_push_root_relative_path($path) . "\0";
-        if (fwrite($this->local_paths_to_delete_handle, $push_root_relative_path_with_nul) !== strlen($push_root_relative_path_with_nul)) {
+        $path_with_nul = $path . "\0";
+        if (fwrite($this->local_paths_to_delete_handle, $path_with_nul) !== strlen($path_with_nul)) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
         }
     }
@@ -1113,44 +1091,15 @@ class PushPlan
      */
     private function path_conflicts_with_excluded_paths(string $path): bool
     {
-        $push_root_relative_path =
-            $this->local_relative_path_to_push_root_relative_path($path);
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                path_is_within_root($push_root_relative_path, $excluded_path)
-                || path_is_within_root($excluded_path, $push_root_relative_path)
+                path_is_within_root($path, $excluded_path)
+                || path_is_within_root($excluded_path, $path)
             ) {
                 return true;
             }
         }
         return false;
-    }
-
-    /**
-     * Maps a local relative path to its push-root-relative path.
-     */
-    private function local_relative_path_to_push_root_relative_path(
-        string $local_relative_path
-    ): string {
-        if ($this->push_root_local_relative_path === "") {
-            return $local_relative_path;
-        }
-        $path_remainder = path_remainder_under(
-            $local_relative_path,
-            $this->push_root_local_relative_path
-        );
-        if ($path_remainder === null) {
-            throw new RuntimeException(
-                "Local relative path "
-                . base64_encode($local_relative_path)
-                . " is not below the push root's local relative path "
-                . base64_encode($this->push_root_local_relative_path)
-                . "."
-            );
-        }
-        return $path_remainder === ""
-            ? ""
-            : substr($path_remainder, 1);
     }
 
     /**

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -187,7 +187,6 @@ final class FilesPullLocalIndexTest extends TestCase
         try {
             $sender = \PushFilesSender::start([
                 'filesystem_root' => $this->rawFileRoot,
-                'push_root' => '/',
                 'push_state_directory' => $pushStateDirectory,
                 'remote_reprint_api_url' =>
                     $remoteReprintApiUrl,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -281,7 +281,6 @@ final class FilesPushCommandTest extends TestCase
             json_encode([
                 'push_session_id' => str_repeat('1', 32),
                 'phase' => 'starting_plan',
-                'push_root_local_relative_path' => '',
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -448,7 +448,7 @@ final class PushPlanTest extends TestCase
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
-    public function testResumesCursorWrittenBeforePushRootMappingAndProgressCount(): void
+    public function testResumesCursorWrittenBeforeProgressCount(): void
     {
         $entries = $this->manyFileEntries(2);
         $current = $this->writeIndex($entries);
@@ -457,7 +457,6 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
 
-        unset($this->cursor['push_root_local_relative_path']);
         unset($this->cursor['position']['local_paths_to_push_count']);
 
         $resumedPlan = $this->resumePlan();
@@ -534,13 +533,11 @@ final class PushPlanTest extends TestCase
             'plan_directory',
             'filesystem_root',
             'local_index_file',
-            'push_root_local_relative_path',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
         $this->assertSame(realpath($this->filesystemRoot()), $cursor['filesystem_root']);
         $this->assertSame($this->localIndexFile(), $cursor['local_index_file']);
-        $this->assertSame('', $cursor['push_root_local_relative_path']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_local_index',
@@ -652,35 +649,6 @@ final class PushPlanTest extends TestCase
         );
     }
 
-    public function testPlanAppliesPushRootToDeletionPathsAndTargetExclusions(): void
-    {
-        $this->saveLocalIndex($this->writeIndex([
-            'var/www/html/deleted.txt' => [100, 5, 'file'],
-        ]));
-        $current = $this->writeIndex([
-            'var/www/html/added.txt' => [300, 3, 'file'],
-            'var/www/html/preserved/value.txt' => [300, 3, 'file'],
-        ]);
-
-        $plan = $this->startPlan(
-            $current,
-            ['preserved'],
-            'var/www/html'
-        );
-        $plan->close();
-        $plan = $this->resumePlan();
-        $this->planToCompletion($plan);
-
-        $this->assertSame(
-            ['var/www/html/added.txt'],
-            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
-        );
-        $this->assertSame(
-            "deleted.txt\0",
-            file_get_contents($this->planPath('local_paths_to_delete'))
-        );
-    }
-
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------
@@ -688,8 +656,7 @@ final class PushPlanTest extends TestCase
     /** @param list<string> $excludedPaths */
     private function startPlan(
         ?string $filesystemRootDescriptionFile = null,
-        array $excludedPaths = [],
-        string $pushRootLocalRelativePath = ''
+        array $excludedPaths = []
     ): PushPlan {
         if ($filesystemRootDescriptionFile === null) {
             $filesystemRootDescriptionFile = $this->tempDir . '/empty-filesystem-root.jsonl';
@@ -712,8 +679,7 @@ final class PushPlanTest extends TestCase
             $this->planDirectory(),
             $this->filesystemRoot(),
             $this->localIndexFile(),
-            $this->excludedPathsPath(),
-            $pushRootLocalRelativePath
+            $this->excludedPathsPath()
         );
         $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -448,6 +448,25 @@ final class PushPlanTest extends TestCase
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
+    public function testResumesCursorWrittenBeforePushRootMappingAndProgressCount(): void
+    {
+        $entries = $this->manyFileEntries(2);
+        $current = $this->writeIndex($entries);
+        $plan = $this->startPlan($current);
+
+        $this->assertTrue($this->nextPlanStep($plan));
+        $plan->close();
+
+        unset($this->cursor['push_root_local_relative_path']);
+        unset($this->cursor['position']['local_paths_to_push_count']);
+
+        $resumedPlan = $this->resumePlan();
+        $this->planToCompletion($resumedPlan);
+
+        $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
+        $this->assertNull($resumedPlan->get_local_paths_to_push_count());
+    }
+
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1516,7 +1516,7 @@ final class PushEndpointsTest extends TestCase {
         }
     }
 
-    public function testHighLevelSenderResumesStateWrittenBeforePushRootMappingAndProgress(): void
+    public function testHighLevelSenderResumesStateWrittenBeforeProgress(): void
     {
         $local_docroot = $this->root . '/old-sender-state-local-docroot';
         mkdir($local_docroot, 0700, true);
@@ -1534,10 +1534,8 @@ final class PushEndpointsTest extends TestCase {
         $state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state);
         $this->assertIsArray($state['push_plan_cursor']);
-        unset($state['push_root_local_relative_path']);
         unset($state['local_paths_to_push_count']);
         unset($state['local_paths_pushed']);
-        unset($state['push_plan_cursor']['push_root_local_relative_path']);
         unset($state['push_plan_cursor']['position']['local_paths_to_push_count']);
         file_put_contents(
             $push_state_directory . '/sender.json',
@@ -2552,7 +2550,6 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         $sender = $this->startSender([
             'filesystem_root' => $local_docroot,
-            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
@@ -2737,51 +2734,6 @@ final class PushEndpointsTest extends TestCase {
             'stderr' => $stderr,
             'output' => $stdout . $stderr,
         ];
-    }
-
-    public function testFilesPushCliPushesFromPushRootBelowFilesystemRoot(): void
-    {
-        $this->writeDocrootConfiguration([
-            'document_root' => $this->docroot,
-            'maximum_part_bytes' => 64,
-        ]);
-        $filesystem_root = $this->root . '/cli-filesystem-root';
-        $state_directory = $this->root . '/cli-filesystem-root-state';
-        $push_root = (string) realpath($this->docroot);
-        $local_absolute_push_root = $filesystem_root . $push_root;
-        mkdir($local_absolute_push_root, 0700, true);
-        file_put_contents($local_absolute_push_root . '/newfile.php', "<?php echo 'from filesystem root';");
-
-        $created = $this->runFilesPushCli($filesystem_root, $state_directory, [], $push_root);
-
-        $this->assertSame(0, $created['exit'], $created['output']);
-        $this->assertSame(
-            'complete',
-            $this->lastCliJsonLine($created['stdout'])['status'] ?? null
-        );
-        $this->assertSame(
-            "<?php echo 'from filesystem root';",
-            file_get_contents($this->docroot . '/newfile.php')
-        );
-        $this->assertFileDoesNotExist(
-            $this->docroot . $push_root . '/newfile.php'
-        );
-
-        unlink($local_absolute_push_root . '/newfile.php');
-        file_put_contents($local_absolute_push_root . '/replacement.php', "<?php echo 'replacement';");
-
-        $updated = $this->runFilesPushCli($filesystem_root, $state_directory, [], $push_root);
-
-        $this->assertSame(0, $updated['exit'], $updated['output']);
-        $this->assertSame(
-            'complete',
-            $this->lastCliJsonLine($updated['stdout'])['status'] ?? null
-        );
-        $this->assertFileDoesNotExist($this->docroot . '/newfile.php');
-        $this->assertSame(
-            "<?php echo 'replacement';",
-            file_get_contents($this->docroot . '/replacement.php')
-        );
     }
 
     public function testFilesPushCliPushesAndUpdatesACompleteLocalTree(): void
@@ -3129,14 +3081,12 @@ final class PushEndpointsTest extends TestCase {
     private function runFilesPushCli(
         string $filesystem_root,
         string $state_directory,
-        array $ini_settings = [],
-        string $push_root = '/'
+        array $ini_settings = []
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $filesystem_root,
             $state_directory,
-            $ini_settings,
-            $push_root
+            $ini_settings
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3150,10 +3100,9 @@ final class PushEndpointsTest extends TestCase {
     private function startFilesPushCli(
         string $filesystem_root,
         string $state_directory,
-        array $ini_settings = [],
-        string $push_root = '/'
+        array $ini_settings = []
     ): array {
-        $this->writeFilesPushPreflight($state_directory, $push_root);
+        $this->writeFilesPushPreflight($state_directory);
 
         $command = [PHP_BINARY];
         foreach ($ini_settings as $name => $value) {
@@ -3181,10 +3130,8 @@ final class PushEndpointsTest extends TestCase {
         return [$process, $pipes];
     }
 
-    private function writeFilesPushPreflight(
-        string $state_directory,
-        string $push_root
-    ): void {
+    private function writeFilesPushPreflight(string $state_directory): void
+    {
         $pull_state_file = dirname($this->filesPushStateDirectory($state_directory))
             . '/pull/state.json';
         if (is_file($pull_state_file)) {
@@ -3200,7 +3147,7 @@ final class PushEndpointsTest extends TestCase {
             'http_code' => 200,
             'data' => [
                 'runtime' => [
-                    'document_root' => 'base64:' . base64_encode($push_root),
+                    'document_root' => 'base64:' . base64_encode($this->docroot),
                 ],
             ],
         ];
@@ -3272,7 +3219,6 @@ final class PushEndpointsTest extends TestCase {
     ): array {
         return [
             'filesystem_root' => $filesystem_root,
-            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
@@ -3526,7 +3472,6 @@ final class PushEndpointsTest extends TestCase {
         ]);
         return [
             'filesystem_root' => $filesystem_root,
-            'push_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1516,6 +1516,49 @@ final class PushEndpointsTest extends TestCase {
         }
     }
 
+    public function testHighLevelSenderResumesStateWrittenBeforePushRootMappingAndProgress(): void
+    {
+        $local_docroot = $this->root . '/old-sender-state-local-docroot';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'value');
+        $push_state_directory = $this->root . '/old-sender-state';
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
+
+        $sender = $this->startSender($options);
+        try {
+            $this->takeSenderStepsUntilPhase($sender, 'committing');
+        } finally {
+            $this->closeSender($sender);
+        }
+
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $this->assertIsArray($state['push_plan_cursor']);
+        unset($state['push_root_local_relative_path']);
+        unset($state['local_paths_to_push_count']);
+        unset($state['local_paths_pushed']);
+        unset($state['push_plan_cursor']['push_root_local_relative_path']);
+        unset($state['push_plan_cursor']['position']['local_paths_to_push_count']);
+        file_put_contents(
+            $push_state_directory . '/sender.json',
+            json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+
+        $sender = $this->resumeSender($options);
+        try {
+            $this->assertSame(['phase' => 'committing'], $sender->get_progress());
+            while ($sender->next_step()) {
+                continue;
+            }
+            $this->assertSame('complete', $sender->get_status());
+        } finally {
+            $this->closeSender($sender);
+        }
+
+        $this->assertSame('value', file_get_contents($this->docroot . '/value.txt'));
+        $this->assertNull($this->loadActiveState($push_state_directory));
+    }
+
     /**
      * Continues deleted paths and their completion from successful upload responses.
      */


### PR DESCRIPTION
`files-push --fs-root=DIR` now treats `DIR` as the local representation of the target push root, matching `files-pull`. A local `.htaccess` is sent as `.htaccess`; the target's absolute `/var/www/html` document root is not a prefix inside `DIR`.

Saved preflight data remains mandatory, but only gates the command. Active state written before path-progress counters also resumes without rescanning completed plan work; file-count progress remains unavailable for that lifecycle.

## Testing

The CLI endpoint test uses different local and target absolute roots, pushes and updates a complete tree, and checks target files and deletions. Resume tests cover older progress-less state during planning and commit.
