### PR TITLE
[Push] Select files-push progress output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,8 @@ During the file fetch phase, progress and heartbeat records include `files_done`
 
 During files-push, progress records include `files_done` and `files_total` together after planning. The completed count advances only at target-confirmed request boundaries and survives resume.
 
+Interactive non-verbose files-push output uses one stage-weighted progress bar for the complete lifecycle. The percentage precedes a label which changes only at major lifecycle stages; while pushing local paths, target-confirmed file bytes appear beside the planned file byte total. These terminal-only details are not added to JSONL or `progress.json`.
+
 ## File Organization
 
 - packages/reprint-server/: Packagist server package (previously reprint-exporter)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ During files-push, progress records include `files_done` and `files_total` toget
 
 Interactive non-verbose files-push output uses one stage-weighted progress bar for the complete lifecycle. The percentage precedes a label which changes only at major lifecycle stages; while pushing local paths, target-confirmed file bytes appear beside the planned file byte total. These terminal-only details are not added to JSONL or `progress.json`.
 
+`files-push --progress=auto|tty|jsonl` selects that invocation's progress presentation. `auto` uses terminal output on a TTY and JSONL otherwise; `tty` and `jsonl` force either presentation without changing sender state. Explicit `tty` and `jsonl` modes cannot be combined with `--verbose`.
+
 ## File Organization
 
 - packages/reprint-server/: Packagist server package (previously reprint-exporter)

--- a/README.md
+++ b/README.md
@@ -613,8 +613,15 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
-During `files-push`, terminal output refreshes as the command changes phase and
-shows `Uploading — N / T files` while local paths are sent. Non-interactive
+During `files-push`, interactive non-verbose terminal output uses one
+stage-weighted progress bar. The percentage comes first, followed by a major
+stage such as `Indexing`, `Pushing`, or `Committing`. While pushing local paths,
+the line also shows target-confirmed file bytes against the file byte total
+collected by the plan. Durable index byte offsets, target-confirmed counts and
+byte offsets, and phase milestones advance the bar. The percentage describes
+lifecycle progress, not elapsed time or an estimated completion time.
+
+These terminal-only details do not change machine output. Non-interactive
 output emits `push_progress` JSONL records. After planning completes, those
 records, the final result, and `progress.json` include `files_done` and
 `files_total` together. `files_total` is the number of local paths selected by

--- a/README.md
+++ b/README.md
@@ -613,16 +613,29 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
-During `files-push`, interactive non-verbose terminal output uses one
-stage-weighted progress bar. The percentage comes first, followed by a major
-stage such as `Indexing`, `Pushing`, or `Committing`. While pushing local paths,
-the line also shows target-confirmed file bytes against the file byte total
-collected by the plan. Durable index byte offsets, target-confirmed counts and
-byte offsets, and phase milestones advance the bar. The percentage describes
-lifecycle progress, not elapsed time or an estimated completion time.
+`files-push` accepts `--progress=auto|tty|jsonl`. The default `auto` mode uses
+terminal progress when its output stream is a TTY and JSONL otherwise. Use
+`--progress=tty` to force the single progress bar when output is captured, or
+`--progress=jsonl` to force structured output in a terminal:
 
-These terminal-only details do not change machine output. Non-interactive
-output emits `push_progress` JSONL records. After planning completes, those
+```bash
+php reprint.phar files-push "$URL" --state-dir="$STATE_DIR" \
+    --fs-root="$FS_ROOT" --secret="$SECRET" --progress=jsonl
+```
+
+The selected mode applies only to that invocation and is not retained in push
+state. Explicit `tty` and `jsonl` modes cannot be combined with `--verbose`.
+
+The terminal presentation uses one stage-weighted progress bar. The percentage
+comes first, followed by a major stage such as `Indexing`, `Pushing`, or
+`Committing`. While pushing local paths, the line also shows target-confirmed
+file bytes against the file byte total collected by the plan. Durable index
+byte offsets, target-confirmed counts and byte offsets, and phase milestones
+advance the bar. The percentage describes lifecycle progress, not elapsed time
+or an estimated completion time.
+
+These terminal-only details do not change machine output. The JSONL
+presentation emits `push_progress` records. After planning completes, those
 records, the final result, and `progress.json` include `files_done` and
 `files_total` together. `files_total` is the number of local paths selected by
 the plan; `files_done` advances only after the target confirms the request

--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -368,10 +368,12 @@ begins until both indexes have been consumed and the two path lists are stable.
 `sender.json` contains no copied receiver cursor. It stores the current push
 session, an optional blocking push session, the phase, the document root's local
 relative path, the PushPlan cursor, the next byte offset in
