### PR TITLE
[Push] Preserve filesystem roots while sending local paths

### DIFF
--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -1,5 +1,6 @@
 <?php
 
+use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
@@ -377,7 +378,7 @@ final class PushFilesSender
         if ($resolved_local_filesystem_root === false) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
-        $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/');
+        $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
         $this->document_root_local_relative_path = trim($document_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');
@@ -885,7 +886,12 @@ final class PushFilesSender
             ];
             $upload_completes_local_path = true;
         } elseif ($local_path_type_size_and_ctime['type'] === 'symlink') {
-            $symlink_target = @readlink($this->filesystem_root . '/' . $local_path_to_push['local_relative_path']);
+            $symlink_target = @readlink(
+                wp_join_unix_paths(
+                    $this->filesystem_root,
+                    $local_path_to_push['local_relative_path']
+                )
+            );
             $local_path_type_size_and_ctime_after_read = $this->stat_local_path($local_path_to_push['local_relative_path']);
             if ($local_path_type_size_and_ctime_after_read === null) {
                 $this->close_local_paths_to_push_handle();
@@ -931,7 +937,10 @@ final class PushFilesSender
                 $local_io_failure_detail = null;
                 if (!is_resource($this->local_file_handle)) {
                     $this->local_file_handle = fopen(
-                        $this->filesystem_root . '/' . $local_path_to_push['local_relative_path'],
+                        wp_join_unix_paths(
+                            $this->filesystem_root,
+                            $local_path_to_push['local_relative_path']
+                        ),
                         'rb'
                     );
                 }
@@ -1537,7 +1546,7 @@ final class PushFilesSender
      */
     private function directory_is_empty(string $path): ?bool
     {
-        $directory_handle = @opendir($this->filesystem_root . '/' . $path);
+        $directory_handle = @opendir(wp_join_unix_paths($this->filesystem_root, $path));
         if ($directory_handle === false) {
             return null;
         }
@@ -1569,7 +1578,7 @@ final class PushFilesSender
      */
     private function stat_local_path(string $path): ?array
     {
-        $absolute_path = $this->filesystem_root . '/' . $path;
+        $absolute_path = wp_join_unix_paths($this->filesystem_root, $path);
         clearstatcache(true, $absolute_path);
         $path_stat = @lstat($absolute_path);
         if (!is_array($path_stat)) {

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -350,7 +350,7 @@ class PushPlan
         if ($resolved_local_filesystem_root === false || !is_dir($resolved_local_filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException("PushPlan requires the filesystem root to be a real directory.");
         }
-        $this->filesystem_root = rtrim($resolved_local_filesystem_root, "/");
+        $this->filesystem_root = rtrim($resolved_local_filesystem_root, "/") ?: "/";
     }
 
     /**

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -583,6 +583,25 @@ final class PushPlanTest extends TestCase
         $plan->close();
     }
 
+    public function testCursorKeepsTheFilesystemRootSlash(): void
+    {
+        mkdir($this->planDirectory(), 0755, true);
+        file_put_contents($this->excludedPathsPath(), '[]');
+
+        $plan = PushPlan::start(
+            $this->planDirectory(),
+            '/',
+            $this->localIndexFile(),
+            $this->excludedPathsPath()
+        );
+
+        try {
+            $this->assertSame('/', $plan->get_cursor()['filesystem_root']);
+        } finally {
+            $plan->close();
+        }
+    }
+
     public function testNewInstanceResumesFromTheRetainedCursor(): void
     {
         $currentEntries = [];

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2570,6 +2570,24 @@ final class PushEndpointsTest extends TestCase {
         );
     }
 
+    public function testHighLevelSenderKeepsTheFilesystemRootSlash(): void
+    {
+        $push_state_directory = $this->root . '/root-source-state';
+        $sender = $this->startSender(
+            $this->senderOptions('/', $push_state_directory)
+        );
+
+        try {
+            $filesystem_root_property = new ReflectionProperty(
+                PushFilesSender::class,
+                'filesystem_root'
+            );
+            $this->assertSame('/', $filesystem_root_property->getValue($sender));
+        } finally {
+            $this->closeSender($sender);
+        }
+    }
+
     /**
      * Leaves a missing local push state directory absent when there is nothing to resume.
      */


### PR DESCRIPTION
Push planning and uploads now retain `/` as the filesystem root and join local paths through the filesystem utility.

The sender can therefore read, inspect, and upload paths beneath `/` without constructing double-slash paths.