### PR TITLE
[PHP] Replace ad-hoc path processing with path helpers

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2560,15 +2560,14 @@ class ImportClient
         // Log non-standard WordPress directory layouts for awareness
         $paths = $payload["database"]["wp"]["paths_urls"] ?? null;
         if (is_array($paths)) {
-            $abspath = rtrim($paths["abspath"] ?? "", "/");
-            $content_dir = rtrim($paths["content_dir"] ?? "", "/");
-            $uploads_basedir = rtrim(
-                $paths["uploads"]["basedir"] ?? "",
-                "/",
+            $abspath = $this->clean_preflight_path($paths["abspath"] ?? null);
+            $content_dir = $this->clean_preflight_path($paths["content_dir"] ?? null);
+            $uploads_basedir = $this->clean_preflight_path(
+                $paths["uploads"]["basedir"] ?? null,
             );
             if (
-                $abspath !== "" &&
-                $content_dir !== "" &&
+                $abspath !== null &&
+                $content_dir !== null &&
                 $content_dir !== wp_join_unix_paths($abspath, "wp-content")
             ) {
                 $this->audit_log(
@@ -2577,9 +2576,9 @@ class ImportClient
                 );
             }
             if (
-                $content_dir !== "" &&
-                $uploads_basedir !== "" &&
-                strpos($uploads_basedir, $content_dir) !== 0
+                $content_dir !== null &&
+                $uploads_basedir !== null &&
+                !path_is_within_root($uploads_basedir, $content_dir)
             ) {
                 $this->audit_log(
                     "NON-STANDARD LAYOUT | uploads at {$uploads_basedir} " .
@@ -2652,7 +2651,7 @@ class ImportClient
         foreach ($files as $f) {
             $parent = dirname($f);
             if ($parent !== "" && $parent !== ".") {
-                $by_dir[rtrim($parent, "/")][] = $f;
+                $by_dir[trim_right_slash($parent)][] = $f;
             }
         }
 
@@ -4316,14 +4315,11 @@ class ImportClient
             // source server. Files are downloaded preserving the full
             // remote absolute path, so the local document root is --fs-root +
             // document_root.
-            $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
-            if (is_string($remote_doc_root)) {
-                $remote_doc_root = rtrim($remote_doc_root, "/");
-            } else {
-                $remote_doc_root = "";
-            }
+            $remote_doc_root = $this->clean_preflight_path(
+                $preflight_data["runtime"]["document_root"] ?? null,
+            );
 
-            if ($remote_doc_root !== "") {
+            if ($remote_doc_root !== null) {
                 $raw_local_document_root = wp_join_unix_paths(
                     $this->filesystem_root,
                     $remote_doc_root
@@ -4429,11 +4425,11 @@ class ImportClient
         // directory (e.g. /wordpress/core/X.Y.Z) which maps to
         // filesystem root + ABSPATH when using --fs-root.
         $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
-        $abspath = rtrim($paths_urls["abspath"] ?? "", "/");
+        $abspath = $this->clean_preflight_path($paths_urls["abspath"] ?? null);
         if (!empty($flat_document_root)) {
             // Flattened layout: index.php is at the top level.
             $wordpress_index_php = wp_join_unix_paths($local_document_root, 'index.php');
-        } elseif ($abspath !== "") {
+        } elseif ($abspath !== null) {
             // Raw download: ABSPATH is relative to the download root,
             // not the local document root (which is filesystem root + document root).
             $wordpress_index_php = realpath(
@@ -5365,11 +5361,12 @@ class ImportClient
             $target_db = $options["target_db"] ?? "sqlite_database";
 
             if (!$target_path) {
-                $content_dir = rtrim(
-                    $this->get_state()->get('preflight.database.wp.paths_urls.content_dir') ?? "",
-                    "/",
+                $content_dir = $this->clean_preflight_path(
+                    $this->get_state()->get(
+                        'preflight.database.wp.paths_urls.content_dir'
+                    ),
                 );
-                if(!$content_dir) {
+                if ($content_dir === null) {
                     throw new InvalidArgumentException(
                         "--target-sqlite-path option is required but was missing.",
                     );
@@ -9569,7 +9566,7 @@ class ImportClient
             if ($part === "") {
                 continue;
             }
-            $current .= "/" . $part;
+            $current = wp_join_unix_paths($current, $part);
             if (is_link($current)) {
                 return true;
             }
@@ -9647,7 +9644,7 @@ class ImportClient
             if ($part === "") {
                 continue;
             }
-            $current .= "/" . $part;
+            $current = wp_join_unix_paths($current, $part);
 
             if (is_link($current)) {
                 if ($this->fs_root_nonempty_behavior === 'preserve-local') {
@@ -10172,8 +10169,8 @@ class ImportClient
         foreach (["auto_prepend_file", "auto_append_file"] as $ini_key) {
             $ini_path = $ini_all[$ini_key] ?? "";
             if (is_string($ini_path) && $ini_path !== "" && $ini_path[0] === "/") {
-                $ini_dir = rtrim(dirname($ini_path), "/");
-                if ($ini_dir !== "" && $ini_dir !== "/") {
+                $ini_dir = trim_right_slash(dirname($ini_path));
+                if ($ini_dir !== "/") {
                     $extra_paths[$ini_key] = $ini_dir;
                 }
             }

--- a/packages/reprint-client/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/reprint-client/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -1,6 +1,7 @@
 <?php
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\trim_right_slash;
 
 /**
  * Host analyzer for WP Cloud (wpcom) sites.
@@ -135,8 +136,8 @@ class WpcloudHostAnalyzer implements HostAnalyzer
             if (!is_string($path) || $path === '' || $path[0] !== '/') {
                 continue;
             }
-            $dir = rtrim(dirname($path), '/');
-            if ($dir !== '' && $dir !== '/') {
+            $dir = trim_right_slash(dirname($path));
+            if ($dir !== '/') {
                 $dirs[] = $dir;
             }
         }

--- a/packages/reprint-client/src/lib/host/functions.php
+++ b/packages/reprint-client/src/lib/host/functions.php
@@ -5,6 +5,9 @@
  * Registry, detection logic, and shared preflight extraction helpers.
  */
 
+use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\trim_right_slash;
+
 /**
  * All known host analyzers.
  *
@@ -95,7 +98,10 @@ function extract_php_ini(array $preflight_data): array
 function extract_constants(array $preflight_data): array
 {
     $paths_urls = $preflight_data['database']['wp']['paths_urls'] ?? [];
-    $abspath = rtrim($paths_urls['abspath'] ?? '', '/');
+    $abspath = $paths_urls['abspath'] ?? '';
+    if ($abspath !== '') {
+        $abspath = trim_right_slash($abspath);
+    }
     $content_dir = $paths_urls['content_dir'] ?? '';
 
     $result = [];
@@ -106,7 +112,7 @@ function extract_constants(array $preflight_data): array
     if (
         $content_dir !== ''
         && $abspath !== ''
-        && !\WordPress\Reprint\Exporter\path_is_within_root($content_dir, $abspath)
+        && !path_is_within_root($content_dir, $abspath)
     ) {
         $result['WP_CONTENT_DIR'] = '{fs-root}/wp-content';
     }

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -8,6 +8,8 @@ use Reprint\Importer\State\FileDiffProgressState;
 use Reprint\Importer\State\FilesPullSummaryState;
 use Reprint\Importer\State\RemoteFileIndexCursorState;
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 require_once __DIR__ . '/class-pull-failure-reported-exception.php';
 
 /**
@@ -458,7 +460,7 @@ class Pull
                 if (
                     $state->active_resumable_command->command_name !== 'db-pull' ||
                     $state->active_resumable_command->completion_state !== 'complete' ||
-                    !file_exists($this->client->state_dir . '/db.sql')
+                    !file_exists(wp_join_unix_paths($this->client->state_dir, 'db.sql'))
                 ) {
                     $this->run_until_complete('db-pull', function () {
                         $this->client->run_db_sync();
@@ -562,7 +564,10 @@ class Pull
         $options = $this->validate_database_target_options($options);
 
         if (empty($options['output_dir'])) {
-            $options['output_dir'] = $this->client->state_dir . '/runtime';
+            $options['output_dir'] = wp_join_unix_paths(
+                $this->client->state_dir,
+                'runtime'
+            );
         }
 
         if (!isset($options['filter'])) {
@@ -871,8 +876,11 @@ class Pull
      */
     private function start_server(array $options): void
     {
-        $output_dir = $options['output_dir'] ?? $this->client->state_dir . '/runtime';
-        $start_sh = $output_dir . '/start.sh';
+        $output_dir = $options['output_dir'] ?? wp_join_unix_paths(
+            $this->client->state_dir,
+            'runtime'
+        );
+        $start_sh = wp_join_unix_paths($output_dir, 'start.sh');
 
         if (!file_exists($start_sh)) {
             throw new RuntimeException(

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -311,7 +311,7 @@ final class FileIndexProcessor {
         // a cache path or a path that disappears between scandir() and lstat(),
         // or every resumed request would inspect that same name again.
         $this->directory_stack[$frame_index]["after"] = $entry_name;
-        $path = $this->current_directory . "/" . $entry_name;
+        $path = wp_join_unix_paths($this->current_directory, $entry_name);
 
         // Apply omissions before lstat() and before a directory can enter the
         // stack. Omitted subtrees therefore cost no extra filesystem calls.

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -134,7 +134,7 @@ final class Site_Export_Push_Session {
      *                                      must never receive, delete, or replace.
      */
     private function __construct(string $reprint_directory, string $docroot, string $push_session_id, array $excluded_paths) {
-        $this->reprint_directory = rtrim($reprint_directory, '/');
+        $this->reprint_directory = trim_right_slash($reprint_directory);
         $this->docroot = trim_right_slash($docroot);
         $this->push_session_id = $push_session_id;
         if ($reprint_directory === $this->docroot) {
@@ -2563,7 +2563,7 @@ final class Site_Export_Push_Session {
      * @return string Absolute path in the document root.
      */
     private function docroot_path(string $relative_path): string {
-        return $this->docroot . ( $this->docroot === '/' ? '' : '/' ) . $relative_path;
+        return wp_join_unix_paths($this->docroot, $relative_path);
     }
 
     /**
@@ -2588,7 +2588,7 @@ final class Site_Export_Push_Session {
         }
         $current = $this->work_files_directory;
         foreach (explode('/', $relative) as $segment) {
-            $current .= '/' . $segment;
+            $current = wp_join_unix_paths($current, $segment);
             $identity = $this->lstat_path($current);
             if ($identity === null) {
                 if (!$create_missing) {

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -161,6 +161,51 @@ class RemoteUploadProxyRuntimeTest extends TestCase
         );
     }
 
+    public function testApplyRuntimeFindsRootAbspathInTheRawDownload(): void
+    {
+        mkdir($this->fsRoot . '/remote-document-root');
+        file_put_contents(
+            $this->fsRoot . '/remote-document-root/index.php',
+            "<?php echo 'document root';\n",
+        );
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '/remote-document-root',
+                    ],
+                    'database' => [
+                        'wp' => [
+                            'paths_urls' => [
+                                'abspath' => '/',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        ob_start();
+        try {
+            $this->callPrivate($client, 'run_apply_runtime', [[
+                'runtime' => 'php-builtin',
+                'output_dir' => $this->outputDir,
+            ]]);
+        } finally {
+            ob_end_clean();
+        }
+        $runtime = file_get_contents($this->outputDir . '/runtime.php');
+        $resolved_filesystem_root = realpath($this->fsRoot);
+        $this->assertIsString($resolved_filesystem_root);
+
+        $this->assertStringContainsString(
+            "\$wordpress_core_dir = '" . addslashes($resolved_filesystem_root) . "';",
+            $runtime,
+        );
+    }
+
     public function testApplyRuntimeAddsProxyForEssentialFilesFilter(): void
     {
         $client = $this->makeClient();

--- a/tests/Import/RuntimeFilesRootPathTest.php
+++ b/tests/Import/RuntimeFilesRootPathTest.php
@@ -1,0 +1,198 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match existing importer test class style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+final class RuntimeFilesRootPathTest extends TestCase
+{
+    private string $root;
+    private string $state_directory;
+    private string $filesystem_root;
+    private string $request_log;
+
+    /** @var resource|null */
+    private $server_process = null;
+
+    /** @var array<int,resource> */
+    private array $server_pipes = [];
+
+    private string $target_url;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir()
+            . '/runtime-files-root-path-'
+            . bin2hex(random_bytes(6));
+        $this->state_directory = $this->root . '/state';
+        $this->filesystem_root = $this->root . '/files';
+        $this->request_log = $this->root . '/requests.jsonl';
+        mkdir($this->state_directory, 0700, true);
+        mkdir($this->filesystem_root, 0700, true);
+        $this->target_url = $this->start_server();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            foreach ($this->server_pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->server_process);
+        }
+        $this->remove_tree($this->root);
+        parent::tearDown();
+    }
+
+    public function testRuntimeFileAtTheFilesystemRootUsesTheRootDirectory(): void
+    {
+        if (!function_exists('curl_init')) {
+            $this->markTestSkipped('Runtime file fetching requires the curl extension.');
+        }
+
+        $client = new \ImportClient(
+            $this->target_url,
+            $this->state_directory,
+            $this->filesystem_root,
+        );
+        $download_directory = $this->state_directory . '/runtime-files';
+        $reflection = new \ReflectionClass($client);
+        $fetch_files_into = $reflection->getMethod('fetch_files_into');
+        $downloaded = $fetch_files_into->invoke(
+            $client,
+            $download_directory,
+            ['/runtime.php'],
+        );
+
+        $this->assertSame(1, $downloaded);
+        $this->assertSame(
+            'runtime file at root',
+            file_get_contents($download_directory . '/runtime.php'),
+        );
+
+        $requests = file($this->request_log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertIsArray($requests);
+        $this->assertCount(1, $requests);
+        $request = json_decode($requests[0], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('file_fetch', $request['endpoint']);
+        $this->assertSame(['/'], $request['directory']);
+    }
+
+    private function start_server(): string
+    {
+        $router = $this->root . '/runtime-files-root-router.php';
+        file_put_contents($router, sprintf(<<<'PHP'
+<?php
+$request = array(
+    'endpoint' => $_GET['endpoint'] ?? null,
+    'directory' => $_GET['directory'] ?? null,
+);
+file_put_contents(
+    %s,
+    json_encode($request, JSON_UNESCAPED_SLASHES) . "\n",
+    FILE_APPEND
+);
+
+if (
+    $request['endpoint'] !== 'file_fetch'
+    || !is_array($request['directory'])
+    || ($request['directory'][0] ?? null) !== '/'
+) {
+    http_response_code(400);
+    echo 'file_fetch must receive the filesystem root as its directory';
+    return;
+}
+
+$boundary = 'runtime-files-root-path-test';
+$write_part = static function (array $headers, string $body = '') use ($boundary): void {
+    echo "--{$boundary}\r\n";
+    foreach ($headers as $name => $value) {
+        echo "{$name}: {$value}\r\n";
+    }
+    echo 'Content-Length: ' . strlen($body) . "\r\n\r\n";
+    echo $body . "\r\n";
+};
+
+header('Content-Type: multipart/mixed; boundary=' . $boundary);
+$write_part(array(
+    'X-Chunk-Type' => 'file',
+    'X-File-Path' => base64_encode('/runtime.php'),
+    'X-First-Chunk' => '1',
+    'X-Last-Chunk' => '1',
+), 'runtime file at root');
+$write_part(array(
+    'X-Chunk-Type' => 'completion',
+    'X-Status' => 'complete',
+));
+echo "--{$boundary}--\r\n";
+PHP, json_encode(
+            $this->request_log,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        )));
+
+        $error_number = 0;
+        $error_message = '';
+        $socket = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $error_number,
+            $error_message,
+        );
+        $this->assertIsResource($socket, $error_message);
+        $socket_name = stream_socket_get_name($socket, false);
+        $this->assertIsString($socket_name);
+        fclose($socket);
+        $port = (int) substr(strrchr($socket_name, ':'), 1);
+
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $this->server_pipes,
+            $this->root,
+        );
+        $this->assertIsResource($this->server_process);
+        fclose($this->server_pipes[0]);
+
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen(
+                '127.0.0.1',
+                $port,
+                $error_number,
+                $error_message,
+                0.1,
+            );
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+
+        $this->fail('Runtime file test server did not start.');
+    }
+
+    private function remove_tree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove_tree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -143,4 +143,45 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->assertStringContainsString("define('DB_FILE'", $runtime);
         $this->assertStringContainsString("Constant already defined", $runtime);
     }
+
+    public function testDefaultSqlitePathKeepsTheRootContentDirectory(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'paths_urls' => [
+                                'content_dir' => '/',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = new \ImportClient(
+            'https://source.example/export.php',
+            $this->stateDir,
+            $this->fsRoot,
+        );
+        $this->loadClientState($client);
+        [$connection] = $this->callPrivate(
+            $client,
+            'create_target_db_apply_connection',
+            [['target_engine' => 'sqlite']],
+        );
+        $resolved_filesystem_root = realpath($this->fsRoot);
+        $this->assertIsString($resolved_filesystem_root);
+
+        $this->assertIsObject($connection);
+        $this->assertSame(
+            $resolved_filesystem_root . '/database/.ht.sqlite',
+            $this->callPrivate($client, 'get_state')->apply->target_sqlite_path,
+        );
+    }
 }

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -350,6 +350,21 @@ final class PushSessionTest extends TestCase {
         $this->assertSame($root_session->get_push_directory(), $reopened->get_push_directory());
     }
 
+    public function testRootReprintDirectoryKeepsPushSessionPathsAbsolute(): void {
+        $push_session_id = str_repeat('c', 32);
+        $push_session = Site_Export_Push_Session::open(
+            '/',
+            $this->docroot,
+            $push_session_id,
+            []
+        );
+
+        $this->assertSame(
+            '/.reprint/push/' . $push_session_id,
+            $push_session->get_push_directory()
+        );
+    }
+
     public function testCompletedWorkSymlinkCannotBecomeAnotherWorkPathsParent(): void {
         $push_session = $this->push_session('33333333333333333333333333333333');
         $this->push_parts($push_session, [[


### PR DESCRIPTION
Pull and push retain filesystem-root paths at the remaining helper boundaries, so root-valued inputs no longer become empty strings or malformed request directories.

This replaces direct trimming, containment, and component joins with the existing path helpers. Streamed file-error recovery is intentionally outside this change.