### PR TITLE
[Push] Batch state updates during push planning 

### DIFF
--- a/markdown/PUSH-SYNC.md
+++ b/markdown/PUSH-SYNC.md
@@ -136,11 +136,12 @@ A push plan is an internal part of the sender lifecycle:
    active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
    `plan/excluded_paths.json`, then opens
-   `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each `indexing`
-   step advances one traversal event, appends its JSONL entries when applicable,
-   flushes those bytes, and then updates its traversal cursor and committed byte
-   offset. The sender stores that cursor in `sender.json` before returning
-   from its step.
+   `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each internal
+   `indexing` step advances one traversal event, appends its JSONL entries when
+   applicable, and updates its traversal cursor and fresh-index byte offset.
+   One sender step runs at most 256 internal planning steps without crossing
+   an internal phase boundary, flushes their output, and stores the resulting
+   cursor in `sender.json` before returning.
 3. Once traversal is complete, the plan enters `starting_diff`. The next step
    starts the index diff and enters `diffing`.
 4. Each later `next_step()` compares at most one path represented by either
@@ -356,13 +357,13 @@ remaining handles before `close()` returns.
 
 The sender stores the mandatory preflight document root, creates the push session,
 and stores its exclusion policy before it starts PushPlan. Each internal
-`indexing` step completes one traversal event,
-and `starting_diff` initializes the index diff. Each internal `diffing` step
-compares at most one path and updates the path lists. PushPlan owns the
-meaning of its file-index cursor, index offsets, output lengths, and
-deleted-directory ranges. `sender.json` stores the complete cursor. No
-upload begins until both indexes have been consumed and the two path lists are
-stable.
+`indexing` step completes one traversal event, and `starting_diff` initializes
+the index diff. Each internal `diffing` step compares at most one path and
+updates the path lists. One sender step runs at most 256 internal steps from
+the current phase before flushing their output and storing the complete
+PushPlan cursor in `sender.json`. PushPlan owns the meaning of its file-index
+cursor, index offsets, output lengths, and deleted-directory ranges. No upload
+begins until both indexes have been consumed and the two path lists are stable.
 
 `sender.json` contains no copied receiver cursor. It stores the current push
 session, an optional blocking push session, the phase, the document root's local

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -689,6 +689,9 @@ final class PushFilesSender
     private function next_plan_step(): void
     {
         try {
+            // Run a bounded batch from one PushPlan phase, then flush its
+            // output before storing the cursor. This avoids one flush and
+            // state write per path while preserving each phase boundary.
             $has_next_step = true;
             $plan_cursor = $this->plan->get_cursor();
             $plan_phase = $plan_cursor['position']['phase'];

--- a/packages/reprint-importer/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-importer/src/lib/push/class-push-files-sender.php
@@ -129,6 +129,8 @@
  */
 final class PushFilesSender
 {
+    private const MAXIMUM_PUSH_PLAN_STEPS_PER_SENDER_STEP = 256;
+
     /** @var string Filesystem root whose local paths to push are sent. */
     private string $filesystem_root;
 
@@ -687,12 +689,26 @@ final class PushFilesSender
     private function next_plan_step(): void
     {
         try {
-            $has_next_step = $this->plan->next_step();
+            $has_next_step = true;
+            $plan_cursor = $this->plan->get_cursor();
+            $plan_phase = $plan_cursor['position']['phase'];
+            for (
+                $steps_processed = 0;
+                $has_next_step && $steps_processed < self::MAXIMUM_PUSH_PLAN_STEPS_PER_SENDER_STEP;
+                ++$steps_processed
+            ) {
+                $has_next_step = $this->plan->next_step();
+                $plan_cursor = $this->plan->get_cursor();
+                if ($plan_cursor['position']['phase'] !== $plan_phase) {
+                    break;
+                }
+            }
+            $this->plan->flush_pending_outputs();
         } catch (RuntimeException $exception) {
             $this->fail('local_io_error', $exception->getMessage());
             return;
         }
-        $this->state['push_plan_cursor'] = $this->plan->get_cursor();
+        $this->state['push_plan_cursor'] = $plan_cursor;
         if (!$has_next_step) {
             $this->state['local_paths_to_push_count'] = $this->plan->get_local_paths_to_push_count();
             $this->plan->close();

--- a/packages/reprint-importer/src/lib/push/class-push-plan.php
+++ b/packages/reprint-importer/src/lib/push/class-push-plan.php
@@ -48,13 +48,12 @@ use function WordPress\Reprint\Exporter\path_remainder_under;
  * ## Durability and memory
  *
  * Each indexing step advances one FileIndexProcessor traversal event and
- * flushes any appended JSONL bytes before updating the traversal cursor and
- * committed byte offset returned to the caller.
- * A separate step starts the index diff. Each diff step compares at most one
- * path represented by either index and flushes only the output changed by that
- * step before updating its next cursor. The caller stores that cursor before
- * returning from its own step. `resume()` discards bytes beyond saved offsets,
- * so an interrupted step cannot leave duplicate durable entries.
+ * updates the traversal cursor and fresh-index byte offset returned to the
+ * caller. A separate step starts the index diff. Each diff step compares at
+ * most one path represented by either index and updates its next cursor.
+ * The owner flushes pending output before storing a cursor. `resume()` discards
+ * bytes beyond saved offsets, so an interrupted step cannot leave duplicate
+ * durable entries.
  *
  * PushPlan retains the next entry from each index and the top of an append-only
  * deleted-directory stack needed to suppress redundant descendant deletions. It
@@ -288,6 +287,28 @@ class PushPlan
     }
 
     /**
+     * Flushes plan files before the owner persists the current cursor.
+     *
+     * A later process truncates bytes beyond that cursor before appending.
+     */
+    public function flush_pending_outputs(): void
+    {
+        if (
+            is_resource($this->fresh_local_index_handle)
+            && !fflush($this->fresh_local_index_handle)
+        ) {
+            throw new RuntimeException("Failed to flush the fresh local index.");
+        }
+        if (
+            ( is_resource($this->local_paths_to_push_handle) && !fflush($this->local_paths_to_push_handle) )
+            || ( is_resource($this->local_paths_to_delete_handle) && !fflush($this->local_paths_to_delete_handle) )
+            || ( is_resource($this->deleted_directories_stack_handle) && !fflush($this->deleted_directories_stack_handle) )
+        ) {
+            throw new RuntimeException("Failed to flush a push-plan output.");
+        }
+    }
+
+    /**
      * Initializes paths in the caller-owned active plan directory.
      *
      * @param string $plan_directory   Caller-owned active plan directory.
@@ -459,18 +480,19 @@ class PushPlan
     private function next_file_index_step(): void
     {
         if (!$this->file_index_processor->next_index_step()) {
+            if (!fflush($this->fresh_local_index_handle)) {
+                throw new RuntimeException("Failed to flush the fresh local index.");
+            }
             $this->file_index_processor->close();
             $this->close_fresh_local_index_handle();
             $this->cursor["position"] = ["phase" => "starting_diff"];
             return;
         }
 
-        $fresh_local_index_changed = false;
         switch ($this->file_index_processor->get_step_status()) {
             case FileIndexProcessor::STATUS_INDEXED:
                 foreach ($this->file_index_processor->get_index_entries() as $file_index_processor_entry) {
                     $this->append_fresh_local_index_entry($file_index_processor_entry);
-                    $fresh_local_index_changed = true;
                 }
                 break;
 
@@ -486,9 +508,6 @@ class PushPlan
                 break;
         }
 
-        if ($fresh_local_index_changed && !fflush($this->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to flush the fresh local index.");
-        }
         $fresh_local_index_byte_offset = ftell($this->fresh_local_index_handle);
         if (!is_int($fresh_local_index_byte_offset)) {
             throw new RuntimeException("Failed to determine the fresh local index byte offset.");
@@ -594,9 +613,6 @@ class PushPlan
         $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
         $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
-        $local_paths_to_push_changed = false;
-        $local_paths_to_delete_changed = false;
-        $deleted_directories_stack_changed = false;
 
         if (!$this->fresh_local_index_entry_loaded) {
             $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
@@ -669,20 +685,17 @@ class PushPlan
                     )
                 ) {
                     $this->append_local_path_to_delete($fresh_local_index_entry["path"]);
-                    $local_paths_to_delete_changed = true;
                     $deleted_directory_stack_top_byte_offset =
                         $this->append_deleted_directory_stack_entry(
                             $fresh_local_index_entry["path"],
                             $deleted_directory_stack_top_byte_offset
                         );
-                    $deleted_directories_stack_changed = true;
                 }
                 if (!$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
                     if ($local_paths_to_push_count !== null) {
                         ++$local_paths_to_push_count;
                     }
-                    $local_paths_to_push_changed = true;
                 }
             } elseif ($path_comparison > 0) {
                 $local_empty_directory_is_implied_by_fresh_descendant =
@@ -704,13 +717,11 @@ class PushPlan
                     )
                 ) {
                     $this->append_local_path_to_delete($local_path_to_delete);
-                    $local_paths_to_delete_changed = true;
                     if ($local_path_to_delete !== $local_index_entry["path"]) {
                         $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
                             $local_path_to_delete,
                             $deleted_directory_stack_top_byte_offset
                         );
-                        $deleted_directories_stack_changed = true;
                     }
                 }
             } else {
@@ -743,14 +754,12 @@ class PushPlan
                     )
                 ) {
                     $this->append_local_path_to_delete($local_index_entry["path"]);
-                    $local_paths_to_delete_changed = true;
                 }
                 if ($needs_push && !$path_is_excluded) {
                     $this->append_local_path_to_push($fresh_local_index_entry);
                     if ($local_paths_to_push_count !== null) {
                         ++$local_paths_to_push_count;
                     }
-                    $local_paths_to_push_changed = true;
                 }
             }
 
@@ -768,17 +777,16 @@ class PushPlan
             }
         }
 
-        if (
-            ( $local_paths_to_push_changed && !fflush($this->local_paths_to_push_handle) )
-            || ( $local_paths_to_delete_changed && !fflush($this->local_paths_to_delete_handle) )
-            || ( $deleted_directories_stack_changed && !fflush($this->deleted_directories_stack_handle) )
-        ) {
-            throw new RuntimeException("Failed to flush a push-plan output.");
-        }
-
         $complete = $this->fresh_local_index_entry === null
             && $this->local_index_lookahead_entry === null;
         if ($complete) {
+            if (
+                !fflush($this->local_paths_to_push_handle)
+                || !fflush($this->local_paths_to_delete_handle)
+                || !fflush($this->deleted_directories_stack_handle)
+            ) {
+                throw new RuntimeException("Failed to flush a push-plan output.");
+            }
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
         }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1853,10 +1853,11 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/retained-plan-local-docroot';
         mkdir($local_docroot, 0700, true);
-        for ($index = 0; $index < 3; ++$index) {
+        for ($index = 0; $index < 513; ++$index) {
             file_put_contents($local_docroot . sprintf('/file-%04d.txt', $index), 'x');
         }
         $push_state_directory = $this->root . '/retained-plan-state';
+        $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
         $fresh_local_index_handle_property = new ReflectionProperty(
             PushPlan::class,
@@ -1885,6 +1886,10 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame($plan, $plan_property->getValue($sender));
             $cursor_after_first_step = $this->loadPlanPosition($push_state_directory);
             $this->assertNotSame($cursor_before_step, $cursor_after_first_step);
+            $this->assertCount(
+                256,
+                file($fresh_local_index_path, FILE_IGNORE_NEW_LINES)
+            );
 
             $sender->next_step();
 
@@ -1894,6 +1899,10 @@ final class PushEndpointsTest extends TestCase {
             $this->assertNotSame(
                 $cursor_after_first_step,
                 $this->loadPlanPosition($push_state_directory)
+            );
+            $this->assertCount(
+                512,
+                file($fresh_local_index_path, FILE_IGNORE_NEW_LINES)
             );
         } finally {
             $this->closeSender($sender);
@@ -1909,8 +1918,9 @@ final class PushEndpointsTest extends TestCase {
     {
         $local_docroot = $this->root . '/bounded-index-local-docroot';
         mkdir($local_docroot, 0700, true);
-        file_put_contents($local_docroot . '/a.txt', 'a');
-        file_put_contents($local_docroot . '/b.txt', 'bb');
+        for ($index = 0; $index < 257; ++$index) {
+            file_put_contents($local_docroot . sprintf('/file-%04d.txt', $index), 'x');
+        }
         $push_state_directory = $this->root . '/bounded-index-state';
         $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
@@ -1980,7 +1990,7 @@ final class PushEndpointsTest extends TestCase {
 
         $index_lines = file($fresh_local_index_path, FILE_IGNORE_NEW_LINES);
         $this->assertIsArray($index_lines);
-        $this->assertCount(2, $index_lines);
+        $this->assertCount(257, $index_lines);
     }
 
     /**
@@ -1997,9 +2007,19 @@ final class PushEndpointsTest extends TestCase {
         }
         $local_docroot = $this->root . '/killed-index-local-docroot';
         mkdir($local_docroot, 0700, true);
-        file_put_contents($local_docroot . '/a.txt', 'a');
-        file_put_contents($local_docroot . '/b.txt', 'b');
+        $local_index_entries = [];
+        for ($index = 0; $index < 257; ++$index) {
+            $local_relative_path = sprintf('file-%04d.txt', $index);
+            $path = $local_docroot . '/' . $local_relative_path;
+            file_put_contents($path, 'x');
+            $stat = lstat($path);
+            $this->assertIsArray($stat);
+            $local_index_entries[$local_relative_path] = [$stat['ctime'], $stat['size'], 'file'];
+        }
         $push_state_directory = $this->root . '/killed-index-state';
+        $local_index_fixture_file = $this->root . '/killed-index-local-index.jsonl';
+        $this->writeIndex($local_index_fixture_file, $local_index_entries);
+        $this->seedLocalIndex($push_state_directory, $local_index_fixture_file);
         $options = $this->senderOptions($local_docroot, $push_state_directory);
 
         $child = pcntl_fork();
@@ -2032,7 +2052,7 @@ final class PushEndpointsTest extends TestCase {
             FILE_IGNORE_NEW_LINES
         );
         $this->assertIsArray($local_index_lines);
-        $this->assertCount(2, $local_index_lines);
+        $this->assertCount(257, $local_index_lines);
     }
 
     /**


### PR DESCRIPTION
Processes up to 256 push-planning steps before flushing plan files and storing sender state. On a no-change push over 4,380 paths, this reduced the median runtime from 1.75s to 0.28s.

Each batch remains bounded and stops when PushPlan changes phase. The plan output is flushed before its cursor is stored. A process which stops inside a batch resumes from the preceding stored cursor and discards output beyond that cursor.

The planning tests now cross the 256- and 512-step boundaries and cover close/resume and process death between batches.

## Testing

Run `files-push` twice against a local WordPress site with a few thousand files. Confirm the second, unchanged push completes without selecting files. Stop a push during planning, rerun it, and confirm it resumes to completion.
