### PR TITLE
[Push] Apply progress output modes to every command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ During files-push, progress records include `files_done` and `files_total` toget
 
 Interactive non-verbose files-push output uses one stage-weighted progress bar for the complete lifecycle. The percentage precedes a label which changes only at major lifecycle stages; while pushing local paths, target-confirmed file bytes appear beside the planned file byte total. These terminal-only details are not added to JSONL or `progress.json`.
 
-`files-push --progress=auto|tty|jsonl` selects that invocation's progress presentation. `auto` uses terminal output on a TTY and JSONL otherwise; `tty` and `jsonl` force either presentation without changing sender state. Explicit `tty` and `jsonl` modes cannot be combined with `--verbose`.
+Every command run by `ImportClient` accepts `--progress=auto|tty|jsonl` for that invocation. `auto` uses terminal output on a TTY and JSONL otherwise; `tty` and `jsonl` force either presentation without changing command state. Explicit `tty` and `jsonl` modes cannot be combined with `--verbose`.
 
 ## File Organization
 

--- a/README.md
+++ b/README.md
@@ -613,26 +613,28 @@ Both fields are emitted together only when the fetch list exists — they
 are absent during the index and diff phases. `files_done` grows monotonically
 up to `files_total` and survives exit-code-2 restarts.
 
-`files-push` accepts `--progress=auto|tty|jsonl`. The default `auto` mode uses
-terminal progress when its output stream is a TTY and JSONL otherwise. Use
-`--progress=tty` to force the single progress bar when output is captured, or
-`--progress=jsonl` to force structured output in a terminal:
+Every command run by `ImportClient` accepts `--progress=auto|tty|jsonl`. The
+default `auto` mode uses terminal progress when its output stream is a TTY and
+JSONL otherwise. Use `--progress=tty` to force the terminal presentation when
+output is captured, or `--progress=jsonl` to force structured progress in a
+terminal:
 
 ```bash
 php reprint.phar files-push "$URL" --state-dir="$STATE_DIR" \
     --fs-root="$FS_ROOT" --secret="$SECRET" --progress=jsonl
 ```
 
-The selected mode applies only to that invocation and is not retained in push
-state. Explicit `tty` and `jsonl` modes cannot be combined with `--verbose`.
+The selected mode applies only to that invocation and is not retained in
+command state. Explicit `tty` and `jsonl` modes cannot be combined with
+`--verbose`.
 
-The terminal presentation uses one stage-weighted progress bar. The percentage
-comes first, followed by a major stage such as `Indexing`, `Pushing`, or
-`Committing`. While pushing local paths, the line also shows target-confirmed
-file bytes against the file byte total collected by the plan. Durable index
-byte offsets, target-confirmed counts and byte offsets, and phase milestones
-advance the bar. The percentage describes lifecycle progress, not elapsed time
-or an estimated completion time.
+The files-push terminal presentation uses one stage-weighted progress bar. The
+percentage comes first, followed by a major stage such as `Indexing`, `Pushing`,
+or `Committing`. While pushing local paths, the line also shows target-confirmed
+file bytes against the file byte total collected by the plan. Durable index byte
+offsets, target-confirmed counts and byte offsets, and phase milestones advance
+the bar. The percentage describes lifecycle progress, not elapsed time or an
+estimated completion time.
 
 These terminal-only details do not change machine output. The JSONL
 presentation emits `push_progress` records. After planning completes, those

--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -470,10 +470,11 @@ participate in the directory name. Fragments, URL user-info, and `SECRET_KEY`
 target parameters are rejected. The local push state directory must be outside
 the filesystem root so planning cannot index its own changing files.
 
-`--progress=auto|tty|jsonl` selects progress output for one invocation. The
-default `auto` mode uses terminal progress when its output stream is a TTY and
-JSONL otherwise. `tty` and `jsonl` force the corresponding presentation; they
-are not stored in sender state and cannot be combined with `--verbose`.
+Like every `ImportClient` command, files-push accepts
+`--progress=auto|tty|jsonl` for one invocation. The default `auto` mode uses
+terminal progress when its output stream is a TTY and JSONL otherwise. `tty`
+and `jsonl` force the corresponding presentation; they are not stored in
+sender state and cannot be combined with `--verbose`.
 
 One process starts or resumes exactly one sender. Before every `next_step()` it
 checks whether another step may begin. The wall-clock admission deadline is 80

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -279,9 +279,9 @@ Use these names verbatim:
 | Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
 | Active state | `sender.json`, `$state_path` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
