### PR TITLE
[Push] Map files-push paths from the preflight document root

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -125,10 +125,11 @@ the push plan.
 
 A push plan is an internal part of the sender lifecycle:
 
-1. Before `PushFilesSender::start()`, `files-push` requires saved preflight
-   data. The sender enters `creating` and requests at most 100 target
-   exclusions from `push_create`. It stores the exclusions in
-   `excluded_paths.json` after creating the active `plan/` directory.
+1. Before `PushFilesSender::start()`, `files-push` loads the mandatory
+   preflight document root. The sender enters `creating`, stores the document
+   root's local relative path in `sender.json`, and requests
+   at most 100 target exclusions from `push_create`. It stores the exclusions
+   in `excluded_paths.json` after creating the active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
@@ -143,7 +144,7 @@ A push plan is an internal part of the sender lifecycle:
    both indexes reach EOF. It
    writes files, symlinks, and empty directories with their local relative
    path, planned type, size, and ctime to `plan/local_paths_to_push.jsonl`,
-   and writes raw NUL-delimited local relative paths to
+   and writes raw NUL-delimited document-root-relative paths to
    `plan/local_paths_to_delete`.
 5. The sender closes the plan before consuming those two files.
 6. After the target confirms commit, the sender saves the retained fresh local
@@ -169,8 +170,8 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, filesystem root, local index file, and
-current planning position. During
+The cursor contains the plan directory, filesystem root, local index file,
+document root's local relative path, and current planning position. During
 indexing, that position contains the `FileIndexProcessor` cursor and committed
 fresh-index byte offset. During diffing, each step flushes only the path list or
 append-only deleted-directory stack changed by that step before updating the two index
@@ -317,7 +318,7 @@ state:
       excluded_paths.json               target exclusions for the active push
       fresh_local_index.jsonl           plan-owned fresh local index
       local_paths_to_push.jsonl         local paths to push
-      local_paths_to_delete             raw NUL-delimited local relative paths
+      local_paths_to_delete             raw NUL-delimited document-root-relative paths
       deleted_directories_stack.jsonl   append-only planning stack
 ```
 
@@ -347,9 +348,8 @@ with the work, and seeks only when a newly opened or receiver-confirmed offset
 differs. It closes each handle when its phase or file ends and closes any
 remaining handles before `close()` returns.
 
-The CLI requires saved preflight data before it creates the sender. The sender
-creates the push session and stores its exclusion policy before it starts
-PushPlan. Each internal
+The sender stores the mandatory preflight document root, creates the push session,
+and stores its exclusion policy before it starts PushPlan. Each internal
 `indexing` step completes one traversal event,
 and `starting_diff` initializes the index diff. Each internal `diffing` step
 compares at most one path and updates the path lists. PushPlan owns the
@@ -359,9 +359,9 @@ upload begins until both indexes have been consumed and the two path lists are
 stable.
 
 `sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the PushPlan cursor, the next byte offset in
