### PR TITLE
[PHP] Remove redundant filesystem-root containment checks

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2040,10 +2040,7 @@ class ImportClient
         $push_state_directory = realpath_with_missing_tail(
             $push_state_directory
         );
-        if (
-            $resolved_local_filesystem_root === '/'
-            || path_is_within_root($push_state_directory, $resolved_local_filesystem_root)
-        ) {
+        if (path_is_within_root($push_state_directory, $resolved_local_filesystem_root)) {
             throw new InvalidArgumentException(
                 'The local push state directory ' . $push_state_directory
                 . ' must be outside the filesystem root ' . $resolved_local_filesystem_root . '.'

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -112,7 +112,7 @@ final class Site_Export_Push_Endpoints {
         if ($canonical_docroot === false) {
             $canonical_docroot = normalize_path($docroot);
         }
-        if ($canonical_docroot === '/' || path_is_within_root($canonical_reprint_directory, $canonical_docroot)) {
+        if (path_is_within_root($canonical_reprint_directory, $canonical_docroot)) {
             throw new InvalidArgumentException(
                 'Push endpoints require reprint_directory ' . json_encode($reprint_directory)
                 . ' to be outside docroot ' . json_encode($docroot) . '; observed it inside that document root.'


### PR DESCRIPTION
`path_is_within_root()` already treats `/` as containing every absolute path. Remove the two separate root checks that repeated that rule before calling the helper.

The search found no other production conditions that combine a filesystem-root equality check with `path_is_within_root()`.