### PR TITLE
[PHP] Derive plugin exclusions from document-root paths

### DIFF
--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -301,6 +301,37 @@ function path_remainder_under(string $path, string $prefix): ?string
 }
 
 /**
+ * Returns a path relative to a slash-delimited root, or null when it is not
+ * equal to or below that root.
+ *
+ * Use this when a caller needs a path for a root-relative field. It performs
+ * the component-boundary test and removes the separating slash in one step,
+ * rather than letting a byte-offset slice treat `/srv/site-old` as below
+ * `/srv/site`.
+ *
+ * Examples:
+ *
+ *     relative_path_under('/srv/site/wp-content', '/srv/site'); // 'wp-content'
+ *     relative_path_under('/srv/site', '/srv/site');            // ''
+ *     relative_path_under('/srv/site-old', '/srv/site');        // null
+ *     relative_path_under('/wp-content', '/');                  // 'wp-content'
+ *
+ * Trailing slashes do not change the result. This is a lexical operation: it
+ * does not resolve dot segments or symlinks, and it also accepts relative
+ * slash-delimited paths.
+ *
+ * @param string $path Candidate path to make relative.
+ * @param string $root Root that must contain the candidate path.
+ * @return string|null A path without a leading slash, an empty string for an
+ *                     exact match, or null when the path is outside the root.
+ */
+function relative_path_under(string $path, string $root): ?string
+{
+    $remainder = path_remainder_under($path, $root);
+    return $remainder === null ? null : ltrim($remainder, "/");
+}
+
+/**
  * Validates that a path is a non-empty absolute string without NUL bytes
  * or dot-segments (. or ..).
  *

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -6,6 +6,8 @@
  * triggering any HTTP dispatch.
  */
 
+use function WordPress\Reprint\Exporter\relative_path_under;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -516,7 +518,6 @@ function _site_export_handle_api_request(array $options = []): void {
             }
             $canonical_plugin_directory = realpath(SITE_EXPORT_PLUGIN_DIR);
             $plugin_directory = rtrim($canonical_plugin_directory === false ? SITE_EXPORT_PLUGIN_DIR : $canonical_plugin_directory, '/\\');
-            $docroot_relative_offset = $docroot === '/' ? 1 : strlen($docroot) + 1;
             $logical_plugin_path_added = false;
             if (defined('WP_PLUGIN_DIR') && function_exists('plugin_basename')) {
                 // Keep the registered installation path lexical until its
@@ -531,10 +532,15 @@ function _site_export_handle_api_request(array $options = []): void {
                 $logical_plugin_directory_to_verify = $logical_plugin_directory;
                 $logical_plugin_relative_path = null;
                 if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $lexical_docroot)) {
-                    $lexical_docroot_relative_offset = $lexical_docroot === '/' ? 1 : strlen($lexical_docroot) + 1;
-                    $logical_plugin_relative_path = substr($logical_plugin_directory, $lexical_docroot_relative_offset);
+                    $logical_plugin_relative_path = relative_path_under(
+                        $logical_plugin_directory,
+                        $lexical_docroot
+                    );
                 } elseif (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $docroot)) {
-                    $logical_plugin_relative_path = substr($logical_plugin_directory, $docroot_relative_offset);
+                    $logical_plugin_relative_path = relative_path_under(
+                        $logical_plugin_directory,
+                        $docroot
+                    );
                 } else {
                     // WP_PLUGIN_DIR may itself be a symlink alias into the
                     // document root. Resolve that parent, but keep the
@@ -547,7 +553,10 @@ function _site_export_handle_api_request(array $options = []): void {
                             . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                         );
                         if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory_from_canonical_parent, $docroot)) {
-                            $logical_plugin_relative_path = substr($logical_plugin_directory_from_canonical_parent, $docroot_relative_offset);
+                            $logical_plugin_relative_path = relative_path_under(
+                                $logical_plugin_directory_from_canonical_parent,
+                                $docroot
+                            );
                             $logical_plugin_directory_to_verify = $logical_plugin_directory_from_canonical_parent;
                         }
                     }
@@ -571,12 +580,16 @@ function _site_export_handle_api_request(array $options = []): void {
                     $logical_plugin_path_added = true;
                 }
             }
+            $plugin_relative_path = relative_path_under(
+                $plugin_directory,
+                $docroot
+            );
             if (
                 !$logical_plugin_path_added
-                && \WordPress\Reprint\Exporter\path_is_within_root($plugin_directory, $docroot)
-                && $plugin_directory !== $docroot
+                && $plugin_relative_path !== null
+                && $plugin_relative_path !== ''
             ) {
-                $excluded_paths[] = str_replace('\\', '/', substr($plugin_directory, $docroot_relative_offset));
+                $excluded_paths[] = str_replace('\\', '/', $plugin_relative_path);
             }
             $push_options = [
                 'reprint_directory' => $reprint_directory,

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -5,6 +5,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 require_once __DIR__ . '/../../importer/import.php';
 
@@ -148,6 +149,26 @@ class RemapSeamTest extends TestCase
             'trailing slash on path' => array('', '/home/adam/', '/home/adam'),
             'trailing slash on both' => array('', '/home/adam/', '/home/adam/'),
             'under, prefix has trailing slash' => array('/c', '/a/b/c', '/a/b/'),
+        );
+    }
+
+    /**
+     * @dataProvider provideRelativePathCases
+     */
+    public function testRelativePathUnder(?string $expected, string $path, string $root): void
+    {
+        $this->assertSame($expected, relative_path_under($path, $root));
+    }
+
+    public static function provideRelativePathCases(): array
+    {
+        return array(
+            'filesystem root itself' => array('', '/', '/'),
+            'filesystem root child' => array('child', '/child', '/'),
+            'exact non-root match' => array('', '/a', '/a'),
+            'non-root descendant' => array('b', '/a/b', '/a'),
+            'sibling prefix' => array(null, '/ab', '/a'),
+            'trailing slashes' => array('b', '/a/b/', '/a/'),
         );
     }
 


### PR DESCRIPTION
Plugin exclusions now derive document-root-relative paths through shared helpers instead of slicing at fixed offsets. This preserves root and component-boundary semantics for lexical and canonical plugin locations.

`relative_path_under()` now documents exact matches, descendants, sibling prefixes, and filesystem-root paths with runnable examples. The plugin imports the function once for its repeated calls.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php`; `cd tests && ../vendor/bin/phpunit PushEndpointsTest.php --filter testSymlinkedPluginLogicalPathIsExcludedFromPush`; `vendor/bin/phpstan analyze --memory-limit=1G`.