### PR TITLE
[PHP] Treat empty roots as relative path roots

### DIFF
--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -373,10 +373,12 @@ function path_remainder_under(string $path, string $prefix): ?string
  *     relative_path_under('/srv/site', '/srv/site');            // ''
  *     relative_path_under('/srv/site-old', '/srv/site');        // null
  *     relative_path_under('/wp-content', '/');                  // 'wp-content'
+ *     relative_path_under('wp-content/plugins', '');            // 'wp-content/plugins'
  *
  * Trailing slashes do not change the result. This is a lexical operation: it
  * does not resolve dot segments or symlinks, and it also accepts relative
- * slash-delimited paths.
+ * slash-delimited paths. An empty root contains every relative path, but no
+ * absolute path.
  *
  * @param string $path Candidate path to make relative.
  * @param string $root Root that must contain the candidate path.
@@ -385,6 +387,9 @@ function path_remainder_under(string $path, string $prefix): ?string
  */
 function relative_path_under(string $path, string $root): ?string
 {
+    if ($root === "") {
+        return str_starts_with($path, "/") ? null : rtrim($path, "/");
+    }
     $remainder = path_remainder_under($path, $root);
     return $remainder === null ? null : ltrim($remainder, "/");
 }

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -164,6 +164,11 @@ class RemapSeamTest extends TestCase
     public static function provideRelativePathCases(): array
     {
         return array(
+            'empty relative root itself' => array('', '', ''),
+            'empty relative root child' => array('child/path', 'child/path', ''),
+            'empty relative root child with trailing slash' => array('child/path', 'child/path/', ''),
+            'absolute path outside empty relative root' => array(null, '/child/path', ''),
+            'relative path outside filesystem root' => array(null, 'child/path', '/'),
             'filesystem root itself' => array('', '/', '/'),
             'filesystem root child' => array('child', '/child', '/'),
             'exact non-root match' => array('', '/a', '/a'),


### PR DESCRIPTION
`relative_path_under()` now treats `''` as the root of relative slash-delimited paths while keeping absolute paths outside that namespace.

This lets callers derive paths under a relative root without a local empty-root branch. The test matrix covers the root itself, descendants, trailing slashes, and absolute/relative namespace mismatches.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php`; `composer analyze -- --memory-limit=1G`.
