### PR TITLE
[PHP] Reuse shared dot-segment normalization in file indexing

### DIFF
--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -807,7 +807,9 @@ final class FileIndexProcessor {
             if ($raw_target[0] !== "/") {
                 $raw_target = dirname($path) . "/" . $raw_target;
             }
-            $absolute_raw_target = self::normalize_dot_segments($raw_target);
+            // Resolve only textual dot segments. realpath() would skip the
+            // intermediate links that this walk must inspect.
+            $absolute_raw_target = \WordPress\Reprint\Exporter\normalize_path($raw_target);
             if (
                 $absolute_raw_target !== ""
                 && $absolute_raw_target[0] === "/"
@@ -872,39 +874,5 @@ final class FileIndexProcessor {
             }
         }
         return $entries;
-    }
-
-    /**
-     * Removes dot segments without following symlinks.
-     *
-     * realpath() cannot be used here because it would skip the intermediate
-     * symlinks that find_parent_symlinks() needs to inspect.
-     *
-     * @param string $path Absolute path containing optional dot segments.
-     * @return string Path with dot segments removed.
-     */
-    private static function normalize_dot_segments(string $path): string
-    {
-        $parts = explode("/", $path);
-        $normalized = [];
-
-        // Resolve only textual dot segments. Filesystem resolution here would
-        // skip the intermediate links this path is being prepared to inspect.
-        foreach ($parts as $part) {
-            if ($part === "" || $part === ".") {
-                if (empty($normalized)) {
-                    $normalized[] = "";
-                }
-                continue;
-            }
-            if ($part === "..") {
-                if (count($normalized) > 1) {
-                    array_pop($normalized);
-                }
-                continue;
-            }
-            $normalized[] = $part;
-        }
-        return implode("/", $normalized);
     }
 }

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -148,6 +148,48 @@ final class FileIndexProcessorTest extends TestCase {
         $processor->close();
     }
 
+    public function testFollowedRelativeSymlinkIndexesAnIntermediateLink(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        $real_target = $this->tempDir . '/real/target';
+        $alias = $this->tempDir . '/alias';
+        mkdir($docroot, 0755, true);
+        mkdir($real_target, 0755, true);
+        symlink($this->tempDir . '/real', $alias);
+        symlink('../alias/./target', $docroot . '/link');
+
+        $processor = FileIndexProcessor::start(
+            [ (string) realpath($docroot) ],
+            $docroot,
+            true,
+            true,
+            ''
+        );
+        $entries = [];
+        while ($processor->next_index_step()) {
+            foreach ($processor->get_index_entries() as $entry) {
+                $entries[] = $entry;
+            }
+        }
+        $processor->close();
+
+        $intermediate_entries = array_values(array_filter(
+            $entries,
+            static fn(array $entry): bool => ( $entry['intermediate'] ?? false ) === true
+        ));
+        $this->assertCount(1, $intermediate_entries);
+        $this->assertSame('link', $intermediate_entries[0]['type']);
+        $link_entries = array_values(array_filter(
+            $entries,
+            static fn(array $entry): bool => $entry['path'] === (string) realpath($docroot) . '/link'
+        ));
+        $this->assertCount(1, $link_entries);
+        $this->assertSame(
+            (string) realpath($real_target),
+            $link_entries[0]['target']
+        );
+    }
+
     public function testResumeWithACompletedCursorRemainsComplete(): void
     {
         $docroot = $this->tempDir . '/site';


### PR DESCRIPTION
File-index symlink traversal now uses the shared lexical normalizer instead of maintaining a second dot-segment parser. It still avoids realpath() before intermediate links have been recorded.

The integration test follows a relative symlink through an alias and asserts that the intermediate link remains indexed.

Tests: `cd tests && ../vendor/bin/phpunit FileIndexProcessorTest.php`.