### PR TITLE
[PHP] Centralize root-preserving path slash trimming

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -38,6 +38,7 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 use function Reprint\Importer\merge_local_index_mutations;
 use function Reprint\Importer\write_local_index_update;
 
@@ -424,7 +425,7 @@ class ImportClient
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
-        $this->filesystem_root = rtrim($filesystem_root, "/") ?: "/";
+        $this->filesystem_root = trim_right_slash($filesystem_root);
         $remote_state_directory = self::remote_state_directory_path(
             $this->remote_reprint_api_url,
             $this->state_dir
@@ -2048,7 +2049,7 @@ class ImportClient
         }
         return [
             'remote_reprint_api_url' => rtrim($remote_reprint_api_url, '?&'),
-            'filesystem_root' => rtrim($resolved_local_filesystem_root, '/') ?: '/',
+            'filesystem_root' => trim_right_slash($resolved_local_filesystem_root),
             'push_state_directory' => $push_state_directory,
         ];
     }
@@ -2095,7 +2096,7 @@ class ImportClient
                 'The filesystem root does not exist or is not a directory: ' . $filesystem_root . '.'
             );
         }
-        $resolved_local_filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
+        $resolved_local_filesystem_root = trim_right_slash($resolved_local_filesystem_root);
         // Resolve an absolute physical path even when its final components do not exist.
         $remote_state_directory = self::remote_state_directory_path(
             $remote_reprint_api_url,
@@ -4163,7 +4164,7 @@ class ImportClient
 
         if (!empty($flat_document_root)) {
             // --flat-document-root: used directly as the web root.
-            $raw_local_document_root = rtrim($flat_document_root, "/") ?: "/";
+            $raw_local_document_root = trim_right_slash($flat_document_root);
         } else {
             // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
@@ -4511,7 +4512,7 @@ class ImportClient
             );
         }
 
-        $flatten_to = rtrim($flatten_to, "/") ?: "/";
+        $flatten_to = trim_right_slash($flatten_to);
         $force = $options["force"] ?? false;
 
         // Ensure the filesystem root exists
@@ -4891,7 +4892,7 @@ class ImportClient
         if (!is_string($value) || trim($value) === "") {
             return null;
         }
