### PR TITLE
[PHP] Match followed symlink targets by path boundaries

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8611,10 +8611,7 @@ class ImportClient
     private function next_remote_index_contains_remote_absolute_path_prefix(
         string $remote_absolute_path
     ): bool {
-        $remote_absolute_path = rtrim(normalize_path($remote_absolute_path), "/");
-        if ($remote_absolute_path === "") {
-            return false;
-        }
+        $remote_absolute_path = normalize_path($remote_absolute_path);
 
         if (isset($this->next_remote_index_prefix_cache[$remote_absolute_path])) {
             return $this->next_remote_index_prefix_cache[$remote_absolute_path];
@@ -8631,7 +8628,6 @@ class ImportClient
             return false;
         }
 
-        $remote_absolute_path_prefix = $remote_absolute_path . "/";
         $path_prefix_found = false;
         while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
             try {
@@ -8643,13 +8639,7 @@ class ImportClient
                 continue;
             }
             $next_remote_index_entry_path = $next_remote_index_entry["path"];
-            if (
-                $next_remote_index_entry_path === $remote_absolute_path ||
-                str_starts_with(
-                    $next_remote_index_entry_path,
-                    $remote_absolute_path_prefix
-                )
-            ) {
+            if (path_is_within_root($next_remote_index_entry_path, $remote_absolute_path)) {
                 $path_prefix_found = true;
                 break;
             }

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -247,4 +247,36 @@ class RemapSeamTest extends TestCase
             realpath_with_missing_tail($broken_symlink . '/child')
         );
     }
+
+    public function testNextRemoteIndexMatchesFilesystemRootAndPathBoundaries(): void
+    {
+        $client = $this->clientWithRules(array());
+        $next_remote_index_file = $this->tempDir . '/remote-index.next.jsonl';
+        file_put_contents(
+            $next_remote_index_file,
+            json_encode([
+                'path' => base64_encode('/srv/site/child.txt'),
+                'ctime' => 0,
+                'size' => 1,
+                'type' => 'file',
+            ]) . "\n"
+        );
+        $this->set($client, 'next_remote_index_file', $next_remote_index_file);
+
+        $this->assertTrue($this->call(
+            $client,
+            'next_remote_index_contains_remote_absolute_path_prefix',
+            array('/')
+        ));
+        $this->assertTrue($this->call(
+            $client,
+            'next_remote_index_contains_remote_absolute_path_prefix',
+            array('/srv/site')
+        ));
+        $this->assertFalse($this->call(
+            $client,
+            'next_remote_index_contains_remote_absolute_path_prefix',
+            array('/srv/site-old')
+        ));
+    }
 }


### PR DESCRIPTION
Followed-symlink target lookup now uses the shared containment predicate. A target of `/` matches indexed absolute paths, while sibling prefixes remain outside the target subtree.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php`.