### PR TITLE
[PHP] Trace preserve-local symlink paths relative to filesystem roots

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -36,6 +36,7 @@ use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
+use function WordPress\Reprint\Exporter\relative_path_under;
 use function Reprint\Importer\merge_local_index_mutations;
 use function Reprint\Importer\write_local_index_update;
 
@@ -9330,8 +9331,8 @@ class ImportClient
     private function path_traverses_symlink(string $path): bool
     {
         $root = $this->filesystem_root;
-        $relative = ltrim(substr($path, strlen($root)), "/");
-        if ($relative === "") {
+        $relative = relative_path_under($path, $root);
+        if ($relative === null || $relative === "") {
             return false;
         }
 


### PR DESCRIPTION
Preserve-local symlink traversal now derives its component walk through `relative_path_under()`, so a filesystem-root path and an out-of-root path do not rely on a byte offset.

Tests: `cd tests && ../vendor/bin/phpunit Import/TypeSwapTest.php`.