### PR TITLE
[Push] Finish active commits before creating a push session

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -128,8 +128,12 @@ A push plan is an internal part of the sender lifecycle:
 1. Before `PushFilesSender::start()`, `files-push` loads the mandatory
    preflight document root. The sender enters `creating`, stores the document
    root's local relative path in `sender.json`, and requests
-   at most 100 target exclusions from `push_create`. It stores the exclusions
-   in `excluded_paths.json` after creating the active `plan/` directory.
+   at most 100 target exclusions from `push_create`. If another push session
+   has an active commit, the sender stores its `blocking_push_session_id`, enters
+   `finishing_previous_commit`, and sends one bounded `push_commit` request per
+   step until that commit finishes. It then returns to `creating`. A successful
+   create stores the exclusions in `excluded_paths.json` after creating the
+   active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
    `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
@@ -242,7 +246,9 @@ complete request for authentication.
   sorted, immutable server policy stored for the push session; base64 preserves
   arbitrary path bytes which JSON cannot represent directly. A sender
   consuming this field must omit indexed paths equal to, below, or ancestors
-  of any advertised exclusion.
+  of any advertised exclusion. When another push session has an active commit,
+  the endpoint returns `commit_required` with its `blocking_push_session_id`
+  before creating the requested push session.
 - `POST push_upload` accepts `multipart/mixed`. A successful response contains
   `status`, `push_session_id`, `changes_accepted`, and `last_change`. The last
   change is null for an empty request. Otherwise it contains `state`, `type`,
@@ -358,15 +364,16 @@ deleted-directory ranges. `sender.json` stores the complete cursor. No
 upload begins until both indexes have been consumed and the two path lists are
 stable.
 
-`sender.json` contains no copied receiver cursor. It stores the push session
-and phase, the document root's local relative path, the PushPlan cursor, the next
-byte offset in `local_paths_to_push.jsonl`, the receiver part limit, and
-learned request-body sizing state. Its phases are `creating`, `starting_plan`,
-`planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_local_index`, `completing`, `removing`, and
-`discarding_plan`.
-The separate start, local-index-save, completion, removal, and discard phases ensure
-that a process stop between durable actions repeats only the current action.
+`sender.json` contains no copied receiver cursor. It stores the current push
+session, an optional blocking push session, the phase, the document root's local
+relative path, the PushPlan cursor, the next byte offset in
+`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
+sizing state. Its phases are `creating`, `finishing_previous_commit`,
+`starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
+`saving_local_index`, `completing`, `removing`, and `discarding_plan`.
+The separate previous-commit, start, local-index-save, completion, removal,
+and discard phases ensure that a process stop between durable actions repeats
+only the current action.
 During `planning`, the PushPlan cursor in `sender.json` contains the
 plan's internal phase and continuation offsets. A completed cursor remains until
 the local index is saved, or until the target confirms removal. The sender then

--- a/markdown/PUSH-TERMINOLOGY.md
+++ b/markdown/PUSH-TERMINOLOGY.md
@@ -305,10 +305,10 @@ FileIndexProcessor cursor and the committed byte offset in
 output offsets, and the active byte offset in
 `deleted_directories_stack.jsonl`. The stack file is append-only; each entry
 links to the preceding active directory. The exclusions have a maximum of 100
-paths. The `sender.json` phases are `creating`, `starting_plan`,
-`planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_local_index`, `completing`,
-`removing`, and `discarding_plan`. It stores the push session ID, selected
+paths. The `sender.json` phases are `creating`, `finishing_previous_commit`,
+`starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
+`saving_local_index`, `completing`, `removing`, and `discarding_plan`. It stores
+both the current and blocking push session IDs, selected
 path-list cursor, selected local-path count, target-confirmed local-path count,
 receiver part limit, and request-sizing state. The index diff cursor retains
 the selected local-path count as it builds the path list, and its complete
@@ -429,6 +429,8 @@ Use these names verbatim inside `PushFilesSender`:
 | Open upload request stage | `$upload_request_stage`: `closed`, `sending_parts`, or `finishing` |
 | Whether the open request has sent parts | `MultipartPushStreamClient::has_sent_parts()` |
 | Create push session | `create_push_session()` |
+| Blocking push session ID | `blocking_push_session_id`, `$blocking_push_session_id` |
+| Finish previous commit | `finishing_previous_commit`, `finish_previous_commit()` |
 | Remove push session | `remove_push_session()` |
 | Upload next file chunk | `upload_next_file_chunk()` |
 | Upload next chunk of deleted paths | `upload_next_chunk_of_deleted_paths()` |
