### PR TITLE
[PHP] Symlink monorepo packages during development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,12 +294,15 @@ Inside a class, omit the class name when context already supplies it: use
 
 ## Repo mechanics that will bite you
 
-- Composer's classmap autoloads exporter classes from
-  `vendor/wp-php-toolkit/reprint-exporter/` — a stale mirror silently runs
-  old code under the tests. After editing anything in
-  `packages/reprint-exporter/src/`, copy the file to BOTH
-  `vendor/wp-php-toolkit/reprint-exporter/src/` and
-  `reprint-exporter-wp/vendor/wp-php-toolkit/reprint-exporter/src/`.
+- The root Composer install uses Composer's default path-repository strategy,
+  which symlinks the local exporter and importer packages when the platform
+  supports it. Tests then run the files under `packages/` without a copied
+  `vendor/` tree drifting behind them. The PHAR build temporarily mirrors
+  those packages because the archive must be self-contained, then restores
+  the development links. The `reprint-exporter-wp/vendor/` tree remains a
+  physical copy for the same reason; install it afresh or run
+  `composer reinstall wp-php-toolkit/reprint-exporter` in that directory before
+  testing a local plugin bundle.
 - `packages/reprint-importer/src/lib/upload/` must stay PHP 7.4-PARSEABLE:
   import.php loads it for pull users on 7.4, and the push client's 8.1
   requirement is a runtime check in its constructor.

--- a/bin/build-reprint-phar.sh
+++ b/bin/build-reprint-phar.sh
@@ -34,6 +34,28 @@ if [ ! -f "$PROJECT_ROOT/vendor/autoload.php" ]; then
     exit 1
 fi
 
+# Box does not follow Composer's local package symlinks into the PHAR. Replace
+# them with mirrors for the build, then restore the development install.
+local_package_names=(
+    wp-php-toolkit/reprint-exporter
+    wp-php-toolkit/reprint-importer
+)
+local_packages_are_symlinked=false
+if [ -L "$PROJECT_ROOT/vendor/wp-php-toolkit/reprint-exporter" ] ||
+    [ -L "$PROJECT_ROOT/vendor/wp-php-toolkit/reprint-importer" ]; then
+    if ! command -v composer >/dev/null 2>&1; then
+        echo "Error: composer not found in PATH." >&2
+        exit 1
+    fi
+    local_packages_are_symlinked=true
+    trap '
+        if $local_packages_are_symlinked; then
+            composer reinstall --no-interaction "${local_package_names[@]}"
+        fi
+    ' EXIT
+    COMPOSER_MIRROR_PATH_REPOS=1 composer reinstall --no-interaction "${local_package_names[@]}"
+fi
+
 # ── Locate or download Box ────────────────────────────────────────
 
 BOX_PHAR="$PROJECT_ROOT/box.phar"
@@ -65,6 +87,11 @@ echo "Version: $VERSION"
 rm -f reprint.phar
 
 php -d phar.readonly=0 "$BOX_PHAR" compile
+
+if $local_packages_are_symlinked; then
+    composer reinstall --no-interaction "${local_package_names[@]}"
+    local_packages_are_symlinked=false
+fi
 
 SIZE=$(du -h reprint.phar | cut -f1)
 echo ""

--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,11 @@
     "repositories": [
         {
             "type": "path",
-            "url": "packages/reprint-exporter",
-            "options": {
-                "symlink": false
-            }
+            "url": "packages/reprint-exporter"
         },
         {
             "type": "path",
-            "url": "packages/reprint-importer",
-            "options": {
-                "symlink": false
-            }
+            "url": "packages/reprint-importer"
         }
     ],
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8c44156f8d4efc3dd86e1beae36386a",
+    "content-hash": "80964e8e850ba630412416ac9eca68da",
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
@@ -358,11 +358,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/authenticated-push-endpoints",
+            "version": "dev-adamziel/investigate-push-session-failures",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "2050e07227a82c058c6267c5e8b3e77d0cd4dbdc"
+                "reference": "dbc6c2bfd0027b377cf207cf32afe8fcd76a4f30"
             },
             "require": {
                 "php": ">=7.2",
@@ -403,17 +403,16 @@
             ],
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "transport-options": {
-                "symlink": false,
                 "relative": true
             }
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "dev-f26d/exporter-php-72-support",
+            "version": "dev-adamziel/investigate-push-session-failures",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-importer",
-                "reference": "d76b96ae7385f7e97eff350bbe1f06c55e48e58b"
+                "reference": "b7ed8b1bc68bcb7294d5e5600daf42efa3062850"
             },
             "require": {
                 "ext-pdo": "*",
@@ -432,7 +431,6 @@
             ],
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "transport-options": {
-                "symlink": false,
                 "relative": true
             }
         },


### PR DESCRIPTION
Composer now loads the monorepo exporter and importer through local path links, so switching branches cannot leave PHPUnit running an older copied package tree.

## Background

The root path repositories forced Composer to mirror both packages into the ignored `vendor/` directory. That directory survives checkouts. After #467 landed, its push-session tests loaded the previous exporter copy and reported `complete` where the checked-out source returned `commit_required`.

## This change

The root Composer project uses the default path-repository strategy, which links local packages when supported. The standalone plugin keeps its physical exporter copy.

Box does not include the linked packages in `reprint.phar`, so the PHAR builder temporarily reinstalls them as mirrors. It restores the development links after both successful and unsuccessful builds.

## Testing

Run `composer install` and confirm both local Reprint packages are links. Build `reprint.phar`, run `php reprint.phar --version`, and confirm the links are restored. The push endpoint suite and PHPStan pass; the complete 1,247-test run has only the existing MySQL-unavailable results.
