### PR TITLE
[Push] Accept an existing empty directory when installing an empty directory

### DIFF
--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -1666,6 +1666,11 @@ final class Site_Export_Push_Session {
      * the document root already contains the committed value. Only same-filesystem
      * renames are allowed; copy fallback would break the direct-install model.
      *
+     * An existing empty directory at a directory destination is accepted:
+     * rename() replaces it atomically, so re-pushing after an interrupted
+     * commit already created the directory succeeds instead of reporting the
+     * commit's own leftover as drift. A non-empty directory still conflicts.
+     *
      * @param array $commit_state {
      *     Commit checkpoint, mutated in place.
      *
@@ -1693,10 +1698,13 @@ final class Site_Export_Push_Session {
         $parent_device = $this->require_docroot_ancestors($path, 'install', $expected_type);
         $docroot_value_path = $this->docroot_path($path);
         $docroot_identity = $this->lstat_path($docroot_value_path);
-        $expected_docroot_types = $expected_type === 'directory' ? ['absent'] : ['absent', 'file', 'symlink'];
+        $expected_docroot_types = $expected_type === 'directory' ? ['absent', 'directory'] : ['absent', 'file', 'symlink'];
         $observed_type = $docroot_identity === null ? 'absent' : $docroot_identity['type'];
         if (!in_array($observed_type, $expected_docroot_types, true)) {
             $this->throw_unexpected_docroot_mutation('install', $path, $path, $expected_type, $expected_docroot_types, $docroot_identity);
+        }
+        if ($expected_type === 'directory' && $observed_type === 'directory' && $this->first_directory_entry($docroot_value_path) !== null) {
+            $this->throw_unexpected_docroot_mutation('install', $path, $path, $expected_type, ['absent'], $docroot_identity);
         }
         if ($parent_device !== $work_identity['dev']) {
             $this->throw_same_device('install', $path, $work_identity['dev'], $parent_device);

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -382,6 +382,54 @@ final class PushCommitTest extends TestCase {
         }
     }
 
+    public function testExplicitEmptyDirectoryReplacesAnExistingEmptyDocumentRootDirectory(): void {
+        mkdir($this->docroot . '/empty', 0700);
+
+        $push_session = $this->push_session('05050505050505050505050505050505');
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'directory',
+                'X-Directory-Path' => base64_encode('empty'),
+            ],
+            'body' => '',
+        ]]);
+        $this->commit_all($push_session);
+
+        $this->assertDirectoryExists($this->docroot . '/empty');
+        $this->assertSame([], $this->directory_entries($this->docroot . '/empty'));
+        $this->assertFileDoesNotExist($this->docroot . '/.maintenance');
+    }
+
+    public function testExplicitEmptyDirectoryOverANonEmptyDocumentRootDirectoryRecordsANonRecoverableCommitFailure(): void {
+        mkdir($this->docroot . '/conflict', 0700);
+        file_put_contents($this->docroot . '/conflict/sentinel', 'safe');
+
+        $push_session = $this->push_session('06060606060606060606060606060606');
+        $this->push_parts($push_session, [[
+            'headers' => [
+                'X-Chunk-Type' => 'directory',
+                'X-Directory-Path' => base64_encode('conflict'),
+            ],
+            'body' => '',
+        ]]);
+
+        try {
+            $this->commit_all($push_session);
+            $this->fail('An explicit empty directory replaced a non-empty docroot directory.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
+            $this->assertSame(['absent'], $exception->get_context()['expected_docroot_types']);
+        }
+
+        $this->assertSame('safe', file_get_contents($this->docroot . '/conflict/sentinel'));
+        try {
+            $push_session->commit(1);
+            $this->fail('A non-recoverable commit failure allowed a forced retry.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
+        }
+    }
+
     public function testObservedSymlinkAncestorStopsCommitAndLeavesMaintenanceActive(): void {
         mkdir($this->docroot . '/outside', 0700, true);
         file_put_contents($this->docroot . '/outside/sentinel', 'safe');


### PR DESCRIPTION
## The bug

Commit demanded an **absent** destination when installing an explicit empty directory. Every other install is overwrite-tolerant (files and symlinks rename over existing files/symlinks, deletes skip already-absent paths), but this one check turned a replayed plan into a fatal error — and the state it trips over is usually the push's **own leftover**:

1. A commit is interrupted after creating directory `D` in the docroot.
2. The client re-pushes. The saved local index never advanced (it's only written after a successful commit), so the re-plan contains `D` again — and `D` is not in the delete list, because it wasn't in the saved index.
3. The install finds `D` present, throws `unexpected_docroot_mutation`, and persists it as a non-recoverable commit failure. The recovery run re-creates the exact failure it was recovering from.

## The fix

An existing **empty** directory at the destination is the idempotent outcome, not drift. Accept it — `rename()` already replaces an empty target directory atomically, so the install path doesn't change, only the precondition does. A **non-empty** directory still conflicts and still reports `expected_docroot_types: [\"absent\"]`, because it holds content the plan knows nothing about and silently merging into it would orphan someone else's files.

## Tests

- New: an explicit empty directory commits cleanly over an existing empty docroot directory (failed with `unexpected_docroot_mutation` before the fix, at the exact check this PR relaxes).
- New: a non-empty docroot directory at that path still records a non-recoverable failure, leaves the directory contents untouched, and refuses the forced retry.
- Full `PushCommitTest`, `PushEndpointsTest`, `PushSessionTest`, `FilesPushCommandTest`, `PushPlanTest`: green (172 tests). PHPCS violation counts unchanged vs base for both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)