### PR TITLE
[Push] Join local push workspace paths

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -1400,7 +1400,7 @@ class ImportClient
             . 'writes it after the target finishes applying the push. Use the same '
             . 'remote Reprint API URL and state directory.';
 
-        $plan_directory = $push_state_directory . '/files-diff-plan';
+        $plan_directory = wp_join_unix_paths($push_state_directory, 'files-diff-plan');
         try {
             if (!is_file($this->local_index_file)) {
                 throw new RuntimeException($missing_local_index_message);
@@ -1412,7 +1412,7 @@ class ImportClient
             if (!mkdir($plan_directory, 0755, true)) {
                 throw new RuntimeException('Failed to create the local plan directory: ' . $plan_directory . '.');
             }
-            $excluded_paths_path = $plan_directory . '/no_target_exclusions.json';
+            $excluded_paths_path = wp_join_unix_paths($plan_directory, 'no_target_exclusions.json');
             if (file_put_contents($excluded_paths_path, "[]\n") === false) {
                 throw new RuntimeException('Failed to write the empty exclusions file: ' . $excluded_paths_path . '.');
             }
@@ -1622,7 +1622,7 @@ class ImportClient
             if ($plan_file === '.' || $plan_file === '..') {
                 continue;
             }
-            $plan_file_path = $plan_directory . '/' . $plan_file;
+            $plan_file_path = wp_join_unix_paths($plan_directory, $plan_file);
             if (!is_file($plan_file_path) || !unlink($plan_file_path)) {
                 throw new RuntimeException('Failed to remove a local plan file: ' . $plan_file_path . '.');
             }
@@ -1698,7 +1698,7 @@ class ImportClient
             'chunk_bytes' => $chunk_bytes,
         ];
 
-        $resuming = is_file($context['push_state_directory'] . '/sender.json');
+        $resuming = is_file(wp_join_unix_paths($context['push_state_directory'], 'sender.json'));
         $sender = $resuming
             ? PushFilesSender::resume($sender_options, $process_lock)
             : PushFilesSender::start($sender_options, $process_lock);

--- a/packages/reprint-client/src/lib/class-reprint-process-lock.php
+++ b/packages/reprint-client/src/lib/class-reprint-process-lock.php
@@ -1,5 +1,8 @@
 <?php
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\trim_right_slash;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain local filesystem paths, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
@@ -29,6 +32,7 @@ final class ReprintProcessLock
      */
     public function __construct(string $state_dir)
     {
+        $normalized_state_dir = trim_right_slash($state_dir);
         if (
             !is_dir($state_dir)
             && !mkdir($state_dir, 0755, true)
@@ -39,7 +43,7 @@ final class ReprintProcessLock
                 . $state_dir . '.'
             );
         }
-        $process_lock_path = rtrim($state_dir, '/') . '/process.lock';
+        $process_lock_path = wp_join_unix_paths($normalized_state_dir, 'process.lock');
         $this->handle = fopen($process_lock_path, 'c+b');
         if (!is_resource($this->handle)) {
             throw new RuntimeException('Failed to open the Reprint process lock: ' . $process_lock_path . '.');
@@ -49,7 +53,7 @@ final class ReprintProcessLock
             $this->handle = null;
             throw new RuntimeException(
                 'Another Reprint process is using the state directory: '
-                . rtrim($state_dir, '/') . '.'
+                . $normalized_state_dir . '.'
             );
         }
     }

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -382,12 +382,12 @@ final class PushFilesSender
         $this->filesystem_root = trim_right_slash($resolved_local_filesystem_root);
         $this->document_root_local_relative_path = trim($document_root, '/');
         $this->process_lock = $process_lock;
-        $this->push_state_directory = rtrim($push_state_directory, '/');
-        $this->plan_directory = $this->push_state_directory . '/plan';
+        $this->push_state_directory = trim_right_slash($push_state_directory);
+        $this->plan_directory = wp_join_unix_paths($this->push_state_directory, 'plan');
         $remote_state_directory = dirname($this->push_state_directory);
-        $this->local_index_file = $remote_state_directory . '/local_index.jsonl';
-        $this->state_path = $this->push_state_directory . '/sender.json';
-        $this->excluded_paths_path = $this->push_state_directory . '/excluded_paths.json';
+        $this->local_index_file = wp_join_unix_paths($remote_state_directory, 'local_index.jsonl');
+        $this->state_path = wp_join_unix_paths($this->push_state_directory, 'sender.json');
+        $this->excluded_paths_path = wp_join_unix_paths($this->push_state_directory, 'excluded_paths.json');
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
     }
@@ -1415,7 +1415,7 @@ final class PushFilesSender
             if ($plan_file === '.' || $plan_file === '..') {
                 continue;
             }
-            $plan_file_path = $this->plan_directory . '/' . $plan_file;
+            $plan_file_path = wp_join_unix_paths($this->plan_directory, $plan_file);
             if (!unlink($plan_file_path)) {
                 throw new RuntimeException('Failed to remove a push plan file: ' . $plan_file_path);
             }

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -323,7 +323,7 @@ class PushPlan
         string $local_index_file,
         string $document_root_local_relative_path
     ) {
-        $plan_directory = rtrim($plan_directory, "/");
+        $plan_directory = trim_right_slash($plan_directory);
         if (!is_dir($plan_directory)) {
             throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
@@ -332,11 +332,11 @@ class PushPlan
         $this->local_index_file = $local_index_file;
         $this->document_root_local_relative_path =
             rtrim($document_root_local_relative_path, "/");
-        $this->local_paths_to_push = $plan_directory . "/local_paths_to_push.jsonl";
-        $this->local_paths_to_delete = $plan_directory . "/local_paths_to_delete";
-        $this->fresh_local_index_file = $plan_directory . "/fresh_local_index.jsonl";
-        $this->excluded_paths_file = $plan_directory . "/excluded_paths.json";
-        $this->deleted_directories_stack = $plan_directory . "/deleted_directories_stack.jsonl";
+        $this->local_paths_to_push = wp_join_unix_paths($plan_directory, "local_paths_to_push.jsonl");
+        $this->local_paths_to_delete = wp_join_unix_paths($plan_directory, "local_paths_to_delete");
+        $this->fresh_local_index_file = wp_join_unix_paths($plan_directory, "fresh_local_index.jsonl");
+        $this->excluded_paths_file = wp_join_unix_paths($plan_directory, "excluded_paths.json");
+        $this->deleted_directories_stack = wp_join_unix_paths($plan_directory, "deleted_directories_stack.jsonl");
     }
 
     /**


### PR DESCRIPTION
Files-diff, files-push, and their lock now construct local workspace paths through the filesystem utility. This keeps plan, sender, and lock locations correct when a base path is the filesystem root.