### PR TITLE
[PHP] Preserve filesystem roots while resolving tree paths

### DIFF
--- a/packages/reprint-server/src/class-file-tree-producer.php
+++ b/packages/reprint-server/src/class-file-tree-producer.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Streams a provided list of filesystem paths in sorted order with
  * cursor-based resumption. The caller must pass the same paths array
@@ -182,10 +185,10 @@ class FileTreeProducer
     private function normalize_directories($directories): array
     {
         if (is_string($directories)) {
-            return [rtrim($directories, "/")];
+            return [rtrim($directories, "/") ?: "/"];
         }
         return array_map(function ($d) {
-            return rtrim($d, "/");
+            return rtrim($d, "/") ?: "/";
         }, $directories);
     }
 
@@ -373,7 +376,7 @@ class FileTreeProducer
         }
 
         foreach ($this->directories as $dir) {
-            $candidate = $dir . "/" . ltrim($path, "/");
+            $candidate = wp_join_unix_paths($dir, $path);
             clearstatcache(true, $candidate);
             if (file_exists($candidate) || is_link($candidate)) {
                 return $candidate;

--- a/tests/FileSyncProducer/FilesystemRootTest.php
+++ b/tests/FileSyncProducer/FilesystemRootTest.php
@@ -27,4 +27,21 @@ class FilesystemRootTest extends FileSyncProducerTestBase
         // Should be the scan directory itself (or its real path)
         $this->assertEquals(realpath($dir), $fsRoot);
     }
+
+    public function testRootDirectoryResolvesRelativePaths()
+    {
+        $dir = $this->createTestDirectory('filesystem-root', [
+            'from-root.txt' => 'Content from the filesystem root',
+        ]);
+        $path = $dir . '/from-root.txt';
+
+        $sync = new \FileTreeProducer('/', [
+            'paths' => [ltrim($path, '/')],
+        ]);
+        $chunks = $this->processAllChunks($sync);
+
+        $this->assertSame('/', $sync->get_filesystem_root());
+        $this->assertSame($path, $chunks[0]['path']);
+        $this->assertSame('Content from the filesystem root', $chunks[0]['data']);
+    }
 }


### PR DESCRIPTION
FileTreeProducer now keeps `/` as its filesystem root and joins relative paths through `wp_join_unix_paths()`. A root-relative path list therefore remains rooted when producing file chunks.

Tests: `cd tests && ../vendor/bin/phpunit FileSyncProducer/FilesystemRootTest.php`; `vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-server/src/class-file-tree-producer.php`.