-`local_paths_to_push.jsonl`, the receiver part limit, and learned request-body
-sizing state. Its phases are `creating`, `finishing_previous_commit`,
-`starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
-`saving_local_index`, `completing`, `removing`, and `discarding_plan`.
+`local_paths_to_push.jsonl`, the selected local-path count and file byte total,
+the target-confirmed local-path count and completed file bytes, the receiver
+part limit, and learned request-body sizing state. Its phases are `creating`,
+`finishing_previous_commit`, `starting_plan`, `planning`, `pushing_paths`,
+`pushing_deletes`, `committing`, `saving_local_index`, `completing`, `removing`,
+and `discarding_plan`.
 The separate previous-commit, start, local-index-save, completion, removal,
 and discard phases ensure that a process stop between durable actions repeats
 only the current action.
@@ -389,7 +391,9 @@ upload retains the receiver-confirmed position for later steps in the same
 lifecycle. A partial file resumes only while it still matches the plan. A lost
 upload response leaves the earlier local path-list boundary in place; the next
 process checks the receiver and either advances past complete work or safely
-replays it.
+replays it. The sender persists completed file sizes with that path-list
+boundary. It keeps a partial file's receiver-confirmed byte offset only in
+memory and reads it from `push_status` again after resume.
 
 After all local paths are pushed, a newly opened sender reads
 `work_deletes_bytes` and `work_deletes_complete` from `push_status`. Successful
@@ -485,9 +489,25 @@ The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
 state-directory-wide audit log records opening mode, phase changes, planned pauses, handled
-interruptions, and terminal outcomes. Terminal output names the active phase
-and shows `Uploading — N / T files` while local paths are sent.
-Non-interactive output emits throttled `push_progress` JSONL records.
+interruptions, and terminal outcomes. Interactive non-verbose output uses one
+stage-weighted progress bar. The percentage precedes a label which changes only
+at the major `Preparing`, `Indexing`, `Pushing`, `Pushing deletions`,
+`Committing`, `Saving index`, and `Finishing` stages. The index diff advances
+from durable byte offsets across both indexes, local-path upload advances from
+target-confirmed path counts, and deleted-path upload advances from the
+target-confirmed deletion-list byte offset. While local paths are pushed, the
+line also shows the sum of target-confirmed file bytes against the file byte
+total accumulated by the single-pass plan. Indexing and commit have no bounded
+total, so they advance only at phase milestones. The percentage is lifecycle
+progress, not a time estimate.
+
+PushPlan reports its internal phase and durable index byte counts.
+PushFilesSender combines those with target-confirmed upload counts in one
+progress snapshot. The CLI alone maps that snapshot onto stage weights and
+terminal labels.
+
+The overall bar is terminal-only. Non-interactive output emits the same
+throttled `push_progress` JSONL records as before.
 After planning, those records, the final result, and the flat progress file
 include `files_done` and `files_total` together. The total comes from the
 completed plan; the completed count advances only when the target confirms the

--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -470,6 +470,11 @@ participate in the directory name. Fragments, URL user-info, and `SECRET_KEY`
 target parameters are rejected. The local push state directory must be outside
 the filesystem root so planning cannot index its own changing files.
 
+`--progress=auto|tty|jsonl` selects progress output for one invocation. The
+default `auto` mode uses terminal progress when its output stream is a TTY and
+JSONL otherwise. `tty` and `jsonl` force the corresponding presentation; they
+are not stored in sender state and cannot be combined with `--verbose`.
+
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80
 percent of PHP's finite `max_execution_time`; zero is unlimited. With a finite
@@ -489,7 +494,7 @@ The stable CLI mapping is `complete`/0, `partial`/2, `interrupted`/2,
 `restart`/2, `failed`/1, and `error`/1. Exit 2 asks the operator to run the
 same command again. After `restart`, that next run builds a fresh plan. The
 state-directory-wide audit log records opening mode, phase changes, planned pauses, handled
-interruptions, and terminal outcomes. Interactive non-verbose output uses one
+interruptions, and terminal outcomes. The terminal presentation uses one
 stage-weighted progress bar. The percentage precedes a label which changes only
 at the major `Preparing`, `Indexing`, `Pushing`, `Pushing deletions`,
 `Committing`, `Saving index`, and `Finishing` stages. The index diff advances
@@ -506,8 +511,8 @@ PushFilesSender combines those with target-confirmed upload counts in one
 progress snapshot. The CLI alone maps that snapshot onto stage weights and
 terminal labels.
 
-The overall bar is terminal-only. Non-interactive output emits the same
-throttled `push_progress` JSONL records as before.
+The overall bar is terminal-only. The JSONL presentation emits the same
+throttled `push_progress` records as before.
 After planning, those records, the final result, and the flat progress file
 include `files_done` and `files_total` together. The total comes from the
 completed plan; the completed count advances only when the target confirms the

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -281,6 +281,14 @@ Use these names verbatim:
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Selected local-path count | `local_paths_to_push_count`, `$local_paths_to_push_count`, `get_local_paths_to_push_count()` |
 | Target-confirmed local-path count | `local_paths_pushed`, `$local_paths_pushed` |
+| Selected local file bytes | `local_file_bytes_to_push`, `$local_file_bytes_to_push`, `get_local_file_bytes_to_push()` |
+| Target-confirmed completed local file bytes | `local_file_bytes_pushed`, `$local_file_bytes_pushed` |
+| Consumed index bytes in progress | `index_bytes_done`, `$index_bytes_done` |
+| Combined index bytes in progress | `index_bytes_total`, `$index_bytes_total` |
+| Target-confirmed file bytes in progress | `file_bytes_done`, `$file_bytes_done` |
+| Selected file bytes in progress | `file_bytes_total`, `$file_bytes_total` |
+| Target-confirmed deletion-list bytes in progress | `deleted_paths_bytes_done`, `$deleted_paths_bytes_done` |
+| Deletion-list bytes in progress | `deleted_paths_bytes_total`, `$deleted_paths_bytes_total` |
 | Local path type, size, and ctime | `local_path_type_size_and_ctime`, `$local_path_type_size_and_ctime`, `stat_local_path()` |
 
 `sender.json` and `excluded_paths.json` live directly under the local push
@@ -308,17 +316,17 @@ links to the preceding active directory. The exclusions have a maximum of 100
 paths. The `sender.json` phases are `creating`, `finishing_previous_commit`,
 `starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`, `removing`, and `discarding_plan`. It stores
-both the current and blocking push session IDs, selected
-path-list cursor, selected local-path count, target-confirmed local-path count,
-receiver part limit, and request-sizing state. The index diff cursor retains
-the selected local-path count as it builds the path list, and its complete
-cursor retains the final count. The index diff completes before local paths
-are sent. The index copy after a target-confirmed commit
-has no separate copy cursor and is repeated after interruption. After the index
-is saved or the remote confirms removal, the sender clears the PushPlan
-cursor, then removes the entire plan directory and its exclusions file. It
-does not ask PushPlan to manage terminal cleanup; PushPlan only closes its open
-handles.
+both the current and blocking push session IDs, selected path-list cursor,
+selected local-path count and file byte total, target-confirmed local-path
+count and completed file bytes, receiver part limit, and request-sizing state.
+The index diff cursor retains the selected local-path count and file byte total
+as it builds the path list, and its complete cursor retains both final totals.
+The index diff completes before local paths are sent. The index copy after a
+target-confirmed commit has no separate copy cursor and is repeated after
+interruption. After the index is saved or the remote confirms removal, the
+sender clears the PushPlan cursor, then removes the entire plan directory and
+its exclusions file. It does not ask PushPlan to manage terminal cleanup;
+PushPlan only closes its open handles.
 
 A request failure ends the current sender run. The active state remains in
 place so a later push command can resume from the last durable boundary. Only
@@ -401,11 +409,26 @@ positions remain receiver-owned; they are not a files-push cursor and are not
 copied into `<remote-state-directory>/pull/state.json` or the state-directory-wide
 `progress.json`.
 
-Terminal output names the active phase and uses `Uploading — N / T files`
-while local paths are sent. Non-interactive output emits `push_progress` JSONL
-records. `files_done` and `files_total` appear together after planning in those
-records, the final result, and `progress.json`; they are absent while the plan
-is still being built. `files_total` is the selected local-path count.
+Interactive non-verbose output uses one stage-weighted progress bar. The
+percentage precedes a label which changes only between `Preparing`, `Indexing`,
+`Pushing`, `Pushing deletions`, `Committing`, `Saving index`, and `Finishing`.
+Durable index byte offsets and target-confirmed upload boundaries advance the
+bounded parts of the bar; indexing and commit advance at phase milestones
+because neither has a bounded total. During `Pushing`, the line shows
+target-confirmed file bytes against the selected local file byte total when
+that total is nonzero. The percentage describes lifecycle progress, not time
+remaining. The overall bar is terminal-only.
+
+`PushPlan::get_progress()` reports its internal phase and durable index byte
+counts. `PushFilesSender::get_progress()` folds those counts into one sender
+snapshot alongside target-confirmed path, file-byte, and deletion-list-byte
+counts. The CLI maps that snapshot onto labels and stage weights. PushPlan and
+PushFilesSender do not calculate terminal percentages or choose output format.
+
+Non-interactive output emits `push_progress` JSONL records. `files_done` and
+`files_total` appear together after planning in those records, the final
+result, and `progress.json`; they are absent while the plan is still being
+built. `files_total` is the selected local-path count.
 `files_done` is the target-confirmed local-path count, so an open, failed, or
 canceled request does not advance it. Both counts survive resume.
 
@@ -459,6 +482,7 @@ Use these names verbatim inside `PushFilesSender`:
 | Open directory handle | `$directory_handle` |
 | Open local paths-to-push handle | `$local_paths_to_push_handle` |
 | Open local paths-to-delete handle | `$local_paths_to_delete_handle` |
+| Local paths-to-delete byte total | `$local_paths_to_delete_bytes` |
 | Open local file handle | `$local_file_handle` |
 | Local path stat result | `$path_stat` |
 | File type bits | `$file_type_bits` |
@@ -485,7 +509,9 @@ Use these names verbatim inside `PushPlan`:
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |
 | Byte offset in the fresh local index during diff | `$byte_offset_in_fresh_local_index` |
 | Open fresh local index | `$fresh_local_index_handle` |
+| Combined index bytes | `$index_bytes_total` |
 | Index diff cursor | `IndexDiffCursor` |
+| Plan progress | `get_progress()` |
 | Start index diff | `start_index_diff()` |
 | Seek an index file | `seek_index_file_to_byte_offset()`, `$index_file_handle` |
 | Open push-plan output file | `open_push_plan_output_file_at_byte_offset()`, `$push_plan_output_file_handle` |

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -393,6 +393,13 @@ root as a path beneath that filesystem root. Local relative paths beneath the do
 become push or delete work. It also requires `--secret=TOKEN`; `--force-http`
 is the explicit plain-HTTP opt-in.
 
+The **progress output mode** is the invocation-only `--progress` value for
+`files-push`: `auto`, `tty`, or `jsonl`. `auto` selects the terminal
+presentation when the current progress stream is a TTY and the JSONL
+presentation otherwise. `tty` and `jsonl` force those presentations. Never
+store the progress output mode in sender state. Explicit `tty` and `jsonl`
+modes do not combine with `--verbose`.
+
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash
 directory name is:
@@ -409,8 +416,8 @@ positions remain receiver-owned; they are not a files-push cursor and are not
 copied into `<remote-state-directory>/pull/state.json` or the state-directory-wide
 `progress.json`.
 
-Interactive non-verbose output uses one stage-weighted progress bar. The
-percentage precedes a label which changes only between `Preparing`, `Indexing`,
+The terminal presentation uses one stage-weighted progress bar. The percentage
+precedes a label which changes only between `Preparing`, `Indexing`,
 `Pushing`, `Pushing deletions`, `Committing`, `Saving index`, and `Finishing`.
 Durable index byte offsets and target-confirmed upload boundaries advance the
 bounded parts of the bar; indexing and commit advance at phase milestones
@@ -425,7 +432,7 @@ snapshot alongside target-confirmed path, file-byte, and deletion-list-byte
 counts. The CLI maps that snapshot onto labels and stage weights. PushPlan and
 PushFilesSender do not calculate terminal percentages or choose output format.
 
-Non-interactive output emits `push_progress` JSONL records. `files_done` and
+The JSONL presentation emits `push_progress` records. `files_done` and
 `files_total` appear together after planning in those records, the final
 result, and `progress.json`; they are absent while the plan is still being
 built. `files_total` is the selected local-path count.

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -136,6 +136,9 @@ register_shutdown_function(function () {
 class ImportClient
 {
 
+    /** Progress output modes accepted by files-diff and files-push. */
+    public const PROGRESS_OUTPUT_MODES = ['auto', 'tty', 'jsonl'];
+
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
@@ -205,11 +208,11 @@ class ImportClient
     /** @var bool When true, emit detailed operation logs to stdout. Set via --verbose. */
     private $verbose_mode = false;
 
-    /**
-     * @var bool Whether the progress stream is a TTY, enabling interactive
-     *           progress and terminal colors.
-     */
+    /** @var bool Whether the current progress stream is a TTY. */
     private $is_tty;
+
+    /** @var string Progress output mode for this invocation: auto, tty, or jsonl. */
+    private $progress_output_mode = 'auto';
 
     /** @var int Running count of files pulled in the current invocation. */
     private $files_pulled = 0;
@@ -919,6 +922,7 @@ class ImportClient
      *   - command: Required. One of the entries in $valid_commands below.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
+     *   - progress: Optional files-diff or files-push progress output mode: auto, tty, or jsonl
      * @param ReprintProcessLock|null $process_lock Optional lock already held
      *                                               for this state directory.
      */
@@ -935,6 +939,10 @@ class ImportClient
         }
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->progress->set_verbose_mode($this->verbose_mode);
+        if ($this->progress_output_mode !== 'auto') {
+            $this->progress_output_mode = 'auto';
+            $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
+        }
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         $this->include_caches = $options["include_caches"] ?? false;
         $this->extra_directory = $options["extra_directory"] ?? null;
@@ -1009,6 +1017,29 @@ class ImportClient
             return;
         }
         if ($command === "files-push") {
+            $progress_output_mode = $options['progress'] ?? 'auto';
+            if (
+                !is_string($progress_output_mode)
+                || !in_array($progress_output_mode, self::PROGRESS_OUTPUT_MODES, true)
+            ) {
+                $invalid_progress_output_mode = is_string($progress_output_mode)
+                    ? $progress_output_mode
+                    : gettype($progress_output_mode);
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option errors are not HTML.
+                throw new InvalidArgumentException(
+                    "Invalid --progress value: {$invalid_progress_output_mode}. Valid values: "
+                    . implode(', ', self::PROGRESS_OUTPUT_MODES)
+                );
+            }
+            if ($this->verbose_mode && $progress_output_mode !== 'auto') {
+                throw new InvalidArgumentException(
+                    "files-push does not accept --verbose with --progress={$progress_output_mode}. "
+                    . 'Use --progress=auto with --verbose.'
+                );
+            }
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            $this->progress_output_mode = $progress_output_mode;
+            $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
             if (is_file($this->pull_index_wal_path)) {
                 throw new RuntimeException(
                     "Finish or abort the interrupted files-pull before running files-push."
@@ -1143,7 +1174,7 @@ class ImportClient
             $this->progress_fd = STDERR;
             $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
             $this->progress->set_progress_fd($this->progress_fd);
-            $this->progress->set_is_tty($this->is_tty);
+            $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
         }
 
         // MySQL connection parameters for --sql-output=mysql.
@@ -1375,13 +1406,20 @@ class ImportClient
     private function run_files_diff(array $options): void
     {
         $progress_mode = $options['progress'] ?? ( $this->is_tty ? 'tty' : 'jsonl' );
+        if (
+            !is_string($progress_mode)
+            || !in_array($progress_mode, self::PROGRESS_OUTPUT_MODES, true)
+        ) {
+            $invalid_progress_mode = is_string($progress_mode)
+                ? $progress_mode
+                : gettype($progress_mode);
+            throw new InvalidArgumentException(
+                'Invalid files-diff progress mode: ' . $invalid_progress_mode . '. Valid modes: '
+                . implode(', ', self::PROGRESS_OUTPUT_MODES) . '.'
+            );
+        }
         if ($progress_mode === 'auto') {
             $progress_mode = $this->is_tty ? 'tty' : 'jsonl';
-        }
-        if (!in_array($progress_mode, ['tty', 'jsonl'], true)) {
-            throw new InvalidArgumentException(
-                'Invalid files-diff progress mode: ' . $progress_mode . '. Valid modes: auto, tty, jsonl.'
-            );
         }
         $push_state_directory = $options['files_diff_push_state_directory'] ?? self::resolve_push_state_directory(
             $this->remote_reprint_api_url,
@@ -1646,6 +1684,7 @@ class ImportClient
      *
      *     @type string $secret             HMAC shared secret.
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
+     *     @type string $progress           Progress output mode: auto, tty, or jsonl.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
      * @param ReprintProcessLock $process_lock Lock held for the command's state directory.
@@ -1866,7 +1905,7 @@ class ImportClient
         $this->write_files_push_progress_file($progress_payload);
 
         // Emit the final JSON line after any preceding progress records.
-        if ($this->is_tty && !$this->verbose_mode) {
+        if ($this->uses_terminal_progress() && !$this->verbose_mode) {
             $this->progress->clear_progress_line();
             $this->progress->show_lifecycle_line($result['message'] . "\n");
             return;
@@ -1877,6 +1916,13 @@ class ImportClient
         }
         @fwrite($this->progress_fd, $result_json . "\n");
         @flush();
+    }
+
+    /** Returns whether progress uses the interactive terminal presentation. */
+    private function uses_terminal_progress(): bool
+    {
+        return $this->progress_output_mode === 'tty'
+            || ( $this->progress_output_mode === 'auto' && $this->is_tty );
     }
 
     /**
@@ -1903,7 +1949,7 @@ class ImportClient
         array $sender_progress,
         bool $force_output
     ): void {
-        if ($this->is_tty && !$this->verbose_mode) {
+        if ($this->uses_terminal_progress() && !$this->verbose_mode) {
             switch ($sender_progress['phase']) {
                 case 'starting_plan':
                 case 'planning':
@@ -11529,16 +11575,16 @@ class ImportClient
     }
 
     /**
-     * Output progress as JSON line.
-     * Only outputs in verbose mode or non-TTY mode (for programmatic consumption).
+     * Output progress as a JSON line.
+     * Suppressed when the terminal presentation is active without verbose logs.
      *
      * @param array $data Progress data to output
      * @param bool $force Force output regardless of throttle
      */
     public function output_progress(array $data, bool $force = false): void
     {
-        // In TTY non-verbose mode, suppress JSON output (use show_progress_line instead)
-        if ($this->is_tty && !$this->verbose_mode) {
+        // The non-verbose terminal presentation uses show_progress_line() instead.
+        if ($this->uses_terminal_progress() && !$this->verbose_mode) {
             return;
         }
 
@@ -11678,6 +11724,15 @@ if (
             'commands' => ['files-push'],
         ],
         [
+            'name' => 'progress',
+            'type' => 'value',
+            'target' => 'progress',
+            'placeholder' => 'MODE',
+            'help' => 'Progress output: auto, tty, or jsonl (default: auto)',
+            'commands' => ['files-diff', 'files-push'],
+            'valid_values' => ImportClient::PROGRESS_OUTPUT_MODES,
+        ],
+        [
             'name' => 'abort',
             'type' => 'flag',
             'target' => 'abort',
@@ -11776,17 +11831,6 @@ if (
             'help' => 'Total pipeline steps (for progress file)',
             'help_section' => 'global',
             'commands' => [],
-        ],
-
-        // ── files-diff options ──────────────────────────────────
-        [
-            'name' => 'progress',
-            'type' => 'value',
-            'target' => 'progress',
-            'placeholder' => 'MODE',
-            'valid_values' => ['auto', 'tty', 'jsonl'],
-            'help' => 'Output mode (auto|tty|jsonl); auto selects from stdout',
-            'commands' => ['files-diff'],
         ],
 
         // ── files-pull options ───────────────────────────────────
@@ -12642,7 +12686,7 @@ if (
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
-            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--verbose]",
+            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--progress=MODE] [--verbose]",
             "description" =>
                 "Sends the remote document root's local tree beneath --fs-root.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
@@ -12654,6 +12698,12 @@ if (
                 "Re-run the same command after exit 2.\n" .
                 "After a restart result, the next run starts a fresh plan.\n",
             "extra" =>
+                "Progress output:\n" .
+                "  auto   Use tty on a terminal and jsonl otherwise (default)\n" .
+                "  tty    Force the single interactive progress bar\n" .
+                "  jsonl  Force one JSON object per line\n" .
+                "Explicit tty and jsonl modes cannot be combined with --verbose.\n" .
+                "\n" .
                 "Exit outcomes:\n" .
                 "  0  File push complete\n" .
                 "  2  Partial, interrupted, or restart; run the command again\n" .
@@ -12903,7 +12953,8 @@ if (
             )
                 || strpos($reprint_files_push_command_argument, '--state-dir=') === 0
                 || strpos($reprint_files_push_command_argument, '--fs-root=') === 0
-                || strpos($reprint_files_push_command_argument, '--secret=') === 0;
+                || strpos($reprint_files_push_command_argument, '--secret=') === 0
+                || strpos($reprint_files_push_command_argument, '--progress=') === 0;
             if (!$reprint_files_push_option_allowed) {
                 $reprint_files_push_option_name = explode('=', $reprint_files_push_command_argument, 2)[0];
                 fwrite(STDERR, "Error: files-push does not accept {$reprint_files_push_option_name}.\n");
@@ -12933,7 +12984,7 @@ if (
         fwrite(STDERR, "Error: --force-http is accepted only by files-push.\n");
         exit(1);
     } elseif (isset($options['progress'])) {
-        fwrite(STDERR, "Error: --progress is accepted only by files-diff.\n");
+        fwrite(STDERR, "Error: --progress is accepted only by files-diff and files-push.\n");
         exit(1);
     }
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -1704,9 +1704,9 @@ class ImportClient
         $status = null;
         $reason = null;
         $detail = null;
-        $phase = $sender->get_phase();
-        $previous_phase = $phase;
         $reported_progress = $sender->get_progress();
+        $phase = $reported_progress['phase'];
+        $previous_phase = $phase;
 
         try {
             $this->audit_log(
@@ -1738,7 +1738,8 @@ class ImportClient
                 }
 
                 $has_next_sender_step = $sender->next_step();
-                $phase = $sender->get_phase();
+                $sender_progress = $sender->get_progress();
+                $phase = $sender_progress['phase'];
                 $phase_changed = $phase !== $previous_phase;
                 if ($phase_changed) {
                     $this->audit_log(
@@ -1747,7 +1748,6 @@ class ImportClient
                     );
                     $previous_phase = $phase;
                 }
-                $sender_progress = $sender->get_progress();
                 if ($sender_progress !== $reported_progress) {
                     $this->report_files_push_progress($sender_progress, $phase_changed);
                     $reported_progress = $sender_progress;
@@ -1778,8 +1778,8 @@ class ImportClient
                         . $throwable->getMessage();
                 }
             }
-            $phase = $sender->get_phase();
             $sender_progress = $sender->get_progress();
+            $phase = $sender_progress['phase'];
             try {
                 $sender->close();
             } catch (\Throwable $throwable) {
@@ -1883,21 +1883,70 @@ class ImportClient
      * Reports one files-push progress snapshot.
      *
      * @param array $sender_progress {
-     *     Target-confirmed sender progress.
+     *     Progress through the sender lifecycle.
      *
-     *     @type string $phase       Current sender phase.
-     *     @type int    $files_done  Target-confirmed local paths. Present after planning.
-     *     @type int    $files_total Total local paths selected by the plan. Present after planning.
+     *     @type string $phase                     Current sender phase.
+     *     @type string $planning_phase            Current PushPlan phase. Present while planning.
+     *     @type int    $index_bytes_done          Index bytes consumed. Present while diffing indexes.
+     *     @type int    $index_bytes_total         Combined index size. Present while diffing indexes.
+     *     @type int    $files_done                Target-confirmed local paths. Present after planning.
+     *     @type int    $files_total               Total local paths selected by the plan. Present after planning.
+     *     @type int    $file_bytes_done           Target-confirmed file bytes. Present while pushing local paths.
+     *     @type int    $file_bytes_total          File bytes selected by the plan. Present while pushing local paths.
+     *     @type int    $deleted_paths_bytes_done  Target-confirmed deletion-list bytes. Present while pushing deletions.
+     *     @type int    $deleted_paths_bytes_total Total deletion-list bytes. Present while pushing deletions.
      * }
      * @param bool $force_output Whether to bypass the JSONL progress throttle.
-     * @phpstan-param array{phase:string,files_done?:int,files_total?:int} $sender_progress
+     * @phpstan-param array{phase:string,planning_phase?:string,index_bytes_done?:int,index_bytes_total?:int,files_done?:int,files_total?:int,file_bytes_done?:int,file_bytes_total?:int,deleted_paths_bytes_done?:int,deleted_paths_bytes_total?:int} $sender_progress
      */
     private function report_files_push_progress(
         array $sender_progress,
         bool $force_output
     ): void {
+        if ($this->is_tty && !$this->verbose_mode) {
+            switch ($sender_progress['phase']) {
+                case 'starting_plan':
+                case 'planning':
+                    $terminal_label = 'Indexing';
+                    break;
+                case 'pushing_paths':
+                    $terminal_label = 'Pushing';
+                    if (
+                        isset($sender_progress['file_bytes_done'], $sender_progress['file_bytes_total'])
+                        && $sender_progress['file_bytes_total'] > 0
+                    ) {
+                        $terminal_label .= ' — ' . $this->format_bytes($sender_progress['file_bytes_done'])
+                            . ' / ' . $this->format_bytes($sender_progress['file_bytes_total']);
+                    }
+                    break;
+                case 'pushing_deletes':
+                    $terminal_label = 'Pushing deletions';
+                    break;
+                case 'committing':
+                    $terminal_label = 'Committing';
+                    break;
+                case 'saving_local_index':
+                    $terminal_label = 'Saving index';
+                    break;
+                case 'completing':
+                case 'removing':
+                case 'discarding_plan':
+                    $terminal_label = 'Finishing';
+                    break;
+                case 'creating':
+                case 'finishing_previous_commit':
+                default:
+                    $terminal_label = 'Preparing';
+                    break;
+            }
+            $terminal_message = $this->progress->render_progress_bar(
+                $terminal_label,
+                $this->files_push_terminal_fraction($sender_progress)
+            );
+            $this->progress->show_progress_line($terminal_message);
+        }
+
         $phase = $sender_progress['phase'];
-        $fraction = null;
         switch ($phase) {
             case 'creating':
                 $message = 'Starting files push';
@@ -1909,7 +1958,6 @@ class ImportClient
             case 'pushing_paths':
                 $files_done = $sender_progress['files_done'];
                 $files_total = $sender_progress['files_total'];
-                $fraction = $files_total > 0 ? $files_done / $files_total : null;
                 $message = sprintf(
                     'Uploading — %s / %s files',
                     number_format($files_done),
@@ -1942,7 +1990,6 @@ class ImportClient
                 break;
         }
 
-        $this->progress->show_progress_line($message, $fraction);
         $progress_record = [
             'type' => 'push_progress',
             'command' => 'files-push',
@@ -1966,6 +2013,101 @@ class ImportClient
         $this->output_progress($progress_record, $force_output);
         $progress_payload['ts'] = microtime(true);
         $this->write_files_push_progress_file($progress_payload);
+    }
+
+    /**
+     * Maps durable push phases onto one monotonic terminal fraction.
+     *
+     * Indexing and commit have no bounded total. Their milestones divide the
+     * bar around the byte-bounded diff and deletion stages and the exact
+     * target-confirmed local-path stage.
+     *
+     * @param array $sender_progress {
+     *     Progress through the sender lifecycle.
+     *
+     *     @type string $phase                     Current sender phase.
+     *     @type string $planning_phase            Current PushPlan phase. Present while planning.
+     *     @type int    $index_bytes_done          Index bytes consumed. Present while diffing indexes.
+     *     @type int    $index_bytes_total         Combined index size. Present while diffing indexes.
+     *     @type int    $files_done                Target-confirmed local paths. Present after planning.
+     *     @type int    $files_total               Total local paths selected by the plan. Present after planning.
+     *     @type int    $file_bytes_done           Target-confirmed file bytes. Present while pushing local paths.
+     *     @type int    $file_bytes_total          File bytes selected by the plan. Present while pushing local paths.
+     *     @type int    $deleted_paths_bytes_done  Target-confirmed deletion-list bytes. Present while pushing deletions.
+     *     @type int    $deleted_paths_bytes_total Total deletion-list bytes. Present while pushing deletions.
+     * }
+     * @phpstan-param array{phase:string,planning_phase?:string,index_bytes_done?:int,index_bytes_total?:int,files_done?:int,files_total?:int,file_bytes_done?:int,file_bytes_total?:int,deleted_paths_bytes_done?:int,deleted_paths_bytes_total?:int} $sender_progress
+     */
+    private function files_push_terminal_fraction(array $sender_progress): float
+    {
+        switch ($sender_progress['phase']) {
+            case 'creating':
+            case 'finishing_previous_commit':
+                return 0.0;
+            case 'starting_plan':
+                return 0.15;
+            case 'planning':
+                switch ($sender_progress['planning_phase'] ?? null) {
+                    case 'starting_diff':
+                        return 0.2;
+                    case 'diffing':
+                        $stage_fraction = isset(
+                            $sender_progress['index_bytes_done'],
+                            $sender_progress['index_bytes_total']
+                        )
+                            ? $this->files_push_stage_fraction(
+                                $sender_progress['index_bytes_done'],
+                                $sender_progress['index_bytes_total']
+                            )
+                            : 0.0;
+                        return 0.2 + 0.2 * $stage_fraction;
+                    case 'complete':
+                        return 0.4;
+                    case 'indexing':
+                    default:
+                        return 0.15;
+                }
+            case 'pushing_paths':
+                $stage_fraction = isset($sender_progress['files_done'], $sender_progress['files_total'])
+                    ? $this->files_push_stage_fraction(
+                        $sender_progress['files_done'],
+                        $sender_progress['files_total']
+                    )
+                    : 0.0;
+                return 0.4 + 0.4 * $stage_fraction;
+            case 'pushing_deletes':
+                $stage_fraction = isset(
+                    $sender_progress['deleted_paths_bytes_done'],
+                    $sender_progress['deleted_paths_bytes_total']
+                )
+                    ? $this->files_push_stage_fraction(
+                        $sender_progress['deleted_paths_bytes_done'],
+                        $sender_progress['deleted_paths_bytes_total']
+                    )
+                    : 0.0;
+                return 0.8 + 0.1 * $stage_fraction;
+            case 'committing':
+                return 0.9;
+            case 'saving_local_index':
+                return 0.97;
+            case 'completing':
+            case 'removing':
+            case 'discarding_plan':
+                return 0.99;
+            default:
+                return 0.0;
+        }
+    }
+
+    /**
+     * Returns a bounded fraction for one files-push stage.
+     */
+    private function files_push_stage_fraction(int $done, int $total): float
+    {
+        if ($total === 0) {
+            return 1.0;
+        }
+        return max(0.0, min(1.0, $done / $total));
     }
 
     /**

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -15,9 +15,9 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  * push, and saves the completed fresh local index as the local index for this
  * remote Reprint API URL. The target owns the
  * upload cursor for every path and for the deletion list. Durable sender state
- * retains the top-level phase, the selected path-list cursor, the planned and
- * target-confirmed local-path counts, learned request limits, and the PushPlan
- * cursor needed after a process restart.
+ * retains the top-level phase, the selected path-list cursor, the planned
+ * totals, the target-confirmed completed-path count and file bytes, learned
+ * request limits, and the PushPlan cursor needed after a process restart.
  *
  * ## Usage
  *
@@ -74,9 +74,10 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  *
  * sender.json owns the top-level phase and the cursor returned by
  * PushPlan. PushFilesSender stores that cursor after every completed planning
- * step but never interprets its internal phase or offsets. The sender creates
- * the active plan directory before planning and removes the whole directory
- * only after success or target-session removal. The local index for this remote
+ * step but never interprets its shape. It obtains planning progress from
+ * PushPlan's raw progress snapshot. The sender creates the active plan directory
+ * before planning and removes the whole directory only after success or
+ * target-session removal. The local index for this remote
  * Reprint API URL remains in the remote state directory. Once the plan result
  * is saved or discarded, the sender clears its cursor before removing the plan
  * directory without reopening PushPlan.
@@ -127,7 +128,7 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{local_relative_path:string,document_root_relative_path:string,document_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,local_file_bytes_to_push:int|null,local_file_bytes_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -226,6 +227,9 @@ final class PushFilesSender
     /** @var bool|null Whether the receiver confirmed the complete deleted-paths list during this lifecycle. */
     private ?bool $receiver_confirmed_deleted_paths_complete = null;
 
+    /** @var int|null Size of the completed local paths-to-delete list. */
+    private ?int $local_paths_to_delete_bytes = null;
+
     /** @var array<string,mixed> Options used to construct the PushRequestSizer. */
     private array $request_sizer_options;
 
@@ -283,6 +287,8 @@ final class PushFilesSender
                 'local_paths_to_push_byte_offset' => 0,
                 'local_paths_to_push_count' => null,
                 'local_paths_pushed' => 0,
+                'local_file_bytes_to_push' => null,
+                'local_file_bytes_pushed' => 0,
                 'max_part_bytes' => null,
                 'request_sizer_state' => $sender->push_stream_client->get_request_sizer_state(),
             ];
@@ -476,16 +482,26 @@ final class PushFilesSender
     }
 
     /**
-     * Returns target-confirmed local-path progress for the open sender.
+     * Returns progress through the open sender lifecycle.
+     *
+     * Planning uses durable index byte offsets. Local-path and deletion-list
+     * progress stays at target-confirmed boundaries while a request is open.
      *
      * @return array {
      *     Current files-push progress.
      *
-     *     @type string $phase       Current sender phase.
-     *     @type int    $files_done  Target-confirmed local paths. Present after planning.
-     *     @type int    $files_total Total local paths selected by the plan. Present after planning.
+     *     @type string $phase                     Current sender phase.
+     *     @type string $planning_phase            Current PushPlan phase. Present while planning.
+     *     @type int    $index_bytes_done          Index bytes consumed. Present while diffing indexes.
+     *     @type int    $index_bytes_total         Combined index size. Present while diffing indexes.
+     *     @type int    $files_done                Target-confirmed local paths. Present after planning.
+     *     @type int    $files_total               Total local paths selected by the plan. Present after planning.
+     *     @type int    $file_bytes_done           Target-confirmed file bytes. Present while pushing local paths.
+     *     @type int    $file_bytes_total          File bytes selected by the plan. Present while pushing local paths.
+     *     @type int    $deleted_paths_bytes_done  Target-confirmed deletion-list bytes. Present while pushing deletions.
+     *     @type int    $deleted_paths_bytes_total Total deletion-list bytes. Present while pushing deletions.
      * }
-     * @phpstan-return array{phase:string,files_done?:int,files_total?:int}
+     * @phpstan-return array{phase:string,planning_phase?:string,index_bytes_done?:int,index_bytes_total?:int,files_done?:int,files_total?:int,file_bytes_done?:int,file_bytes_total?:int,deleted_paths_bytes_done?:int,deleted_paths_bytes_total?:int}
      */
     public function get_progress(): array
     {
@@ -493,10 +509,52 @@ final class PushFilesSender
             ? $this->state
             : $this->state_before_upload_request;
         /** @var State $progress_state */
-        $progress = ['phase' => $progress_state['phase']];
+        $phase = $progress_state['phase'];
+        $progress = ['phase' => $phase];
+        if ($phase === 'planning') {
+            $plan_progress = $this->plan->get_progress();
+            $progress['planning_phase'] = $plan_progress['phase'];
+            if (isset($plan_progress['index_bytes_done'], $plan_progress['index_bytes_total'])) {
+                $progress['index_bytes_done'] = $plan_progress['index_bytes_done'];
+                $progress['index_bytes_total'] = $plan_progress['index_bytes_total'];
+            }
+            return $progress;
+        }
+
         if ($progress_state['local_paths_to_push_count'] !== null) {
             $progress['files_done'] = $progress_state['local_paths_pushed'];
             $progress['files_total'] = $progress_state['local_paths_to_push_count'];
+        }
+        if ($phase === 'pushing_paths') {
+            if ($progress_state['local_file_bytes_to_push'] !== null) {
+                $file_bytes_done = $progress_state['local_file_bytes_pushed']
+                    + ( $this->receiver_confirmed_file_byte_offset ?? 0 );
+                $progress['file_bytes_done'] = min(
+                    $file_bytes_done,
+                    $progress_state['local_file_bytes_to_push']
+                );
+                $progress['file_bytes_total'] = $progress_state['local_file_bytes_to_push'];
+            }
+            return $progress;
+        }
+        if ($phase !== 'pushing_deletes') {
+            return $progress;
+        }
+
+        if ($this->local_paths_to_delete_bytes === null) {
+            $local_paths_to_delete_path = $this->plan->get_local_paths_to_delete_path();
+            clearstatcache(true, $local_paths_to_delete_path);
+            $local_paths_to_delete_bytes = filesize($local_paths_to_delete_path);
+            if (is_int($local_paths_to_delete_bytes)) {
+                $this->local_paths_to_delete_bytes = $local_paths_to_delete_bytes;
+            }
+        }
+        if ($this->local_paths_to_delete_bytes !== null) {
+            $progress['deleted_paths_bytes_done'] = min(
+                $this->receiver_confirmed_deleted_paths_byte_offset ?? 0,
+                $this->local_paths_to_delete_bytes
+            );
+            $progress['deleted_paths_bytes_total'] = $this->local_paths_to_delete_bytes;
         }
         return $progress;
     }
@@ -716,6 +774,7 @@ final class PushFilesSender
         $this->state['push_plan_cursor'] = $plan_cursor;
         if (!$has_next_step) {
             $this->state['local_paths_to_push_count'] = $this->plan->get_local_paths_to_push_count();
+            $this->state['local_file_bytes_to_push'] = $this->plan->get_local_file_bytes_to_push();
             $this->plan->close();
             $this->state['phase'] = 'pushing_paths';
         }
@@ -839,6 +898,9 @@ final class PushFilesSender
                 $this->close_local_file_handle();
                 $this->state['local_paths_to_push_byte_offset'] = $local_path_to_push['next_local_paths_to_push_byte_offset'];
                 ++$this->state['local_paths_pushed'];
+                if ($local_path_type_size_and_ctime['type'] === 'file') {
+                    $this->state['local_file_bytes_pushed'] += $local_path_type_size_and_ctime['size'];
+                }
                 $this->local_path_to_push = null;
                 $this->store_state($this->state);
                 return;
@@ -1025,6 +1087,9 @@ final class PushFilesSender
             $this->close_local_file_handle();
             $this->state['local_paths_to_push_byte_offset'] = $local_path_to_push['next_local_paths_to_push_byte_offset'];
             ++$this->state['local_paths_pushed'];
+            if ($local_path_type_size_and_ctime['type'] === 'file') {
+                $this->state['local_file_bytes_pushed'] += $local_path_type_size_and_ctime['size'];
+            }
             $this->next_file_byte_offset = null;
             $this->local_path_to_push = null;
         } else {
@@ -1646,6 +1711,11 @@ final class PushFilesSender
             // Keep the sender single-pass when older state has no path progress.
             $state['local_paths_to_push_count'] = null;
             $state['local_paths_pushed'] = 0;
+        }
+        if (!array_key_exists('local_file_bytes_to_push', $state)) {
+            // Keep the sender single-pass when older state has no file byte total.
+            $state['local_file_bytes_to_push'] = null;
+            $state['local_file_bytes_pushed'] = 0;
         }
 
         /** @var State $state */

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -62,8 +62,8 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
- * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
+ * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
  * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
@@ -137,6 +137,9 @@ class PushPlan
     private $local_paths_to_delete_handle = null;
     /** @var resource|null */
     private $deleted_directories_stack_handle = null;
+
+    /** @var int|null Combined size of the two retained indexes during the index diff. */
+    private ?int $index_bytes_total = null;
 
     /**
      * Starts a push plan by opening a fresh local index traversal.
@@ -218,6 +221,14 @@ class PushPlan
             $position["local_paths_to_push_count"] = null;
             $cursor["position"] = $position;
         }
+        if (
+            ( $position["phase"] === "diffing" || $position["phase"] === "complete" )
+            && !array_key_exists("local_file_bytes_to_push", $position)
+        ) {
+            // Keep the plan single-pass when an older cursor has no file byte total.
+            $position["local_file_bytes_to_push"] = null;
+            $cursor["position"] = $position;
+        }
 
         $plan = new self(
             $cursor["plan_directory"],
@@ -268,6 +279,50 @@ class PushPlan
             throw new LogicException("Cannot count local paths to push before the push plan is complete.");
         }
         return $position["local_paths_to_push_count"];
+    }
+
+    /**
+     * Returns the sum of file sizes in the completed push plan.
+     *
+     * Null means the plan resumed from an older cursor without a saved byte total.
+     */
+    public function get_local_file_bytes_to_push(): ?int
+    {
+        $position = $this->cursor["position"];
+        if ($position["phase"] !== "complete") {
+            throw new LogicException("Cannot total local file bytes before the push plan is complete.");
+        }
+        return $position["local_file_bytes_to_push"];
+    }
+
+    /**
+     * Returns progress through the open plan.
+     *
+     * Durable byte offsets across both indexes describe diff progress. An
+     * exact path count would require another pass over the local index.
+     *
+     * @return array {
+     *     Current planning progress.
+     *
+     *     @type string $phase             Current PushPlan phase.
+     *     @type int    $index_bytes_done  Index bytes consumed. Present while diffing.
+     *     @type int    $index_bytes_total Combined size of both indexes. Present while diffing.
+     * }
+     * @phpstan-return array{phase:string,index_bytes_done?:int,index_bytes_total?:int}
+     */
+    public function get_progress(): array
+    {
+        $position = $this->cursor["position"];
+        $progress = ["phase" => $position["phase"]];
+        if ($position["phase"] !== "diffing" || $this->index_bytes_total === null) {
+            return $progress;
+        }
+
+        $index_bytes_done = $position["byte_offset_in_fresh_local_index"]
+            + $position["byte_offset_in_local_index"];
+        $progress["index_bytes_done"] = min($index_bytes_done, $this->index_bytes_total);
+        $progress["index_bytes_total"] = $this->index_bytes_total;
+        return $progress;
     }
 
     /**
@@ -418,6 +473,14 @@ class PushPlan
                 throw new RuntimeException("Failed to open the local index: {$this->local_index_file}");
             }
         }
+        $fresh_local_index_stat = fstat($this->fresh_local_index_handle);
+        $local_index_stat = is_resource($this->local_index_file_handle)
+            ? fstat($this->local_index_file_handle)
+            : ["size" => 0];
+        if (is_array($fresh_local_index_stat) && is_array($local_index_stat)) {
+            $this->index_bytes_total = (int) $fresh_local_index_stat["size"]
+                + (int) $local_index_stat["size"];
+        }
         $this->seek_index_file_to_byte_offset(
             $this->fresh_local_index_handle,
             $cursor["byte_offset_in_fresh_local_index"],
@@ -539,6 +602,7 @@ class PushPlan
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "local_paths_to_push_count" => 0,
+            "local_file_bytes_to_push" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
             "previous_fresh_local_index_entry_path" => null,
         ];
@@ -615,6 +679,7 @@ class PushPlan
         $byte_offset_in_fresh_local_index = $cursor["byte_offset_in_fresh_local_index"];
         $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
         $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
+        $local_file_bytes_to_push = $cursor["local_file_bytes_to_push"];
         $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
 
         if (!$this->fresh_local_index_entry_loaded) {
@@ -699,6 +764,12 @@ class PushPlan
                     if ($local_paths_to_push_count !== null) {
                         ++$local_paths_to_push_count;
                     }
+                    if (
+                        $local_file_bytes_to_push !== null
+                        && $fresh_local_index_entry["type"] === "file"
+                    ) {
+                        $local_file_bytes_to_push += $fresh_local_index_entry["size"];
+                    }
                 }
             } elseif ($path_comparison > 0) {
                 $local_empty_directory_is_implied_by_fresh_descendant =
@@ -763,6 +834,12 @@ class PushPlan
                     if ($local_paths_to_push_count !== null) {
                         ++$local_paths_to_push_count;
                     }
+                    if (
+                        $local_file_bytes_to_push !== null
+                        && $fresh_local_index_entry["type"] === "file"
+                    ) {
+                        $local_file_bytes_to_push += $fresh_local_index_entry["size"];
+                    }
                 }
             }
 
@@ -797,6 +874,7 @@ class PushPlan
             ? [
                 "phase" => "complete",
                 "local_paths_to_push_count" => $local_paths_to_push_count,
+                "local_file_bytes_to_push" => $local_file_bytes_to_push,
             ]
             : [
                 "phase" => "diffing",
@@ -805,6 +883,7 @@ class PushPlan
                 "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
                 "local_paths_to_push_count" => $local_paths_to_push_count,
+                "local_file_bytes_to_push" => $local_file_bytes_to_push,
                 "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
                 "previous_fresh_local_index_entry_path" =>
                     $this->previous_fresh_local_index_entry_path,

--- a/packages/reprint-client/src/lib/terminal-progress/class-terminal-progress.php
+++ b/packages/reprint-client/src/lib/terminal-progress/class-terminal-progress.php
@@ -225,7 +225,7 @@ class TerminalProgress
 
     /**
      * Render a progress bar line:
-     *   ━━━━━━━━━━━━░░░░░░  Downloading files — 1,234 / 5,091 24%
+     *   ━━━━━━━━━━━━░░░░░░  24% Downloading files — 1,234 / 5,091
      */
     public function render_progress_bar(string $label, float $fraction): string
     {
@@ -235,7 +235,7 @@ class TerminalProgress
         $empty = $bar_width - $filled;
         $bar = str_repeat("━", $filled) . str_repeat("░", $empty);
         $pct = (int) round($fraction * 100);
-        return "  \033[36m{$bar}\033[0m  {$label} \033[2m{$pct}%\033[0m";
+        return "  \033[36m{$bar}\033[0m  {$pct}% {$label}";
     }
 
     /**

--- a/packages/reprint-client/src/lib/terminal-progress/class-terminal-progress.php
+++ b/packages/reprint-client/src/lib/terminal-progress/class-terminal-progress.php
@@ -15,14 +15,14 @@
  *   suppressed so the parent command can provide its own framing
  *   without sub-command noise.
  *
- * Both methods are no-ops when stdout is not a TTY (so machine
- * consumers reading JSONL don't get progress noise interleaved) or
- * when verbose_mode is on (so debug output isn't visually disturbed).
+ * Both methods are no-ops when terminal output is disabled (so machine
+ * consumers reading JSONL don't get progress noise interleaved) or when
+ * verbose_mode is on (so debug output isn't visually disturbed).
  */
 class TerminalProgress
 {
-    /** @var bool Whether the progress stream is a TTY. */
-    private bool $is_tty;
+    /** @var bool Whether terminal progress output is enabled. */
+    private bool $terminal_output_enabled;
 
     /** @var resource Stream to write progress to (STDOUT or STDERR). */
     private $progress_fd;
@@ -55,16 +55,16 @@ class TerminalProgress
     /** @var float|null Fraction from the last progress call, or null for no bar. */
     private ?float $last_progress_fraction = null;
 
-    public function __construct(bool $is_tty, $progress_fd, bool $verbose_mode = false)
+    public function __construct(bool $terminal_output_enabled, $progress_fd, bool $verbose_mode = false)
     {
-        $this->is_tty = $is_tty;
+        $this->terminal_output_enabled = $terminal_output_enabled;
         $this->progress_fd = $progress_fd;
         $this->verbose_mode = $verbose_mode;
     }
 
-    public function set_is_tty(bool $is_tty): void
+    public function set_terminal_output_enabled(bool $terminal_output_enabled): void
     {
-        $this->is_tty = $is_tty;
+        $this->terminal_output_enabled = $terminal_output_enabled;
     }
 
     public function set_progress_fd($progress_fd): void
@@ -115,7 +115,7 @@ class TerminalProgress
      */
     public function show_progress_line(string $message, ?float $fraction = null): void
     {
-        if (!$this->is_tty || $this->verbose_mode) {
+        if (!$this->terminal_output_enabled || $this->verbose_mode) {
             return;
         }
         if ($this->is_mode('pipeline')) {
@@ -148,7 +148,7 @@ class TerminalProgress
      */
     public function show_lifecycle_line(string $message): void
     {
-        if (!$this->is_tty || $this->verbose_mode || $this->is_mode('pipeline')) {
+        if (!$this->terminal_output_enabled || $this->verbose_mode || $this->is_mode('pipeline')) {
             return;
         }
         fwrite($this->progress_fd, $message);
@@ -160,7 +160,7 @@ class TerminalProgress
      */
     public function print_line(string $message): void
     {
-        if (!$this->is_tty || $this->verbose_mode) {
+        if (!$this->terminal_output_enabled || $this->verbose_mode) {
             return;
         }
         fwrite($this->progress_fd, $message);
@@ -171,7 +171,7 @@ class TerminalProgress
      */
     public function clear_progress_line(): void
     {
-        if (!$this->is_tty || $this->verbose_mode) {
+        if (!$this->terminal_output_enabled || $this->verbose_mode) {
             return;
         }
         fwrite($this->progress_fd, "\r\033[K");
@@ -185,7 +185,7 @@ class TerminalProgress
      */
     public function tick_spinner(): void
     {
-        if (!$this->is_mode('pipeline') || !$this->is_tty || $this->verbose_mode) {
+        if (!$this->is_mode('pipeline') || !$this->terminal_output_enabled || $this->verbose_mode) {
             return;
         }
         if ($this->active_label === null && $this->last_progress_message === null) {

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -119,6 +119,8 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('--secret=TOKEN', $output);
         $this->assertStringContainsString('--force-http', $output);
+        $this->assertStringContainsString('--progress=MODE', $output);
+        $this->assertStringContainsString('auto, tty, or jsonl', $output);
         $this->assertStringContainsString('--verbose, -v', $output);
         $this->assertStringContainsString('low-level, files-only command', $output);
         $this->assertStringContainsString("document root's local tree beneath --fs-root", $output);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -393,7 +393,7 @@ final class FilesDiffCommandTest extends TestCase
         );
     }
 
-    public function testOtherCommandsRejectTheFilesDiffProgressOption(): void
+    public function testOtherCommandsRejectTheProgressOption(): void
     {
         $result = $this->runCli([
             'files-pull',
@@ -405,7 +405,10 @@ final class FilesDiffCommandTest extends TestCase
 
         $this->assertSame(1, $result['exit'], $result['output']);
         $this->assertSame('', $result['stdout']);
-        $this->assertSame("Error: --progress is accepted only by files-diff.\n", $result['stderr']);
+        $this->assertSame(
+            "Error: --progress is accepted only by files-diff and files-push.\n",
+            $result['stderr']
+        );
     }
 
     public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -135,6 +135,71 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushRejectsAnInvalidProgressMode(): void
+    {
+        $result = $this->runFilesPush(
+            'https://example.test/?reprint-api=1',
+            ['--secret=token', '--progress=rich']
+        );
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertSame(
+            "Invalid --progress value: rich. Valid values: auto, tty, jsonl\n",
+            $result['stderr']
+        );
+        $this->assertNoSenderState($this->stateDirectory);
+    }
+
+    public function testDirectFilesPushRejectsAnInvalidProgressModeBeforePreflight(): void
+    {
+        $client = new ImportClient(
+            'https://example.test/?reprint-api=1',
+            $this->stateDirectory,
+            $this->localTree,
+            'files-push'
+        );
+        $processLock = new \ReprintProcessLock($this->stateDirectory);
+        try {
+            $client->run(
+                ['command' => 'files-push', 'progress' => 'rich'],
+                $processLock
+            );
+            $this->fail('The invalid progress mode was accepted.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Invalid --progress value: rich. Valid values: auto, tty, jsonl',
+                $exception->getMessage()
+            );
+        } finally {
+            $processLock->close();
+        }
+
+        $this->assertNoSenderState($this->stateDirectory);
+        $this->assertFileDoesNotExist(
+            $this->pullStateFileForRemoteReprintApiUrl(
+                'https://example.test/?reprint-api=1'
+            )
+        );
+    }
+
+    public function testFilesPushRejectsVerboseWithAnExplicitProgressMode(): void
+    {
+        foreach (['tty', 'jsonl'] as $progressMode) {
+            $result = $this->runFilesPush(
+                'https://example.test/?reprint-api=1',
+                ['--secret=token', '--progress=' . $progressMode, '--verbose']
+            );
+
+            $this->assertSame(1, $result['exit'], $progressMode . ': ' . $result['output']);
+            $this->assertStringContainsString(
+                'files-push does not accept --verbose with --progress=' . $progressMode . '.',
+                $result['output']
+            );
+        }
+
+        $this->assertNoSenderState($this->stateDirectory);
+    }
+
     public function testFilesPushRejectsInvalidInputsBeforeStartingSender(): void
     {
         $missingSecret = $this->runFilesPush('https://example.test/?reprint-api=1', []);
@@ -396,6 +461,40 @@ final class FilesPushCommandTest extends TestCase
         $this->assertStringNotContainsString('Diffing', $output);
         $this->assertStringNotContainsString('Uploading', $output);
         $this->assertStringNotContainsString('Applying', $output);
+    }
+
+    public function testFilesPushProgressModeCanOverrideTtyDetection(): void
+    {
+        $client = new ImportClient(
+            'https://example.test/?reprint-api=1',
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        $isTty = new \ReflectionProperty(ImportClient::class, 'is_tty');
+        $progressOutputMode = new \ReflectionProperty(
+            ImportClient::class,
+            'progress_output_mode'
+        );
+        $usesTerminalProgress = new \ReflectionMethod(
+            ImportClient::class,
+            'uses_terminal_progress'
+        );
+
+        foreach ([
+            ['auto', false, false],
+            ['auto', true, true],
+            ['tty', false, true],
+            ['jsonl', true, false],
+        ] as [$mode, $stdoutIsTty, $expected]) {
+            $progressOutputMode->setValue($client, $mode);
+            $isTty->setValue($client, $stdoutIsTty);
+            $this->assertSame(
+                $expected,
+                $usesTerminalProgress->invoke($client),
+                $mode . ' with is_tty=' . ( $stdoutIsTty ? 'true' : 'false' )
+            );
+        }
     }
 
     /** @param list<string> $extraOptions */

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -324,6 +324,80 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushTerminalProgressUsesOneOverallBar(): void
+    {
+        $progressStream = fopen('php://memory', 'w+b');
+        $this->assertIsResource($progressStream);
+        $client = new ImportClient(
+            'https://example.test/?reprint-api=1',
+            $this->stateDirectory,
+            $this->localTree,
+            'files-diff'
+        );
+        $progressProperty = new \ReflectionProperty(ImportClient::class, 'progress');
+        $progressProperty->setValue($client, new \TerminalProgress(true, $progressStream));
+        $isTtyProperty = new \ReflectionProperty(ImportClient::class, 'is_tty');
+        $isTtyProperty->setValue($client, true);
+        $reportProgress = new \ReflectionMethod(
+            ImportClient::class,
+            'report_files_push_progress'
+        );
+
+        foreach ([
+            ['phase' => 'creating'],
+            [
+                'phase' => 'planning',
+                'planning_phase' => 'indexing',
+            ],
+            [
+                'phase' => 'planning',
+                'planning_phase' => 'diffing',
+                'index_bytes_done' => 1,
+                'index_bytes_total' => 2,
+            ],
+            [
+                'phase' => 'pushing_paths',
+                'files_done' => 1,
+                'files_total' => 2,
+                'file_bytes_done' => 14 * 1024 * 1024,
+                'file_bytes_total' => 112 * 1024 * 1024,
+            ],
+            [
+                'phase' => 'pushing_deletes',
+                'files_done' => 2,
+                'files_total' => 2,
+                'deleted_paths_bytes_done' => 1,
+                'deleted_paths_bytes_total' => 2,
+            ],
+            ['phase' => 'committing'],
+            ['phase' => 'saving_local_index'],
+            ['phase' => 'completing'],
+        ] as $senderProgress) {
+            $reportProgress->invoke($client, $senderProgress, false);
+        }
+
+        rewind($progressStream);
+        $output = stream_get_contents($progressStream);
+        fclose($progressStream);
+        $this->assertIsString($output);
+        foreach ([
+            '0% Preparing',
+            '15% Indexing',
+            '30% Indexing',
+            '60% Pushing — 14.0 MB / 112.0 MB',
+            '85% Pushing deletions',
+            '90% Committing',
+            '97% Saving index',
+            '99% Finishing',
+        ] as $progressText) {
+            $this->assertStringContainsString($progressText, $output);
+        }
+        $this->assertStringNotContainsString('Indexing and pushing files', $output);
+        $this->assertStringNotContainsString('Diffing', $output);
+        $this->assertStringNotContainsString('Uploading', $output);
+        $this->assertStringNotContainsString('Applying', $output);
+    }
+
     /** @param list<string> $extraOptions */
     private function runFilesPush(string $remoteReprintApiUrl, array $extraOptions): array
     {

--- a/tests/Import/ProgressLineWidthTest.php
+++ b/tests/Import/ProgressLineWidthTest.php
@@ -82,6 +82,15 @@ class ProgressLineWidthTest extends TestCase
             $this->displayWidth($result) . ", max: 60. Output: " . $result);
     }
 
+    public function testProgressBarPercentageComesFirstAndUsesDefaultOutputColor(): void
+    {
+        $progress = $this->createProgress();
+        $result = $progress->render_progress_bar('Pushing', 0.6);
+
+        $this->assertStringContainsString('60% Pushing', $result);
+        $this->assertStringNotContainsString("\033[2m", $result);
+    }
+
     public function testUnicodeSpinnerWidth(): void
     {
         $progress = $this->createProgress(80);

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -46,7 +46,7 @@ class PullFilterFakeClient extends \ImportClient
         $progress = $property->getValue($this);
 
         $this->terminal_progress_stream = fopen('php://temp', 'w+');
-        $progress->set_is_tty(true);
+        $progress->set_terminal_output_enabled(true);
         $progress->set_progress_fd($this->terminal_progress_stream);
     }
 

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -120,6 +120,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(2, 0);
         $this->assertSame(2, $plan->get_local_paths_to_push_count());
+        $this->assertSame(10, $plan->get_local_file_bytes_to_push());
         $this->assertSame(
             ['index.php', 'wp-content/themes/foo/style.css'],
             $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
@@ -307,6 +308,7 @@ final class PushPlanTest extends TestCase
             [
                 'phase' => 'complete',
                 'local_paths_to_push_count' => 0,
+                'local_file_bytes_to_push' => 0,
             ],
             $complete_cursor
         );
@@ -467,7 +469,32 @@ final class PushPlanTest extends TestCase
         $this->assertCount(2, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));
     }
 
-    public function testResumesCursorWrittenBeforeDocumentRootMappingAndProgressCount(): void
+    public function testReportsDiffProgressAcrossResume(): void
+    {
+        $this->saveLocalIndex($this->writeIndex([
+            'deleted-1.txt' => [1, 1, 'file'],
+            'deleted-2.txt' => [1, 1, 'file'],
+        ]));
+        $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
+
+        $progress = $plan->get_progress();
+        $this->assertSame('diffing', $progress['phase']);
+        $this->assertSame(0, $progress['index_bytes_done']);
+        $this->assertGreaterThan(0, $progress['index_bytes_total']);
+
+        $this->assertTrue($this->nextPlanStep($plan));
+        $progress = $plan->get_progress();
+        $this->assertSame('diffing', $progress['phase']);
+        $this->assertGreaterThan(0, $progress['index_bytes_done']);
+        $this->assertLessThan($progress['index_bytes_total'], $progress['index_bytes_done']);
+        $plan->close();
+
+        $resumedPlan = $this->resumePlan();
+        $this->assertSame($progress, $resumedPlan->get_progress());
+        $resumedPlan->close();
+    }
+
+    public function testResumesCursorWrittenBeforeDocumentRootMappingAndProgressTotals(): void
     {
         $entries = $this->manyFileEntries(2);
         $current = $this->writeIndex($entries);
@@ -478,12 +505,14 @@ final class PushPlanTest extends TestCase
 
         unset($this->cursor['document_root_local_relative_path']);
         unset($this->cursor['position']['local_paths_to_push_count']);
+        unset($this->cursor['position']['local_file_bytes_to_push']);
 
         $resumedPlan = $this->resumePlan();
         $this->planToCompletion($resumedPlan);
 
         $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertNull($resumedPlan->get_local_paths_to_push_count());
+        $this->assertNull($resumedPlan->get_local_file_bytes_to_push());
     }
 
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
@@ -567,10 +596,12 @@ final class PushPlanTest extends TestCase
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'local_paths_to_push_count',
+            'local_file_bytes_to_push',
             'deleted_directory_stack_top_byte_offset',
             'previous_fresh_local_index_entry_path',
         ], array_keys($cursor['position']));
         $this->assertSame(1, $cursor['position']['local_paths_to_push_count']);
+        $this->assertSame(1, $cursor['position']['local_file_bytes_to_push']);
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
             $cursor['position']['byte_offset_in_local_paths_to_push']
@@ -617,6 +648,7 @@ final class PushPlanTest extends TestCase
 
         $this->assertPathCounts(3, 3);
         $this->assertSame(3, $reopened->get_local_paths_to_push_count());
+        $this->assertSame(3, $reopened->get_local_file_bytes_to_push());
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1585,12 +1585,20 @@ final class PushEndpointsTest extends TestCase {
             }
             $this->assertGreaterThan($finished_requests, $this->countEndpointRequests('push_upload'));
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
+            $confirmed_progress = $sender->get_progress();
+            $this->assertSame(6000, $confirmed_progress['file_bytes_total']);
+            $this->assertGreaterThan(0, $confirmed_progress['file_bytes_done']);
+            $this->assertLessThan(6000, $confirmed_progress['file_bytes_done']);
             clearstatcache(true, $state_path);
             $this->assertSame($state_inode_before_upload, fileinode($state_path));
 
             $this->assertTrue($sender->next_step());
 
             $this->assertSame(1, $this->countEndpointRequests('push_status'));
+            $this->assertSame(
+                $confirmed_progress['file_bytes_done'],
+                $sender->get_progress()['file_bytes_done']
+            );
         } finally {
             $sender->cancel();
             $this->closeSender($sender);
@@ -1617,14 +1625,18 @@ final class PushEndpointsTest extends TestCase {
                     'phase' => 'pushing_paths',
                     'files_done' => 0,
                     'files_total' => 2,
+                    'file_bytes_done' => 0,
+                    'file_bytes_total' => 11,
                 ],
                 $sender->get_progress()
             );
 
             $this->assertTrue($sender->next_step());
             $this->assertSame(0, $sender->get_progress()['files_done']);
+            $this->assertSame(0, $sender->get_progress()['file_bytes_done']);
             $sender->cancel();
             $this->assertSame(0, $sender->get_progress()['files_done']);
+            $this->assertSame(0, $sender->get_progress()['file_bytes_done']);
 
             $files_done = $sender->get_progress()['files_done'];
             for ($step = 0; $step < 20 && $files_done === 0; ++$step) {
@@ -1634,6 +1646,11 @@ final class PushEndpointsTest extends TestCase {
             $confirmed_progress = $sender->get_progress();
             $this->assertGreaterThan(0, $confirmed_progress['files_done']);
             $this->assertLessThanOrEqual(2, $confirmed_progress['files_done']);
+            $this->assertSame(11, $confirmed_progress['file_bytes_total']);
+            $this->assertSame(
+                $confirmed_progress['files_done'] === 1 ? 5 : 11,
+                $confirmed_progress['file_bytes_done']
+            );
         } finally {
             if ($sender->get_status() === 'continue') {
                 $sender->cancel();
@@ -1660,7 +1677,7 @@ final class PushEndpointsTest extends TestCase {
         }
     }
 
-    public function testHighLevelSenderResumesStateWrittenBeforeDocumentRootMappingAndProgress(): void
+    public function testHighLevelSenderResumesStateWrittenBeforeDocumentRootMappingAndProgressTotals(): void
     {
         $local_docroot = $this->root . '/old-sender-state-local-docroot';
         mkdir($local_docroot, 0700, true);
@@ -1681,8 +1698,11 @@ final class PushEndpointsTest extends TestCase {
         unset($state['document_root_local_relative_path']);
         unset($state['local_paths_to_push_count']);
         unset($state['local_paths_pushed']);
+        unset($state['local_file_bytes_to_push']);
+        unset($state['local_file_bytes_pushed']);
         unset($state['push_plan_cursor']['document_root_local_relative_path']);
         unset($state['push_plan_cursor']['position']['local_paths_to_push_count']);
+        unset($state['push_plan_cursor']['position']['local_file_bytes_to_push']);
         file_put_contents(
             $push_state_directory . '/sender.json',
             json_encode($state, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
@@ -1723,6 +1743,12 @@ final class PushEndpointsTest extends TestCase {
         );
         try {
             $this->takeSenderStepsUntilPhase($sender, 'pushing_deletes');
+            $progress = $sender->get_progress();
+            $this->assertSame('pushing_deletes', $progress['phase']);
+            $this->assertSame(0, $progress['files_done']);
+            $this->assertSame(0, $progress['files_total']);
+            $this->assertSame(0, $progress['deleted_paths_bytes_done']);
+            $this->assertGreaterThan(0, $progress['deleted_paths_bytes_total']);
             $this->takeSenderStepsUntilPhase($sender, 'committing');
 
             $this->assertGreaterThan(1, $this->countEndpointRequests('push_upload'));
@@ -1980,6 +2006,11 @@ final class PushEndpointsTest extends TestCase {
             $plan_cursor = $this->loadPlanPosition($push_state_directory);
             $this->assertSame('diffing', $plan_cursor['phase']);
             $this->assertFileExists($fresh_local_index_path);
+            $progress = $sender->get_progress();
+            $this->assertSame('planning', $progress['phase']);
+            $this->assertSame('diffing', $progress['planning_phase']);
+            $this->assertSame(0, $progress['index_bytes_done']);
+            $this->assertGreaterThan(0, $progress['index_bytes_total']);
             $state = $this->loadActiveState($push_state_directory);
             $this->assertIsArray($state);
             $this->assertArrayNotHasKey('file_index_cursor', $state);

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -3089,6 +3089,56 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
     }
 
+    public function testFilesPushCliCanSelectTerminalOrJsonlProgress(): void
+    {
+        $this->writeDocrootConfiguration([
+            'document_root' => $this->docroot,
+            'maximum_part_bytes' => 64,
+        ]);
+        $local_docroot = $this->root . '/cli-progress-local-docroot';
+        $state_directory = $this->root . '/cli-progress-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', str_repeat('value-', 40));
+
+        $terminal = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            '/',
+            ['--progress=tty']
+        );
+
+        $this->assertSame(0, $terminal['exit'], $terminal['output']);
+        $this->assertStringContainsString("\r\033[K", $terminal['stdout']);
+        $this->assertStringContainsString('15% Indexing', $terminal['stdout']);
+        $this->assertStringContainsString('40% Pushing', $terminal['stdout']);
+        $this->assertStringContainsString('90% Committing', $terminal['stdout']);
+        $this->assertStringContainsString('Files push complete.', $terminal['stdout']);
+        $this->assertSame([], $this->cliJsonLines($terminal['stdout']));
+        $this->assertSame('', $terminal['stderr']);
+
+        $jsonl = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            '/',
+            ['--progress=jsonl']
+        );
+
+        $this->assertSame(0, $jsonl['exit'], $jsonl['output']);
+        $this->assertStringNotContainsString("\033", $jsonl['stdout']);
+        $this->assertStringNotContainsString("\r", $jsonl['stdout']);
+        $jsonl_records = [];
+        foreach (preg_split('/\R/', trim($jsonl['stdout'])) ?: [] as $line) {
+            $record = json_decode($line, true);
+            $this->assertIsArray($record, $line);
+            $jsonl_records[] = $record;
+        }
+        $this->assertNotEmpty($jsonl_records);
+        $this->assertSame('complete', $jsonl_records[count($jsonl_records) - 1]['status'] ?? null);
+        $this->assertSame('', $jsonl['stderr']);
+    }
+
     public function testFilesPushCliStopsAtTheCallerDeadlineAndAnotherProcessCompletes(): void
     {
         $local_docroot = $this->root . '/cli-partial-local-docroot';
@@ -3322,19 +3372,22 @@ final class PushEndpointsTest extends TestCase {
      * Runs the production CLI against the production endpoint router.
      *
      * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @param list<string> $extra_options Additional files-push CLI options.
      * @return array{exit:int,stdout:string,stderr:string,output:string}
      */
     private function runFilesPushCli(
         string $filesystem_root,
         string $state_directory,
         array $ini_settings = [],
-        string $document_root = '/'
+        string $document_root = '/',
+        array $extra_options = []
     ): array {
         [$process, $pipes] = $this->startFilesPushCli(
             $filesystem_root,
             $state_directory,
             $ini_settings,
-            $document_root
+            $document_root,
+            $extra_options
         );
         return $this->finishFilesPushCli($process, $pipes);
     }
@@ -3343,13 +3396,15 @@ final class PushEndpointsTest extends TestCase {
      * Starts a production files-push CLI subprocess.
      *
      * @param array<string,string> $ini_settings PHP ini values for the subprocess.
+     * @param list<string> $extra_options Additional files-push CLI options.
      * @return array{0:resource,1:array<int,resource>}
      */
     private function startFilesPushCli(
         string $filesystem_root,
         string $state_directory,
         array $ini_settings = [],
-        string $document_root = '/'
+        string $document_root = '/',
+        array $extra_options = []
     ): array {
         $this->writeFilesPushPreflight($state_directory, $document_root);
 
@@ -3366,7 +3421,7 @@ final class PushEndpointsTest extends TestCase {
             '--fs-root=' . $filesystem_root,
             '--secret=' . self::SECRET,
             '--force-http',
-        ]);
+        ], $extra_options);
         $process = proc_open(
             $command,
             [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],


### PR DESCRIPTION
`files-push` can now select terminal or JSONL progress explicitly while keeping TTY detection as the default.

This is stacked on #484 and extends the `--progress=auto|tty|jsonl` selector from #492 to `files-push`.

```sh
# Keep the single progress bar when stdout is captured.
reprint files-push "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" \
  --secret="$SECRET" --progress=tty

# Keep the existing JSONL stream when running in a terminal.
reprint files-push "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" \
  --secret="$SECRET" --progress=jsonl
```

`--progress=auto` preserves the current behavior: terminal output on a TTY and JSONL otherwise. `tty` forces the bar from #484; `jsonl` forces the existing `push_progress` records and final result. Both presentations consume the same sender progress snapshot. The selection belongs to one invocation and is not written to sender state.

This uses a progress selector instead of a general `--format` option because it changes only the live progress presentation, not Reprint's result schema. The shape follows [BuildKit's `--progress=auto|tty|rawjson` selector](https://docs.docker.com/reference/cli/docker/buildx/build/#set-type-of-progress-output---progress), while `jsonl` names the line-delimited format Reprint already emits.

Explicit `tty` and `jsonl` modes reject `--verbose`, so detailed log lines cannot corrupt the selected presentation.

## Testing

Run `files-push --progress=tty` with stdout captured and check that one bar redraws through `Indexing`, `Pushing`, and `Committing`. Run `--progress=jsonl` directly in a terminal and check that each output line is a JSON record. Try either explicit mode with `--verbose` and check that the command rejects the combination before starting a sender.
