### PR TITLE
Read preflight config through PullState::get() with a defaults registry

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1592,8 +1592,8 @@ class ImportClient
         if (!is_array($context)) {
             throw new InvalidArgumentException('files-push requires its validated command context.');
         }
-        $document_root = $this->get_state()->preflight["data"]["runtime"]["document_root"] ?? null;
-        if (!is_string($document_root) || $document_root === '' || $document_root[0] !== '/') {
+        $document_root = $this->get_state()->get('preflight.runtime.document_root');
+        if ($document_root === '' || $document_root[0] !== '/') {
             throw new RuntimeException(
                 "Preflight did not report an absolute document root. Run 'preflight' or 'preflight-assert' again."
             );
@@ -2324,7 +2324,7 @@ class ImportClient
                 : null,
         ];
 
-        $this->get_state()->preflight = $entry;
+        $this->get_state()->set_preflight_record($entry);
 
         // Store WordPress version at the top level for easy access
         $wp_version = $payload["database"]["wp"]["wp_version"] ?? null;
@@ -2410,7 +2410,7 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        $ini_all = $this->get_state()->preflight["data"]["runtime"]["ini_get_all"] ?? [];
+        $ini_all = $this->get_state()->get('preflight.runtime.ini_get_all');
         $files = [];
         foreach (["auto_prepend_file", "auto_append_file"] as $key) {
             $path = $ini_all[$key] ?? "";
@@ -2573,7 +2573,7 @@ class ImportClient
      */
     private function require_preflight(): void
     {
-        $entry = $this->get_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight_record();
         if (!is_array($entry) || empty($entry["data"])) {
             throw new RuntimeException(
                 "No preflight data found. Run 'preflight' or 'preflight-assert' first.",
@@ -2590,7 +2590,7 @@ class ImportClient
      */
     private function run_preflight_report(): void
     {
-        $entry = $this->get_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight_record();
         if ($entry === null) {
             echo "No preflight data available.\n";
             exit(1);
@@ -2611,7 +2611,7 @@ class ImportClient
      */
     private function run_preflight_assert(): void
     {
-        $entry = $this->get_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight_record();
         $data = $entry["data"] ?? null;
         $checks = [];
         $all_pass = true;
@@ -4035,7 +4035,7 @@ class ImportClient
     {
         $state = $this->get_state();
         $pull = $state->pull_pipeline;
-        $database = $state->preflight["data"]["database"] ?? [];
+        $database = $state->preflight_record()["data"]["database"] ?? [];
         $wordpress = $database["wp"] ?? [];
 
         return [
@@ -4102,7 +4102,7 @@ class ImportClient
         }
 
         // Load state to get preflight data and detected webhost.
-        $entry = $this->get_state()->preflight ?? null;
+        $entry = $this->get_state()->preflight_record();
         if (!is_array($entry) || empty($entry["data"])) {
             throw new RuntimeException(
                 "apply-runtime requires a prior preflight run. " .
@@ -4475,33 +4475,20 @@ class ImportClient
 
         // Require preflight data so we know where WP components live
         $this->require_preflight();
-        $preflight = $this->get_state()->preflight["data"] ?? [];
+        $state = $this->get_state();
 
         // Extract WordPress directory paths from preflight
-        $paths_urls = $preflight["database"]["wp"]["paths_urls"] ?? null;
-        $abspath = null;
-        $wp_admin_path = null;
-        $wp_includes_path = null;
-        $content_dir = null;
-        $plugins_dir = null;
-        $mu_plugins_dir = null;
-        $uploads_basedir = null;
-
-        if (is_array($paths_urls)) {
-            $abspath = $this->clean_preflight_path( $paths_urls["abspath"] ?? null);
-            $wp_admin_path = $this->clean_preflight_path( $paths_urls["wp_admin_path"] ?? null);
-            $wp_includes_path = $this->clean_preflight_path( $paths_urls["wp_includes_path"] ?? null);
-            $content_dir = $this->clean_preflight_path( $paths_urls["content_dir"] ?? null);
-            $plugins_dir = $this->clean_preflight_path( $paths_urls["plugins_dir"] ?? null);
-            $mu_plugins_dir = $this->clean_preflight_path( $paths_urls["mu_plugins_dir"] ?? null);
-            $uploads_basedir = $this->clean_preflight_path(
-                $paths_urls["uploads"]["basedir"] ?? null,
-            );
-        }
+        $abspath = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.abspath'));
+        $wp_admin_path = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.wp_admin_path'));
+        $wp_includes_path = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.wp_includes_path'));
+        $content_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.content_dir'));
+        $plugins_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.plugins_dir'));
+        $mu_plugins_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.mu_plugins_dir'));
+        $uploads_basedir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.uploads.basedir'));
 
         // Fall back to wp_detect roots if abspath not available
         if ($abspath === null) {
-            $roots = $preflight["wp_detect"]["roots"] ?? [];
+            $roots = $state->get('preflight.wp_detect.roots');
             if (!empty($roots)) {
                 $abspath = $this->clean_preflight_path( $roots[0]["path"] ?? null);
             }
@@ -5164,7 +5151,7 @@ class ImportClient
 
             if (!$target_path) {
                 $content_dir = rtrim(
-                    $this->get_state()->preflight["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
+                    $this->get_state()->get('preflight.database.wp.paths_urls.content_dir') ?? "",
                     "/",
                 );
                 if(!$content_dir) {
@@ -5349,7 +5336,7 @@ class ImportClient
         // Set up SQL statement rewriter if we have URL mappings
         $stmt_rewriter = null;
         if (!empty($url_mapping)) {
-            $table_prefix = $this->get_state()->preflight["data"]["database"]["wp"]["table_prefix"] ?? 'wp_';
+            $table_prefix = $this->get_state()->get('preflight.database.wp.table_prefix');
             $stmt_rewriter = new SqlStatementRewriter(
                 new StructuredDataUrlRewriter($url_mapping),
                 $table_prefix,
@@ -5752,7 +5739,7 @@ class ImportClient
     {
         $webhost = $this->get_state()->webhost ?? "other";
         $analyzer = host_analyzer_for($webhost);
-        $preflight_data = $this->get_state()->preflight["data"] ?? [];
+        $preflight_data = $this->get_state()->preflight_record()["data"] ?? [];
         $manifest = $analyzer->analyze($preflight_data);
 
         $plugin_dirs = [];
@@ -5818,8 +5805,7 @@ class ImportClient
             return [];
         }
 
-        $preflight_data = $this->get_state()->preflight["data"] ?? [];
-        $table_prefix = $preflight_data["database"]["wp"]["table_prefix"] ?? 'wp_';
+        $table_prefix = $this->get_state()->get('preflight.database.wp.table_prefix');
         // Quote the table name to prevent SQL injection from a crafted prefix.
         $options_table = '`' . str_replace('`', '``', $table_prefix . 'options') . '`';
 
@@ -6888,7 +6874,7 @@ class ImportClient
         // Cap the batch at 80% of the server's max request size so the
         // multipart envelope and headers still fit.  Floor at 256 KB so
         // tiny max_request values don't produce degenerate single-file batches.
-        $max_request = $this->get_max_request_bytes();
+        $max_request = $this->get_state()->get('preflight.limits.max_request_bytes');
         $limit = (int) max(256 * 1024, $max_request * 0.8);
 
         // Open the fetch list and seek to where the previous batch left off.
@@ -7004,24 +6990,6 @@ class ImportClient
             "next_offset" => $next_offset,
             "entries" => $entries,
         ];
-    }
-
-    /**
-     * Determine maximum request size for file_fetch uploads.
-     */
-    private function get_max_request_bytes(): int
-    {
-        $preflight = $this->get_state()->preflight["data"]["limits"] ?? null;
-        $max_request = null;
-        if (is_array($preflight) && isset($preflight["max_request_bytes"])) {
-            $max_request = (int) $preflight["max_request_bytes"];
-        }
-
-        if ($max_request === null || $max_request <= 0) {
-            return 4 * 1024 * 1024;
-        }
-
-        return $max_request;
     }
 
     /**
@@ -8999,19 +8967,19 @@ class ImportClient
      */
     private function remote_path_tokens(): array
     {
-        $preflight = $this->get_state()->preflight["data"] ?? [];
-        $paths = $preflight["database"]["wp"]["paths_urls"] ?? [];
+        $state = $this->get_state();
 
-        $content_dir = $this->clean_preflight_path( $paths["content_dir"] ?? null);
+        $content_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.content_dir'));
 
-        $abspath = $this->clean_preflight_path( $paths["abspath"] ?? null);
+        $abspath = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.abspath'));
         if ($abspath === null) {
-            $abspath = $this->clean_preflight_path( $preflight["wp_detect"]["roots"][0]["path"] ?? null);
+            $roots = $state->get('preflight.wp_detect.roots');
+            $abspath = $this->clean_preflight_path( $roots[0]["path"] ?? null);
         }
 
-        $plugins_dir = $this->clean_preflight_path( $paths["plugins_dir"] ?? null);
-        $mu_plugins_dir = $this->clean_preflight_path( $paths["mu_plugins_dir"] ?? null);
-        $uploads_dir = $this->clean_preflight_path( $paths["uploads"]["basedir"] ?? null);
+        $plugins_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.plugins_dir'));
+        $mu_plugins_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.mu_plugins_dir'));
+        $uploads_dir = $this->clean_preflight_path($state->get('preflight.database.wp.paths_urls.uploads.basedir'));
 
         // If preflight did not report a directory path, use its conventional
         // location under WP_CONTENT_DIR when WP_CONTENT_DIR is known.
@@ -9891,8 +9859,8 @@ class ImportClient
      */
     private function get_root_directories_from_preflight(): array
     {
-        $roots = $this->get_state()->preflight["data"]["wp_detect"]["roots"] ?? [];
-        if (!is_array($roots) || empty($roots)) {
+        $roots = $this->get_state()->get('preflight.wp_detect.roots');
+        if (empty($roots)) {
             return [];
         }
         $dirs = [];
@@ -9960,12 +9928,12 @@ class ImportClient
             return $this->export_directories_cache;
         }
 
-        $preflight = $this->get_state()->preflight["data"] ?? [];
+        $state = $this->get_state();
 
         // Collect extra paths that may live outside the wp_detect roots.
         $extra_paths = [
-            "document_root" => rtrim($preflight["runtime"]["document_root"] ?? "", "/"),
-            "content_dir" => rtrim($preflight["database"]["wp"]["paths_urls"]["content_dir"] ?? "", "/"),
+            "document_root" => rtrim($state->get('preflight.runtime.document_root'), "/"),
+            "content_dir" => rtrim($state->get('preflight.database.wp.paths_urls.content_dir') ?? "", "/"),
         ];
 
         if ($this->extra_directory !== null && $this->extra_directory !== "") {
@@ -9984,7 +9952,7 @@ class ImportClient
         // auto_prepend_file / auto_append_file may point to directories
         // outside the WordPress roots (e.g. /scripts/env.php on Atomic).
         // Include those directories so the remote exporter traverses them.
-        $ini_all = $preflight["runtime"]["ini_get_all"] ?? [];
+        $ini_all = $state->get('preflight.runtime.ini_get_all');
         foreach (["auto_prepend_file", "auto_append_file"] as $ini_key) {
             $ini_path = $ini_all[$ini_key] ?? "";
             if (is_string($ini_path) && $ini_path !== "" && $ini_path[0] === "/") {
@@ -10917,7 +10885,7 @@ class ImportClient
     {
         $previous_state = $this->state;
         $this->state = new PullState();
-        $this->state->preflight = $previous_state->preflight;
+        $this->state->set_preflight_record($previous_state->preflight_record());
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -412,7 +412,7 @@ class Pull
         switch ($stage) {
             case 'preflight':
                 $this->client->run_preflight();
-                $preflight = $this->client->get_state()->preflight;
+                $preflight = $this->client->get_state()->preflight_record();
                 $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
                 if (!$ok) {
                     $this->client->exit_code = 1;

--- a/packages/reprint-importer/src/lib/state/class-pull-state.php
+++ b/packages/reprint-importer/src/lib/state/class-pull-state.php
@@ -19,10 +19,30 @@ use Reprint\Importer\State\ResumableCommandCheckpointState;
  */
 class PullState
 {
+    /**
+     * Config paths readable via get(), mapped to the default applied when the
+     * preflight payload has no usable value at that path. A null default means
+     * absence is meaningful and the caller handles it.
+     */
+    private const CONFIG_DEFAULTS = [
+        'preflight.limits.max_request_bytes' => 4 * 1024 * 1024,
+        'preflight.runtime.document_root' => '',
+        'preflight.runtime.ini_get_all' => [],
+        'preflight.database.wp.table_prefix' => 'wp_',
+        'preflight.database.wp.paths_urls.abspath' => null,
+        'preflight.database.wp.paths_urls.wp_admin_path' => null,
+        'preflight.database.wp.paths_urls.wp_includes_path' => null,
+        'preflight.database.wp.paths_urls.content_dir' => null,
+        'preflight.database.wp.paths_urls.plugins_dir' => null,
+        'preflight.database.wp.paths_urls.mu_plugins_dir' => null,
+        'preflight.database.wp.paths_urls.uploads.basedir' => null,
+        'preflight.wp_detect.roots' => [],
+    ];
+
     /** Resume checkpoint for a lower-level command run directly or inside a pull pipeline. */
     public ResumableCommandCheckpointState $active_resumable_command;
-    /** @var array<string,mixed>|null */
-    public ?array $preflight = null;
+    /** @var array<string,mixed>|null Verbatim preflight record; read it through preflight_record() or get(). */
+    private ?array $preflight = null;
     public ?int $remote_protocol_version = null;
     /** @var string|null Source WordPress version saved with state. */
     public ?string $version = null;
@@ -124,6 +144,73 @@ class PullState
         $state->tuning = AdaptiveTuningState::from_array($data['tuning']);
         $state->pull_pipeline = PullPipelineCheckpointState::from_array($data['pull_pipeline']);
         return $state;
+    }
+
+    /**
+     * The verbatim preflight record, for code that reports what the server
+     * said (pipeline status, pull metadata, host analyzers). Code that needs
+     * an effective config value uses get() instead.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function preflight_record(): ?array
+    {
+        return $this->preflight;
+    }
+
+    /** @param array<string,mixed>|null $entry */
+    public function set_preflight_record(?array $entry): void
+    {
+        $this->preflight = $entry;
+    }
+
+    /**
+     * Read an effective config value from the preflight payload.
+     *
+     * $preflight stays exactly what the server reported; defaults for missing
+     * or unusable values are applied here instead. Every path read anywhere in
+     * the importer must be registered in CONFIG_DEFAULTS, so a typo throws
+     * instead of silently returning null.
+     */
+    public function get(string $path)
+    {
+        if (!array_key_exists($path, self::CONFIG_DEFAULTS)) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Hardcoded path from our own call sites, never HTML output.
+            throw new UnexpectedValueException('Unknown config path: ' . $path);
+        }
+        $default = self::CONFIG_DEFAULTS[$path];
+
+        $segments = explode('.', $path);
+        // The leading "preflight" segment maps to $preflight['data'], the raw payload.
+        array_shift($segments);
+        $value = $this->preflight['data'] ?? null;
+        foreach ($segments as $segment) {
+            if (!is_array($value) || !array_key_exists($segment, $value)) {
+                $value = null;
+                break;
+            }
+            $value = $value[$segment];
+        }
+
+        if ($value === null) {
+            return $default;
+        }
+
+        // A reported value of the wrong type is as unusable as a missing one.
+        // The int defaults are all sizes and limits, where the exporter reports
+        // 0 when the host has none configured; stay conservative and use the
+        // default there too.
+        if (is_int($default)) {
+            return is_numeric($value) && (int) $value > 0 ? (int) $value : $default;
+        }
+        if (is_string($default) && !is_string($value)) {
+            return $default;
+        }
+        if (is_array($default) && !is_array($value)) {
+            return $default;
+        }
+
+        return $value;
     }
 
     public function to_array(): array

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -668,7 +668,7 @@ final class FilesPullLocalIndexTest extends TestCase
     {
         mkdir($this->pullStateDirectory, 0700, true);
         $state = new \PullState();
-        $state->preflight = [
+        $state->set_preflight_record([
             'http_code' => 200,
             'data' => [
                 'ok' => true,
@@ -695,7 +695,7 @@ final class FilesPullLocalIndexTest extends TestCase
                     ],
                 ],
             ],
-        ];
+        ]);
         file_put_contents(
             $this->pullStateDirectory . '/state.json',
             json_encode(

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -345,14 +345,14 @@ final class FilesPushCommandTest extends TestCase
             mkdir($pullStateDirectory, 0700, true);
         }
         $pullState = new \PullState();
-        $pullState->preflight = [
+        $pullState->set_preflight_record([
             'http_code' => 200,
             'data' => [
                 'runtime' => [
                     'document_root' => 'base64:' . base64_encode($documentRoot),
                 ],
             ],
-        ];
+        ]);
         file_put_contents(
             $pullStateFile,
             json_encode($pullState->to_array(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -73,7 +73,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     private function client(array $preflightData): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $c->get_state()->preflight = array('data' => $preflightData);
+        $c->get_state()->set_preflight_record(array('data' => $preflightData));
         $this->set($c, 'audit_log_file', $this->tempDir . '/audit.log');
         return $c;
     }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -70,7 +70,7 @@ class PullFilterFakeClient extends \ImportClient
     {
         $this->preflight_runs++;
         $state = $this->get_state();
-        $state->preflight = [
+        $state->set_preflight_record([
             "http_code" => 200,
             "data" => [
                 "ok" => true,
@@ -89,7 +89,7 @@ class PullFilterFakeClient extends \ImportClient
                     "phpversion" => "8.2",
                 ],
             ],
-        ];
+        ]);
         $state->active_resumable_command->completion_state = "complete";
         $this->save_state();
     }
@@ -144,10 +144,10 @@ class PullFailingPreflightFakeClient extends PullFilterFakeClient
         $this->preflight_runs++;
         $this->last_error_code = 'HTTP_ERROR';
         $state = $this->get_state();
-        $state->preflight = [
+        $state->set_preflight_record([
             "http_code" => 500,
             "error" => "Exporter unavailable",
-        ];
+        ]);
         $state->active_resumable_command->completion_state = "complete";
         $this->save_state();
     }

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -60,6 +60,43 @@ class PullStateTest extends TestCase
         $this->assertSame(99, $array['sql_statements_counted']);
     }
 
+    public function testGetAppliesDefaultsOverVerbatimPreflight(): void
+    {
+        $state = new \PullState();
+
+        // Preflight has not run yet.
+        $this->assertSame(4 * 1024 * 1024, $state->get('preflight.limits.max_request_bytes'));
+
+        // Server reported a usable limit.
+        $state->set_preflight_record(['data' => ['limits' => ['max_request_bytes' => 8 * 1024 * 1024]]]);
+        $this->assertSame(8 * 1024 * 1024, $state->get('preflight.limits.max_request_bytes'));
+
+        // Server reported 0 (host without a request-size limit): the effective
+        // value falls back to the default while the record keeps the 0.
+        $state->set_preflight_record(['data' => ['limits' => ['max_request_bytes' => 0]]]);
+        $this->assertSame(4 * 1024 * 1024, $state->get('preflight.limits.max_request_bytes'));
+        $this->assertSame(0, $state->preflight_record()['data']['limits']['max_request_bytes']);
+
+        // String and array paths default the same way; null-default paths
+        // report absence as null for the caller to handle.
+        $state = new \PullState();
+        $this->assertSame('wp_', $state->get('preflight.database.wp.table_prefix'));
+        $this->assertSame([], $state->get('preflight.wp_detect.roots'));
+        $this->assertNull($state->get('preflight.database.wp.paths_urls.abspath'));
+
+        // A value of the wrong type is as unusable as a missing one.
+        $state->set_preflight_record(['data' => ['database' => ['wp' => ['table_prefix' => 123]]]]);
+        $this->assertSame('wp_', $state->get('preflight.database.wp.table_prefix'));
+    }
+
+    public function testGetRejectsUnregisteredConfigPaths(): void
+    {
+        $state = new \PullState();
+
+        $this->expectException(\UnexpectedValueException::class);
+        $state->get('preflight.limits.max_request_bytez');
+    }
+
     public function testStateObjectsDoNotExposeArrayOffsetMutation(): void
     {
         $state = new \PullState();

--- a/tests/Import/RemapResolveTest.php
+++ b/tests/Import/RemapResolveTest.php
@@ -74,9 +74,9 @@ class RemapResolveTest extends TestCase
     private function client(array $pathsUrls): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $c->get_state()->preflight = array('data' => array(
+        $c->get_state()->set_preflight_record(array('data' => array(
             'database' => array('wp' => array('paths_urls' => $pathsUrls)),
-        ));
+        )));
         return $c;
     }
 

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -3342,14 +3342,14 @@ final class PushEndpointsTest extends TestCase {
             mkdir($pull_state_directory, 0700, true);
         }
         $pull_state = new PullState();
-        $pull_state->preflight = [
+        $pull_state->set_preflight_record([
             'http_code' => 200,
             'data' => [
                 'runtime' => [
                     'document_root' => 'base64:' . base64_encode($document_root),
                 ],
             ],
-        ];
+        ]);
         file_put_contents(
             $pull_state_file,
             json_encode($pull_state->to_array(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)


### PR DESCRIPTION
## What it does

Routes every preflight config read through one accessor with centralized defaults:

```php
$max_request = $this->get_state()->get('preflight.limits.max_request_bytes');
$table_prefix = $this->get_state()->get('preflight.database.wp.table_prefix');
```

`get()` resolves the dot-path against the verbatim preflight payload and falls back to `PullState::CONFIG_DEFAULTS` when the value is missing, null, wrong-typed, or — for limits — non-positive. Unregistered paths throw, so the registry is the complete manifest of what the importer consumes from preflight.

## Why

Defaults were scattered across call sites (`?? 'wp_'`, `?? []`, a dedicated `get_max_request_bytes()`); every new reader had to remember to copy them. Backfilling defaults into stored state was rejected on purpose: `state.json` must keep what the server actually reported — e.g. `max_request_bytes: 0` (host without a limit) stays in the record while the effective value falls back to 4 MiB.

`$preflight` is now private: effective values via `get()`, report consumers (pipeline status, pull metadata, host analyzers) via `preflight_record()`. No state schema change.

## Testing

```bash
cd tests && ../vendor/bin/phpunit Import/PullStateTest.php Import/FilesPullLocalIndexTest.php
```