### PR TITLE
[Push] Sort fresh local indexes before diffing

### DIFF
--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Reprint\Importer\sort_index_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
@@ -500,10 +501,15 @@ class PushPlan
     }
 
     /**
-     * Starts the index diff and opens its plan files.
+     * Sorts the fresh local index by raw path, then starts the index diff.
      */
     private function start_index_diff(): void
     {
+        if (!sort_index_file($this->fresh_local_index_file)) {
+            throw new RuntimeException(
+                "Failed to sort the fresh local index: {$this->fresh_local_index_file}"
+            );
+        }
         if (file_put_contents($this->deleted_directories_stack, "") !== 0) {
             throw new RuntimeException("Failed to initialize the deleted-directory stack: {$this->deleted_directories_stack}");
         }

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\sort_index_file;
 
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/sort-index-file.php';
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/push/class-push-plan.php';
 
 /**
@@ -173,6 +175,23 @@ final class PushPlanTest extends TestCase
             'b/c.txt' => [200, 7, 'file'],
         ]);
         $this->saveLocalIndex($index);
+
+        $plan = $this->startPlan($index);
+        $this->planToCompletion($plan);
+
+        $this->assertPathCounts(0, 0);
+        $this->assertSame([], $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
+        $this->assertSame('', file_get_contents($this->planPath('local_paths_to_delete')));
+    }
+
+    public function testUnchangedRawPathSortedIndexProducesEmptyPlans(): void
+    {
+        $index = $this->writeIndex([
+            'wp-admin/js/widgets.js' => [100, 5, 'file'],
+            'wp-admin/js/widgets/custom-html-widgets.js' => [200, 7, 'file'],
+        ]);
+        $this->saveLocalIndex($index);
+        sort_index_file($this->localIndexFile());
 
         $plan = $this->startPlan($index);
         $this->planToCompletion($plan);


### PR DESCRIPTION
Fresh local indexes are now sorted by raw path before PushPlan merges them with the retained local index.

The filesystem walker is depth-first, so a subtree such as `widgets/custom-html-widgets.js` could precede its sibling `widgets.js`. Pull-created local indexes use raw path order. Comparing those streams directly selected unchanged paths for both push and deletion.

Stacked on #465.

## Testing

```sh
cd tests
../vendor/bin/phpunit Import/PushPlanTest.php Import/FilesPushCommandTest.php PushEndpointsTest.php Import/PushClientPhpCompatibilityTest.php Import/SortIndexFileTest.php
php ../.context/composer.phar analyze -- --memory-limit=1G
git diff --check
```
