### PR TITLE
[PHP] Join runtime pipeline artifact paths

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -304,8 +304,8 @@ class Pull
                 $state->files_pull_path_selection_fingerprint = null;
                 $this->client->save_state();
                 foreach ([
-                    "{$pull_state_directory}/remote-index.next.jsonl",
-                    "{$pull_state_directory}/fetch-list.jsonl",
+                    wp_join_unix_paths($pull_state_directory, 'remote-index.next.jsonl'),
+                    wp_join_unix_paths($pull_state_directory, 'fetch-list.jsonl'),
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -323,9 +323,10 @@ class Pull
                 $state->db_index = new DatabaseTableIndexState();
                 $this->client->save_state();
                 foreach ([
-                    "{$state_dir}/db.sql",
-                    "{$state_dir}/db-session-setup.sql",
-                    "{$state_dir}/db-tables.jsonl",
+                    wp_join_unix_paths($state_dir, 'db.sql'),
+                    wp_join_unix_paths($state_dir, 'db-session-setup.sql'),
+                    wp_join_unix_paths($state_dir, 'db-tables.jsonl'),
+                    wp_join_unix_paths($pull_state_directory, 'domains.json'),
                 ] as $path) {
                     if (file_exists($path)) {
                         @unlink($path);
@@ -832,6 +833,7 @@ class Pull
             $paths[] = wp_join_unix_paths($state_dir, 'db.sql');
             $paths[] = wp_join_unix_paths($state_dir, 'db-session-setup.sql');
             $paths[] = wp_join_unix_paths($state_dir, 'db-tables.jsonl');
+            $paths[] = wp_join_unix_paths($pull_state_directory, 'domains.json');
         }
 
         foreach ($paths as $path) {

--- a/tests/Import/RuntimeArtifactPathTest.php
+++ b/tests/Import/RuntimeArtifactPathTest.php
@@ -1,0 +1,129 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/host/class-runtime-manifest.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/target-runtime/load.php';
+
+class RuntimeArtifactPathTest extends TestCase
+{
+    private string $tempDir;
+    private string $filesystemRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempDir = sys_get_temp_dir() . '/runtime-artifact-paths-' . uniqid('', true);
+        $this->filesystemRoot = $this->tempDir . '/filesystem-root';
+        mkdir($this->filesystemRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testNginxRuntimeArtifactsUseOneSeparator(): void
+    {
+        $outputDir = $this->tempDir . '/nginx///';
+        $canonicalOutputDir = $this->tempDir . '/nginx';
+
+        $applier = new \NginxFpmApplier();
+        $summary = $applier->apply(
+            new \RuntimeManifest('other'),
+            $this->filesystemRoot,
+            $outputDir,
+        );
+
+        $this->assertSame([
+            "Wrote {$canonicalOutputDir}/runtime.php",
+            "Wrote {$canonicalOutputDir}/nginx.conf",
+        ], array_slice($summary, 0, 2));
+        $this->assertFileExists($canonicalOutputDir . '/runtime.php');
+        $this->assertFileExists($canonicalOutputDir . '/nginx.conf');
+    }
+
+    public function testPhpBuiltinRuntimeArtifactsUseOneSeparator(): void
+    {
+        $outputDir = $this->tempDir . '/php-builtin///';
+        $canonicalOutputDir = $this->tempDir . '/php-builtin';
+
+        $applier = new \PhpBuiltinApplier();
+        $summary = $applier->apply(
+            new \RuntimeManifest('other'),
+            $this->filesystemRoot,
+            $outputDir,
+        );
+
+        $this->assertSame([
+            "Wrote {$canonicalOutputDir}/runtime.php",
+            "Wrote {$canonicalOutputDir}/start.sh",
+        ], array_slice($summary, 0, 2));
+        $this->assertFileExists($canonicalOutputDir . '/runtime.php');
+        $this->assertFileExists($canonicalOutputDir . '/start.sh');
+    }
+
+    public function testPlaygroundRuntimeArtifactsUseOneSeparator(): void
+    {
+        $outputDir = $this->tempDir . '/playground///';
+        $canonicalOutputDir = $this->tempDir . '/playground';
+
+        $applier = new \PlaygroundCliApplier();
+        $summary = $applier->apply(
+            new \RuntimeManifest('other'),
+            $this->filesystemRoot,
+            $outputDir,
+        );
+
+        $this->assertSame([
+            "Wrote {$canonicalOutputDir}/runtime.php",
+            "Wrote {$canonicalOutputDir}/blueprint.json",
+            "Wrote {$canonicalOutputDir}/start.sh",
+            "Wrote {$canonicalOutputDir}/start.json",
+        ], array_slice($summary, 0, 4));
+        $this->assertFileExists($canonicalOutputDir . '/runtime.php');
+        $this->assertFileExists($canonicalOutputDir . '/blueprint.json');
+        $this->assertFileExists($canonicalOutputDir . '/start.sh');
+        $this->assertFileExists($canonicalOutputDir . '/start.json');
+
+        $startConfig = json_decode(
+            file_get_contents($canonicalOutputDir . '/start.json'),
+            true,
+        );
+        $this->assertIsArray($startConfig);
+        $this->assertSame(
+            $canonicalOutputDir . '/blueprint.json',
+            $startConfig['blueprint'],
+        );
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            $this->recursiveDelete($path);
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Import/SqliteRuntimePluginCopyTest.php
+++ b/tests/Import/SqliteRuntimePluginCopyTest.php
@@ -60,6 +60,14 @@ class SqliteRuntimePluginCopyTest extends TestCase
         $this->assertFileExists($database_dir . '/load.php');
     }
 
+    public function testCopyNormalizesTrailingOutputDirectorySlashes(): void
+    {
+        $copied = \copy_sqlite_plugin($this->pluginSource(), $this->tempDir . '///');
+
+        $this->assertSame($this->tempDir . '/sqlite-database-integration', $copied);
+        $this->assertFileExists($copied . '/wp-includes/database/version.php');
+    }
+
     public function testCopyRepairsExistingOutputMissingDatabaseDriver(): void
     {
         $target_database_dir = $this->tempDir . '/sqlite-database-integration/wp-includes/database';
@@ -80,6 +88,20 @@ class SqliteRuntimePluginCopyTest extends TestCase
             $this->tempDir . '/sqlite-database-integration',
             $copied,
         );
+        $this->assertFileExists($copied . '/wp-includes/database/version.php');
+    }
+
+    public function testDatabaseDriverSourceSupportsPharStreamPaths(): void
+    {
+        $archive_path = $this->tempDir . '/sqlite-plugin.tar';
+        $plugin_path = 'packages/plugin-sqlite-database-integration';
+        $archive = new \PharData($archive_path);
+        $archive[$plugin_path . '/wp-includes/database/version.php'] = '<?php';
+        unset($archive);
+
+        $source_dir = 'phar://' . $archive_path . '/' . $plugin_path;
+        $copied = \copy_sqlite_plugin($source_dir, $this->tempDir);
+
         $this->assertFileExists($copied . '/wp-includes/database/version.php');
     }
 }


### PR DESCRIPTION
Runtime output and pull-pipeline artifact paths now collapse redundant separators, so slash-terminated directories produce one stable path spelling.

`wp_join_unix_paths()` now builds pull cleanup artifacts, generated runtime files, Playground mount source paths, and the copied SQLite plugin directory. Focused tests cover all three runtime appliers and the SQLite copy path.