-| Selected local-path count | `local_paths_to_push_count`, `$local_paths_to_push_count`, `get_local_paths_to_push_count()` |
+| Selected local-path count | `local_paths_to_push_count`, `$local_paths_to_push_count` |
 | Target-confirmed local-path count | `local_paths_pushed`, `$local_paths_pushed` |
-| Selected local file bytes | `local_file_bytes_to_push`, `$local_file_bytes_to_push`, `get_local_file_bytes_to_push()` |
+| Selected local file bytes | `local_file_bytes_to_push`, `$local_file_bytes_to_push` |
 | Target-confirmed completed local file bytes | `local_file_bytes_pushed`, `$local_file_bytes_pushed` |
 | Consumed index bytes in progress | `index_bytes_done`, `$index_bytes_done` |
 | Combined index bytes in progress | `index_bytes_total`, `$index_bytes_total` |
@@ -355,6 +355,15 @@ request. In `pushing_paths` or
 returns true while another step may be performed and false when `get_status()`
 reports `complete`, `restart`, or `failed`.
 
+## CLI progress output names
+
+The **progress output mode** is the invocation-only `--progress` value accepted
+by every command executed by `ImportClient`: `auto`, `tty`, or `jsonl`. `auto`
+selects the terminal presentation when the current progress stream is a TTY and
+the JSONL presentation otherwise. `tty` and `jsonl` force those presentations.
+Never store the progress output mode in command state. Explicit `tty` and
+`jsonl` modes do not combine with `--verbose`.
+
 ## Files-diff CLI names
 
 The local-only command is `files-diff`. Its `remote Reprint API URL` and
@@ -393,12 +402,8 @@ root as a path beneath that filesystem root. Local relative paths beneath the do
 become push or delete work. It also requires `--secret=TOKEN`; `--force-http`
 is the explicit plain-HTTP opt-in.
 
-The **progress output mode** is the invocation-only `--progress` value for
-`files-push`: `auto`, `tty`, or `jsonl`. `auto` selects the terminal
-presentation when the current progress stream is a TTY and the JSONL
-presentation otherwise. `tty` and `jsonl` force those presentations. Never
-store the progress output mode in sender state. Explicit `tty` and `jsonl`
-modes do not combine with `--verbose`.
+`files-push` uses the shared progress output mode. It never stores that mode in
+sender state.
 
 The **local push state directory** is
 `<state-dir>/remotes/<md5-of-trimmed-remote-reprint-api-url>/push`. The hash

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -137,7 +137,28 @@ register_shutdown_function(function () {
 class ImportClient
 {
 
-    /** Progress output modes accepted by files-diff and files-push. */
+    /** Commands executed by ImportClient. */
+    public const COMMANDS = [
+        "pull",
+        "pull-files",
+        "pull-db",
+        "files-pull",
+        "files-diff",
+        "files-push",
+        "files-index",
+        "files-stats",
+        "db-pull",
+        "db-index",
+        "db-domains",
+        "db-apply",
+        "pull-metadata",
+        "preflight",
+        "preflight-assert",
+        "flat-docroot",
+        "apply-runtime",
+    ];
+
+    /** Progress output modes accepted by every command. */
     public const PROGRESS_OUTPUT_MODES = ['auto', 'tty', 'jsonl'];
 
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
@@ -920,10 +941,10 @@ class ImportClient
      * reading or writing command state. A supplied lock remains caller-owned.
      *
      * @param array $options Options:
-     *   - command: Required. One of the entries in $valid_commands below.
+     *   - command: Required. One of the entries in self::COMMANDS.
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
-     *   - progress: Optional files-diff or files-push progress output mode: auto, tty, or jsonl
+     *   - progress: Optional progress output mode: auto, tty, or jsonl
      * @param ReprintProcessLock|null $process_lock Optional lock already held
      *                                               for this state directory.
      */
@@ -940,10 +961,6 @@ class ImportClient
         }
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->progress->set_verbose_mode($this->verbose_mode);
-        if ($this->progress_output_mode !== 'auto') {
-            $this->progress_output_mode = 'auto';
-            $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
-        }
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         $this->include_caches = $options["include_caches"] ?? false;
         $this->extra_directory = $options["extra_directory"] ?? null;
@@ -974,37 +991,41 @@ class ImportClient
         $this->pipeline_step = $options["pipeline_step"] ?? null;
         $this->pipeline_steps = $options["pipeline_steps"] ?? null;
 
-        $valid_commands = [
-            "pull",
-            "pull-files",
-            "pull-db",
-            "files-pull",
-            "files-diff",
-            "files-push",
-            "files-index",
-            "files-stats",
-            "db-pull",
-            "db-index",
-            "db-domains",
-            "db-apply",
-            "pull-metadata",
-            "preflight",
-            "preflight-assert",
-            "flat-docroot",
-            "apply-runtime",
-        ];
-
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: " . implode(", ", $valid_commands),
+                "Command is required. Valid commands: " . implode(", ", self::COMMANDS),
             );
         }
 
