### PR TITLE
[Push] Coordinate durable push ownership

### DIFF
--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -243,9 +243,10 @@ by file-index and file-fetch responses and exclusive for a bounded commit call.
 `push_status`, `push_commit`, and `push_remove` request supplies that epoch.
 A request whose `(push_session_id, ownership_epoch)` is no longer current
 receives `sync_overtaken`. A second owner receives `sync_locked` with the
-current identity unless it makes an explicit takeover request naming the same
-blocking identity. A completed target commit advances the document-root
-generation once before readers reopen. File-index and file-fetch metadata carry
+current identity unless `files-push --force-takeover` makes an explicit takeover
+request naming that same blocking identity. A completed target commit advances
+the document-root generation once before readers reopen. File-index and
+file-fetch metadata carry
 that generation in `document_root_generation` and the
 `X-Document-Root-Generation` header.
 

--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -129,9 +129,9 @@ A push plan is an internal part of the sender lifecycle:
    preflight document root. The sender enters `creating`, stores the document
    root's local relative path in `sender.json`, and requests
    at most 100 target exclusions from `push_create`. If another push session
-   has an active commit, the sender stores its `blocking_push_session_id`, enters
-   `finishing_previous_commit`, and sends one bounded `push_commit` request per
-   step until that commit finishes. It then returns to `creating`. A successful
+   owns the target, create returns `sync_locked` with its session ID and
+   ownership epoch. The sender does not advance that lifecycle; the caller
+   retries within its budget or requests an explicit takeover. A successful
    create stores the exclusions in `excluded_paths.json` after creating the
    active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
@@ -230,6 +230,29 @@ only.
 more cleanup remains and must be retried. A push with a commit in progress is
 not removable; its next commit request resumes the durable cursor instead.
 
+## Durable push coordination
+
+Each document root keeps coordination state beside its push sessions at
+`<reprint-directory>/.reprint/push/`. `state.json` records the current owner,
+its monotonically increasing ownership epoch, the document-root generation, and
+bounded terminal-owner records. `state.lock` protects only that metadata;
+`push-request.lock` serializes one owner request; and `file-read.lock` is shared
+by file-index and file-fetch responses and exclusive for a bounded commit call.
+
+`push_create` grants a session an ownership epoch. Every later `push_upload`,
+`push_status`, `push_commit`, and `push_remove` request supplies that epoch.
+A request whose `(push_session_id, ownership_epoch)` is no longer current
+receives `sync_overtaken`. A second owner receives `sync_locked` with the
+current identity unless it makes an explicit takeover request naming the same
+blocking identity. A completed target commit advances the document-root
+generation once before readers reopen. File-index and file-fetch metadata carry
+that generation in `document_root_generation` and the
+`X-Document-Root-Generation` header.
+
+A completed sender removes its target push session after saving the local index.
+That releases durable ownership only after private-work cleanup has finished;
+repeated remove calls remain idempotent through the terminal-owner records.
+
 ## Push HTTP operations
 
 The production exporter router exposes five authenticated push operations.
@@ -247,9 +270,9 @@ complete request for authentication.
   sorted, immutable server policy stored for the push session; base64 preserves
   arbitrary path bytes which JSON cannot represent directly. A sender
   consuming this field must omit indexed paths equal to, below, or ancestors
-  of any advertised exclusion. When another push session has an active commit,
-  the endpoint returns `commit_required` with its `blocking_push_session_id`
-  before creating the requested push session.
+  of any advertised exclusion. When another push session owns the target,
+  the endpoint returns `sync_locked` with `blocking_push_session_id` and
+  `blocking_ownership_epoch` before creating the requested push session.
 - `POST push_upload` accepts `multipart/mixed`. A successful response contains
   `status`, `push_session_id`, `changes_accepted`, and `last_change`. The last
   change is null for an empty request. Otherwise it contains `state`, `type`,

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -402,7 +402,9 @@ exporter API URL, and its `filesystem root` is the resolved absolute directory s
 `--fs-root`. It requires saved preflight data and treats its remote document
 root as a path beneath that filesystem root. Local relative paths beneath the document root become document-root-relative paths; other local paths do not
 become push or delete work. It also requires `--secret=TOKEN`; `--force-http`
-is the explicit plain-HTTP opt-in.
+is the explicit plain-HTTP opt-in. `--force-takeover` first learns the current
+push owner, then sends a guarded takeover request naming that owner and its
+ownership epoch.
 
 `files-push` uses the shared progress output mode. It never stores that mode in
 sender state.

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -1668,6 +1668,7 @@ class ImportClient
      *
      *     @type string $secret             HMAC shared secret.
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
+     *     @type bool   $force_takeover     Whether the operator may take over the target's reported push owner.
      *     @type string $progress           Progress output mode: auto, tty, or jsonl.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
      * }
@@ -1717,6 +1718,7 @@ class ImportClient
             'remote_reprint_api_url' => $context['remote_reprint_api_url'],
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
+            'force_takeover' => $options['force_takeover'] ?? false,
             'chunk_bytes' => $chunk_bytes,
         ];
 
@@ -2139,6 +2141,7 @@ class ImportClient
      *
      *     @type string $secret     HMAC shared secret.
      *     @type bool   $force_http Whether the operator allowed a plain-HTTP target.
