### PR TITLE
[PHP] Keep filesystem roots in normalized export path lists

### DIFF
--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -733,7 +733,7 @@ function normalize_path_list(array $paths): array
         }
         $real = realpath($path);
         $final = $real !== false ? $real : $path;
-        $final = rtrim($final, "/");
+        $final = $final === "/" ? "/" : rtrim($final, "/");
         if ($final === "") {
             continue;
         }

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -33,6 +33,20 @@ final class ExportLibraryLoadTest extends TestCase {
         $this->assertStringContainsString('endpoint-handlers-loaded', $result['output']);
     }
 
+    public function testNormalizePathListKeepsTheFilesystemRoot(): void
+    {
+        $export_path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($export_path, 'export.php must exist');
+
+        $result = $this->runPhpCode(
+            "<?php\nrequire " . var_export($export_path, true) . ";\n"
+            . "echo json_encode(normalize_path_list(['/']), JSON_UNESCAPED_SLASHES);\n"
+        );
+
+        $this->assertSame(0, $result['status'], $result['output']);
+        $this->assertSame('["/"]', trim($result['output']));
+    }
+
     public function testPluginRuntimeLoaderSkipsAutoloadAlreadyLoadedThroughSymlinkedPluginDirectory(): void
     {
         $tmp_dir = sys_get_temp_dir() . '/export-runtime-loader-test-' . uniqid('', true);


### PR DESCRIPTION
`normalize_path_list()` no longer discards `/` while removing trailing slashes, so callers can retain a configured filesystem root.

Tests: `cd tests && ../vendor/bin/phpunit ../tests/ExportLibraryLoadTest.php`; `vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-server/src/export.php`.