### PR TITLE
[Push] Traverse private work paths relative to their root

### DIFF
--- a/packages/reprint-exporter/src/class-push-session.php
+++ b/packages/reprint-exporter/src/class-push-session.php
@@ -4,6 +4,7 @@
 
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
 use function WordPress\Reprint\Exporter\path_remainder_under;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
@@ -2567,7 +2568,7 @@ final class Site_Export_Push_Session {
      */
     private function ensure_private_parent(string $path, bool $create_missing = true): void {
         $parent = dirname($path);
-        $relative = path_remainder_under($parent, $this->work_files_directory);
+        $relative = relative_path_under($parent, $this->work_files_directory);
         if ($relative === null) {
             throw new LogicException('Private work path escaped work/files.');
         }
@@ -2575,7 +2576,7 @@ final class Site_Export_Push_Session {
             return;
         }
         $current = $this->work_files_directory;
-        foreach (explode('/', ltrim($relative, '/')) as $segment) {
+        foreach (explode('/', $relative) as $segment) {
             $current .= '/' . $segment;
             $identity = $this->lstat_path($current);
             if ($identity === null) {


### PR DESCRIPTION
Private work-parent creation now receives a path without a leading slash from `relative_path_under()`, while retaining the existing escape rejection.

Tests: `cd tests && ../vendor/bin/phpunit PushSessionTest.php --filter testCompletedWorkSymlinkCannotBecomeAnotherWorkPathsParent`.