### PR TITLE
[PHP] Match followed symlinks against visited root lists

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3327,14 +3327,7 @@ class ImportClient
             }
             // Skip if this directory is a subdirectory of an already-visited path,
             // since those files were already included in the parent's index.
-            $already_covered = false;
-            foreach ($visited as $v => $_) {
-                if (str_starts_with($dir, $v . "/")) {
-                    $already_covered = true;
-                    break;
-                }
-            }
-            if ($already_covered) {
+            if (path_is_within_root($dir, array_keys($visited))) {
                 $this->audit_log(
                     "FOLLOW SYMLINK SKIP | {$dir} already covered by a visited parent",
                     true,
@@ -3478,14 +3471,7 @@ class ImportClient
             }
 
             // Check containment: skip if already under a visited root
-            $contained = false;
-            foreach ($visited as $root => $_) {
-                if (str_starts_with($symlink_target, $root . "/")) {
-                    $contained = true;
-                    break;
-                }
-            }
-            if ($contained) {
+            if (path_is_within_root($symlink_target, array_keys($visited))) {
                 continue;
             }
 

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -76,6 +76,32 @@ class PullSymlinkTest extends TestCase
         $this->assertEquals('target', readlink($symlinkPath), 'Symlink target should match');
     }
 
+    public function testSymlinkTargetBesideVisitedRootRemainsQueued()
+    {
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
+        $indexPath = $this->tempDir . '/remote-index.jsonl';
+        file_put_contents($indexPath, implode("\n", [
+            json_encode([
+                'type' => 'link',
+                'target' => base64_encode('/srv/site/covered'),
+            ]),
+            json_encode([
+                'type' => 'link',
+                'target' => base64_encode('/srv/site-old/queued'),
+            ]),
+            '',
+        ]));
+
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('next_remote_index_file')->setValue($client, $indexPath);
+        $targets = $reflection->getMethod('extract_symlink_directories_from_next_remote_index')->invoke(
+            $client,
+            ['/srv/site' => true]
+        );
+
+        $this->assertSame(['/srv/site-old/queued'], $targets);
+    }
+
     /**
      * A relative symlink that escapes the filesystem root should be rejected.
      * Path /a/link with target ../../../escape resolves to


### PR DESCRIPTION
Followed-symlink discovery now uses the shared list-aware containment predicate for both queued targets and indexed symlink entries.

The focused test confirms that `/srv/site-old` remains distinct from the visited `/srv/site` root.

Tests: `cd tests && ../vendor/bin/phpunit Import/PullSymlinkTest.php`.