### PR TITLE
[PHP] Join file-index symlink traversal paths through filesystem utility

### DIFF
--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Exporter classes use unprefixed domain names.
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Traversal failures become API or CLI values, never HTML output.
 
@@ -805,7 +807,7 @@ final class FileIndexProcessor {
         $raw_target = @readlink($path);
         if ($raw_target !== false && $raw_target !== "") {
             if ($raw_target[0] !== "/") {
-                $raw_target = dirname($path) . "/" . $raw_target;
+                $raw_target = wp_join_unix_paths(dirname($path), $raw_target);
             }
             // Resolve only textual dot segments. realpath() would skip the
             // intermediate links that this walk must inspect.
@@ -846,7 +848,7 @@ final class FileIndexProcessor {
                 $current = "/";
                 continue;
             }
-            $current = rtrim($current, "/") . "/" . $part;
+            $current = wp_join_unix_paths($current, $part);
             if (!@is_link($current)) {
                 continue;
             }

--- a/tests/FileIndexDedupTest.php
+++ b/tests/FileIndexDedupTest.php
@@ -100,10 +100,12 @@ final class FileIndexDedupTest extends TestCase
 <?php
 declare(strict_types=1);
 require_once %s;
+require_once %s;
 $config = json_decode(file_get_contents(%s), true, 512, JSON_THROW_ON_ERROR);
 $budget = new ResourceBudget(microtime(true), 10, 128 * 1024 * 1024, 0.9);
 endpoint_file_index($config, $budget);
 PHP,
+                var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
                 var_export(dirname(__DIR__) . '/packages/reprint-server/src/export.php', true),
                 var_export($configPath, true),
             ),

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -494,10 +494,12 @@ final class FileIndexSkipDefaultsTest extends TestCase
 <?php
 declare(strict_types=1);
 require_once %s;
+require_once %s;
 $config = json_decode(file_get_contents(%s), true, 512, JSON_THROW_ON_ERROR);
 $budget = new ResourceBudget(microtime(true), 10, 128 * 1024 * 1024, 0.9);
 endpoint_file_index($config, $budget);
 PHP,
+                var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
                 var_export(dirname(__DIR__) . '/packages/reprint-server/src/export.php', true),
                 var_export($configPath, true),
             ),


### PR DESCRIPTION
File-index symlink handling now uses `wp_join_unix_paths()` when resolving a relative target and when advancing its parent walk. The existing lexical normalization and per-component link inspection remain unchanged.

Tests: `cd tests && ../vendor/bin/phpunit ../tests/FileIndexProcessorTest.php ../tests/FileIndexSkipDefaultsTest.php`; `vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-server/src/class-file-index-processor.php`.