+     *     @type bool   $force_takeover Whether the operator may take over the target's reported push owner.
      * }
      * @phpstan-param array<string,mixed> $options
      * @return array {
@@ -11714,6 +11717,13 @@ if (
             'commands' => ['files-push'],
         ],
         [
+            'name' => 'force-takeover',
+            'type' => 'flag',
+            'target' => 'force_takeover',
+            'help' => 'Take over the target push owner after it is identified; the displaced sender stops at its next request',
+            'commands' => ['files-push'],
+        ],
+        [
             'name' => 'progress',
             'type' => 'value',
             'target' => 'progress',
@@ -12677,7 +12687,7 @@ if (
         "files-push" => [
             "level" => "low",
             "short" => "Push one local file tree without database work",
-            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--progress=MODE] [--verbose]",
+            "usage" => "reprint files-push <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR --secret=TOKEN [--force-http] [--force-takeover] [--progress=MODE] [--verbose]",
             "description" =>
                 "Sends the remote document root's local tree beneath --fs-root.\n" .
                 "This is a low-level, files-only command: it performs no database work,\n" .
@@ -12939,7 +12949,7 @@ if (
         foreach ($reprint_files_command_arguments as $reprint_files_push_command_argument) {
             $reprint_files_push_option_allowed = in_array(
                 $reprint_files_push_command_argument,
-                ['--force-http', '--verbose', '-v'],
+                ['--force-http', '--force-takeover', '--verbose', '-v'],
                 true
             )
                 || strpos($reprint_files_push_command_argument, '--state-dir=') === 0

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -129,7 +129,7 @@ use function WordPress\Reprint\Exporter\trim_right_slash;
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{local_relative_path:string,document_root_relative_path:string,document_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,ownership_epoch:int|null,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -278,6 +278,7 @@ final class PushFilesSender
             $sender->push_stream_client = $sender->create_push_stream_client(null);
             $sender->state = [
                 'push_session_id' => bin2hex(random_bytes(16)),
+                'ownership_epoch' => null,
                 'blocking_push_session_id' => null,
                 'phase' => 'creating',
                 'document_root_local_relative_path' => $sender->document_root_local_relative_path,
@@ -578,6 +579,17 @@ final class PushFilesSender
     }
 
     /**
+     * Returns the target identity established by push_create.
+     */
+    private function require_ownership_epoch(): int
+    {
+        if (!is_int($this->state['ownership_epoch']) || $this->state['ownership_epoch'] <= 0) {
+            throw new LogicException('The active push sender has no ownership epoch.');
+        }
+        return $this->state['ownership_epoch'];
+    }
+
+    /**
      * Creates the push session and stores the policy returned by the target.
      */
     private function create_push_session(): void
@@ -597,8 +609,13 @@ final class PushFilesSender
             return;
         }
 
-        /** @var array{max_part_bytes:int,post_max_bytes:?int,excluded_paths_b64:list<string>} $response */
+        /** @var array{ownership_epoch:int,max_part_bytes:int,post_max_bytes:?int,excluded_paths_b64:list<string>} $response */
         $response = $request_result['response'];
+        if (!is_int($response['ownership_epoch'] ?? null) || $response['ownership_epoch'] <= 0) {
+            $this->fail('unexpected_response', 'push_create did not return a positive ownership_epoch.');
+            return;
+        }
+        $this->state['ownership_epoch'] = $response['ownership_epoch'];
         if (count($response['excluded_paths_b64']) > 100) {
             $this->fail(
                 'unexpected_response',
@@ -823,6 +840,7 @@ final class PushFilesSender
         } else {
             $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                 'push_session_id' => $this->state['push_session_id'],
+                'ownership_epoch' => $this->require_ownership_epoch(),
                 'path_b64' => $local_path_to_push['document_root_relative_path_b64'],
             ], ['accepted']);
             if ($this->handle_request_failure($request_result)) {
@@ -1003,7 +1021,7 @@ final class PushFilesSender
         // cancellation return to the last target-confirmed sender boundary.
         if ($this->upload_request_stage === 'closed') {
             $this->state_before_upload_request = $this->state;
-            if (!$this->push_stream_client->start_upload_request($this->state['push_session_id'])) {
+            if (!$this->push_stream_client->start_upload_request($this->state['push_session_id'], $this->require_ownership_epoch())) {
                 $this->state_before_upload_request = null;
                 $this->fail('request_failed', $this->push_stream_client->get_last_error());
                 return;
@@ -1066,6 +1084,7 @@ final class PushFilesSender
                 if ($this->receiver_confirmed_deleted_paths_byte_offset === null) {
                     $request_result = $this->push_stream_client->send_push_request('GET', 'push_status', [
                         'push_session_id' => $this->state['push_session_id'],
+                        'ownership_epoch' => $this->require_ownership_epoch(),
                     ], ['accepted']);
                     if ($this->handle_request_failure($request_result)) {
                         return;
@@ -1161,7 +1180,7 @@ final class PushFilesSender
         // Open a request only after the next complete part is ready.
         if ($this->upload_request_stage === 'closed') {
             $this->state_before_upload_request = $this->state;
-            if (!$this->push_stream_client->start_upload_request($this->state['push_session_id'])) {
+            if (!$this->push_stream_client->start_upload_request($this->state['push_session_id'], $this->require_ownership_epoch())) {
                 $this->state_before_upload_request = null;
                 $this->fail('request_failed', $this->push_stream_client->get_last_error());
                 return;
@@ -1291,6 +1310,7 @@ final class PushFilesSender
     {
         $request_result = $this->push_stream_client->send_push_request('POST', 'push_commit', [
             'push_session_id' => $this->state['push_session_id'],
+            'ownership_epoch' => $this->require_ownership_epoch(),
         ], ['accepted']);
         if ($this->handle_request_failure($request_result)) {
             return;
@@ -1325,7 +1345,7 @@ final class PushFilesSender
             return;
         }
         $this->state['push_plan_cursor'] = null;
-        $this->state['phase'] = 'completing';
+        $this->state['phase'] = 'removing';
         $this->store_state($this->state);
     }
 
@@ -1368,6 +1388,7 @@ final class PushFilesSender
     {
         $request_result = $this->push_stream_client->send_push_request('POST', 'push_remove', [
             'push_session_id' => $this->state['push_session_id'],
+            'ownership_epoch' => $this->require_ownership_epoch(),
         ], ['accepted']);
         if ($this->handle_request_failure($request_result)) {
             return;
@@ -1375,6 +1396,10 @@ final class PushFilesSender
         /** @var array{removed:bool} $response */
         $response = $request_result['response'];
         if (!$response['removed']) {
+            return;
+        }
+        if ($this->state['push_plan_cursor'] === null) {
+            $this->complete_push();
             return;
         }
         $this->state['push_plan_cursor'] = null;

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -130,7 +130,7 @@ use function WordPress\Reprint\Exporter\trim_right_slash;
  * @phpstan-type LocalPathStat array{type:'file'|'directory'|'symlink'|'unsupported',size:int,ctime:int}
  * @phpstan-type LocalPathToPush array{local_relative_path:string,document_root_relative_path:string,document_root_relative_path_b64:string,next_local_paths_to_push_byte_offset:int,planned_local_path_type_size_and_ctime:LocalPathTypeSizeAndCtime}
  * @phpstan-type LocalPathToDelete array{path:string,delete_list_byte_offset:int,next_delete_list_byte_offset:int}
- * @phpstan-type State array{push_session_id:string,ownership_epoch:int|null,blocking_push_session_id:string|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,local_file_bytes_to_push:int|null,local_file_bytes_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
+ * @phpstan-type State array{push_session_id:string,ownership_epoch:int|null,blocking_push_session_id:string|null,blocking_ownership_epoch:int|null,phase:'creating'|'finishing_previous_commit'|'starting_plan'|'planning'|'pushing_paths'|'pushing_deletes'|'committing'|'saving_local_index'|'completing'|'removing'|'discarding_plan',document_root_local_relative_path:string,push_plan_cursor:array<string,mixed>|null,local_paths_to_push_byte_offset:int,local_paths_to_push_count:int|null,local_paths_pushed:int,local_file_bytes_to_push:int|null,local_file_bytes_pushed:int,max_part_bytes:int|null,request_sizer_state:array{request_body_bytes:int,ceiling_bytes:int|null}}
  */
 final class PushFilesSender
 {
@@ -238,6 +238,12 @@ final class PushFilesSender
     /** @var array<string,mixed> Push stream client options used by start() or resume(). */
     private array $push_stream_client_options;
 
+    /** @var bool Whether this command may take over the owner reported by push_create. */
+    private bool $force_takeover;
+
+    /** @var bool Whether this process already sent its guarded takeover request. */
+    private bool $force_takeover_request_sent = false;
+
     /**
      * Starts a new sender while the caller holds the Reprint process lock.
      *
@@ -253,6 +259,7 @@ final class PushFilesSender
      *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
+     *     @type bool                    $force_takeover          Explicitly take over the owner reported by push_create. Default false.
      *     @type int|float|string        $chunk_bytes             Maximum bytes read from one local file. Default 4 MiB.
      *     @type int|float|string        $connect_timeout         Connect phase seconds. Default 30.
      *     @type int|float|string        $stall_timeout           No-upload-progress seconds. Default 60.
@@ -284,6 +291,7 @@ final class PushFilesSender
                 'push_session_id' => bin2hex(random_bytes(16)),
                 'ownership_epoch' => null,
                 'blocking_push_session_id' => null,
+                'blocking_ownership_epoch' => null,
                 'phase' => 'creating',
                 'document_root_local_relative_path' => $sender->document_root_local_relative_path,
                 'push_plan_cursor' => null,
@@ -370,6 +378,10 @@ final class PushFilesSender
         if (!is_array($request_sizer_options)) {
             throw new InvalidArgumentException('request_sizer_options must be an array.');
         }
+        $force_takeover = $options['force_takeover'] ?? false;
+        if (!is_bool($force_takeover)) {
+            throw new InvalidArgumentException('force_takeover must be boolean.');
+        }
 
         $push_stream_client_options = [
             'remote_reprint_api_url' => $options['remote_reprint_api_url'] ?? null,
@@ -397,6 +409,7 @@ final class PushFilesSender
         $this->excluded_paths_path = wp_join_unix_paths($this->push_state_directory, 'excluded_paths.json');
         $this->request_sizer_options = $request_sizer_options;
         $this->push_stream_client_options = $push_stream_client_options;
+        $this->force_takeover = $force_takeover;
     }
 
     /**
@@ -652,13 +665,43 @@ final class PushFilesSender
      */
     private function create_push_session(): void
     {
-        $request_result = $this->push_stream_client->send_push_request('POST', 'push_create', [
+        $parameters = [
             'push_session_id' => $this->state['push_session_id'],
-        ], ['created']);
+        ];
+        if (
+            $this->force_takeover
+            && $this->state['blocking_push_session_id'] !== null
+            && $this->state['blocking_ownership_epoch'] !== null
+        ) {
+            $parameters['force_takeover'] = true;
+            $parameters['blocking_push_session_id'] = $this->state['blocking_push_session_id'];
+            $parameters['blocking_ownership_epoch'] = $this->state['blocking_ownership_epoch'];
+            $this->force_takeover_request_sent = true;
+        }
+        $request_result = $this->push_stream_client->send_push_request('POST', 'push_create', $parameters, ['created']);
+        if ($request_result['reason'] === 'sync_locked') {
+            /** @var array{blocking_push_session_id:mixed,blocking_ownership_epoch:mixed} $response */
+            $response = $request_result['response'];
+            if (
+                !is_string($response['blocking_push_session_id'])
+                || !is_int($response['blocking_ownership_epoch'])
+                || $response['blocking_ownership_epoch'] <= 0
+            ) {
+                $this->fail('unexpected_response', 'sync_locked did not return a valid blocking push owner.');
+                return;
+            }
+            $this->state['blocking_push_session_id'] = $response['blocking_push_session_id'];
+            $this->state['blocking_ownership_epoch'] = $response['blocking_ownership_epoch'];
+            $this->store_state($this->state);
+            if ($this->force_takeover && !$this->force_takeover_request_sent) {
+                return;
+            }
+        }
         if ($request_result['reason'] === 'commit_required') {
             /** @var array{blocking_push_session_id:string} $response */
             $response = $request_result['response'];
             $this->state['blocking_push_session_id'] = $response['blocking_push_session_id'];
+            $this->state['blocking_ownership_epoch'] = null;
             $this->state['phase'] = 'finishing_previous_commit';
             $this->store_state($this->state);
             return;
@@ -674,6 +717,8 @@ final class PushFilesSender
             return;
         }
         $this->state['ownership_epoch'] = $response['ownership_epoch'];
+        $this->state['blocking_push_session_id'] = null;
+        $this->state['blocking_ownership_epoch'] = null;
         if (count($response['excluded_paths_b64']) > 100) {
             $this->fail(
                 'unexpected_response',
@@ -1753,6 +1798,9 @@ final class PushFilesSender
             // Keep the sender single-pass when older state has no file byte total.
             $state['local_file_bytes_to_push'] = null;
             $state['local_file_bytes_pushed'] = 0;
+        }
+        if (!array_key_exists('blocking_ownership_epoch', $state)) {
+            $state['blocking_ownership_epoch'] = null;
         }
 
         /** @var State $state */

--- a/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
@@ -17,7 +17,7 @@ use function Reprint\Importer\apply_curl_proxy_from_environment;
  *
  * Example:
  *
- *     if (!$client->start_upload_request($push_session_id)) {
+ *     if (!$client->start_upload_request($push_session_id, $ownership_epoch)) {
  *         throw new RuntimeException($client->get_last_error());
  *     }
  *
@@ -249,7 +249,7 @@ class MultipartPushStreamClient
      * @throws InvalidArgumentException If the push session ID is malformed.
      * @throws RuntimeException If another upload request is already open.
      */
-    public function start_upload_request(string $push_session_id): bool
+    public function start_upload_request(string $push_session_id, int $ownership_epoch): bool
     {
         if ($this->curl_handle !== null) {
             throw new RuntimeException('An upload request is already open; call finish_request() first.');
@@ -273,7 +273,7 @@ class MultipartPushStreamClient
         $this->response_body = '';
         $this->response_too_large = false;
 
-        $request_url = $this->endpoint_url('push_upload', ['push_session_id' => $push_session_id]);
+        $request_url = $this->endpoint_url('push_upload', ['push_session_id' => $push_session_id, 'ownership_epoch' => $ownership_epoch]);
         $headers = $this->hmac_client->get_envelope_auth_headers('POST', $request_url);
         $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
         $header_lines = [];

--- a/packages/reprint-server/composer.json
+++ b/packages/reprint-server/composer.json
@@ -29,6 +29,7 @@
             "src/class-multipart-processor.php",
             "src/class-push-configuration-exception.php",
             "src/class-push-exception.php",
+            "src/class-push-coordinator.php",
             "src/class-push-endpoints.php",
             "src/class-push-session.php",
             "src/class-sqlite-driver-pdo.php",

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -323,6 +323,17 @@ final class Site_Export_HTTP_Server {
             $budget = $this->create_resource_budget($config);
         }
 
+        if (
+            $this->push_endpoints !== null
+            && ($endpoint === 'file_index' || $endpoint === 'file_fetch')
+        ) {
+            $this->push_endpoints->with_file_read(function (int $document_root_generation) use ($handler, $config, $budget) {
+                $config['document_root_generation'] = $document_root_generation;
+                return call_user_func($handler, $config, $budget);
+            });
+            return;
+        }
+
         call_user_func($handler, $config, $budget);
     }
 

--- a/packages/reprint-server/src/class-push-coordinator.php
+++ b/packages/reprint-server/src/class-push-coordinator.php
@@ -1,0 +1,449 @@
+<?php
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Authenticated push protocol errors are JSON responses, not rendered HTML.
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
+if (!class_exists('Site_Export_Push_Exception', false)) {
+    require_once __DIR__ . '/class-push-exception.php';
+}
+
+/**
+ * Stores the durable owner and document-root generation for one push target.
+ *
+ * The coordination state outlives HTTP requests. Short-lived flock gates only
+ * serialize metadata, owner requests, and document-root reads or mutations.
+ */
+final class Site_Export_Push_Coordinator {
+
+    private const TERMINAL_OWNER_LIMIT = 8;
+
+    /** @var string */
+    private $directory;
+    /** @var string */
+    private $state_path;
+    /** @var string */
+    private $state_lock_path;
+    /** @var string */
+    private $push_request_lock_path;
+    /** @var string */
+    private $file_read_lock_path;
+    /** @var string */
+    private $docroot_b64;
+    /** @var list<string> */
+    private $excluded_paths_b64;
+
+    /**
+     * @param string $reprint_directory Private reprint directory.
+     * @param string $docroot Document root controlled by this coordinator.
+     * @param list<string> $excluded_paths Immutable push exclusions.
+     */
+    public function __construct(string $reprint_directory, string $docroot, array $excluded_paths) {
+        $this->directory = wp_join_unix_paths($reprint_directory, '.reprint', 'push');
+        $this->state_path = wp_join_unix_paths($this->directory, 'state.json');
+        $this->state_lock_path = wp_join_unix_paths($this->directory, 'state.lock');
+        $this->push_request_lock_path = wp_join_unix_paths($this->directory, 'push-request.lock');
+        $this->file_read_lock_path = wp_join_unix_paths($this->directory, 'file-read.lock');
+        $this->docroot_b64 = base64_encode($docroot);
+        $this->excluded_paths_b64 = array_map('base64_encode', $excluded_paths);
+    }
+
+    /**
+     * Claims ownership for a new push session or returns its existing identity.
+     *
+     * @return array{ownership_epoch:int,document_root_generation:int,phase:string}
+     */
+    public function claim_owner(
+        string $push_session_id,
+        bool $force_takeover,
+        ?string $blocking_push_session_id,
+        ?int $blocking_ownership_epoch
+    ): array {
+        return $this->with_state_lock(function () use ($push_session_id, $force_takeover, $blocking_push_session_id, $blocking_ownership_epoch): array {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            foreach ([$this->push_request_lock_path, $this->file_read_lock_path] as $lock_path) {
+                $lock = $this->open_lock($lock_path, 'coordination');
+                fclose($lock);
+            }
+            $owner = $state['owner'];
+            if ($owner !== null && $owner['push_session_id'] === $push_session_id) {
+                return [
+                    'ownership_epoch' => $owner['ownership_epoch'],
+                    'document_root_generation' => $state['document_root_generation'],
+                    'phase' => $state['phase'],
+                ];
+            }
+            if ($owner !== null) {
+                if (
+                    !$force_takeover
+                    || $blocking_push_session_id !== $owner['push_session_id']
+                    || $blocking_ownership_epoch !== $owner['ownership_epoch']
+                ) {
+                    throw new Site_Export_Push_Exception(
+                        Site_Export_Push_Session::ERROR_SYNC_LOCKED,
+                        'Push session ' . $owner['push_session_id'] . ' owns this document root at ownership epoch ' . $owner['ownership_epoch'] . '.',
+                        [
+                            'blocking_push_session_id' => $owner['push_session_id'],
+                            'blocking_ownership_epoch' => $owner['ownership_epoch'],
+                        ]
+                    );
+                }
+                $state['terminal_owners'][] = [
+                    'push_session_id' => $owner['push_session_id'],
+                    'ownership_epoch' => $owner['ownership_epoch'],
+                    'result' => 'displaced',
+                ];
+                $state['terminal_owners'] = array_slice($state['terminal_owners'], -self::TERMINAL_OWNER_LIMIT);
+                $state['recovery'] = [
+                    'displaced_push_session_id' => $owner['push_session_id'],
+                    'displaced_ownership_epoch' => $owner['ownership_epoch'],
+                ];
+                $state['phase'] = 'recovering_displaced_push';
+            } else {
+                $state['phase'] = 'creating_push';
+            }
+            ++$state['ownership_epoch'];
+            $state['owner'] = [
+                'push_session_id' => $push_session_id,
+                'ownership_epoch' => $state['ownership_epoch'],
+            ];
+            $this->write_state($state);
+            return [
+                'ownership_epoch' => $state['ownership_epoch'],
+                'document_root_generation' => $state['document_root_generation'],
+                'phase' => $state['phase'],
+            ];
+        });
+    }
+
+    /**
+     * Releases a claim when private push-session creation could not begin.
+     */
+    public function abandon_creation(string $push_session_id, int $ownership_epoch): void {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            if (
+                $state['owner'] === null
+                || $state['owner']['push_session_id'] !== $push_session_id
+                || $state['owner']['ownership_epoch'] !== $ownership_epoch
+                || !in_array($state['phase'], ['creating_push', 'recovering_displaced_push'], true)
+            ) {
+                return;
+            }
+            $state['owner'] = null;
+            $state['phase'] = 'idle';
+            $state['recovery'] = null;
+            $this->write_state($state);
+        });
+    }
+
+    /**
+     * Runs one owner request while holding the request gate for its full duration.
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function with_owner_request(string $push_session_id, int $ownership_epoch, callable $callback) {
+        $lock = $this->open_lock($this->push_request_lock_path, 'push request');
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                throw new Site_Export_Push_Exception(
+                    Site_Export_Push_Session::ERROR_SYNC_LOCKED,
+                    'Another push request is still operating on this document root.'
+                );
+            }
+            $this->assert_owner($push_session_id, $ownership_epoch);
+            return $callback();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Marks a request as receiving private work after it passed owner fencing.
+     */
+    public function mark_receiving_work(string $push_session_id, int $ownership_epoch): void {
+        $this->change_phase($push_session_id, $ownership_epoch, 'receiving_work');
+    }
+
+    /**
+     * Marks commit intent before acquiring the exclusive document-root gate.
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function with_commit(string $push_session_id, int $ownership_epoch, callable $callback) {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            $this->assert_state_owner($state, $push_session_id, $ownership_epoch);
+            if ($state['phase'] !== 'finalizing') {
+                $state['phase'] = 'committing';
+                $this->write_state($state);
+            }
+        });
+        $lock = $this->open_lock($this->file_read_lock_path, 'file-read');
+        try {
+            if (!flock($lock, LOCK_EX)) {
+                throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not acquire the document-root mutation gate.');
+            }
+            $this->assert_owner($push_session_id, $ownership_epoch);
+            $result = $callback();
+            if (is_array($result) && ( $result['phase'] ?? null ) === 'complete') {
+                $this->complete_commit($push_session_id, $ownership_epoch);
+            }
+            return $result;
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Holds a shared document-root gate while a pull response streams.
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function with_file_read(callable $callback) {
+        $this->assert_reads_open();
+        $lock = $this->open_lock($this->file_read_lock_path, 'file-read');
+        try {
+            if (!flock($lock, LOCK_SH)) {
+                throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not acquire the document-root read gate.');
+            }
+            $this->assert_reads_open();
+            return $callback($this->get_document_root_generation());
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * Clears a completed owner only after its private work was removed.
+     */
+    public function complete_removal(string $push_session_id, int $ownership_epoch): void {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            if ($state['owner'] === null) {
+                foreach ($state['terminal_owners'] as $terminal_owner) {
+                    if (
+                        is_array($terminal_owner)
+                        && ( $terminal_owner['push_session_id'] ?? null ) === $push_session_id
+                        && ( $terminal_owner['ownership_epoch'] ?? null ) === $ownership_epoch
+                        && ( $terminal_owner['result'] ?? null ) === 'complete'
+                    ) {
+                        return;
+                    }
+                }
+            }
+            $this->assert_state_owner($state, $push_session_id, $ownership_epoch);
+            $state['terminal_owners'][] = [
+                'push_session_id' => $push_session_id,
+                'ownership_epoch' => $ownership_epoch,
+                'result' => 'complete',
+            ];
+            $state['terminal_owners'] = array_slice($state['terminal_owners'], -self::TERMINAL_OWNER_LIMIT);
+            $state['owner'] = null;
+            $state['phase'] = 'idle';
+            $state['recovery'] = null;
+            $this->write_state($state);
+        });
+    }
+
+    /**
+     * Reports whether a former owner completed private-work removal.
+     */
+    public function is_terminal_owner(string $push_session_id, int $ownership_epoch): bool {
+        return $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): bool {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            foreach ($state['terminal_owners'] as $terminal_owner) {
+                if (
+                    is_array($terminal_owner)
+                    && ( $terminal_owner['push_session_id'] ?? null ) === $push_session_id
+                    && ( $terminal_owner['ownership_epoch'] ?? null ) === $ownership_epoch
+                    && ( $terminal_owner['result'] ?? null ) === 'complete'
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Returns the generation attached to a file response.
+     */
+    public function get_document_root_generation(): int {
+        return $this->with_state_lock(function (): int {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            return $state['document_root_generation'];
+        });
+    }
+
+    private function complete_commit(string $push_session_id, int $ownership_epoch): void {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            $this->assert_state_owner($state, $push_session_id, $ownership_epoch);
+            if ($state['phase'] !== 'finalizing') {
+                ++$state['document_root_generation'];
+                $state['phase'] = 'finalizing';
+                $this->write_state($state);
+            }
+        });
+    }
+
+    private function change_phase(string $push_session_id, int $ownership_epoch, string $phase): void {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch, $phase): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            $this->assert_state_owner($state, $push_session_id, $ownership_epoch);
+            if ($state['phase'] !== $phase) {
+                $state['phase'] = $phase;
+                $this->write_state($state);
+            }
+        });
+    }
+
+    private function assert_owner(string $push_session_id, int $ownership_epoch): void {
+        $this->with_state_lock(function () use ($push_session_id, $ownership_epoch): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            $this->assert_state_owner($state, $push_session_id, $ownership_epoch);
+        });
+    }
+
+    private function assert_reads_open(): void {
+        $this->with_state_lock(function (): void {
+            $state = $this->read_state();
+            $this->assert_configuration($state);
+            if ($state['phase'] === 'committing' || $state['phase'] === 'commit_failed') {
+                throw new Site_Export_Push_Exception(
+                    Site_Export_Push_Session::ERROR_SYNC_LOCKED,
+                    'File synchronization is unavailable while the document root is committing.'
+                );
+            }
+        });
+    }
+
+    /**
+     * @param array<string,mixed> $state
+     */
+    private function assert_configuration(array $state): void {
+        if ($state['docroot_b64'] !== $this->docroot_b64 || $state['excluded_paths_b64'] !== $this->excluded_paths_b64) {
+            throw new Site_Export_Push_Exception(
+                Site_Export_Push_Session::ERROR_PUSH_CONFIGURATION_CHANGED,
+                'The document root or excluded paths changed while Reprint coordination state exists.'
+            );
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $state
+     */
+    private function assert_state_owner(array $state, string $push_session_id, int $ownership_epoch): void {
+        $owner = $state['owner'];
+        if (
+            $owner === null
+            || $owner['push_session_id'] !== $push_session_id
+            || $owner['ownership_epoch'] !== $ownership_epoch
+        ) {
+            throw new Site_Export_Push_Exception(
+                Site_Export_Push_Session::ERROR_SYNC_OVERTAKEN,
+                'This push session no longer owns the document root at the supplied ownership epoch.'
+            );
+        }
+    }
+
+    /**
+     * @param callable $callback
+     * @return mixed
+     */
+    private function with_state_lock(callable $callback) {
+        if (!is_dir($this->directory) && !@mkdir($this->directory, 0700, true) && !is_dir($this->directory)) {
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not create the push coordination directory.');
+        }
+        $lock = $this->open_lock($this->state_lock_path, 'state');
+        try {
+            if (!flock($lock, LOCK_EX)) {
+                throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not acquire the push coordination state lock.');
+            }
+            return $callback();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * @return resource
+     */
+    private function open_lock(string $path, string $name) {
+        $lock = @fopen($path, 'c+b');
+        if ($lock === false) {
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not open the ' . $name . ' coordination lock.');
+        }
+        return $lock;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function read_state(): array {
+        if (!file_exists($this->state_path)) {
+            return [
+                'docroot_b64' => $this->docroot_b64,
+                'excluded_paths_b64' => $this->excluded_paths_b64,
+                'document_root_generation' => 0,
+                'ownership_epoch' => 0,
+                'owner' => null,
+                'phase' => 'idle',
+                'recovery' => null,
+                'terminal_owners' => [],
+            ];
+        }
+        $json = @file_get_contents($this->state_path);
+        $state = is_string($json) ? json_decode($json, true) : null;
+        if (!is_array($state)
+            || !is_string($state['docroot_b64'] ?? null)
+            || !is_array($state['excluded_paths_b64'] ?? null)
+            || !is_int($state['document_root_generation'] ?? null)
+            || !is_int($state['ownership_epoch'] ?? null)
+            || !array_key_exists('owner', $state)
+            || !is_string($state['phase'] ?? null)
+            || !is_array($state['terminal_owners'] ?? null)
+        ) {
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_CORRUPTED_PUSH_STATE, 'Push coordination state is malformed.');
+        }
+        if ($state['owner'] !== null
+            && ( !is_array($state['owner'])
+                || !is_string($state['owner']['push_session_id'] ?? null)
+                || !is_int($state['owner']['ownership_epoch'] ?? null) )) {
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_CORRUPTED_PUSH_STATE, 'Push coordination owner is malformed.');
+        }
+        return $state;
+    }
+
+    /**
+     * @param array<string,mixed> $state
+     */
+    private function write_state(array $state): void {
+        $json = json_encode($state, JSON_UNESCAPED_SLASHES);
+        if (!is_string($json)) {
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not encode push coordination state.');
+        }
+        $temporary_path = $this->state_path . '.swap';
+        if (@file_put_contents($temporary_path, $json . "\n", LOCK_EX) === false || !@rename($temporary_path, $this->state_path)) {
+            @unlink($temporary_path);
+            throw new Site_Export_Push_Exception(Site_Export_Push_Session::ERROR_FILESYSTEM, 'Could not atomically store push coordination state.');
+        }
+    }
+}

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -10,6 +10,10 @@ use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 
+if (!class_exists('Site_Export_Push_Coordinator', false)) {
+    require_once __DIR__ . '/class-push-coordinator.php';
+}
+
 /**
  * Exposes push-session operations through the exporter HTTP dispatcher.
  *
@@ -48,6 +52,9 @@ final class Site_Export_Push_Endpoints {
 
     /** @var int|null */
     private $post_max_bytes;
+
+    /** @var Site_Export_Push_Coordinator */
+    private $coordinator;
 
     /**
      * Stores the server-supplied push directories, path policy, and limits.
@@ -142,6 +149,7 @@ final class Site_Export_Push_Endpoints {
             $this->post_max_bytes = $parsed_post_max_bytes > 0 ? $parsed_post_max_bytes : null;
         }
 
+        $this->coordinator = new Site_Export_Push_Coordinator($reprint_directory, $docroot, $excluded_paths);
         $this->reprint_directory = $reprint_directory;
         $this->docroot = $docroot;
         $this->excluded_paths = $excluded_paths;
@@ -154,6 +162,16 @@ final class Site_Export_Push_Endpoints {
             }
             $this->commit_start_denial_detail = $options['commit_start_denial_detail'];
         }
+    }
+
+    /**
+     * Holds the shared document-root gate for one file response.
+     *
+     * @param callable $callback Receives the current document-root generation.
+     * @return mixed Callback return value.
+     */
+    public function with_file_read(callable $callback) {
+        return $this->coordinator->with_file_read($callback);
     }
 
     /**
@@ -186,15 +204,28 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            Site_Export_Push_Session::create(
-                $this->reprint_directory,
-                $this->docroot,
-                $this->excluded_paths,
-                $push_session_id
+            $owner = $this->coordinator->claim_owner(
+                $push_session_id,
+                $this->read_force_takeover($config),
+                $this->read_optional_push_session_id($config, 'blocking_push_session_id'),
+                $this->read_optional_ownership_epoch($config, 'blocking_ownership_epoch')
             );
+            try {
+                Site_Export_Push_Session::create(
+                    $this->reprint_directory,
+                    $this->docroot,
+                    $this->excluded_paths,
+                    $push_session_id
+                );
+            } catch (Throwable $exception) {
+                $this->coordinator->abandon_creation($push_session_id, $owner['ownership_epoch']);
+                throw $exception;
+            }
             $this->respond(200, [
                 'status' => 'created',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => $owner['ownership_epoch'],
+                'document_root_generation' => $owner['document_root_generation'],
                 'max_part_bytes' => $this->maximum_part_bytes,
                 'post_max_bytes' => $this->post_max_bytes,
                 'excluded_paths_b64' => array_map('base64_encode', $this->excluded_paths),
@@ -261,42 +292,47 @@ final class Site_Export_Push_Endpoints {
                     'Could not open the multipart upload request body.'
                 );
             }
-            $push_session = Site_Export_Push_Session::open(
-                $this->reprint_directory,
-                $this->docroot,
-                $push_session_id,
-                $this->excluded_paths
-            );
-            $push_session->accept_upload(
-                $input,
-                new Site_Export_Multipart_Processor($boundary),
-                $this->maximum_part_bytes,
-                $this->post_max_bytes ?? PHP_INT_MAX
-            );
-            $upload_open = true;
-            $changes_accepted = 0;
-            $last_change = null;
-            while ($push_session->next_change()) {
-                ++$changes_accepted;
-                $current_change = $push_session->get_current_change();
-                if ($current_change === null) {
-                    throw new LogicException('An accepted multipart part did not set its receiver-confirmed change.');
+            $ownership_epoch = $this->read_ownership_epoch($config);
+            $this->coordinator->with_owner_request($push_session_id, $ownership_epoch, function () use ($input, $boundary, $push_session_id, &$push_session, &$upload_open, &$changes_accepted, &$last_change, $ownership_epoch): void {
+                $this->coordinator->mark_receiving_work($push_session_id, $ownership_epoch);
+                $push_session = Site_Export_Push_Session::open(
+                    $this->reprint_directory,
+                    $this->docroot,
+                    $push_session_id,
+                    $this->excluded_paths
+                );
+                $push_session->accept_upload(
+                    $input,
+                    new Site_Export_Multipart_Processor($boundary),
+                    $this->maximum_part_bytes,
+                    $this->post_max_bytes ?? PHP_INT_MAX
+                );
+                $upload_open = true;
+                $changes_accepted = 0;
+                $last_change = null;
+                while ($push_session->next_change()) {
+                    ++$changes_accepted;
+                    $current_change = $push_session->get_current_change();
+                    if ($current_change === null) {
+                        throw new LogicException('An accepted multipart part did not set its receiver-confirmed change.');
+                    }
+                    $last_change = [];
+                    if (array_key_exists('path_b64', $current_change)) {
+                        $last_change['path_b64'] = $current_change['path_b64'];
+                    }
+                    $last_change['state'] = $current_change['state'];
+                    $last_change['type'] = $current_change['type'];
+                    $last_change['accepted_bytes'] = $current_change['accepted_bytes'];
                 }
-                $last_change = [];
-                if (array_key_exists('path_b64', $current_change)) {
-                    $last_change['path_b64'] = $current_change['path_b64'];
-                }
-                $last_change['state'] = $current_change['state'];
-                $last_change['type'] = $current_change['type'];
-                $last_change['accepted_bytes'] = $current_change['accepted_bytes'];
-            }
-            $push_session->finish_upload();
-            $upload_open = false;
+                $push_session->finish_upload();
+                $upload_open = false;
+            });
             fclose($input);
             $input = null;
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => $ownership_epoch,
                 'changes_accepted' => $changes_accepted,
                 'last_change' => $last_change,
             ]);
@@ -353,13 +389,16 @@ final class Site_Export_Push_Endpoints {
                     throw new InvalidArgumentException('path_b64 must be valid base64 text.');
                 }
             }
-            $push_session = Site_Export_Push_Session::open(
-                $this->reprint_directory,
-                $this->docroot,
-                $push_session_id,
-                $this->excluded_paths
-            );
-            $push_status = $push_session->get_status($path);
+            $ownership_epoch = $this->read_ownership_epoch($config);
+            $push_status = $this->coordinator->with_owner_request($push_session_id, $ownership_epoch, function () use ($push_session_id, $path): array {
+                $push_session = Site_Export_Push_Session::open(
+                    $this->reprint_directory,
+                    $this->docroot,
+                    $push_session_id,
+                    $this->excluded_paths
+                );
+                return $push_session->get_status($path);
+            });
             $path_status = null;
             if ($push_status['path'] !== null) {
                 $path_status = [
@@ -374,6 +413,8 @@ final class Site_Export_Push_Endpoints {
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => $ownership_epoch,
+                'document_root_generation' => $this->coordinator->get_document_root_generation(),
                 'phase' => $push_status['phase'],
                 'work_deletes_bytes' => $push_status['work_deletes_bytes'],
                 'work_deletes_complete' => $push_status['work_deletes_complete'],
@@ -406,19 +447,38 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            $push_session = Site_Export_Push_Session::open(
-                $this->reprint_directory,
-                $this->docroot,
-                $push_session_id,
-                $this->excluded_paths
-            );
-            $commit = $push_session->commit(
-                $this->maximum_commit_entries,
-                $this->commit_start_denial_detail
-            );
+            $ownership_epoch = $this->read_ownership_epoch($config);
+            if ($this->commit_start_denial_detail !== null) {
+                // Preserve the authorization contract for a first denied commit:
+                // a missing private session is reported as push_disabled, not as
+                // a coordination failure before the session can be identified.
+                $denied_push_session = Site_Export_Push_Session::open(
+                    $this->reprint_directory,
+                    $this->docroot,
+                    $push_session_id,
+                    $this->excluded_paths
+                );
+                $denied_push_session->get_status();
+            }
+            $commit = $this->coordinator->with_owner_request($push_session_id, $ownership_epoch, function () use ($push_session_id, $ownership_epoch): array {
+                return $this->coordinator->with_commit($push_session_id, $ownership_epoch, function () use ($push_session_id): array {
+                    $push_session = Site_Export_Push_Session::open(
+                        $this->reprint_directory,
+                        $this->docroot,
+                        $push_session_id,
+                        $this->excluded_paths
+                    );
+                    return $push_session->commit(
+                        $this->maximum_commit_entries,
+                        $this->commit_start_denial_detail
+                    );
+                });
+            });
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => $ownership_epoch,
+                'document_root_generation' => $this->coordinator->get_document_root_generation(),
                 'phase' => $commit['phase'],
                 'send_next_request' => $commit['send_next_request'],
                 'entries_processed' => $commit['entries_processed'],
@@ -460,15 +520,26 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            $remove_complete = Site_Export_Push_Session::remove(
-                $this->reprint_directory,
-                $this->docroot,
-                $push_session_id,
-                $this->excluded_paths
-            );
+            $ownership_epoch = $this->read_ownership_epoch($config);
+            if ($this->coordinator->is_terminal_owner($push_session_id, $ownership_epoch)) {
+                $remove_complete = true;
+            } else {
+                $remove_complete = $this->coordinator->with_owner_request($push_session_id, $ownership_epoch, function () use ($push_session_id): bool {
+                    return Site_Export_Push_Session::remove(
+                        $this->reprint_directory,
+                        $this->docroot,
+                        $push_session_id,
+                        $this->excluded_paths
+                    );
+                });
+            }
+            if ($remove_complete) {
+                $this->coordinator->complete_removal($push_session_id, $ownership_epoch);
+            }
             $this->respond(200, [
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => $ownership_epoch,
                 'removed' => $remove_complete,
             ]);
         } catch (Throwable $exception) {
@@ -490,6 +561,69 @@ final class Site_Export_Push_Endpoints {
                 'Push endpoint requires ' . $expected_method . '; observed ' . ( $observed_method === '' ? 'no request method' : $observed_method ) . '.'
             );
         }
+    }
+
+    /**
+     * Reads the identity which fences every owner request.
+     *
+     * @param array<string,mixed> $config Request parameters.
+     */
+    private function read_ownership_epoch(array $config): int {
+        $ownership_epoch = $config['ownership_epoch'] ?? null;
+        if (!is_int($ownership_epoch) && ! ( is_string($ownership_epoch) && ctype_digit($ownership_epoch) )) {
+            throw new InvalidArgumentException('ownership_epoch must be a positive integer.');
+        }
+        $ownership_epoch = (int) $ownership_epoch;
+        if ($ownership_epoch <= 0) {
+            throw new InvalidArgumentException('ownership_epoch must be a positive integer.');
+        }
+        return $ownership_epoch;
+    }
+
+    /**
+     * @param array<string,mixed> $config Request parameters.
+     */
+    private function read_optional_ownership_epoch(array $config, string $name): ?int {
+        if (!array_key_exists($name, $config)) {
+            return null;
+        }
+        if (!is_int($config[$name]) && ! ( is_string($config[$name]) && ctype_digit($config[$name]) )) {
+            throw new InvalidArgumentException($name . ' must be a positive integer.');
+        }
+        $ownership_epoch = (int) $config[$name];
+        if ($ownership_epoch <= 0) {
+            throw new InvalidArgumentException($name . ' must be a positive integer.');
+        }
+        return $ownership_epoch;
+    }
+
+    /**
+     * @param array<string,mixed> $config Request parameters.
+     */
+    private function read_optional_push_session_id(array $config, string $name): ?string {
+        if (!array_key_exists($name, $config)) {
+            return null;
+        }
+        if (!is_string($config[$name])) {
+            throw new InvalidArgumentException($name . ' must be a string.');
+        }
+        return $config[$name];
+    }
+
+    /**
+     * @param array<string,mixed> $config Request parameters.
+     */
+    private function read_force_takeover(array $config): bool {
+        if (!array_key_exists('force_takeover', $config)) {
+            return false;
+        }
+        if ($config['force_takeover'] === true || $config['force_takeover'] === '1') {
+            return true;
+        }
+        if ($config['force_takeover'] === false || $config['force_takeover'] === '0') {
+            return false;
+        }
+        throw new InvalidArgumentException('force_takeover must be boolean.');
     }
 
     /**
@@ -551,10 +685,13 @@ final class Site_Export_Push_Endpoints {
                 'reason' => $reason,
                 'detail' => $exception->getMessage(),
             ];
-            if ($reason === Site_Export_Push_Session::ERROR_COMMIT_REQUIRED) {
+            if ($reason === Site_Export_Push_Session::ERROR_COMMIT_REQUIRED || $reason === Site_Export_Push_Session::ERROR_SYNC_LOCKED) {
                 $context = $exception->get_context();
                 if (is_string($context['blocking_push_session_id'] ?? null)) {
                     $response['blocking_push_session_id'] = $context['blocking_push_session_id'];
+                }
+                if (is_int($context['blocking_ownership_epoch'] ?? null)) {
+                    $response['blocking_ownership_epoch'] = $context['blocking_ownership_epoch'];
                 }
             }
             if ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -65,6 +65,9 @@ final class Site_Export_Push_Session {
     public const ERROR_SAME_DEVICE = 'same_device';
     public const ERROR_REQUEST_TOO_LARGE = 'request_too_large';
     public const ERROR_PUSH_DISABLED = 'push_disabled';
+    public const ERROR_SYNC_LOCKED = 'sync_locked';
+    public const ERROR_SYNC_OVERTAKEN = 'sync_overtaken';
+    public const ERROR_PUSH_CONFIGURATION_CHANGED = 'push_configuration_changed';
 
     private const MAX_PATH_BYTES = 4096;
     private const MAX_METADATA_BYTES = 1048576;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2249,6 +2249,7 @@ function stream_file_producer(
                 $filesystem_root = $producer->get_filesystem_root();
                 $metadata = [
                     "filesystem_root" => base64_encode($filesystem_root ?? ""),
+                    "document_root_generation" => (int) ($config["document_root_generation"] ?? 0),
                 ];
                 $metadata_json = json_encode_or_throw($metadata);
 
@@ -2258,6 +2259,7 @@ function stream_file_producer(
                     "Content-Length: " . strlen($metadata_json) . "\r\n" .
                     "X-Chunk-Type: metadata\r\n" .
                     "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
+                    "X-Document-Root-Generation: " . (int) ($config["document_root_generation"] ?? 0) . "\r\n" .
                     "\r\n" .
                     $metadata_json . "\r\n"
                 );
@@ -2592,6 +2594,7 @@ function endpoint_file_index(
         $metadata = [
             "filesystem_root" => base64_encode($filesystem_root),
             "list_dir" => base64_encode($list_directory),
+            "document_root_generation" => (int) ($config["document_root_generation"] ?? 0),
         ];
         $metadata_json = json_encode_or_throw($metadata);
         $gz->write(
@@ -2601,6 +2604,7 @@ function endpoint_file_index(
             "X-Chunk-Type: metadata\r\n" .
             "X-Filesystem-Root: " . base64_encode($filesystem_root) . "\r\n" .
             "X-Index-Dir: " . base64_encode($list_directory) . "\r\n" .
+            "X-Document-Root-Generation: " . (int) ($config["document_root_generation"] ?? 0) . "\r\n" .
             "\r\n" .
             $metadata_json . "\r\n"
         );

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -135,6 +135,15 @@ final class FilesPushCommandTest extends TestCase
         );
     }
 
+    public function testFilesPushHelpDocumentsForceTakeover(): void
+    {
+        $result = $this->runCli(['files-push', '--help']);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('--force-takeover', $result['output']);
+        $this->assertStringContainsString('Take over the target push owner', $result['output']);
+    }
+
     public function testFilesPushRejectsAnInvalidProgressMode(): void
     {
         $result = $this->runFilesPush(

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -32,7 +32,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         ]);
 
         $this->assertFalse($client->has_sent_parts());
-        $this->assertTrue($client->start_upload_request(str_repeat('a', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('a', 32), 1));
         $this->assertFalse($client->has_sent_parts());
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
@@ -164,7 +164,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
         foreach (['first.bin', 'second.bin'] as $request_number => $path) {
-            $this->assertTrue($client->start_upload_request(str_repeat( (string) ( $request_number + 4 ), 32)));
+            $this->assertTrue($client->start_upload_request(str_repeat( (string) ( $request_number + 4 ), 32), 1));
             $this->assertTrue($client->send_part([
                 'type' => 'file',
                 'path' => $path,
@@ -198,7 +198,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'connect_timeout' => 2,
         ]);
         $this->assertSame(7, $client->next_file_body_bytes('bounded.bin', 100, 0));
-        $this->assertTrue($client->start_upload_request(str_repeat('b', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('b', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->read_available($connection);
@@ -229,7 +229,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'chunk_bytes' => 1024,
             'connect_timeout' => 2,
         ]);
-        $this->assertTrue($client->start_upload_request(str_repeat('d', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('d', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->read_available($connection);
@@ -278,7 +278,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
 
-        $this->assertTrue($client->start_upload_request(str_repeat('c', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('c', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->read_available($connection);
@@ -327,7 +327,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
         $before = $client->get_request_sizer_state();
-        $this->assertTrue($client->start_upload_request(str_repeat('7', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('7', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $response = (string) json_encode(['status' => 'accepted', 'accepted' => []]);
@@ -361,7 +361,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
 
-        $this->assertTrue($client->start_upload_request(str_repeat('4', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('4', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->read_available($connection);
@@ -406,7 +406,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
 
-        $this->assertTrue($client->start_upload_request(str_repeat('e', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('e', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->read_available($connection);
@@ -548,7 +548,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'stall_timeout' => 2,
             'response_timeout' => 2,
         ]);
-        $this->assertTrue($client->start_upload_request(str_repeat('6', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('6', 32), 1));
         $this->assertTrue($client->send_part([
             'type' => 'file',
             'path' => 'oversized-response.bin',
@@ -674,7 +674,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 2,
         ]);
 
-        $this->assertTrue($client->start_upload_request(str_repeat('f', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('f', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $started = microtime(true);
@@ -716,7 +716,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 1,
         ]);
 
-        $this->assertTrue($client->start_upload_request(str_repeat('1', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('1', 32), 1));
         $connection = stream_socket_accept($listener, 3);
         $this->assertNotFalse($connection);
         $this->assertTrue($client->send_part([
@@ -798,7 +798,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'stall_timeout' => 2,
             'response_timeout' => 1,
         ]);
-        $this->assertTrue($client->start_upload_request(str_repeat('3', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('3', 32), 1));
         $this->assertTrue($client->send_part([
             'type' => 'file',
             'path' => 'slow-response.bin',
@@ -881,7 +881,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'response_timeout' => 5,
         ]);
         $started = microtime(true);
-        $this->assertTrue($client->start_upload_request(str_repeat('2', 32)));
+        $this->assertTrue($client->start_upload_request(str_repeat('2', 32), 1));
         $sent = $client->send_part([
             'type' => 'file',
             'path' => 'slow-progress.bin',

--- a/tests/PushCoordinatorTest.php
+++ b/tests/PushCoordinatorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../packages/reprint-server/src/class-push-exception.php';
+require_once __DIR__ . '/../packages/reprint-server/src/class-push-session.php';
+require_once __DIR__ . '/../packages/reprint-server/src/class-push-coordinator.php';
+
+final class PushCoordinatorTest extends TestCase {
+
+    private string $root;
+    private string $docroot;
+    private string $reprintDirectory;
+
+    protected function setUp(): void {
+        $this->root = sys_get_temp_dir() . '/push-coordinator-' . bin2hex(random_bytes(8));
+        $this->docroot = $this->root . '/docroot';
+        $this->reprintDirectory = $this->root . '/reprint';
+        mkdir($this->docroot, 0700, true);
+        mkdir($this->reprintDirectory, 0700, true);
+    }
+
+    protected function tearDown(): void {
+        $this->removeTree($this->root);
+    }
+
+    public function testOwnerEpochFencesDisplacedPushAndCommitAdvancesGenerationOnce(): void {
+        $coordinator = new Site_Export_Push_Coordinator(
+            $this->reprintDirectory,
+            $this->docroot,
+            ['preserved']
+        );
+        $firstPushSessionId = str_repeat('1', 32);
+        $secondPushSessionId = str_repeat('2', 32);
+
+        $firstOwner = $coordinator->claim_owner($firstPushSessionId, false, null, null);
+        $this->assertSame(1, $firstOwner['ownership_epoch']);
+        $this->assertSame(0, $firstOwner['document_root_generation']);
+        $coordinationDirectory = $this->reprintDirectory . '/.reprint/push';
+        $this->assertFileExists($coordinationDirectory . '/state.json');
+        $this->assertFileExists($coordinationDirectory . '/state.lock');
+        $this->assertFileExists($coordinationDirectory . '/push-request.lock');
+        $this->assertFileExists($coordinationDirectory . '/file-read.lock');
+
+        try {
+            $coordinator->claim_owner($secondPushSessionId, false, null, null);
+            $this->fail('A second push owner was admitted.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame(Site_Export_Push_Session::ERROR_SYNC_LOCKED, $exception->get_error_code());
+            $this->assertSame($firstPushSessionId, $exception->get_context()['blocking_push_session_id']);
+            $this->assertSame(1, $exception->get_context()['blocking_ownership_epoch']);
+        }
+
+        $secondOwner = $coordinator->claim_owner($secondPushSessionId, true, $firstPushSessionId, 1);
+        $this->assertSame(2, $secondOwner['ownership_epoch']);
+
+        try {
+            $coordinator->with_owner_request($firstPushSessionId, 1, static function (): void {});
+            $this->fail('A displaced owner completed a request.');
+        } catch (Site_Export_Push_Exception $exception) {
+            $this->assertSame(Site_Export_Push_Session::ERROR_SYNC_OVERTAKEN, $exception->get_error_code());
+        }
+
+        $commit = $coordinator->with_owner_request(
+            $secondPushSessionId,
+            2,
+            function () use ($coordinator, $secondPushSessionId): array {
+                return $coordinator->with_commit(
+                    $secondPushSessionId,
+                    2,
+                    function () use ($coordinator): array {
+                        try {
+                            $coordinator->with_file_read(static function (): void {});
+                            $this->fail('A pull began while the document root was committing.');
+                        } catch (Site_Export_Push_Exception $exception) {
+                            $this->assertSame(Site_Export_Push_Session::ERROR_SYNC_LOCKED, $exception->get_error_code());
+                        }
+                        return ['phase' => 'complete'];
+                    }
+                );
+            }
+        );
+        $this->assertSame('complete', $commit['phase']);
+        $this->assertSame(1, $coordinator->get_document_root_generation());
+        $this->assertSame(1, $coordinator->with_file_read(static function (int $generation): int {
+            return $generation;
+        }));
+
+        $coordinator->with_owner_request(
+            $secondPushSessionId,
+            2,
+            function () use ($coordinator, $secondPushSessionId): void {
+                $coordinator->with_commit(
+                    $secondPushSessionId,
+                    2,
+                    static function (): array {
+                        return ['phase' => 'complete'];
+                    }
+                );
+            }
+        );
+        $this->assertSame(1, $coordinator->get_document_root_generation());
+    }
+
+    private function removeTree(string $path): void {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (!is_dir($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        foreach (scandir($path) ?: [] as $name) {
+            if ($name !== '.' && $name !== '..') {
+                $this->removeTree($path . '/' . $name);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -841,6 +841,44 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('sync_overtaken', $overtaken['reason']);
     }
 
+    public function testPushCreateDoesNotTakeOverANewerOwner(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $firstPushSessionId = str_repeat('5', 32);
+        $secondPushSessionId = str_repeat('6', 32);
+        $thirdPushSessionId = str_repeat('7', 32);
+        $first = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $firstPushSessionId,
+        ], ['created']);
+        $this->assertSame('complete', $first['status'], (string) json_encode($first));
+
+        $blocked = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $secondPushSessionId,
+        ], ['created']);
+        $this->assertSame('failed', $blocked['status'], (string) json_encode($blocked));
+        $this->assertSame('sync_locked', $blocked['reason']);
+
+        $takeover = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $thirdPushSessionId,
+            'force_takeover' => true,
+            'blocking_push_session_id' => $firstPushSessionId,
+            'blocking_ownership_epoch' => 1,
+        ], ['created']);
+        $this->assertSame('complete', $takeover['status'], (string) json_encode($takeover));
+        $this->assertSame(2, $takeover['response']['ownership_epoch']);
+
+        $stale_takeover = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $secondPushSessionId,
+            'force_takeover' => true,
+            'blocking_push_session_id' => $firstPushSessionId,
+            'blocking_ownership_epoch' => 1,
+        ], ['created']);
+        $this->assertSame('failed', $stale_takeover['status'], (string) json_encode($stale_takeover));
+        $this->assertSame('sync_locked', $stale_takeover['reason']);
+        $this->assertSame($thirdPushSessionId, $stale_takeover['response']['blocking_push_session_id']);
+        $this->assertSame(2, $stale_takeover['response']['blocking_ownership_epoch']);
+    }
+
     public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void
     {
         $client = $this->newClient(self::SECRET);
@@ -3182,6 +3220,70 @@ final class PushEndpointsTest extends TestCase {
         $this->assertFileExists($this->localIndexFile(dirname($push_state_directory)));
         $this->assertFileDoesNotExist($push_state_directory . '/sender.json');
         $this->assertDirectoryDoesNotExist($push_state_directory . '/plan');
+    }
+
+    public function testFilesPushCliReportsTheCurrentOwnerWithoutTakeover(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $blocking_push_session_id = str_repeat('8', 32);
+        $create = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $blocking_push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $local_docroot = $this->root . '/cli-locked-local-docroot';
+        $state_directory = $this->root . '/cli-locked-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'new value');
+
+        $blocked = $this->runFilesPushCli($local_docroot, $state_directory);
+
+        $this->assertSame(1, $blocked['exit'], $blocked['output']);
+        $result = $this->lastCliJsonLine($blocked['stdout']);
+        $this->assertSame('failed', $result['status'] ?? null);
+        $this->assertSame('sync_locked', $result['reason'] ?? null);
+        $state = $this->loadActiveState($this->filesPushStateDirectory($state_directory));
+        $this->assertIsArray($state);
+        $this->assertSame('creating', $state['phase']);
+        $this->assertSame($blocking_push_session_id, $state['blocking_push_session_id']);
+        $this->assertSame(1, $state['blocking_ownership_epoch']);
+        $this->assertFileDoesNotExist($this->docroot . '/value.txt');
+    }
+
+    public function testFilesPushCliTakesOverTheCurrentOwner(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $blocking_push_session_id = str_repeat('9', 32);
+        $create = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $blocking_push_session_id,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $local_docroot = $this->root . '/cli-takeover-local-docroot';
+        $state_directory = $this->root . '/cli-takeover-state';
+        mkdir($local_docroot, 0700, true);
+        file_put_contents($local_docroot . '/value.txt', 'new value');
+        $push_create_requests = $this->countEndpointRequests('push_create');
+
+        $completed = $this->runFilesPushCli(
+            $local_docroot,
+            $state_directory,
+            [],
+            '/',
+            ['--force-takeover']
+        );
+
+        $this->assertSame(0, $completed['exit'], $completed['output']);
+        $this->assertSame('complete', $this->lastCliJsonLine($completed['stdout'])['status'] ?? null);
+        $this->assertSame($push_create_requests + 2, $this->countEndpointRequests('push_create'));
+        $this->assertSame('new value', file_get_contents($this->docroot . '/value.txt'));
+
+        $overtaken = $client->send_push_request('GET', 'push_status', [
+            'push_session_id' => $blocking_push_session_id,
+            'ownership_epoch' => 1,
+        ], ['status']);
+        $this->assertSame('failed', $overtaken['status'], (string) json_encode($overtaken));
+        $this->assertSame('sync_overtaken', $overtaken['reason']);
     }
 
     public function testFilesPushCliCanSelectTerminalOrJsonlProgress(): void

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -243,6 +243,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('6', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
 
@@ -287,6 +288,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('7', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
 
@@ -311,6 +313,7 @@ final class PushEndpointsTest extends TestCase {
         for ($request = 0; $request < 10; ++$request) {
             $commit_before_revocation = $client->send_push_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             $this->assertSame('complete', $commit_before_revocation['status'], (string) json_encode($commit_before_revocation));
             if (is_file($this->docroot . '/installed.txt')) {
@@ -326,6 +329,7 @@ final class PushEndpointsTest extends TestCase {
         do {
             $commit = $client->send_push_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
         } while ($commit['response']['send_next_request']);
@@ -342,6 +346,7 @@ final class PushEndpointsTest extends TestCase {
 
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $this->assertSame('created', $create['response']['status']);
@@ -352,7 +357,7 @@ final class PushEndpointsTest extends TestCase {
         $client->set_max_part_bytes($create['response']['max_part_bytes']);
         $client->apply_reported_limits([$create['response']['post_max_bytes']]);
 
-        $this->assertTrue($client->start_upload_request($push_session_id));
+        $this->assertTrue($client->start_upload_request($push_session_id, 1));
         $this->assertTrue($client->send_part([
             'type' => 'file',
             'path' => 'nested/file.bin',
@@ -399,6 +404,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'changes_accepted' => 8,
             'last_change' => [
                 'state' => 'complete',
@@ -410,12 +416,15 @@ final class PushEndpointsTest extends TestCase {
 
         $status = $client->send_push_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'path_b64' => base64_encode('nested/file.bin'),
         ], ['accepted']);
         $this->assertSame('complete', $status['status'], (string) json_encode($status));
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
+            'document_root_generation' => 0,
             'phase' => 'receiving_work',
             'work_deletes_bytes' => strlen($delete_payload),
             'work_deletes_complete' => true,
@@ -432,11 +441,14 @@ final class PushEndpointsTest extends TestCase {
         do {
             $commit = $client->send_push_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
             $this->assertSame([
                 'status',
                 'push_session_id',
+                'ownership_epoch',
+                'document_root_generation',
                 'phase',
                 'send_next_request',
                 'entries_processed',
@@ -468,11 +480,13 @@ final class PushEndpointsTest extends TestCase {
         do {
             $remove = $client->send_push_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             $this->assertSame('complete', $remove['status'], (string) json_encode($remove));
             $this->assertSame([
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => 1,
                 'removed' => $remove['response']['removed'],
                 'http_code' => 200,
             ], $remove['response']);
@@ -488,6 +502,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('c', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $push_directory = $this->reprint_directory . '/.reprint/push/' . $push_session_id;
@@ -497,6 +512,7 @@ final class PushEndpointsTest extends TestCase {
         try {
             $remove = $client->send_push_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
         } finally {
             $this->stopLockProcess($lock_process);
@@ -516,6 +532,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('d', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
 
@@ -539,11 +556,13 @@ final class PushEndpointsTest extends TestCase {
         $tombstone = $push_sessions_directory . '/.removing-' . $push_session_id;
         $first_remove = $client->send_push_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['accepted']);
         $this->assertSame('complete', $first_remove['status'], (string) json_encode($first_remove));
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'removed' => false,
             'http_code' => 200,
         ], $first_remove['response']);
@@ -554,6 +573,7 @@ final class PushEndpointsTest extends TestCase {
 
         $blocked_create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('retry', $blocked_create['status'], (string) json_encode($blocked_create));
         $this->assertSame('lock_acquisition_failure', $blocked_create['reason']);
@@ -567,6 +587,7 @@ final class PushEndpointsTest extends TestCase {
         try {
             $blocked_remove = $client->send_push_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
         } finally {
             $this->stopLockProcess($lock_process);
@@ -581,6 +602,7 @@ final class PushEndpointsTest extends TestCase {
         do {
             $remove = $client->send_push_request('POST', 'push_remove', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             ++$remove_requests;
             $this->assertLessThan(10, $remove_requests, 'Bounded HTTP removal did not converge.');
@@ -588,6 +610,7 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame([
                 'status' => 'accepted',
                 'push_session_id' => $push_session_id,
+                'ownership_epoch' => 1,
                 'removed' => $remove['response']['removed'],
                 'http_code' => 200,
             ], $remove['response']);
@@ -595,11 +618,13 @@ final class PushEndpointsTest extends TestCase {
 
         $repeated_remove = $client->send_push_request('POST', 'push_remove', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['accepted']);
         $this->assertSame('complete', $repeated_remove['status'], (string) json_encode($repeated_remove));
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'removed' => true,
             'http_code' => 200,
         ], $repeated_remove['response']);
@@ -608,6 +633,7 @@ final class PushEndpointsTest extends TestCase {
 
         $recreated = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $recreated['status'], (string) json_encode($recreated));
         $this->assertSame(200, $recreated['response']['http_code']);
@@ -634,14 +660,18 @@ final class PushEndpointsTest extends TestCase {
 
         $created = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $reopened = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $expected_response = [
             'status' => 'created',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
+            'document_root_generation' => 0,
             'max_part_bytes' => 4,
             'post_max_bytes' => self::POST_MAX_BYTES,
             'excluded_paths_b64' => $expected_excluded_paths_b64,
@@ -668,6 +698,7 @@ final class PushEndpointsTest extends TestCase {
 
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $committing_push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $upload = $this->sendUploadRequest($client, $committing_push_session_id, [
@@ -688,22 +719,24 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
         $commit = $client->send_push_request('POST', 'push_commit', [
             'push_session_id' => $committing_push_session_id,
+            'ownership_epoch' => 1,
         ], ['accepted']);
         $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
         $this->assertTrue($commit['response']['send_next_request']);
 
         $create_while_committing = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $next_push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $this->assertSame('failed', $create_while_committing['status'], (string) json_encode($create_while_committing));
-        $this->assertSame('commit_required', $create_while_committing['reason']);
+        $this->assertSame('sync_locked', $create_while_committing['reason']);
         $this->assertSame(
             $committing_push_session_id,
             $create_while_committing['response']['blocking_push_session_id']
         );
         $this->assertSame(
-            'Push session ' . $committing_push_session_id . ' must finish committing this document root before another push session can start.',
+            'Push session ' . $committing_push_session_id . ' owns this document root at ownership epoch 1.',
             $create_while_committing['detail']
         );
         $this->assertSame(409, $create_while_committing['response']['http_code']);
@@ -722,6 +755,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('4', 32);
         $result = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $this->assertSame('failed', $result['status'], (string) json_encode($result));
@@ -733,75 +767,33 @@ final class PushEndpointsTest extends TestCase {
         $this->assertDirectoryDoesNotExist($push_sessions_directory . '/' . $push_session_id);
     }
 
-    public function testHighLevelSenderFinishesPreviousCommitBeforeCreatingItsPushSession(): void
+    public function testHighLevelSenderLeavesAnotherPushOwnerInControl(): void
     {
         $client = $this->newClient(self::SECRET);
-        $blocking_push_session_id = str_repeat('5', 32);
-
+        $blockingPushSessionId = str_repeat('5', 32);
         $create = $client->send_push_request('POST', 'push_create', [
-            'push_session_id' => $blocking_push_session_id,
+            'push_session_id' => $blockingPushSessionId,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
-        $upload = $this->sendUploadRequest($client, $blocking_push_session_id, [
-            [
-                'type' => 'file',
-                'path' => 'blocking.txt',
-                'total_bytes' => 4,
-                'offset' => 0,
-                'payload' => 'hold',
-            ],
-            [
-                'type' => 'delete-list',
-                'offset' => 0,
-                'complete' => true,
-                'payload' => '',
-            ],
-        ]);
-        $this->assertSame('complete', $upload['status'], (string) json_encode($upload));
-        $commit = $client->send_push_request('POST', 'push_commit', [
-            'push_session_id' => $blocking_push_session_id,
-        ], ['accepted']);
-        $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
-        $this->assertTrue($commit['response']['send_next_request']);
 
-        $local_docroot = $this->root . '/next-local-docroot';
-        $push_state_directory = $this->root . '/next-sender-state';
-        mkdir($local_docroot, 0700, true);
-        file_put_contents($local_docroot . '/next.txt', 'next');
-        $options = $this->senderOptions($local_docroot, $push_state_directory);
+        $localDocroot = $this->root . '/next-local-docroot';
+        $pushStateDirectory = $this->root . '/next-sender-state';
+        mkdir($localDocroot, 0700, true);
+        file_put_contents($localDocroot . '/next.txt', 'next');
 
-        $sender = $this->startSender($options);
-        $initial_state = $this->loadActiveState($push_state_directory);
-        $this->assertIsArray($initial_state);
-        $current_push_session_id = $initial_state['push_session_id'];
+        $sender = $this->startSender($this->senderOptions($localDocroot, $pushStateDirectory));
         try {
-            $this->assertTrue($sender->next_step());
-            $this->assertSame('finishing_previous_commit', $sender->get_phase());
-            $state = $this->loadActiveState($push_state_directory);
-            $this->assertIsArray($state);
-            $this->assertSame($current_push_session_id, $state['push_session_id']);
-            $this->assertSame($blocking_push_session_id, $state['blocking_push_session_id']);
+            $this->assertFalse($sender->next_step());
+            $this->assertSame('failed', $sender->get_status());
+            $this->assertSame('sync_locked', $sender->get_reason());
         } finally {
             $this->closeSender($sender);
         }
 
-        $resumed_sender = $this->resumeSender($options);
-        try {
-            $this->assertTrue($resumed_sender->next_step());
-            $this->assertSame('finishing_previous_commit', $resumed_sender->get_phase());
-        } finally {
-            $this->closeSender($resumed_sender);
-        }
-
-        $state = $this->loadActiveState($push_state_directory);
+        $state = $this->loadActiveState($pushStateDirectory);
         $this->assertIsArray($state);
-        $this->assertSame($blocking_push_session_id, $state['blocking_push_session_id']);
-        $result = $this->runSender($local_docroot, $push_state_directory);
-
-        $this->assertSame('complete', $result['status'], (string) json_encode($result));
-        $this->assertSame('hold', file_get_contents($this->docroot . '/blocking.txt'));
-        $this->assertSame('next', file_get_contents($this->docroot . '/next.txt'));
-        $this->assertNull($this->loadActiveState($push_state_directory));
+        $this->assertSame('creating', $state['phase']);
+        $this->assertSame($blockingPushSessionId, $create['response']['push_session_id']);
     }
 
     public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void
@@ -810,6 +802,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('b', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
 
@@ -824,6 +817,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'changes_accepted' => 1,
             'last_change' => [
                 'path_b64' => base64_encode('value.txt'),
@@ -836,12 +830,15 @@ final class PushEndpointsTest extends TestCase {
 
         $status = $client->send_push_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             'path_b64' => base64_encode('missing.txt'),
         ], ['accepted']);
         $this->assertSame('complete', $status['status'], (string) json_encode($status));
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
+            'document_root_generation' => 0,
             'phase' => 'receiving_work',
             'work_deletes_bytes' => 0,
             'work_deletes_complete' => false,
@@ -857,7 +854,7 @@ final class PushEndpointsTest extends TestCase {
     public function testUploadReportsDeclaredRequestBodyLimitOn413(): void
     {
         $push_session_id = str_repeat('d', 32);
-        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id . '&ownership_epoch=1';
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: multipart/mixed; boundary=oversized-endpoint-test'];
         foreach ($headers as $name => $value) {
@@ -889,13 +886,14 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('f', 32);
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $this->assertSame(self::POST_MAX_BYTES, $create['response']['post_max_bytes']);
 
         // MultipartPushStreamClient uses CURLOPT_UPLOAD without a known body
         // length, so this reaches the production router as chunked transport.
-        $this->assertTrue($client->start_upload_request($push_session_id));
+        $this->assertTrue($client->start_upload_request($push_session_id, 1));
         for ($part = 0; $part < 200; ++$part) {
             if (!$client->send_part([
                 'type' => 'directory',
@@ -933,6 +931,7 @@ final class PushEndpointsTest extends TestCase {
             $clean_push_session_id = str_repeat('0', 32);
             $clean_create = $client->send_push_request('POST', 'push_create', [
                 'push_session_id' => $clean_push_session_id,
+            'ownership_epoch' => 1,
             ], ['created']);
             $this->assertSame('complete', $clean_create['status'], (string) json_encode($clean_create));
             $this->assertSame($maximum_request_body_bytes, $clean_create['response']['post_max_bytes']);
@@ -961,10 +960,18 @@ final class PushEndpointsTest extends TestCase {
             );
             $this->assertSame(200, $clean_upload['http_code'], (string) json_encode($clean_upload));
             $this->assertSame('accepted', $clean_upload['response']['status']);
+            do {
+                $clean_remove = $client->send_push_request('POST', 'push_remove', [
+                    'push_session_id' => $clean_push_session_id,
+                    'ownership_epoch' => 1,
+                ], ['accepted']);
+                $this->assertSame('complete', $clean_remove['status'], (string) json_encode($clean_remove));
+            } while (!$clean_remove['response']['removed']);
 
             $over_limit_push_session_id = str_repeat('1', 32);
             $over_limit_create = $client->send_push_request('POST', 'push_create', [
                 'push_session_id' => $over_limit_push_session_id,
+            'ownership_epoch' => 1,
             ], ['created']);
             $this->assertSame('complete', $over_limit_create['status'], (string) json_encode($over_limit_create));
             $over_limit_upload = $this->sendChunkedUploadRequest(
@@ -972,13 +979,21 @@ final class PushEndpointsTest extends TestCase {
                 $over_limit_push_session_id,
                 $boundary,
                 $multipart_body,
-                'y'
+                'y',
+                $over_limit_create['response']['ownership_epoch']
             );
             $this->assertSame(413, $over_limit_upload['http_code'], (string) json_encode($over_limit_upload));
             $this->assertSame('rejected', $over_limit_upload['response']['status']);
             $this->assertSame('request_too_large', $over_limit_upload['response']['reason']);
             $this->assertSame($maximum_request_body_bytes + 1, $over_limit_upload['response']['observed_request_body_bytes']);
             $this->assertSame($maximum_request_body_bytes, $over_limit_upload['response']['post_max_bytes']);
+            do {
+                $overLimitRemove = $client->send_push_request('POST', 'push_remove', [
+                    'push_session_id' => $over_limit_push_session_id,
+                    'ownership_epoch' => $over_limit_create['response']['ownership_epoch'],
+                ], ['accepted']);
+                $this->assertSame('complete', $overLimitRemove['status'], (string) json_encode($overLimitRemove));
+            } while (!$overLimitRemove['response']['removed']);
         } finally {
             $this->stopServer($server_process, $server_pipes);
         }
@@ -990,6 +1005,7 @@ final class PushEndpointsTest extends TestCase {
             $trailing_byte_push_session_id = str_repeat('2', 32);
             $create = $client->send_push_request('POST', 'push_create', [
                 'push_session_id' => $trailing_byte_push_session_id,
+            'ownership_epoch' => 1,
             ], ['created']);
             $this->assertSame('complete', $create['status'], (string) json_encode($create));
             $this->assertSame($larger_maximum_request_body_bytes, $create['response']['post_max_bytes']);
@@ -999,7 +1015,8 @@ final class PushEndpointsTest extends TestCase {
                 $trailing_byte_push_session_id,
                 $boundary,
                 $multipart_body,
-                'y'
+                'y',
+                $create['response']['ownership_epoch']
             );
             $this->assertSame(400, $trailing_byte_upload['http_code'], (string) json_encode($trailing_byte_upload));
             $this->assertSame('rejected', $trailing_byte_upload['response']['status']);
@@ -1154,6 +1171,7 @@ final class PushEndpointsTest extends TestCase {
 
         $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $this->assertSame('failed', $response['status'], (string) json_encode($response));
@@ -1179,6 +1197,7 @@ final class PushEndpointsTest extends TestCase {
 
         $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $this->assertSame('complete', $response['status'], (string) json_encode($response));
@@ -1203,6 +1222,7 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('7', 32);
         $response = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
 
         $this->assertSame('complete', $response['status'], (string) json_encode($response));
@@ -1263,11 +1283,14 @@ final class PushEndpointsTest extends TestCase {
 
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
         $this->assertSame([
             'status' => 'created',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
+            'document_root_generation' => 0,
             'max_part_bytes' => 1024,
             'post_max_bytes' => self::POST_MAX_BYTES,
             'excluded_paths_b64' => [base64_encode($logical_plugin_path)],
@@ -1323,6 +1346,7 @@ final class PushEndpointsTest extends TestCase {
         do {
             $commit = $client->send_push_request('POST', 'push_commit', [
                 'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
             ], ['accepted']);
             $this->assertSame('complete', $commit['status'], (string) json_encode($commit));
         } while ($commit['response']['send_next_request']);
@@ -1360,17 +1384,21 @@ final class PushEndpointsTest extends TestCase {
         $push_session_id = str_repeat('2', 32);
         $create = $this->newClient(self::SECRET)->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status'], (string) json_encode($create));
 
         $status = $this->sendPushRequestWithHeaders('GET', 'push_status', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], self::SECRET);
 
         $this->assertSame(200, $status['http_code'], $status['body']);
         $this->assertSame([
             'status' => 'accepted',
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
+            'document_root_generation' => 0,
             'phase' => 'receiving_work',
             'work_deletes_bytes' => 0,
             'work_deletes_complete' => false,
@@ -1397,6 +1425,7 @@ final class PushEndpointsTest extends TestCase {
 
         $wrong_method = $client->send_push_request('GET', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('failed', $wrong_method['status']);
         $this->assertSame('invalid_request', $wrong_method['reason']);
@@ -1405,6 +1434,7 @@ final class PushEndpointsTest extends TestCase {
         $wrong_secret = $this->newClient('not-the-server-secret');
         $authentication = $wrong_secret->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('failed', $authentication['status']);
         $this->assertSame('auth_failed', $authentication['reason']);
@@ -1412,6 +1442,7 @@ final class PushEndpointsTest extends TestCase {
 
         $create = $client->send_push_request('POST', 'push_create', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['created']);
         $this->assertSame('complete', $create['status']);
         $push_lock = fopen($this->reprint_directory . '/.reprint/push/' . $push_session_id . '/push.lock', 'c+b');
@@ -1419,13 +1450,14 @@ final class PushEndpointsTest extends TestCase {
         $this->assertTrue(flock($push_lock, LOCK_EX | LOCK_NB));
         $lock_contention = $client->send_push_request('GET', 'push_status', [
             'push_session_id' => $push_session_id,
+            'ownership_epoch' => 1,
         ], ['accepted']);
         $this->assertSame('retry', $lock_contention['status']);
         $this->assertSame('lock_acquisition_failure', $lock_contention['reason']);
         flock($push_lock, LOCK_UN);
         fclose($push_lock);
 
-        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $url = $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id . '&ownership_epoch=1';
         $headers = ( new Site_Export_HMAC_Client(self::SECRET) )->get_envelope_auth_headers('POST', $url);
         $curl_headers = ['Content-Type: application/json'];
         foreach ($headers as $name => $value) {
@@ -1521,7 +1553,7 @@ final class PushEndpointsTest extends TestCase {
                 $this->assertSame($initial_local_index_contents, file_get_contents($local_index_file));
                 $saw_saving_local_index = true;
             }
-            if (is_array($state) && $state['phase'] === 'completing') {
+            if (is_array($state) && $state['phase'] === 'removing') {
                 $this->assertNull($state['push_plan_cursor']);
                 $this->assertDirectoryExists($push_state_directory . '/plan');
                 $fresh_local_index_file = $push_state_directory . '/plan/fresh_local_index.jsonl';
@@ -1649,7 +1681,7 @@ final class PushEndpointsTest extends TestCase {
             }
             $this->assertSame(
                 [
-                    'phase' => 'completing',
+                    'phase' => 'removing',
                     'files_done' => 2,
                     'files_total' => 2,
                 ],
@@ -2801,7 +2833,7 @@ final class PushEndpointsTest extends TestCase {
             . "Content-Length: 0\r\n\r\n\r\n"
             . '--' . $boundary . "--\r\n";
         $this->sendPostAndDiscardResponse(
-            $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'],
+            $this->remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $state['push_session_id'] . '&ownership_epoch=1',
             'multipart/mixed; boundary=' . $boundary,
             $delete_body
         );
@@ -3047,7 +3079,7 @@ final class PushEndpointsTest extends TestCase {
             }
         ));
         $this->assertNotEmpty($files_push_lines);
-        $this->assertStringContainsString('COMPLETE files-push | phase=completing', $audit);
+        $this->assertStringContainsString('COMPLETE files-push | phase=removing', $audit);
         preg_match_all('/PHASE files-push .* from=([^ ]+) \| to=([^ ]+)/', $audit, $phase_matches);
         $phase_transitions = array_map(
             static function (string $from, string $to): string {
@@ -3538,9 +3570,10 @@ final class PushEndpointsTest extends TestCase {
         string $push_session_id,
         string $boundary,
         string $multipart_body,
-        string $trailing_bytes = ''
+        string $trailing_bytes = '',
+        int $ownership_epoch = 1
     ): array {
-        $request_url = $remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id;
+        $request_url = $remote_reprint_api_url . '&endpoint=push_upload&push_session_id=' . $push_session_id . '&ownership_epoch=' . $ownership_epoch;
         $url = parse_url($request_url);
         $this->assertIsArray($url);
         $this->assertSame('http', $url['scheme'] ?? null);
@@ -4032,7 +4065,7 @@ final class PushEndpointsTest extends TestCase {
      */
     private function sendUploadRequest(MultipartPushStreamClient $client, string $push_session_id, array $parts): array
     {
-        $this->assertTrue($client->start_upload_request($push_session_id));
+        $this->assertTrue($client->start_upload_request($push_session_id, 1));
         foreach ($parts as $part) {
             $client->send_part($part);
         }
@@ -4108,7 +4141,8 @@ final class PushEndpointsTest extends TestCase {
     ): array {
         $url = $this->remote_reprint_api_url
             . '&endpoint=' . rawurlencode($endpoint)
-            . '&push_session_id=' . rawurlencode($push_session_id);
+            . '&push_session_id=' . rawurlencode($push_session_id)
+            . '&ownership_epoch=1';
         $curl_headers = [];
         if ($content_type !== null) {
             $curl_headers[] = 'Content-Type: ' . $content_type;

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -793,7 +793,52 @@ final class PushEndpointsTest extends TestCase {
         $state = $this->loadActiveState($pushStateDirectory);
         $this->assertIsArray($state);
         $this->assertSame('creating', $state['phase']);
-        $this->assertSame($blockingPushSessionId, $create['response']['push_session_id']);
+        $this->assertSame($blockingPushSessionId, $state['blocking_push_session_id']);
+        $this->assertSame(1, $state['blocking_ownership_epoch']);
+    }
+
+    public function testHighLevelSenderTakesOverTheReportedPushOwner(): void
+    {
+        $client = $this->newClient(self::SECRET);
+        $blockingPushSessionId = str_repeat('5', 32);
+        $create = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => $blockingPushSessionId,
+        ], ['created']);
+        $this->assertSame('complete', $create['status'], (string) json_encode($create));
+
+        $localDocroot = $this->root . '/next-local-docroot';
+        $pushStateDirectory = $this->root . '/next-sender-state';
+        mkdir($localDocroot, 0700, true);
+        file_put_contents($localDocroot . '/next.txt', 'next');
+        $senderOptions = $this->senderOptions($localDocroot, $pushStateDirectory);
+        $senderOptions['force_takeover'] = true;
+
+        $sender = $this->startSender($senderOptions);
+        try {
+            $this->assertTrue($sender->next_step());
+            $state = $this->loadActiveState($pushStateDirectory);
+            $this->assertIsArray($state);
+            $this->assertSame($blockingPushSessionId, $state['blocking_push_session_id']);
+            $this->assertSame(1, $state['blocking_ownership_epoch']);
+
+            $this->assertTrue($sender->next_step());
+            $this->assertSame('starting_plan', $sender->get_phase());
+        } finally {
+            $this->closeSender($sender);
+        }
+
+        $state = $this->loadActiveState($pushStateDirectory);
+        $this->assertIsArray($state);
+        $this->assertSame(2, $state['ownership_epoch']);
+        $this->assertNull($state['blocking_push_session_id']);
+        $this->assertNull($state['blocking_ownership_epoch']);
+
+        $overtaken = $client->send_push_request('GET', 'push_status', [
+            'push_session_id' => $blockingPushSessionId,
+            'ownership_epoch' => 1,
+        ], ['status']);
+        $this->assertSame('failed', $overtaken['status'], (string) json_encode($overtaken));
+        $this->assertSame('sync_overtaken', $overtaken['reason']);
     }
 
     public function testUploadAndMissingPathStatusExposeOnlyDocumentedFields(): void


### PR DESCRIPTION
Pushes now retain one durable owner with an epoch, so stale requests cannot change the target and file reads remain open until a commit begins.

The server persists ownership, generation, terminal-owner records, and separate metadata, request, and document-root gates. Push routes carry the epoch, completed senders remove private target work, and file streams carry the target generation.

Tests: targeted PHPUnit suite (85 tests, 2,513 assertions) and PHPStan.
