### PR TITLE
[PHP] Derive root-relative paths through relative_path_under()

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -617,7 +617,7 @@ class ImportClient
     private function local_relative_path_from_local_absolute_path(
         string $local_absolute_path
     ): ?string {
-        $local_relative_path = path_remainder_under(
+        $local_relative_path = relative_path_under(
             $local_absolute_path,
             $this->filesystem_root
         );
@@ -627,7 +627,6 @@ class ImportClient
         ) {
             return null;
         }
-        $local_relative_path = ltrim($local_relative_path, "/");
         return FileIndexProcessor::path_is_default_skipped(
             $local_relative_path
         )

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPress\Reprint\Exporter\relative_path_under;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
@@ -1472,14 +1474,11 @@ final class PushFilesSender
         if ($local_relative_path === false) {
             throw new RuntimeException('Failed to decode a path in the local paths-to-push file.');
         }
-        $document_root_local_relative_path = $this->state['document_root_local_relative_path'];
-        if ($document_root_local_relative_path === '') {
-            $document_root_relative_path = $local_relative_path;
-        } else {
-            $document_root_relative_path = $local_relative_path === $document_root_local_relative_path
-                ? ''
-                : substr($local_relative_path, strlen($document_root_local_relative_path) + 1);
-        }
+        $document_root_relative_path = relative_path_under(
+            $local_relative_path,
+            $this->state['document_root_local_relative_path']
+        );
+        /** @var string $document_root_relative_path PushPlan includes only paths beneath the document root. */
         return [
             'local_relative_path' => $local_relative_path,
             'document_root_relative_path' => $document_root_relative_path,

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -4,7 +4,7 @@ use function Reprint\Importer\sort_index_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
-use function WordPress\Reprint\Exporter\path_remainder_under;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -571,14 +571,13 @@ class PushPlan
             );
         }
 
