### PR TITLE
[PHP] Classify custom content directories by path boundaries

### DIFF
--- a/packages/reprint-importer/src/lib/host/functions.php
+++ b/packages/reprint-importer/src/lib/host/functions.php
@@ -103,7 +103,11 @@ function extract_constants(array $preflight_data): array
     // WP_CONTENT_DIR: if wp-content lives outside ABSPATH on the source
     // (e.g. wpcloud has ABSPATH at /wordpress/core/X.Y.Z/ but wp-content
     // at /srv/htdocs/wp-content), we need to explicitly set it.
-    if ($content_dir !== '' && $abspath !== '' && strpos($content_dir, $abspath) !== 0) {
+    if (
+        $content_dir !== ''
+        && $abspath !== ''
+        && !\WordPress\Reprint\Exporter\path_is_within_root($content_dir, $abspath)
+    ) {
         $result['WP_CONTENT_DIR'] = '{fs-root}/wp-content';
     }
 

--- a/tests/Import/WpcloudHostAnalyzerTest.php
+++ b/tests/Import/WpcloudHostAnalyzerTest.php
@@ -178,6 +178,25 @@ class WpcloudHostAnalyzerTest extends TestCase
         $this->assertSame('{fs-root}/__wp__/', $manifest->server_vars['WP_DIR']);
     }
 
+    public function testExtractConstantsTreatsASiblingPrefixAsOutsideAbspath(): void
+    {
+        $constants = \extract_constants([
+            'database' => [
+                'wp' => [
+                    'paths_urls' => [
+                        'abspath' => '/srv/site',
+                        'content_dir' => '/srv/site-old/wp-content',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['WP_CONTENT_DIR' => '{fs-root}/wp-content'],
+            $constants
+        );
+    }
+
     public function testScoreIdentifiesWpcloudSite(): void
     {
         $preflight = $this->wpcloudPreflight();


### PR DESCRIPTION
Host configuration now treats a content directory with an ABSPATH sibling prefix as outside ABSPATH, rather than accepting a raw string prefix.

The focused test covers `/srv/site-old/wp-content` beside `/srv/site`.

Tests: `cd tests && ../vendor/bin/phpunit Import/WpcloudHostAnalyzerTest.php`.