### PR TITLE
[PHP] Match export directories against root lists

### DIFF
--- a/packages/reprint-exporter/src/class-file-index-processor.php
+++ b/packages/reprint-exporter/src/class-file-index-processor.php
@@ -807,7 +807,9 @@ final class FileIndexProcessor {
             if ($raw_target[0] !== "/") {
                 $raw_target = dirname($path) . "/" . $raw_target;
             }
-            $absolute_raw_target = self::normalize_dot_segments($raw_target);
+            // Resolve only textual dot segments. realpath() would skip the
+            // intermediate links that this walk must inspect.
+            $absolute_raw_target = \WordPress\Reprint\Exporter\normalize_path($raw_target);
             if (
                 $absolute_raw_target !== ""
                 && $absolute_raw_target[0] === "/"
@@ -872,39 +874,5 @@ final class FileIndexProcessor {
             }
         }
         return $entries;
-    }
-
-    /**
-     * Removes dot segments without following symlinks.
-     *
-     * realpath() cannot be used here because it would skip the intermediate
-     * symlinks that find_parent_symlinks() needs to inspect.
-     *
-     * @param string $path Absolute path containing optional dot segments.
-     * @return string Path with dot segments removed.
-     */
-    private static function normalize_dot_segments(string $path): string
-    {
-        $parts = explode("/", $path);
-        $normalized = [];
-
-        // Resolve only textual dot segments. Filesystem resolution here would
-        // skip the intermediate links this path is being prepared to inspect.
-        foreach ($parts as $part) {
-            if ($part === "" || $part === ".") {
-                if (empty($normalized)) {
-                    $normalized[] = "";
-                }
-                continue;
-            }
-            if ($part === "..") {
-                if (count($normalized) > 1) {
-                    array_pop($normalized);
-                }
-                continue;
-            }
-            $normalized[] = $part;
-        }
-        return implode("/", $normalized);
     }
 }

--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Push errors become authenticated API JSON, never HTML output.
 
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 
 if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
