### PR TITLE
[PHP] Match paths against filesystem roots and root lists

### DIFF
--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -240,10 +240,41 @@ function normalize_excluded_paths(array $excluded_paths): array
 // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
 /**
- * Returns true when $path is equal to $root or strictly under it.
+ * Returns true when one path is equal to or strictly under one root.
+ *
+ * Either argument may be a list. The result is true when any path-and-root
+ * pair matches. The filesystem root contains every absolute path, and cannot
+ * use the normal root-plus-slash prefix because that would produce `//`.
+ *
+ * @param string|list<string> $path Candidate path or paths.
+ * @param string|list<string> $root Containing root or roots.
+ * @return bool Whether a candidate path belongs to a root.
+ * @throws InvalidArgumentException If either scalar value is not a string.
  */
-function path_is_within_root(string $path, string $root): bool
+function path_is_within_root($path, $root): bool
 {
+    if (is_array($path)) {
+        foreach ($path as $candidate_path) {
+            if (path_is_within_root($candidate_path, $root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (is_array($root)) {
+        foreach ($root as $candidate_root) {
+            if (path_is_within_root($path, $candidate_root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (!is_string($path) || !is_string($root)) {
+        throw new InvalidArgumentException('Path containment expects strings or lists of strings.');
+    }
+    if ($root === "/") {
+        return str_starts_with($path, "/");
+    }
     return $path === $root || str_starts_with($path, $root . "/");
 }
 

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -3,6 +3,7 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 
 require_once __DIR__ . '/../../importer/import.php';
@@ -148,5 +149,39 @@ class RemapSeamTest extends TestCase
             'trailing slash on both' => array('', '/home/adam/', '/home/adam/'),
             'under, prefix has trailing slash' => array('/c', '/a/b/c', '/a/b/'),
         );
+    }
+
+    /**
+     * @dataProvider providePathWithinRootCases
+     */
+    public function testPathIsWithinRoot(bool $expected, string $path, string $root): void
+    {
+        $this->assertSame($expected, path_is_within_root($path, $root));
+    }
+
+    public static function providePathWithinRootCases(): array
+    {
+        return array(
+            'filesystem root itself' => array(true, '/', '/'),
+            'filesystem root child' => array(true, '/child', '/'),
+            'relative path is outside filesystem root' => array(false, 'child', '/'),
+            'exact non-root match' => array(true, '/a', '/a'),
+            'non-root descendant' => array(true, '/a/b', '/a'),
+            'sibling prefix' => array(false, '/ab', '/a'),
+        );
+    }
+
+    public function testPathIsWithinRootMatchesAnyPathAndRoot(): void
+    {
+        $this->assertTrue(path_is_within_root('/a/b', ['/elsewhere', '/a']));
+        $this->assertTrue(path_is_within_root(['/elsewhere', '/a/b'], '/a'));
+        $this->assertTrue(path_is_within_root(
+            ['/elsewhere', '/a/b'],
+            ['/not-this-one', '/a']
+        ));
+        $this->assertFalse(path_is_within_root(
+            ['/elsewhere', '/other'],
+            ['/not-this-one', '/a']
+        ));
     }
 }


### PR DESCRIPTION
The shared containment predicate now recognizes every absolute path as beneath `/` and can compare one path or path list against one root or root list.

The focused test matrix covers root, descendants, non-root exact matches, sibling-prefix rejection, and list matching.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php`. 