### PR TITLE
[PHP] Canonicalize paths through existing ancestors

### DIFF
--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -184,6 +184,64 @@ function normalize_path(string $path): string
 }
 
 /**
+ * Canonicalizes an absolute path through the nearest ancestor realpath() can resolve.
+ *
+ * The final components need not exist. The function resolves a real ancestor,
+ * then appends the missing components without creating them. A broken symlink
+ * cannot be resolved safely, so its normalized lexical spelling is retained.
+ *
+ * Examples:
+ *
+ *     realpath_with_missing_tail('/srv/site');
+ *     // '/srv/site' when /srv/site exists
+ *
+ *     realpath_with_missing_tail('/srv/site/state/push');
+ *     // '/srv/site/state/push' when /srv/site exists but state/push do not
+ *
+ *     realpath_with_missing_tail('/links/site/state');
+ *     // '/srv/site/state' when /links/site is a symlink to /srv/site
+ *
+ * This does not create, remove, or otherwise modify filesystem entries.
+ *
+ * @throws InvalidArgumentException When $absolute_path is not absolute.
+ */
+function realpath_with_missing_tail(string $absolute_path): string
+{
+    if ($absolute_path === '' || $absolute_path[0] !== '/') {
+        throw new InvalidArgumentException('Path must be absolute: ' . $absolute_path);
+    }
+
+    $normalized_path = normalize_path($absolute_path);
+    $missing_components = [];
+    $existing_ancestor = $normalized_path;
+    $canonical_existing_ancestor = realpath($existing_ancestor);
+
+    while ($canonical_existing_ancestor === false) {
+        // Keep a broken symlink lexical: resolving past it would change what a
+        // future replacement of that link means.
+        if (is_link($existing_ancestor)) {
+            return $normalized_path;
+        }
+
+        $parent = dirname($existing_ancestor);
+        if ($parent === $existing_ancestor) {
+            return $normalized_path;
+        }
+        array_unshift($missing_components, basename($existing_ancestor));
+        $existing_ancestor = $parent;
+        $canonical_existing_ancestor = realpath($existing_ancestor);
+    }
+
+    if ($missing_components === []) {
+        return normalize_path($canonical_existing_ancestor);
+    }
+
+    return normalize_path(
+        $canonical_existing_ancestor . '/' . implode('/', $missing_components)
+    );
+}
+
+/**
  * Normalizes document-root-relative excluded paths.
  *
  * Rejects non-string, empty, absolute, NUL-containing, backslash-containing,

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -5,6 +5,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
+use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
 
 require_once __DIR__ . '/../../client/cli.php';
@@ -204,5 +205,41 @@ class RemapSeamTest extends TestCase
             ['/elsewhere', '/other'],
             ['/not-this-one', '/a']
         ));
+    }
+
+    public function testRealpathWithMissingTail(): void
+    {
+        $existing_directory = $this->tempDir . '/existing';
+        mkdir($existing_directory);
+        $canonical_existing_directory = realpath($existing_directory);
+        $this->assertIsString($canonical_existing_directory);
+
+        $this->assertSame(
+            $canonical_existing_directory,
+            realpath_with_missing_tail($existing_directory)
+        );
+        $this->assertSame(
+            $canonical_existing_directory . '/missing',
+            realpath_with_missing_tail($existing_directory . '/missing')
+        );
+        $this->assertSame(
+            $canonical_existing_directory . '/missing/child',
+            realpath_with_missing_tail($existing_directory . '/missing/child')
+        );
+        $this->assertSame('/', realpath_with_missing_tail('/'));
+
+        $symlink = $this->tempDir . '/existing-link';
+        symlink($existing_directory, $symlink);
+        $this->assertSame(
+            $canonical_existing_directory . '/missing-through-link',
+            realpath_with_missing_tail($symlink . '/missing-through-link')
+        );
+
+        $broken_symlink = $this->tempDir . '/broken-link';
+        symlink($this->tempDir . '/missing-target', $broken_symlink);
+        $this->assertSame(
+            $broken_symlink . '/child',
+            realpath_with_missing_tail($broken_symlink . '/child')
+        );
     }
 }


### PR DESCRIPTION
Canonicalizes a non-existent absolute path through its nearest resolvable ancestor, so callers retain the real location of a symlinked parent without creating the missing path.

The helper preserves a broken symlink lexically and covers existing paths, missing tails, the filesystem root, and symlinked ancestors.