-        $local_relative_path = path_remainder_under(
+        $local_relative_path = relative_path_under(
             $file_index_processor_entry["path"],
             $this->filesystem_root
         );
         if ($local_relative_path === null) {
             throw new LogicException("File index path is outside the filesystem root.");
         }
-        $local_relative_path = ltrim($local_relative_path, "/");
         $fresh_local_index_entry = [
             "path" => base64_encode($local_relative_path),
             "ctime" => $file_index_processor_entry["ctime"],
@@ -1031,8 +1030,10 @@ class PushPlan
      */
     private function append_local_path_to_delete(string $path): void
     {
-        $document_root_relative_path =
-            $this->local_relative_path_to_document_root_relative_path($path);
+        $document_root_relative_path = relative_path_under(
+            $path,
+            $this->document_root_local_relative_path
+        );
         if ($document_root_relative_path === null) {
             return;
         }
@@ -1135,8 +1136,10 @@ class PushPlan
      */
     private function path_conflicts_with_excluded_paths(string $path): bool
     {
-        $document_root_relative_path =
-            $this->local_relative_path_to_document_root_relative_path($path);
+        $document_root_relative_path = relative_path_under(
+            $path,
+            $this->document_root_local_relative_path
+        );
         if ($document_root_relative_path === null) {
             return true;
         }
@@ -1149,28 +1152,6 @@ class PushPlan
             }
         }
         return false;
-    }
-
-    /**
-     * Returns the document-root-relative path, or null when the local
-     * relative path is outside the document root.
-     */
-    private function local_relative_path_to_document_root_relative_path(
-        string $local_relative_path
-    ): ?string {
-        if ($this->document_root_local_relative_path === "") {
-            return $local_relative_path;
-        }
-        $path_remainder = path_remainder_under(
-            $local_relative_path,
-            $this->document_root_local_relative_path
-        );
-        if ($path_remainder === null) {
-            return null;
-        }
-        return $path_remainder === ""
-            ? ""
-            : substr($path_remainder, 1);
     }
 
     /**

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -530,18 +530,17 @@ function _site_export_handle_api_request(array $options = []): void {
                     . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                 );
                 $logical_plugin_directory_to_verify = $logical_plugin_directory;
-                $logical_plugin_relative_path = null;
-                if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $lexical_docroot)) {
-                    $logical_plugin_relative_path = relative_path_under(
-                        $logical_plugin_directory,
-                        $lexical_docroot
-                    );
-                } elseif (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory, $docroot)) {
+                $logical_plugin_relative_path = relative_path_under(
+                    $logical_plugin_directory,
+                    $lexical_docroot
+                );
+                if ($logical_plugin_relative_path === null) {
                     $logical_plugin_relative_path = relative_path_under(
                         $logical_plugin_directory,
                         $docroot
                     );
-                } else {
+                }
+                if ($logical_plugin_relative_path === null) {
                     // WP_PLUGIN_DIR may itself be a symlink alias into the
                     // document root. Resolve that parent, but keep the
                     // registered plugin subdirectory lexical so its installed
@@ -552,11 +551,11 @@ function _site_export_handle_api_request(array $options = []): void {
                             str_replace('\\', '/', $canonical_wordpress_plugin_directory)
                             . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                         );
-                        if (\WordPress\Reprint\Exporter\path_is_within_root($logical_plugin_directory_from_canonical_parent, $docroot)) {
-                            $logical_plugin_relative_path = relative_path_under(
-                                $logical_plugin_directory_from_canonical_parent,
-                                $docroot
-                            );
+                        $logical_plugin_relative_path = relative_path_under(
+                            $logical_plugin_directory_from_canonical_parent,
+                            $docroot
+                        );
+                        if ($logical_plugin_relative_path !== null) {
                             $logical_plugin_directory_to_verify = $logical_plugin_directory_from_canonical_parent;
                         }
                     }

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 require_once dirname(__DIR__) . '/packages/reprint-server/src/class-file-index-processor.php';
 
@@ -303,11 +304,12 @@ final class FileIndexProcessorTest extends TestCase {
      */
     private function relativePaths(array $entries, string $docroot): array
     {
-        $prefix = rtrim( (string) realpath($docroot), '/') . '/';
+        $root = (string) realpath($docroot);
         $paths = [];
         foreach ($entries as $entry) {
-            if (strpos($entry['path'], $prefix) === 0) {
-                $paths[] = substr($entry['path'], strlen($prefix));
+            $relativePath = relative_path_under($entry['path'], $root);
+            if ($relativePath !== null && $relativePath !== '') {
+                $paths[] = $relativePath;
             }
         }
         return $paths;

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 /**
  * Coverage for the default deny-list applied by endpoint_file_index().
@@ -460,12 +461,11 @@ final class FileIndexSkipDefaultsTest extends TestCase
         // endpoint_file_index() reports canonical paths. macOS exposes /tmp
         // and /var through /private symlinks, so compare against the same form.
         $siteRoot = realpath($siteDir) ?: $siteDir;
-        $prefix = rtrim($siteRoot, '/') . '/';
         $out = [];
         foreach ($entries as $e) {
-            $p = $e['path'];
-            if (strpos($p, $prefix) === 0) {
-                $out[substr($p, strlen($prefix))] = $e;
+            $relativePath = relative_path_under($e['path'], $siteRoot);
+            if ($relativePath !== null && $relativePath !== '') {
+                $out[$relativePath] = $e;
             }
         }
         ksort($out);


### PR DESCRIPTION
`relative_path_under()` now handles root-relative path derivation throughout push planning, push sending, pull-index WAL updates, plugin exclusions, and file-index test helpers.

The callers no longer maintain separate containment checks, leading-slash cleanup, or byte-offset slices. PR #503 defines the empty relative-root behavior this cleanup relies on.

Tests: `cd tests && ../vendor/bin/phpunit`; `composer analyze -- --memory-limit=1G`; PHP 7.2/7.4 compatibility checks for the changed production files.