-        if (!in_array($command, $valid_commands, true)) {
+        if (!in_array($command, self::COMMANDS, true)) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: " . implode(", ", $valid_commands),
+                "Invalid command: {$command}. Valid commands: " . implode(", ", self::COMMANDS),
             );
         }
+
+        $progress_output_mode = $options['progress'] ?? 'auto';
+        if (
+            !is_string($progress_output_mode)
+            || !in_array($progress_output_mode, self::PROGRESS_OUTPUT_MODES, true)
+        ) {
+            $invalid_progress_output_mode = is_string($progress_output_mode)
+                ? $progress_output_mode
+                : gettype($progress_output_mode);
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option errors are not HTML.
+            throw new InvalidArgumentException(
+                "Invalid --progress value: {$invalid_progress_output_mode}. Valid values: "
+                . implode(', ', self::PROGRESS_OUTPUT_MODES)
+            );
+        }
+        if ($this->verbose_mode && $progress_output_mode !== 'auto') {
+            throw new InvalidArgumentException(
+                "{$command} does not accept --verbose with --progress={$progress_output_mode}. "
+                . 'Use --progress=auto with --verbose.'
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        $this->progress_output_mode = $progress_output_mode;
+        $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
 
         // files-diff uses local push state and must not load or write the
         // pull command's pull/state.json file.
@@ -1018,29 +1039,6 @@ class ImportClient
             return;
         }
         if ($command === "files-push") {
-            $progress_output_mode = $options['progress'] ?? 'auto';
-            if (
-                !is_string($progress_output_mode)
-                || !in_array($progress_output_mode, self::PROGRESS_OUTPUT_MODES, true)
-            ) {
-                $invalid_progress_output_mode = is_string($progress_output_mode)
-                    ? $progress_output_mode
-                    : gettype($progress_output_mode);
-                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option errors are not HTML.
-                throw new InvalidArgumentException(
-                    "Invalid --progress value: {$invalid_progress_output_mode}. Valid values: "
-                    . implode(', ', self::PROGRESS_OUTPUT_MODES)
-                );
-            }
-            if ($this->verbose_mode && $progress_output_mode !== 'auto') {
-                throw new InvalidArgumentException(
-                    "files-push does not accept --verbose with --progress={$progress_output_mode}. "
-                    . 'Use --progress=auto with --verbose.'
-                );
-            }
-            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
-            $this->progress_output_mode = $progress_output_mode;
-            $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
             if (is_file($this->pull_index_wal_path)) {
                 throw new RuntimeException(
                     "Finish or abort the interrupted files-pull before running files-push."
@@ -1406,22 +1404,7 @@ class ImportClient
      */
     private function run_files_diff(array $options): void
     {
-        $progress_mode = $options['progress'] ?? ( $this->is_tty ? 'tty' : 'jsonl' );
-        if (
-            !is_string($progress_mode)
-            || !in_array($progress_mode, self::PROGRESS_OUTPUT_MODES, true)
-        ) {
-            $invalid_progress_mode = is_string($progress_mode)
-                ? $progress_mode
-                : gettype($progress_mode);
-            throw new InvalidArgumentException(
-                'Invalid files-diff progress mode: ' . $invalid_progress_mode . '. Valid modes: '
-                . implode(', ', self::PROGRESS_OUTPUT_MODES) . '.'
-            );
-        }
-        if ($progress_mode === 'auto') {
-            $progress_mode = $this->is_tty ? 'tty' : 'jsonl';
-        }
+        $progress_mode = $this->uses_terminal_progress() ? 'tty' : 'jsonl';
         $push_state_directory = $options['files_diff_push_state_directory'] ?? self::resolve_push_state_directory(
             $this->remote_reprint_api_url,
             $this->state_dir,
@@ -11730,7 +11713,8 @@ if (
             'target' => 'progress',
             'placeholder' => 'MODE',
             'help' => 'Progress output: auto, tty, or jsonl (default: auto)',
-            'commands' => ['files-diff', 'files-push'],
+            'help_section' => 'global',
+            'commands' => ImportClient::COMMANDS,
             'valid_values' => ImportClient::PROGRESS_OUTPUT_MODES,
         ],
         [
@@ -12974,18 +12958,8 @@ if (
                 exit(1);
             }
         }
-        $reprint_files_diff_progress_mode = $options['progress'] ?? 'auto';
-        if ($reprint_files_diff_progress_mode === 'auto') {
-            $reprint_stdout_is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
-            $reprint_files_diff_progress_mode = $reprint_stdout_is_tty ? 'tty' : 'jsonl';
-        }
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Existing parsed option hash.
-        $options['progress'] = $reprint_files_diff_progress_mode;
     } elseif (!empty($options['force_http'])) {
         fwrite(STDERR, "Error: --force-http is accepted only by files-push.\n");
-        exit(1);
-    } elseif (isset($options['progress'])) {
-        fwrite(STDERR, "Error: --progress is accepted only by files-diff and files-push.\n");
         exit(1);
     }
 
@@ -13067,9 +13041,14 @@ if (
         }
         return;
     } catch (\Throwable $e) {
-        $is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
+        $reprint_progress_output_mode = $options['progress'] ?? 'auto';
+        $reprint_progress_stream = ( $options['sql_output'] ?? null ) === 'stdout' ? STDERR : STDOUT;
+        $reprint_progress_stream_is_tty =
+            function_exists("posix_isatty") && posix_isatty($reprint_progress_stream);
+        $reprint_uses_terminal_progress = $reprint_progress_output_mode === 'tty'
+            || ( $reprint_progress_output_mode === 'auto' && $reprint_progress_stream_is_tty );
         $error_code = isset($client) ? $client->last_error_code : null;
-        if ($command === 'files-diff' ? ( $options['progress'] ?? 'tty' ) !== 'jsonl' : $is_tty) {
+        if ($reprint_uses_terminal_progress && empty($options['verbose'])) {
             fwrite(STDERR, ( $command === 'files-diff' ? '' : "\n" ) . "Error: " . $e->getMessage() . "\n");
         } else {
             $error = [

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -775,8 +775,10 @@ final class PushFilesSender
         }
         $this->state['push_plan_cursor'] = $plan_cursor;
         if (!$has_next_step) {
-            $this->state['local_paths_to_push_count'] = $this->plan->get_local_paths_to_push_count();
-            $this->state['local_file_bytes_to_push'] = $this->plan->get_local_file_bytes_to_push();
+            /** @var array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null} $completed_plan_position */
+            $completed_plan_position = $plan_cursor['position'];
+            $this->state['local_paths_to_push_count'] = $completed_plan_position['local_paths_to_push_count'];
+            $this->state['local_file_bytes_to_push'] = $completed_plan_position['local_file_bytes_to_push'];
             $this->plan->close();
             $this->state['phase'] = 'pushing_paths';
         }

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -269,34 +269,6 @@ class PushPlan
     }
 
     /**
-     * Returns the number of local paths in the completed push plan.
-     *
-     * Null means the plan resumed from an older cursor without a saved count.
-     */
-    public function get_local_paths_to_push_count(): ?int
-    {
-        $position = $this->cursor["position"];
-        if ($position["phase"] !== "complete") {
-            throw new LogicException("Cannot count local paths to push before the push plan is complete.");
-        }
-        return $position["local_paths_to_push_count"];
-    }
-
-    /**
-     * Returns the sum of file sizes in the completed push plan.
-     *
-     * Null means the plan resumed from an older cursor without a saved byte total.
-     */
-    public function get_local_file_bytes_to_push(): ?int
-    {
-        $position = $this->cursor["position"];
-        if ($position["phase"] !== "complete") {
-            throw new LogicException("Cannot total local file bytes before the push plan is complete.");
-        }
-        return $position["local_file_bytes_to_push"];
-    }
-
-    /**
      * Returns progress through the open plan.
      *
      * Durable byte offsets across both indexes describe diff progress. An

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -2,7 +2,10 @@
 
 namespace ImportTests;
 
+use ImportClient;
 use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
 
 class CliHelpTest extends TestCase
 {
@@ -166,9 +169,21 @@ class CliHelpTest extends TestCase
 
         $this->assertStringContainsString('files-push', $output);
         $this->assertStringContainsString('files-diff', $output);
+        $this->assertStringContainsString('--progress=MODE', $output);
         $this->assertStringContainsString('Low-level commands:', $output);
         $this->assertStringNotContainsString('Low-level commands (used by pull internally):', $output);
         $this->assertStringNotContainsString('State is stored in --state-dir/pull/state.json', $output);
         $this->assertStringNotContainsString('Use --abort to abort the current', $output);
+    }
+
+    public function testProgressOutputModeAppearsInEveryCommandHelp(): void
+    {
+        foreach (ImportClient::COMMANDS as $command) {
+            $this->assertStringContainsString(
+                '--progress=MODE',
+                $this->runHelp($command),
+                $command
+            );
+        }
     }
 }

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -393,22 +393,18 @@ final class FilesDiffCommandTest extends TestCase
         );
     }
 
-    public function testOtherCommandsRejectTheProgressOption(): void
+    public function testOtherCommandsAcceptTheProgressOption(): void
     {
         $result = $this->runCli([
-            'files-pull',
+            'pull-metadata',
             $this->remoteReprintApiUrl,
             '--state-dir=' . $this->stateDirectory,
-            '--fs-root=' . $this->filesystemRoot,
             '--progress=jsonl',
         ]);
 
-        $this->assertSame(1, $result['exit'], $result['output']);
-        $this->assertSame('', $result['stdout']);
-        $this->assertSame(
-            "Error: --progress is accepted only by files-diff and files-push.\n",
-            $result['stderr']
-        );
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('"hasCompletedOnce": false', $result['stdout']);
+        $this->assertSame('', $result['stderr']);
     }
 
     public function testInterruptedFilesDiffReportsTheCompleteDiffWhenItIsRunAgain(): void

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -432,6 +432,7 @@ class PullFilterOptionTest extends TestCase
 
         $client->run([
             "command" => "pull-files",
+            "progress" => "tty",
         ]);
 
         $output = $client->terminalProgressOutput();
@@ -447,6 +448,7 @@ class PullFilterOptionTest extends TestCase
 
         $client->run([
             "command" => "pull-files",
+            "progress" => "tty",
             "only" => ["/var/www/html/wp-content/uploads/reprint-demo"],
         ]);
 

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -119,8 +119,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($plan);
 
         $this->assertPathCounts(2, 0);
-        $this->assertSame(2, $plan->get_local_paths_to_push_count());
-        $this->assertSame(10, $plan->get_local_file_bytes_to_push());
+        $this->assertSame(2, $this->planCursor()['local_paths_to_push_count']);
+        $this->assertSame(10, $this->planCursor()['local_file_bytes_to_push']);
         $this->assertSame(
             ['index.php', 'wp-content/themes/foo/style.css'],
             $this->listPaths($this->planPath('local_paths_to_push.jsonl'))
@@ -511,8 +511,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($resumedPlan);
 
         $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertNull($resumedPlan->get_local_paths_to_push_count());
-        $this->assertNull($resumedPlan->get_local_file_bytes_to_push());
+        $this->assertNull($this->planCursor()['local_paths_to_push_count']);
+        $this->assertNull($this->planCursor()['local_file_bytes_to_push']);
     }
 
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
@@ -666,8 +666,8 @@ final class PushPlanTest extends TestCase
         $this->planToCompletion($reopened);
 
         $this->assertPathCounts(3, 3);
-        $this->assertSame(3, $reopened->get_local_paths_to_push_count());
-        $this->assertSame(3, $reopened->get_local_file_bytes_to_push());
+        $this->assertSame(3, $this->planCursor()['local_paths_to_push_count']);
+        $this->assertSame(3, $this->planCursor()['local_file_bytes_to_push']);
         $this->assertSame(array_keys($currentEntries), $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
         $this->assertSame(array_keys($localIndexEntries), $this->localPathsToDelete($this->planPath('local_paths_to_delete')));
         $this->assertCount(3, $this->indexEntries($this->planPath('fresh_local_index.jsonl')));


### PR DESCRIPTION
`--progress=auto|tty|jsonl` now selects the progress presentation for every command run by `ImportClient`, rather than only files-diff and files-push.

```bash
php reprint.phar pull "$URL" \
    --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" \
    --secret="$SECRET" --progress=jsonl

php reprint.phar files-pull "$URL" \
    --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" \
    --secret="$SECRET" --progress=tty
```

Progress-mode validation and the explicit-mode/verbose conflict now happen once in `ImportClient::run()` before command dispatch. The same command list drives run validation and per-command help. files-diff consumes the effective shared mode instead of validating and resolving it again.

The sender also reads the selected local-path count and selected local file bytes from the completed PushPlan cursor it already holds. The two one-call PushPlan getters are gone.

## Testing

Run a command with redirected output and `--progress=tty`, then run it in a terminal with `--progress=jsonl`. Confirm each explicit mode overrides TTY detection and that the files-push lifecycle bar is unchanged.