-        return rtrim($value, "/") ?: "/";
+        return trim_right_slash($value);
     }
 
     /**
@@ -9094,7 +9095,7 @@ class ImportClient
         }
 
         if ($resolved !== "") {
-            $resolved = rtrim($resolved, "/") ?: "/";
+            $resolved = trim_right_slash($resolved);
         }
         assert_valid_path($resolved, "path \"{$raw}\"");
 
@@ -10000,7 +10001,7 @@ class ImportClient
         ];
 
         if ($this->extra_directory !== null && $this->extra_directory !== "") {
-            $extra_paths["extra_directory"] = rtrim($this->extra_directory, "/") ?: "/";
+            $extra_paths["extra_directory"] = trim_right_slash($this->extra_directory);
         }
 
         // Ensure every --remap source is enumerated — including plugins or

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -2,6 +2,7 @@
 
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Sender failures are CLI/API values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
@@ -378,7 +379,7 @@ final class PushFilesSender
         if ($resolved_local_filesystem_root === false) {
             throw new InvalidArgumentException('PushFilesSender requires a real filesystem root directory.');
         }
-        $this->filesystem_root = rtrim($resolved_local_filesystem_root, '/') ?: '/';
+        $this->filesystem_root = trim_right_slash($resolved_local_filesystem_root);
         $this->document_root_local_relative_path = trim($document_root, '/');
         $this->process_lock = $process_lock;
         $this->push_state_directory = rtrim($push_state_directory, '/');

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -5,6 +5,7 @@ use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -350,7 +351,7 @@ class PushPlan
         if ($resolved_local_filesystem_root === false || !is_dir($resolved_local_filesystem_root) || is_link($filesystem_root)) {
             throw new InvalidArgumentException("PushPlan requires the filesystem root to be a real directory.");
         }
-        $this->filesystem_root = rtrim($resolved_local_filesystem_root, "/") ?: "/";
+        $this->filesystem_root = trim_right_slash($resolved_local_filesystem_root);
     }
 
     /**

--- a/packages/reprint-server/src/class-file-tree-producer.php
+++ b/packages/reprint-server/src/class-file-tree-producer.php
@@ -1,6 +1,7 @@
 <?php
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 /**
  * Streams a provided list of filesystem paths in sorted order with
@@ -185,10 +186,10 @@ class FileTreeProducer
     private function normalize_directories($directories): array
     {
         if (is_string($directories)) {
-            return [rtrim($directories, "/") ?: "/"];
+            return [trim_right_slash($directories)];
         }
         return array_map(function ($d) {
-            return rtrim($d, "/") ?: "/";
+            return trim_right_slash($d);
         }, $directories);
     }
 

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -5,6 +5,7 @@
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
@@ -133,7 +134,7 @@ final class Site_Export_Push_Session {
      */
     private function __construct(string $reprint_directory, string $docroot, string $push_session_id, array $excluded_paths) {
         $this->reprint_directory = rtrim($reprint_directory, '/');
-        $this->docroot = $docroot === '/' ? '/' : rtrim($docroot, '/');
+        $this->docroot = trim_right_slash($docroot);
         $this->push_session_id = $push_session_id;
         if ($reprint_directory === $this->docroot) {
             throw new InvalidArgumentException('The reprint directory must not be the document root itself.');
@@ -2789,7 +2790,7 @@ final class Site_Export_Push_Session {
         if ($real_path === false || !is_dir($real_path) || is_link($path)) {
             throw new InvalidArgumentException('The ' . $description . ' is not a real directory: ' . $path . '.');
         }
-        return $real_path === '/' ? '/' : rtrim($real_path, '/');
+        return trim_right_slash($real_path);
     }
 
     /**

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -9,6 +9,7 @@ use function WordPress\Reprint\Exporter\build_pdo_dsn;
 use function WordPress\Reprint\Exporter\json_encode_or_throw;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 require_once __DIR__ . '/class-file-index-processor.php';
 
@@ -1685,13 +1686,13 @@ function endpoint_preflight(array $config): array
                         // find the directory at the resolved location where
                         // files are actually downloaded.
                         $abspath_raw = defined("ABSPATH")
-                            ? (rtrim(ABSPATH, "/") ?: "/")
+                            ? trim_right_slash(ABSPATH)
                             : null;
                         $abspath_resolved = null;
                         if ($abspath_raw !== null) {
                             $abspath_real = realpath($abspath_raw);
                             $abspath_resolved = $abspath_real !== false
-                                ? (rtrim($abspath_real, "/") ?: "/")
+                                ? trim_right_slash($abspath_real)
                                 : $abspath_raw;
                         }
 
@@ -1958,21 +1959,21 @@ function endpoint_preflight(array $config): array
     // Scan each directory to list installed plugins, mu-plugins, and themes.
     $wp_runtime_paths = null;
     if ($db["wp"]["wp_load_loaded"]) {
-        $runtime_root = defined("ABSPATH") ? (rtrim(ABSPATH, "/") ?: "/") : null;
+        $runtime_root = defined("ABSPATH") ? trim_right_slash(ABSPATH) : null;
         $content_dir = defined("WP_CONTENT_DIR")
-            ? (rtrim(WP_CONTENT_DIR, "/") ?: "/")
+            ? trim_right_slash(WP_CONTENT_DIR)
             : null;
         $plugins_dir = defined("WP_PLUGIN_DIR")
-            ? (rtrim(WP_PLUGIN_DIR, "/") ?: "/")
+            ? trim_right_slash(WP_PLUGIN_DIR)
             : null;
         $mu_plugins_dir = defined("WPMU_PLUGIN_DIR")
-            ? (rtrim(WPMU_PLUGIN_DIR, "/") ?: "/")
+            ? trim_right_slash(WPMU_PLUGIN_DIR)
             : null;
         $themes_dir = null;
         if (function_exists("get_theme_root")) {
             $themes_dir = get_theme_root();
             if (is_string($themes_dir)) {
-                $themes_dir = rtrim($themes_dir, "/") ?: "/";
+                $themes_dir = trim_right_slash($themes_dir);
             } else {
                 $themes_dir = null;
             }

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -184,6 +184,27 @@ function normalize_path(string $path): string
 }
 
 /**
+ * Removes trailing slashes without changing the filesystem root into an empty path.
+ *
+ * Unlike rtrim($path, '/'), this returns `/` for both the filesystem root and
+ * an empty input. It only changes the lexical spelling; it does not validate
+ * the path or resolve dot segments and symlinks.
+ *
+ * Examples:
+ *
+ *     trim_right_slash('/srv/site///'); // '/srv/site'
+ *     trim_right_slash('/');            // '/'
+ *     trim_right_slash('');             // '/'
+ *
+ * @param string $path Path whose trailing slashes to remove.
+ * @return string A path without trailing slashes, or `/` for the filesystem root.
+ */
+function trim_right_slash(string $path): string
+{
+    return rtrim($path, '/') ?: '/';
+}
+
+/**
  * Canonicalizes an absolute path through the nearest ancestor realpath() can resolve.
  *
  * The final components need not exist. The function resolves a real ancestor,

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -7,6 +7,7 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
@@ -150,6 +151,24 @@ class RemapSeamTest extends TestCase
             'trailing slash on path' => array('', '/home/adam/', '/home/adam'),
             'trailing slash on both' => array('', '/home/adam/', '/home/adam/'),
             'under, prefix has trailing slash' => array('/c', '/a/b/c', '/a/b/'),
+        );
+    }
+
+    /**
+     * @dataProvider provideTrailingSlashPathCases
+     */
+    public function testTrimRightSlash(string $expected, string $path): void
+    {
+        $this->assertSame($expected, trim_right_slash($path));
+    }
+
+    public static function provideTrailingSlashPathCases(): array
+    {
+        return array(
+            'path without trailing slashes' => array('/srv/site', '/srv/site'),
+            'path with trailing slashes' => array('/srv/site', '/srv/site///'),
+            'filesystem root' => array('/', '/'),
+            'empty input becomes filesystem root' => array('/', ''),
         );
     }
 


### PR DESCRIPTION
Filesystem paths now use one helper that removes trailing slashes without turning `/` into an empty path. The helper keeps root normalization consistent across the client and server.