-`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
-sizing state. Its phases are `creating`, `starting_plan`,
+and phase, the document root's local relative path, the PushPlan cursor, the next
+byte offset in `local_paths_to_push.jsonl`, the receiver part limit, and
+learned request-body sizing state. Its phases are `creating`, `starting_plan`,
 `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`, `removing`, and
 `discarding_plan`.
@@ -387,8 +387,8 @@ After all local paths are pushed, a newly opened sender reads
 `work_deletes_bytes` and `work_deletes_complete` from `push_status`. Successful
 uploads retain those values in memory for later deletion steps. Those
 receiver-owned values are the only work-delete cursor; `sender.json` does not
-duplicate it. Each uploaded deletion-list part contains one complete local
-relative path, sent unchanged as a push-root-relative path.
+duplicate it. Each uploaded deletion-list part contains one complete
+document-root-relative path.
 The sender trusts this completed, immutable plan without consulting the fresh
 local index or live filesystem root again. If a deleted path reappears after planning,
 the current push may delete it on the target and the next push will send it.
@@ -435,12 +435,11 @@ truncate a paused upload; pull remains PHP 7.4-compatible.
 ## Low-level files-push command
 
 `reprint files-push <remote-reprint-api-url>` is the production CLI caller for one
-`PushFilesSender`. The resolved filesystem root named by `--fs-root` represents
-the target push root locally. Every local relative path is sent unchanged as a
-push-root-relative path; the target's absolute document root is not a prefix
-within the local filesystem root. It requires `--state-dir`, `--fs-root`,
-`--secret`, and saved preflight data; HTTPS is required unless the operator
-passes `--force-http`. It reads but never writes
+`PushFilesSender`. It treats the saved preflight document root as a path beneath
+the resolved filesystem root named by `--fs-root`. It removes that local prefix when producing document-root-relative paths and excludes local paths
+outside the document root from push and delete work. It requires `--state-dir`,
+`--fs-root`, `--secret`, and saved preflight data; HTTPS is required unless the
+operator passes `--force-http`. It reads but never writes
 `<remote-state-directory>/pull/state.json`. It does not run preflight itself,
 show a plan, ask for confirmation, transfer a database, retry a failed request,
 or start a replacement sender after a `restart` outcome.

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -16,9 +16,6 @@ is absolute or relative to a named root.
   pushed. Use `$filesystem_root`.
 - The **remote Reprint API URL** is the configured URL used for Reprint
   requests. Use `$remote_reprint_api_url`.
-- The **push root** is the remote root selected by the receiving push session.
-  Use `$push_root`.
-
 The domain path terms are:
 
 | Term | Meaning | Preferred name |
@@ -26,7 +23,7 @@ The domain path terms are:
 | Remote absolute path | Absolute path on the remote machine. | `$remote_absolute_path` |
 | Local absolute path | Absolute path on the local machine. | `$local_absolute_path` |
 | Local relative path | Path relative to the filesystem root. | `$local_relative_path` |
-| Push-root-relative path | Path relative to the push root. | `$push_root_relative_path` |
+| Document-root-relative path | Path relative to the document root. | `$document_root_relative_path` |
 
 An **absolute path** begins at `/`. A **relative path** has no leading slash.
 A **normalized path** has repeated separators and `.` or `..` segments removed
@@ -42,7 +39,7 @@ is present.
 
 The pull conversion flow is remote absolute path → local absolute path →
 local relative path. Push applies the reverse mapping from a
-local relative path to a push-root-relative path.
+local relative path to a document-root-relative path.
 
 ## Indexes and mappings
 
@@ -66,17 +63,17 @@ local relative path to a push-root-relative path.
 - The **pull index WAL** records completed pull mutations awaiting application
   to the remote and local indexes.
 - A **pull plan** lists remote absolute paths still scheduled for download or
-  deletion. A **push plan** maps local relative paths to push-root-relative
+  deletion. A **push plan** maps local relative paths to document-root-relative
   paths.
 
 A **resolved path mapping** is an immutable mapping between remote absolute
 prefixes and local absolute prefixes. A **pull mapping** converts a remote
 absolute path to a local absolute path. A **push mapping** converts a
-local relative path to a push-root-relative path. An **addressable mapping**
-maps every relevant local relative path to exactly one push-root-relative path below the
-push root; an **ambiguous mapping** has more than one push-root-relative path,
+local relative path to a document-root-relative path. An **addressable mapping**
+maps every relevant local relative path to exactly one document-root-relative path below the
+document root; an **ambiguous mapping** has more than one document-root-relative path,
 and an **unaddressable mapping** has none. An **identity mapping** leaves local
-and push-root-relative paths identical. `path-mapping.json` stores the resolved
+and document-root-relative paths identical. `path-mapping.json` stores the resolved
 path mapping.
 
 A state directory belongs to one filesystem root. Reusing its mapping state
@@ -377,10 +374,10 @@ running the command again prints the complete report.
 
 The low-level, files-only command is `files-push`. Its `remote Reprint API URL` is the
 exporter API URL, and its `filesystem root` is the resolved absolute directory supplied by
-`--fs-root` and represents the push root locally. Every local relative path is
-also its push-root-relative path; the target's absolute document root is not a
-local path prefix. It requires saved preflight data and `--secret=TOKEN`;
-`--force-http` is the explicit plain-HTTP opt-in.
+`--fs-root`. It requires saved preflight data and treats its remote document
+root as a path beneath that filesystem root. Local relative paths beneath the document root become document-root-relative paths; other local paths do not
+become push or delete work. It also requires `--secret=TOKEN`; `--force-http`
+is the explicit plain-HTTP opt-in.
 
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1001,8 +1001,8 @@ class ImportClient
                     "Finish or abort the interrupted files-pull before running files-push."
                 );
             }
-            // files-push requires saved preflight data, but its lifecycle never
-            // writes pull state.
+            // files-push reads preflight to locate the remote document root,
+            // but its lifecycle never writes pull state.
             $this->state = $this->load_state();
             $this->require_preflight();
             $this->run_files_push($options, $process_lock);
@@ -1584,6 +1584,13 @@ class ImportClient
         if (!is_array($context)) {
             throw new InvalidArgumentException('files-push requires its validated command context.');
         }
+        $document_root = $this->get_state()->preflight["data"]["runtime"]["document_root"] ?? null;
+        if (!is_string($document_root) || $document_root === '' || $document_root[0] !== '/') {
+            throw new RuntimeException(
+                "Preflight did not report an absolute document root. Run 'preflight' or 'preflight-assert' again."
+            );
+        }
+
         $this->enable_files_push_signal_handling();
 
         if (!class_exists('Site_Export_HMAC_Client')) {
@@ -1600,6 +1607,7 @@ class ImportClient
             : parse_size($memory_limit_value);
         $sender_options = [
             'filesystem_root' => $context['filesystem_root'],
+            'document_root' => $document_root,
             'push_state_directory' => $context['push_state_directory'],
             'remote_reprint_api_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
@@ -12490,10 +12498,10 @@ if (
             "short" => "Push one local file tree without database work",
             "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
             "description" =>
-                "Sends the existing filesystem root at --fs-root to the remote Reprint API.\n" .
+                "Sends the remote document root's local tree beneath --fs-root.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
                 "plan display, confirmation prompt, automatic retry, or automatic restart.\n" .
-                "It requires saved preflight data.\n" .
+                "It requires saved preflight data for the remote document root.\n" .
                 "\n" .
                 "Each process runs one sender until it completes, reaches a caller time or\n" .
                 "memory boundary, or receives a signal handled by this PHP runtime.\n" .

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -123,14 +123,17 @@
  *
  * @phpstan-type LocalPathTypeSizeAndCtime array{type:'file'|'directory'|'symlink',size:int,ctime:int}
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
- * @phpstan-type LocalPathToPush array{local_relative_path:string,local_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
+ * @phpstan-type LocalPathToPush array{local_relative_path:string,document_root_relative_path:string,document_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
     /** @var string Filesystem root whose local paths to push are sent. */
     private string $filesystem_root;
+
+    /** @var string Document root relative to the local filesystem root. */
+    private string $document_root_local_relative_path;
 
     /** @var string Local push state directory owned by this sender. */
     private string $push_state_directory;
@@ -235,6 +238,7 @@ final class PushFilesSender
      *     Push, push stream client, and local-file options.
      *
      *     @type string                  $filesystem_root         Required filesystem root directory.
+     *     @type string                  $document_root           Required remote absolute document root.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
@@ -269,6 +273,7 @@ final class PushFilesSender
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'phase' => 'creating',
+                'document_root_local_relative_path' => $sender->document_root_local_relative_path,
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
@@ -335,6 +340,8 @@ final class PushFilesSender
     private function __construct(array $options, ReprintProcessLock $process_lock)
     {
         $filesystem_root = $options['filesystem_root'] ?? null;
+        /** @var string $document_root */
+        $document_root = $options['document_root'];
         $push_state_directory = $options['push_state_directory'] ?? null;
         if (!is_string($filesystem_root) || !is_dir($filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
@@ -366,6 +373,7 @@ final class PushFilesSender
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
         $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/');
+        $this->document_root_local_relative_path = trim($document_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
         $this->plan_directory = $this->push_state_directory . '/plan';
@@ -620,7 +628,8 @@ final class PushFilesSender
             $this->plan_directory,
             $this->filesystem_root,
             $this->local_index_file,
-            $this->excluded_paths_path
+            $this->excluded_paths_path,
+            $this->state['document_root_local_relative_path']
         );
         $this->state['push_plan_cursor'] = $this->plan->get_cursor();
         $this->state['phase'] = 'planning';
@@ -748,7 +757,7 @@ final class PushFilesSender
         } else {
             $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
-                'path_b64' => $local_path_to_push['local_relative_path_b64'],
+                'path_b64' => $local_path_to_push['document_root_relative_path_b64'],
             ], ['accepted']);
             if ($this->handle_request_failure($request_result)) {
                 return;
@@ -807,7 +816,7 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => 'directory',
-                'path' => $local_path_to_push['local_relative_path'],
+                'path' => $local_path_to_push['document_root_relative_path'],
                 'payload' => '',
             ];
             $upload_completes_local_path = true;
@@ -830,7 +839,7 @@ final class PushFilesSender
             }
             $upload_part = [
                 'type' => 'symlink',
-                'path' => $local_path_to_push['local_relative_path'],
+                'path' => $local_path_to_push['document_root_relative_path'],
                 'target' => $symlink_target,
                 'payload' => '',
             ];
@@ -840,7 +849,7 @@ final class PushFilesSender
         // A file contributes at most one bounded chunk during this call and remains open for the next.
         if ($local_path_type_size_and_ctime['type'] === 'file') {
             $maximum_file_payload_bytes = $this->push_stream_client->next_file_body_bytes(
-                $local_path_to_push['local_relative_path'],
+                $local_path_to_push['document_root_relative_path'],
                 $local_path_type_size_and_ctime['size'],
                 $file_byte_offset
             );
@@ -908,7 +917,7 @@ final class PushFilesSender
 
             $upload_part = [
                 'type' => 'file',
-                'path' => $local_path_to_push['local_relative_path'],
+                'path' => $local_path_to_push['document_root_relative_path'],
                 'total_bytes' => $local_path_type_size_and_ctime['size'],
                 'offset' => $file_byte_offset,
                 'payload' => $payload,
@@ -1397,14 +1406,22 @@ final class PushFilesSender
             throw new RuntimeException('Failed to decode a local path to push.', 0, $exception);
         }
         /** @var array{path:string,type:'file'|'directory'|'symlink',size:int,ctime:int} $decoded_local_path */
-        $local_relative_path_b64 = $decoded_local_path['path'];
-        $local_relative_path = base64_decode($local_relative_path_b64, true);
+        $local_relative_path = base64_decode($decoded_local_path['path'], true);
         if ($local_relative_path === false) {
             throw new RuntimeException('Failed to decode a path in the local paths-to-push file.');
         }
+        $document_root_local_relative_path = $this->state['document_root_local_relative_path'];
+        if ($document_root_local_relative_path === '') {
+            $document_root_relative_path = $local_relative_path;
+        } else {
+            $document_root_relative_path = $local_relative_path === $document_root_local_relative_path
+                ? ''
+                : substr($local_relative_path, strlen($document_root_local_relative_path) + 1);
+        }
         return [
             'local_relative_path' => $local_relative_path,
-            'local_relative_path_b64' => $local_relative_path_b64,
+            'document_root_relative_path' => $document_root_relative_path,
+            'document_root_relative_path_b64' => base64_encode($document_root_relative_path),
             'next_local_paths_to_push_byte_offset' => $next_local_paths_to_push_byte_offset,
             'planned_local_path_type_size_and_ctime' => [
                 'type' => $decoded_local_path['type'],
@@ -1560,6 +1577,10 @@ final class PushFilesSender
         }
 
         /** @var array<string,mixed> $state */
+        if (!array_key_exists('document_root_local_relative_path', $state)) {
+            // Older state had no document-root mapping and sent local relative paths unchanged.
+            $state['document_root_local_relative_path'] = '';
+        }
         if (!array_key_exists('local_paths_to_push_count', $state)) {
             // Keep the sender single-pass when older state has no path progress.
             $state['local_paths_to_push_count'] = null;

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -3,6 +3,7 @@
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -64,13 +65,16 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
  * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
 {
     /** @var string Resolved filesystem root inspected while building the fresh local index. */
     private string $filesystem_root;
+
+    /** @var string Document root relative to the local filesystem root. */
+    private string $document_root_local_relative_path;
 
     /** @var string Caller-owned active plan directory. */
     private string $plan_directory;
@@ -145,15 +149,22 @@ class PushPlan
      * @param string $filesystem_root     Resolved filesystem root.
      * @param string $local_index_file    Local index file this plan diffs against.
      * @param string $excluded_paths_path Caller-owned target exclusions file.
+     * @param string $document_root_local_relative_path Document root relative to the local filesystem root.
      * @return self Open plan positioned at the initial indexing cursor.
      */
     public static function start(
         string $plan_directory,
         string $filesystem_root,
         string $local_index_file,
-        string $excluded_paths_path
+        string $excluded_paths_path,
+        string $document_root_local_relative_path = ""
     ): self {
-        $plan = new self($plan_directory, $filesystem_root, $local_index_file);
+        $plan = new self(
+            $plan_directory,
+            $filesystem_root,
+            $local_index_file,
+            $document_root_local_relative_path
+        );
         if (!@copy($excluded_paths_path, $plan->excluded_paths_file)) {
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
@@ -173,6 +184,7 @@ class PushPlan
             "plan_directory" => $plan->plan_directory,
             "filesystem_root" => $plan->filesystem_root,
             "local_index_file" => $plan->local_index_file,
+            "document_root_local_relative_path" => $plan->document_root_local_relative_path,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" => $plan->file_index_processor->get_cursor(),
@@ -193,6 +205,10 @@ class PushPlan
      */
     public static function resume(array $cursor): self
     {
+        if (!array_key_exists("document_root_local_relative_path", $cursor)) {
+            // Older cursors had no document-root mapping and used local relative paths unchanged.
+            $cursor["document_root_local_relative_path"] = "";
+        }
         $position = $cursor["position"];
         if (
             ($position["phase"] === "diffing" || $position["phase"] === "complete")
@@ -206,7 +222,8 @@ class PushPlan
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["filesystem_root"],
-            $cursor["local_index_file"]
+            $cursor["local_index_file"],
+            $cursor["document_root_local_relative_path"]
         );
         $plan->cursor = $cursor;
         $position = $plan->cursor["position"];
@@ -275,11 +292,13 @@ class PushPlan
      * @param string $plan_directory   Caller-owned active plan directory.
      * @param string $filesystem_root  Resolved filesystem root.
      * @param string $local_index_file Local index file this plan diffs against.
+     * @param string $document_root_local_relative_path Document root relative to the local filesystem root.
      */
     private function __construct(
         string $plan_directory,
         string $filesystem_root,
-        string $local_index_file
+        string $local_index_file,
+        string $document_root_local_relative_path
     ) {
         $plan_directory = rtrim($plan_directory, "/");
         if (!is_dir($plan_directory)) {
@@ -288,6 +307,8 @@ class PushPlan
         $this->plan_directory = $plan_directory;
         $this->set_filesystem_root($filesystem_root);
         $this->local_index_file = $local_index_file;
+        $this->document_root_local_relative_path =
+            rtrim($document_root_local_relative_path, "/");
         $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
         $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
         $this->fresh_local_index_file = $plan_directory . "/fresh_local_index.jsonl";
@@ -992,8 +1013,13 @@ class PushPlan
      */
     private function append_local_path_to_delete(string $path): void
     {
-        $path_with_nul = $path . "\0";
-        if (fwrite($this->local_paths_to_delete_handle, $path_with_nul) !== strlen($path_with_nul)) {
+        $document_root_relative_path =
+            $this->local_relative_path_to_document_root_relative_path($path);
+        if ($document_root_relative_path === null) {
+            return;
+        }
+        $document_root_relative_path_with_nul = $document_root_relative_path . "\0";
+        if (fwrite($this->local_paths_to_delete_handle, $document_root_relative_path_with_nul) !== strlen($document_root_relative_path_with_nul)) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
         }
     }
@@ -1091,15 +1117,42 @@ class PushPlan
      */
     private function path_conflicts_with_excluded_paths(string $path): bool
     {
+        $document_root_relative_path =
+            $this->local_relative_path_to_document_root_relative_path($path);
+        if ($document_root_relative_path === null) {
+            return true;
+        }
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                path_is_within_root($path, $excluded_path)
-                || path_is_within_root($excluded_path, $path)
+                path_is_within_root($document_root_relative_path, $excluded_path)
+                || path_is_within_root($excluded_path, $document_root_relative_path)
             ) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Returns the document-root-relative path, or null when the local
+     * relative path is outside the document root.
+     */
+    private function local_relative_path_to_document_root_relative_path(
+        string $local_relative_path
+    ): ?string {
+        if ($this->document_root_local_relative_path === "") {
+            return $local_relative_path;
+        }
+        $path_remainder = path_remainder_under(
+            $local_relative_path,
+            $this->document_root_local_relative_path
+        );
+        if ($path_remainder === null) {
+            return null;
+        }
+        return $path_remainder === ""
+            ? ""
+            : substr($path_remainder, 1);
     }
 
     /**

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -121,7 +121,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--force-http', $output);
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
-        $this->assertStringContainsString('existing filesystem root at --fs-root', $output);
+        $this->assertStringContainsString("document root's local tree beneath --fs-root", $output);
         $this->assertStringContainsString('requires saved preflight data', $output);
         $this->assertStringContainsString('read or modify', $output);
         $this->assertStringNotContainsString('--abort', $output);

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -187,6 +187,7 @@ final class FilesPullLocalIndexTest extends TestCase
         try {
             $sender = \PushFilesSender::start([
                 'filesystem_root' => $this->rawFileRoot,
+                'document_root' => '/',
                 'push_state_directory' => $pushStateDirectory,
                 'remote_reprint_api_url' =>
                     $remoteReprintApiUrl,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -281,6 +281,7 @@ final class FilesPushCommandTest extends TestCase
             json_encode([
                 'push_session_id' => str_repeat('1', 32),
                 'phase' => 'starting_plan',
+                'document_root_local_relative_path' => '',
                 'push_plan_cursor' => null,
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
@@ -336,7 +337,7 @@ final class FilesPushCommandTest extends TestCase
 
     private function writePreflightState(
         string $remoteReprintApiUrl,
-        string $pushRoot = '/'
+        string $documentRoot = '/'
     ): void {
         $pullStateFile = $this->pullStateFileForRemoteReprintApiUrl($remoteReprintApiUrl);
         $pullStateDirectory = dirname($pullStateFile);
@@ -348,7 +349,7 @@ final class FilesPushCommandTest extends TestCase
             'http_code' => 200,
             'data' => [
                 'runtime' => [
-                    'document_root' => 'base64:' . base64_encode($pushRoot),
+                    'document_root' => 'base64:' . base64_encode($documentRoot),
                 ],
             ],
         ];

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -448,7 +448,7 @@ final class PushPlanTest extends TestCase
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
-    public function testResumesCursorWrittenBeforeProgressCount(): void
+    public function testResumesCursorWrittenBeforeDocumentRootMappingAndProgressCount(): void
     {
         $entries = $this->manyFileEntries(2);
         $current = $this->writeIndex($entries);
@@ -457,6 +457,7 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($this->nextPlanStep($plan));
         $plan->close();
 
+        unset($this->cursor['document_root_local_relative_path']);
         unset($this->cursor['position']['local_paths_to_push_count']);
 
         $resumedPlan = $this->resumePlan();
@@ -533,11 +534,13 @@ final class PushPlanTest extends TestCase
             'plan_directory',
             'filesystem_root',
             'local_index_file',
+            'document_root_local_relative_path',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
         $this->assertSame(realpath($this->filesystemRoot()), $cursor['filesystem_root']);
         $this->assertSame($this->localIndexFile(), $cursor['local_index_file']);
+        $this->assertSame('', $cursor['document_root_local_relative_path']);
         $this->assertSame([
             'phase',
             'byte_offset_in_fresh_local_index',
@@ -649,6 +652,37 @@ final class PushPlanTest extends TestCase
         );
     }
 
+    public function testPlanMapsDocumentRootAndIgnoresPathsOutsideIt(): void
+    {
+        $this->saveLocalIndex($this->writeIndex([
+            'outside-deleted.txt' => [100, 5, 'file'],
+            'var/www/html/deleted.txt' => [100, 5, 'file'],
+        ]));
+        $current = $this->writeIndex([
+            '.htaccess' => [300, 3, 'file'],
+            'var/www/html/added.txt' => [300, 3, 'file'],
+            'var/www/html/preserved/value.txt' => [300, 3, 'file'],
+        ]);
+
+        $plan = $this->startPlan(
+            $current,
+            ['preserved'],
+            'var/www/html'
+        );
+        $plan->close();
+        $plan = $this->resumePlan();
+        $this->planToCompletion($plan);
+
+        $this->assertSame(
+            ['var/www/html/added.txt'],
+            $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
+        );
+        $this->assertSame(
+            "deleted.txt\0",
+            file_get_contents($this->planPath('local_paths_to_delete'))
+        );
+    }
+
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------
@@ -656,7 +690,8 @@ final class PushPlanTest extends TestCase
     /** @param list<string> $excludedPaths */
     private function startPlan(
         ?string $filesystemRootDescriptionFile = null,
-        array $excludedPaths = []
+        array $excludedPaths = [],
+        string $documentRootLocalRelativePath = ''
     ): PushPlan {
         if ($filesystemRootDescriptionFile === null) {
             $filesystemRootDescriptionFile = $this->tempDir . '/empty-filesystem-root.jsonl';
@@ -679,7 +714,8 @@ final class PushPlanTest extends TestCase
             $this->planDirectory(),
             $this->filesystemRoot(),
             $this->localIndexFile(),
-            $this->excludedPathsPath()
+            $this->excludedPathsPath(),
+            $documentRootLocalRelativePath
         );
         $this->cursor = $plan->get_cursor();
         for ($step = 0; $step < 100; ++$step) {

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1516,7 +1516,7 @@ final class PushEndpointsTest extends TestCase {
         }
     }
 
-    public function testHighLevelSenderResumesStateWrittenBeforeProgress(): void
+    public function testHighLevelSenderResumesStateWrittenBeforeDocumentRootMappingAndProgress(): void
     {
         $local_docroot = $this->root . '/old-sender-state-local-docroot';
         mkdir($local_docroot, 0700, true);
@@ -1534,8 +1534,10 @@ final class PushEndpointsTest extends TestCase {
         $state = $this->loadActiveState($push_state_directory);
         $this->assertIsArray($state);
         $this->assertIsArray($state['push_plan_cursor']);
+        unset($state['document_root_local_relative_path']);
         unset($state['local_paths_to_push_count']);
         unset($state['local_paths_pushed']);
+        unset($state['push_plan_cursor']['document_root_local_relative_path']);
         unset($state['push_plan_cursor']['position']['local_paths_to_push_count']);
         file_put_contents(
             $push_state_directory . '/sender.json',
@@ -2550,6 +2552,7 @@ final class PushEndpointsTest extends TestCase {
         mkdir($local_docroot, 0700, true);
         $sender = $this->startSender([
             'filesystem_root' => $local_docroot,
+            'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
@@ -2734,6 +2737,53 @@ final class PushEndpointsTest extends TestCase {
             'stderr' => $stderr,
             'output' => $stdout . $stderr,
         ];
+    }
+
+    public function testFilesPushCliPushesFromDocumentRootBelowFilesystemRoot(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
+        ]);
+        $filesystem_root = $this->root . '/cli-filesystem-root';
+        $state_directory = $this->root . '/cli-filesystem-root-state';
+        $document_root = (string) realpath($this->docroot);
+        $local_absolute_document_root = $filesystem_root . $document_root;
+        mkdir($local_absolute_document_root, 0700, true);
+        file_put_contents($filesystem_root . '/.filesystem-root-only', 'outside document root');
+        file_put_contents($local_absolute_document_root . '/newfile.php', "<?php echo 'from filesystem root';");
+
+        $created = $this->runFilesPushCli($filesystem_root, $state_directory, [], $document_root);
+
+        $this->assertSame(0, $created['exit'], $created['output']);
+        $this->assertSame(
+            'complete',
+            $this->lastCliJsonLine($created['stdout'])['status'] ?? null
+        );
+        $this->assertSame(
+            "<?php echo 'from filesystem root';",
+            file_get_contents($this->docroot . '/newfile.php')
+        );
+        $this->assertFileDoesNotExist(
+            $this->docroot . $document_root . '/newfile.php'
+        );
+        $this->assertFileDoesNotExist($this->docroot . '/.filesystem-root-only');
+
+        unlink($local_absolute_document_root . '/newfile.php');
+        file_put_contents($local_absolute_document_root . '/replacement.php', "<?php echo 'replacement';");
+
+        $updated = $this->runFilesPushCli($filesystem_root, $state_directory, [], $document_root);
+
+        $this->assertSame(0, $updated['exit'], $updated['output']);
+        $this->assertSame(
+            'complete',
+            $this->lastCliJsonLine($updated['stdout'])['status'] ?? null
+        );
+        $this->assertFileDoesNotExist($this->docroot . '/newfile.php');
+        $this->assertSame(
+            "<?php echo 'replacement';",
+            file_get_contents($this->docroot . '/replacement.php')
+        );
     }
 
     public function testFilesPushCliPushesAndUpdatesACompleteLocalTree(): void
@@ -3081,12 +3131,14 @@ final class PushEndpointsTest extends TestCase {
     private function runFilesPushCli(
         string $filesystem_root,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        string $document_root = '/'
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $filesystem_root,
             $state_directory,
-            $ini_settings
+            $ini_settings,
+            $document_root
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3100,9 +3152,10 @@ final class PushEndpointsTest extends TestCase {
     private function startFilesPushCli(
         string $filesystem_root,
         string $state_directory,
-        array $ini_settings = []
+        array $ini_settings = [],
+        string $document_root = '/'
     ): array {
-        $this->writeFilesPushPreflight($state_directory);
+        $this->writeFilesPushPreflight($state_directory, $document_root);
 
         $command = [PHP_BINARY];
         foreach ($ini_settings as $name => $value) {
@@ -3130,8 +3183,10 @@ final class PushEndpointsTest extends TestCase {
         return [$process, $pipes];
     }
 
-    private function writeFilesPushPreflight(string $state_directory): void
-    {
+    private function writeFilesPushPreflight(
+        string $state_directory,
+        string $document_root
+    ): void {
         $pull_state_file = dirname($this->filesPushStateDirectory($state_directory))
             . '/pull/state.json';
         if (is_file($pull_state_file)) {
@@ -3147,7 +3202,7 @@ final class PushEndpointsTest extends TestCase {
             'http_code' => 200,
             'data' => [
                 'runtime' => [
-                    'document_root' => 'base64:' . base64_encode($this->docroot),
+                    'document_root' => 'base64:' . base64_encode($document_root),
                 ],
             ],
         ];
@@ -3219,6 +3274,7 @@ final class PushEndpointsTest extends TestCase {
     ): array {
         return [
             'filesystem_root' => $filesystem_root,
+            'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,
@@ -3472,6 +3528,7 @@ final class PushEndpointsTest extends TestCase {
         ]);
         return [
             'filesystem_root' => $filesystem_root,
+            'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
             'allow_http' => true,


### PR DESCRIPTION
`files-push --fs-root` now mirrors `files-pull --fs-root`: preflight locates the target document root beneath the local filesystem root, and only that subtree is sent.

Paths outside the mapped document-root subtree are left alone. Push state written before document-root mapping remains resumable with identity mapping.

## Testing

```sh
cd tests
../vendor/bin/phpunit Import/PushPlanTest.php Import/FilesPushCommandTest.php PushEndpointsTest.php Import/PushClientPhpCompatibilityTest.php Import/FilesPullLocalIndexTest.php Import/CliHelpTest.php
php ../.context/composer.phar analyze -- --memory-limit=1G
git diff --check
```