@@ -136,9 +137,9 @@ final class Site_Export_Push_Session {
         if ($reprint_directory === $this->docroot) {
             throw new InvalidArgumentException('The reprint directory must not be the document root itself.');
         }
-        $docroot_prefix = $this->docroot === '/' ? '/' : $this->docroot . '/';
-        if (strpos($reprint_directory . '/', $docroot_prefix) === 0) {
-            $relative_reprint_directory = ltrim(substr($reprint_directory, strlen($this->docroot)), '/');
+        $relative_reprint_directory = path_remainder_under($reprint_directory, $this->docroot);
+        if ($relative_reprint_directory !== null) {
+            $relative_reprint_directory = ltrim($relative_reprint_directory, '/');
             if ($relative_reprint_directory !== '') {
                 $excluded_paths[] = $relative_reprint_directory;
             }
@@ -2382,7 +2383,7 @@ final class Site_Export_Push_Session {
     private function assert_path_does_not_overlap_excluded_paths(string $path): void {
         $this->assert_path_is_not_excluded($path);
         foreach ($this->excluded_paths as $excluded_path) {
-            if (strpos($excluded_path, $path . '/') === 0) {
+            if (path_remainder_under($excluded_path, $path) !== null) {
                 throw new InvalidArgumentException(
                     'Excluded document-root-relative path ' . base64_encode($excluded_path)
                     . ' is contained by the requested path, which cannot be changed: '
@@ -2411,7 +2412,7 @@ final class Site_Export_Push_Session {
                     . base64_encode($path) . '.'
                 );
             }
-            if (strpos($path, $excluded_path . '/') === 0) {
+            if (path_remainder_under($path, $excluded_path) !== null) {
                 throw new InvalidArgumentException(
                     'Excluded document-root-relative path ' . base64_encode($excluded_path)
                     . ' contains the requested descendant, which cannot be changed: '
@@ -2566,22 +2567,15 @@ final class Site_Export_Push_Session {
      */
     private function ensure_private_parent(string $path, bool $create_missing = true): void {
         $parent = dirname($path);
-        $root = null;
-        foreach ([$this->work_files_directory] as $candidate) {
-            if ($parent === $candidate || strpos($parent . '/', $candidate . '/') === 0) {
-                $root = $candidate;
-                break;
-            }
-        }
-        if ($root === null) {
+        $relative = path_remainder_under($parent, $this->work_files_directory);
+        if ($relative === null) {
             throw new LogicException('Private work path escaped work/files.');
         }
-        if ($parent === $root) {
+        if ($relative === '') {
             return;
         }
-        $relative = substr($parent, strlen($root) + 1);
-        $current = $root;
-        foreach (explode('/', $relative) as $segment) {
+        $current = $this->work_files_directory;
+        foreach (explode('/', ltrim($relative, '/')) as $segment) {
             $current .= '/' . $segment;
             $identity = $this->lstat_path($current);
             if ($identity === null) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -9968,17 +9968,7 @@ class ImportClient
                 continue;
             }
             // Check if this path is already covered by an existing dir.
-            $covered = false;
-            foreach ($dirs as $root) {
-                if (
-                    $path === $root ||
-                    str_starts_with($path, $root . "/")
-                ) {
-                    $covered = true;
-                    break;
-                }
-            }
-            if (!$covered) {
+            if (!path_is_within_root($path, $dirs)) {
                 $dirs[] = $path;
                 $this->audit_log(
                     "DIRECTORY AUTO-DETECT | adding {$label} outside roots: " .

--- a/packages/reprint-importer/src/lib/host/functions.php
+++ b/packages/reprint-importer/src/lib/host/functions.php
@@ -103,7 +103,11 @@ function extract_constants(array $preflight_data): array
     // WP_CONTENT_DIR: if wp-content lives outside ABSPATH on the source
     // (e.g. wpcloud has ABSPATH at /wordpress/core/X.Y.Z/ but wp-content
     // at /srv/htdocs/wp-content), we need to explicitly set it.
-    if ($content_dir !== '' && $abspath !== '' && strpos($content_dir, $abspath) !== 0) {
+    if (
+        $content_dir !== ''
+        && $abspath !== ''
+        && !\WordPress\Reprint\Exporter\path_is_within_root($content_dir, $abspath)
+    ) {
         $result['WP_CONTENT_DIR'] = '{fs-root}/wp-content';
     }
 

--- a/packages/reprint-importer/src/lib/local-index-update-functions.php
+++ b/packages/reprint-importer/src/lib/local-index-update-functions.php
@@ -2,6 +2,8 @@
 
 namespace Reprint\Importer;
 
+use function WordPress\Reprint\Exporter\path_is_within_root;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exceptions contain CLI filesystem paths, never HTML output.
 
 /**
@@ -151,10 +153,10 @@ function merge_local_index_mutations(
 			 */
 			while (
 				$local_index_entries->valid()
-				&& strpos(
-					   $local_index_entries->current()['path'],
-					   $local_index_update_path . '/'
-				   ) === 0
+				&& path_is_within_root(
+					$local_index_entries->current()['path'],
+					$local_index_update_path
+				)
 			) {
 				$local_index_entries->next();
 			}

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -148,6 +148,48 @@ final class FileIndexProcessorTest extends TestCase {
         $processor->close();
     }
 
+    public function testFollowedRelativeSymlinkIndexesAnIntermediateLink(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        $real_target = $this->tempDir . '/real/target';
+        $alias = $this->tempDir . '/alias';
+        mkdir($docroot, 0755, true);
+        mkdir($real_target, 0755, true);
+        symlink($this->tempDir . '/real', $alias);
+        symlink('../alias/./target', $docroot . '/link');
+
+        $processor = FileIndexProcessor::start(
+            [ (string) realpath($docroot) ],
+            $docroot,
+            true,
+            true,
+            ''
+        );
+        $entries = [];
+        while ($processor->next_index_step()) {
+            foreach ($processor->get_index_entries() as $entry) {
+                $entries[] = $entry;
+            }
+        }
+        $processor->close();
+
+        $intermediate_entries = array_values(array_filter(
+            $entries,
+            static fn(array $entry): bool => ( $entry['intermediate'] ?? false ) === true
+        ));
+        $this->assertCount(1, $intermediate_entries);
+        $this->assertSame('link', $intermediate_entries[0]['type']);
+        $link_entries = array_values(array_filter(
+            $entries,
+            static fn(array $entry): bool => $entry['path'] === (string) realpath($docroot) . '/link'
+        ));
+        $this->assertCount(1, $link_entries);
+        $this->assertSame(
+            (string) realpath($real_target),
+            $link_entries[0]['target']
+        );
+    }
+
     public function testResumeWithACompletedCursorRemainsComplete(): void
     {
         $docroot = $this->tempDir . '/site';

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -199,6 +199,19 @@ class ExportDirectoryAutoDetectTest extends TestCase
         $this->assertSame(1, $count['/srv/htdocs'] ?? 0);
     }
 
+    public function testAddsExtraDirectoryBesideAConfiguredRoot(): void
+    {
+        $this->writeState([]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->setPrivate($client, 'extra_directory', '/srv/htdocs-old');
+
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertContains('/srv/htdocs-old', $dirs);
+    }
+
     public function testIgnoresEmptyAutoPrependFile(): void
     {
         $this->writeState([

--- a/tests/Import/WpcloudHostAnalyzerTest.php
+++ b/tests/Import/WpcloudHostAnalyzerTest.php
@@ -178,6 +178,25 @@ class WpcloudHostAnalyzerTest extends TestCase
         $this->assertSame('{fs-root}/__wp__/', $manifest->server_vars['WP_DIR']);
     }
 
+    public function testExtractConstantsTreatsASiblingPrefixAsOutsideAbspath(): void
+    {
+        $constants = \extract_constants([
+            'database' => [
+                'wp' => [
+                    'paths_urls' => [
+                        'abspath' => '/srv/site',
+                        'content_dir' => '/srv/site-old/wp-content',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['WP_CONTENT_DIR' => '{fs-root}/wp-content'],
+            $constants
+        );
+    }
+
     public function testScoreIdentifiesWpcloudSite(): void
     {
         $preflight = $this->wpcloudPreflight();

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -342,6 +342,9 @@ final class PushSessionTest extends TestCase {
             $this->assertStringContainsString('Excluded', $exception->getMessage());
         }
 
+        $this->push_file($push_session, 'private-workshop/allowed.php', 'safe');
+        $this->assertSame('complete', $push_session->get_status('private-workshop/allowed.php')['path']['state']);
+
         $root_session = Site_Export_Push_Session::create($this->reprint_directory, '/', [], str_repeat('b', 32));
         $reopened = Site_Export_Push_Session::open($this->reprint_directory, '/', $root_session->get_push_session_id(), []);
         $this->assertSame($root_session->get_push_directory(), $reopened->get_push_directory());


### PR DESCRIPTION
Export-directory detection now asks the shared containment helper whether an extra directory belongs to any configured root.

The focused test keeps a sibling-prefix extra directory separate from `/srv/htdocs`.

Tests: `cd tests && ../vendor/bin/phpunit Import/ExportDirectoryAutoDetectTest.php`.