### PR TITLE
[PHP] Match export directories against root lists

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -9968,17 +9968,7 @@ class ImportClient
                 continue;
             }
             // Check if this path is already covered by an existing dir.
-            $covered = false;
-            foreach ($dirs as $root) {
-                if (
-                    $path === $root ||
-                    str_starts_with($path, $root . "/")
-                ) {
-                    $covered = true;
-                    break;
-                }
-            }
-            if (!$covered) {
+            if (!path_is_within_root($path, $dirs)) {
                 $dirs[] = $path;
                 $this->audit_log(
                     "DIRECTORY AUTO-DETECT | adding {$label} outside roots: " .

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -199,6 +199,19 @@ class ExportDirectoryAutoDetectTest extends TestCase
         $this->assertSame(1, $count['/srv/htdocs'] ?? 0);
     }
 
+    public function testAddsExtraDirectoryBesideAConfiguredRoot(): void
+    {
+        $this->writeState([]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->setPrivate($client, 'extra_directory', '/srv/htdocs-old');
+
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertContains('/srv/htdocs-old', $dirs);
+    }
+
     public function testIgnoresEmptyAutoPrependFile(): void
     {
         $this->writeState([


### PR DESCRIPTION
Export-directory detection now asks the shared containment helper whether an extra directory belongs to any configured root.

The focused test keeps a sibling-prefix extra directory separate from `/srv/htdocs`.

Tests: `cd tests && ../vendor/bin/phpunit Import/ExportDirectoryAutoDetectTest.php`.