### PR TITLE
[PHP] Join WP Cloud document-root paths through filesystem utility

### DIFF
--- a/packages/reprint-client/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/reprint-client/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Host analyzer for WP Cloud (wpcom) sites.
  *
@@ -31,7 +34,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         // WP Cloud sites have a __wp__ symlink in the document root pointing
         // to the WordPress core installation.
         if (is_string($doc_root) && $doc_root !== '') {
-            $wp_dir = rtrim($doc_root, '/') . '/__wp__';
+            $wp_dir = wp_join_unix_paths($doc_root, '__wp__');
             $dir_checks = $preflight_data['filesystem']['directories'] ?? [];
             foreach ($dir_checks as $check) {
                 $path = $check['path'] ?? '';
@@ -46,7 +49,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         // WP Cloud typically has WordPress installed at doc_root/__wp__/.
         $wp_roots = $preflight_data['wp_detect']['roots'] ?? [];
         if (is_string($doc_root) && $doc_root !== '') {
-            $wp_subdir = rtrim($doc_root, '/') . '/__wp__';
+            $wp_subdir = wp_join_unix_paths($doc_root, '__wp__');
             foreach ($wp_roots as $root) {
                 $path = $root['path'] ?? '';
                 if ($path === $wp_subdir) {

--- a/tests/Import/WpcloudHostAnalyzerTest.php
+++ b/tests/Import/WpcloudHostAnalyzerTest.php
@@ -206,6 +206,27 @@ class WpcloudHostAnalyzerTest extends TestCase
         $this->assertGreaterThanOrEqual(0.5, $score);
     }
 
+    public function testScoreMatchesWpcloudMarkersUnderTheFilesystemRoot(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'document_root' => '/',
+            ],
+            'filesystem' => [
+                'directories' => [
+                    ['path' => '/__wp__', 'exists' => true],
+                ],
+            ],
+            'wp_detect' => [
+                'roots' => [
+                    ['path' => '/__wp__'],
+                ],
+            ],
+        ]);
+
+        $this->assertGreaterThanOrEqual(0.9, \WpcloudHostAnalyzer::score($preflight));
+    }
+
     public function testScoreRejectsNonWpcloudSite(): void
     {
         $preflight = [


### PR DESCRIPTION
WP Cloud detection now constructs its `__wp__` markers with `wp_join_unix_paths()` rather than stripping and re-adding slashes. This keeps the root-directory form consistent with other filesystem joins.

Tests: `cd tests && ../vendor/bin/phpunit Import/WpcloudHostAnalyzerTest.php`; `vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-client/src/lib/host/analyzers/class-wpcloud-host-analyzer.php`.