@@ -486,8 +488,8 @@ Use these names verbatim inside `PushPlan`:
 
 The work-upload endpoint is `push_upload` and its push-session parameter is
 `push_session_id`. Endpoint names and endpoint prefixes begin with `push_`.
-JSON responses use `push_session_id`, `receiving_work`, and
-`work_deletes_bytes`. Push-session failures are
+JSON responses use `push_session_id`, `blocking_push_session_id`,
+`receiving_work`, and `work_deletes_bytes`. Push-session failures are
 `lock_acquisition_failure`, `offset_gap`, `push_not_found`, `filesystem_error`,
 `commit_required`, `unexpected_docroot_mutation`, `corrupted_push_state`, and
 `same_device`. Authentication, authorization, and request-boundary failures

--- a/packages/reprint-exporter/src/class-push-endpoints.php
+++ b/packages/reprint-exporter/src/class-push-endpoints.php
@@ -187,6 +187,9 @@ final class Site_Export_Push_Endpoints {
      * - `post_max_bytes`: the decoded request-body limit, or null.
      * - `excluded_paths_b64`: the stored excluded paths in base64.
      *
+     * An HTTP 409 `commit_required` response also contains
+     * `blocking_push_session_id`, which names the commit that must finish first.
+     *
      * @param array $config {
      *     Create request parameters.
      *
@@ -563,6 +566,12 @@ final class Site_Export_Push_Endpoints {
                 'reason' => $reason,
                 'detail' => $exception->getMessage(),
             ];
+            if ($reason === Site_Export_Push_Session::ERROR_COMMIT_REQUIRED) {
+                $context = $exception->get_context();
+                if (is_string($context['blocking_push_session_id'] ?? null)) {
+                    $response['blocking_push_session_id'] = $context['blocking_push_session_id'];
+                }
+            }
             if ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
                 $context = $exception->get_context();
                 if (is_int($context['observed_request_body_bytes'] ?? null)) {

--- a/packages/reprint-exporter/src/class-push-exception.php
+++ b/packages/reprint-exporter/src/class-push-exception.php
@@ -50,7 +50,8 @@ final class Site_Export_Push_Exception extends RuntimeException {
      * @param array<string,mixed> $context Structured observations. Common keys
      *     are operation, path_b64, conflict_path_b64,
      *     expected_docroot_types, observed_docroot_identity, work_device,
-     *     docroot_device, work_type, and observed_request_body_bytes.
+     *     docroot_device, work_type, blocking_push_session_id, and
+     *     observed_request_body_bytes.
      */
     public function __construct(string $error_code, string $message, array $context = []) {
         parent::__construct($message);
@@ -78,7 +79,7 @@ final class Site_Export_Push_Exception extends RuntimeException {
      * @return array<string,mixed> Structured observations. Common keys are
      *     operation, path_b64, conflict_path_b64, expected_docroot_types,
      *     observed_docroot_identity, work_device, docroot_device, work_type,
-     *     and observed_request_body_bytes.
+     *     blocking_push_session_id, and observed_request_body_bytes.
      */
     public function get_context(): array {
         return $this->context;

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -75,6 +75,10 @@ final class Site_Export_Push_Session {
     /** @var list<string> */
     private $excluded_paths;
     /** @var string */
+    private $commit_state_path;
+    /** @var string */
+    private $commit_state_lock_path;
+    /** @var string */
     private $push_directory;
     /** @var string */
     private $work_dir;
@@ -140,7 +144,10 @@ final class Site_Export_Push_Session {
             }
         }
         $this->excluded_paths = normalize_excluded_paths($excluded_paths);
-        $this->push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
+        $push_sessions_directory = $this->reprint_directory . '/.reprint/push';
+        $this->commit_state_path = $push_sessions_directory . '/commit-state';
+        $this->commit_state_lock_path = $push_sessions_directory . '/commit-state.lock';
+        $this->push_directory = $push_sessions_directory . '/' . $push_session_id;
         $this->push_json_path = $this->push_directory . '/push.json';
         $this->commit_json_path = $this->push_directory . '/commit.json';
         $this->push_lock_path = $this->push_directory . '/push.lock';
@@ -181,6 +188,16 @@ final class Site_Export_Push_Session {
         $push_sessions_directory = self::create_push_sessions_directory($reprint_directory);
         $create_remove_lock = self::acquire_create_remove_lock($push_sessions_directory, 'create');
         try {
+            $push_session->with_commit_state_lock(function () use ($push_session): void {
+                $active_owner = $push_session->read_commit_owner();
+                if ($active_owner !== null && $active_owner !== $push_session->push_session_id) {
+                    throw new Site_Export_Push_Exception(
+                        self::ERROR_COMMIT_REQUIRED,
+                        'Push session ' . $active_owner . ' must finish committing this document root before another push session can start.',
+                        ['blocking_push_session_id' => $active_owner]
+                    );
+                }
+            });
             $removing_push_directory = $push_sessions_directory . '/.removing-' . $push_session_id;
             if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
                 throw new Site_Export_Push_Exception(
@@ -678,12 +695,11 @@ final class Site_Export_Push_Session {
                 ];
             }
             $this->with_commit_state_lock(function (): void {
-                $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
-                $active_owner = @file_get_contents($active_path);
-                if (is_string($active_owner) && trim($active_owner) !== '' && trim($active_owner) !== $this->push_session_id) {
-                    throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Another push session is already committing this document root: ' . trim($active_owner) . '.');
+                $active_owner = $this->read_commit_owner();
+                if ($active_owner !== null && $active_owner !== $this->push_session_id) {
+                    throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Another push session is already committing this document root: ' . $active_owner . '.');
                 }
-                $this->write_atomic_file($active_path, $this->push_session_id . "\n", 0600);
+                $this->write_atomic_file($this->commit_state_path, $this->push_session_id . "\n", 0600);
             });
             $maintenance_docroot_path = $this->docroot_path('.maintenance');
             $maintenance_identity = $this->lstat_path($maintenance_docroot_path);
@@ -1954,18 +1970,17 @@ final class Site_Export_Push_Session {
     /**
      * Releases this push session's document-root-wide commit claim if it still owns it.
      *
-     * The active marker is advisory state excluded by the commit-state lock. Missing
-     * or foreign contents are left untouched so cleanup cannot erase another
-     * push session's claim after an operator or retry changed document-root ownership.
+     * The active marker is advisory state excluded by the commit-state lock. A
+     * missing marker or another session's valid claim is left untouched so cleanup
+     * cannot erase document-root ownership which changed after this commit.
      */
     private function release_commit_state(): void {
         $this->with_commit_state_lock(function (): void {
-            $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
-            $active_owner = @file_get_contents($active_path);
-            if (!is_string($active_owner) || trim($active_owner) !== $this->push_session_id) {
+            $active_owner = $this->read_commit_owner();
+            if ($active_owner !== $this->push_session_id) {
                 return;
             }
-            if (!@unlink($active_path)) {
+            if (!@unlink($this->commit_state_path)) {
                 throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not release the commit-state owner.');
             }
         });
@@ -1982,7 +1997,7 @@ final class Site_Export_Push_Session {
      * @param callable $callback Critical section to execute while locked.
      */
     private function with_commit_state_lock(callable $callback): void {
-        $lock = @fopen($this->reprint_directory . '/.reprint/push/commit-state.lock', 'c+b');
+        $lock = @fopen($this->commit_state_lock_path, 'c+b');
         if ($lock === false) {
             throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the commit-state lock.');
         }
@@ -1995,6 +2010,43 @@ final class Site_Export_Push_Session {
             flock($lock, LOCK_UN);
             fclose($lock);
         }
+    }
+
+    /**
+     * Reads the validated push session ID which owns the document-root commit.
+     *
+     * This method is called only while the commit-state lock is held. A missing
+     * marker means no commit owns the document root. Existing state must be a
+     * readable regular file containing one valid push session ID.
+     */
+    private function read_commit_owner(): ?string {
+        $identity = $this->lstat_path($this->commit_state_path);
+        if ($identity === null) {
+            return null;
+        }
+        if ($identity['type'] !== 'file') {
+            throw new Site_Export_Push_Exception(
+                self::ERROR_CORRUPTED_PUSH_STATE,
+                'Reprint cannot identify the active push commit because its commit-state marker is not a regular file.'
+            );
+        }
+        $active_owner = @file_get_contents($this->commit_state_path);
+        if (!is_string($active_owner)) {
+            throw new Site_Export_Push_Exception(
+                self::ERROR_FILESYSTEM,
+                'Reprint could not read the active push commit from its commit-state marker.'
+            );
+        }
+        $active_owner = trim($active_owner);
+        try {
+            self::require_push_session_id($active_owner);
+        } catch (InvalidArgumentException $exception) {
+            throw new Site_Export_Push_Exception(
+                self::ERROR_CORRUPTED_PUSH_STATE,
+                'Reprint cannot identify the active push commit because its commit-state marker is malformed.'
+            );
+        }
+        return $active_owner;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1837,6 +1837,9 @@ class ImportClient
             case 'pushing_deletes':
                 $message = 'Uploading deleted paths';
                 break;
+            case 'finishing_previous_commit':
+                $message = 'Finishing previous push commit';
+                break;
             case 'committing':
                 $message = 'Applying file changes';
                 break;

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -125,7 +125,7 @@
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{local_relative_path:string,document_root_relative_path:string,document_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,phase:'creating'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -272,6 +272,7 @@ final class PushFilesSender
             $sender->push_stream_client = $sender->create_push_stream_client(null);
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
+                'blocking_push_session_id' => null,
                 'phase' => 'creating',
                 'document_root_local_relative_path' => $sender->document_root_local_relative_path,
                 'push_plan_cursor' => null,
@@ -411,6 +412,9 @@ final class PushFilesSender
         switch ($this->state['phase']) {
             case 'creating':
                 $this->create_push_session();
+                break;
+            case 'finishing_previous_commit':
+                $this->finish_previous_commit();
                 break;
             case 'starting_plan':
                 $this->start_plan();
@@ -575,6 +579,14 @@ final class PushFilesSender
         $request_result = $this->push_stream_client->send_push_request('POST', 'push_create', [
             'push_session_id' => $this->state['push_session_id'],
         ], ['created']);
+        if ($request_result['reason'] === 'commit_required') {
+            /** @var array{blocking_push_session_id:string} $response */
+            $response = $request_result['response'];
+            $this->state['blocking_push_session_id'] = $response['blocking_push_session_id'];
+            $this->state['phase'] = 'finishing_previous_commit';
+            $this->store_state($this->state);
+            return;
+        }
         if ($this->handle_request_failure($request_result)) {
             return;
         }
@@ -603,6 +615,37 @@ final class PushFilesSender
         $this->state['max_part_bytes'] = $response['max_part_bytes'];
         $this->state['request_sizer_state'] = $this->push_stream_client->get_request_sizer_state();
         $this->state['phase'] = 'starting_plan';
+        $this->store_state($this->state);
+    }
+
+    /**
+     * Advances the commit which prevents this sender from creating its push session.
+     *
+     * One step sends one commit request. The target owns that commit checkpoint,
+     * so a later process can continue it from the saved blocking push session ID.
+     */
+    private function finish_previous_commit(): void
+    {
+        $blocking_push_session_id = $this->state['blocking_push_session_id'];
+        if ($blocking_push_session_id === null) {
+            throw new LogicException(
+                'The finishing_previous_commit phase requires a blocking_push_session_id.'
+            );
+        }
+        $request_result = $this->push_stream_client->send_push_request('POST', 'push_commit', [
+            'push_session_id' => $blocking_push_session_id,
+        ], ['accepted']);
+        if ($this->handle_request_failure($request_result)) {
+            return;
+        }
+        /** @var array{send_next_request:bool} $response */
+        $response = $request_result['response'];
+
+        if ($response['send_next_request']) {
+            return;
+        }
+        $this->state['blocking_push_session_id'] = null;
+        $this->state['phase'] = 'creating';
         $this->store_state($this->state);
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -660,6 +660,150 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame($expected_excluded_paths_b64, $push_metadata['excluded_paths_b64']);
     }
 
+    public function testPushCreateReportsTheActiveCommitBeforeCreatingAnotherSession(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $committing_push_session_id = str_repeat('3', 32);
+        $next_push_session_id = str_repeat('4', 32);
+
+        $create = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $committing_push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $upload = $this->sendUploadRequest($client, $committing_push_session_id, [
+            [
+                'type' => 'file',
+                'path' => 'installed.txt',
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'new!',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+        $commit = $client->send_push_request('POST', 'push_commit', [
+            'push_session_id' => $committing_push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        $this->assertTrue($commit['response']['send_next_request']);
+
+        $create_while_committing = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $next_push_session_id,
+        ], ['created']);
+
+        $this->assertSame('failed', $create_while_committing['status'], (string) json_encode($create_while_committing));
+        $this->assertSame('commit_required', $create_while_committing['reason']);
+        $this->assertSame(
+            $committing_push_session_id,
+            $create_while_committing['response']['blocking_push_session_id']
+        );
+        $this->assertSame(
+            'Push session ' . $committing_push_session_id . ' must finish committing this document root before another push session can start.',
+            $create_while_committing['detail']
+        );
+        $this->assertSame(409, $create_while_committing['response']['http_code']);
+        $this->assertDirectoryDoesNotExist(
+            $this->reprint_directory . '/.reprint/push/' . $next_push_session_id
+        );
+    }
+
+    public function testPushCreateRejectsCorruptCommitOwnerState(): void
+    {
+        $push_sessions_directory = $this->reprint_directory . '/.reprint/push';
+        mkdir($push_sessions_directory, 0700, true);
+        file_put_contents($push_sessions_directory . '/commit-state', "not-a-push-session\n");
+
+        $client = $this->newClient(self::SECRET);
+        $push_session_id = str_repeat('4', 32);
+        $result = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $push_session_id,
+        ], ['created']);
+
+        $this->assertSame('failed', $result['status'], (string) json_encode($result));
+        $this->assertSame('corrupted_push_state', $result['reason']);
+        $this->assertSame(
+            'Reprint cannot identify the active push commit because its commit-state marker is malformed.',
+            $result['detail']
+        );
+        $this->assertDirectoryDoesNotExist($push_sessions_directory . '/' . $push_session_id);
+    }
+
+    public function testHighLevelSenderFinishesPreviousCommitBeforeCreatingItsPushSession(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $blocking_push_session_id = str_repeat('5', 32);
+
+        $create = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $blocking_push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+        $upload = $this->sendUploadRequest($client, $blocking_push_session_id, [
+            [
+                'type' => 'file',
+                'path' => 'blocking.txt',
+                'total_bytes' => 4,
+                'offset' => 0,
+                'payload' => 'hold',
+            ],
+            [
+                'type' => 'delete-list',
+                'offset' => 0,
+                'complete' => true,
+                'payload' => '',
+            ],
+        ]);
+        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
+        $commit = $client->send_push_request('POST', 'push_commit', [
+            'push_session_id' => $blocking_push_session_id,
+        ], ['accepted']);
+        $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
+        $this->assertTrue($commit['response']['send_next_request']);
+
+        $local_docroot = $this->root . '/next-local-docroot';
+        $push_state_directory = $this->root . '/next-sender-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/next.txt', 'next');
+        $options = $this->senderOptions($local_docroot, $push_state_directory);
+
+        $sender = $this->startSender($options);
+        $initial_state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($initial_state);
+        $current_push_session_id = $initial_state['push_session_id'];
+        try {
+            $this->assertTrue($sender->next_step());
+            $this->assertSame('finishing_previous_commit', $sender->get_phase());
+            $state = $this->loadActiveState($push_state_directory);
+            $this->assertIsArray($state);
+            $this->assertSame($current_push_session_id, $state['push_session_id']);
+            $this->assertSame($blocking_push_session_id, $state['blocking_push_session_id']);
+        } finally {
+            $this->closeSender($sender);
+        }
+
+        $resumed_sender = $this->resumeSender($options);
+        try {
+            $this->assertTrue($resumed_sender->next_step());
+            $this->assertSame('finishing_previous_commit', $resumed_sender->get_phase());
+        } finally {
+            $this->closeSender($resumed_sender);
+        }
+
+        $state = $this->loadActiveState($push_state_directory);
+        $this->assertIsArray($state);
+        $this->assertSame($blocking_push_session_id, $state['blocking_push_session_id']);
+        $result = $this->runSender($local_docroot, $push_state_directory);
+
+        $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        $this->assertSame('hold', file_get_contents($this->docroot . '/blocking.txt'));
+        $this->assertSame('next', file_get_contents($this->docroot . '/next.txt'));
+        $this->assertNull($this->loadActiveState($push_state_directory));
+    }
+
     public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void
     {
         $client = $this->newClient(self::SECRET);


### PR DESCRIPTION
`files-push` now finishes an active target commit before creating its next push session.

When `push_create` returns `commit_required`, the response includes the `blocking_push_session_id`. The sender saves that ID in `sender.json` and sends one bounded `push_commit` request per step. A later command resumes the same phase after interruption. Once the previous commit finishes, the sender returns to `creating` and builds a fresh plan.

The target derives its commit-state paths once per push session and reads the commit owner through one locked operation. A missing marker means there is no owner; a malformed marker fails as corrupted push state, and a failed read reports a filesystem error.

## Testing

Start a push commit, then run `files-push` from another state directory. Stop and rerun it while it reports `Finishing previous push commit`; confirm that the previous commit and the new push both complete.
