### PR TITLE
[PHP] Route command status and heartbeats through --progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,10 @@ The selected mode applies only to that invocation and is not retained in
 command state. Explicit `tty` and `jsonl` modes cannot be combined with
 `--verbose`.
 
+The selector governs progress, lifecycle, and status output. It does not
+reformat a command's data result, such as preflight or pull-metadata JSON,
+files-stats JSON, db-domains lines, or SQL written with `--sql-output=stdout`.
+
 The files-push terminal presentation uses one stage-weighted progress bar. The
 percentage comes first, followed by a major stage such as `Indexing`, `Pushing`,
 or `Committing`. While pushing local paths, the line also shows target-confirmed
@@ -771,7 +775,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 ```
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
-* `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
+* `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary in terminal mode or one structured result in JSONL mode. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -362,7 +362,9 @@ by every command executed by `ImportClient`: `auto`, `tty`, or `jsonl`. `auto`
 selects the terminal presentation when the current progress stream is a TTY and
 the JSONL presentation otherwise. `tty` and `jsonl` force those presentations.
 Never store the progress output mode in command state. Explicit `tty` and
-`jsonl` modes do not combine with `--verbose`.
+`jsonl` modes do not combine with `--verbose`. The progress output mode governs
+progress, lifecycle, and status output; it does not reformat a command's data
+result.
 
 ## Files-diff CLI names
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2807,7 +2807,8 @@ class ImportClient
      *
      * Inspects the preflight response (already fetched by run_preflight())
      * and exits with code 0 if migration looks feasible, code 1 if not.
-     * Prints a human-readable pass/fail summary to stdout.
+     * Prints a human-readable pass/fail summary in terminal mode or one
+     * structured result in JSONL mode.
      */
     private function run_preflight_assert(): void
     {
@@ -2897,22 +2898,28 @@ class ImportClient
         // We do not check for any encoding issues here. We'll move over
         // the entire database as it is.
 
-        // Print summary
+        // Print the terminal summary or emit one structured result.
+        $human_summary = "";
         foreach ($checks as $check) {
             $icon = $check["pass"] ? "PASS" : "FAIL";
-            echo "[{$icon}] {$check["label"]}: {$check["detail"]}\n";
+            $human_summary .= "[{$icon}] {$check["label"]}: {$check["detail"]}\n";
         }
 
-        echo "\n";
-        if ($all_pass) {
-            echo "Migration looks feasible.\n";
-            $this->write_progress_file();
-            exit(0);
-        } else {
-            echo "Migration may not be feasible. Review the failures above.\n";
-            $this->write_progress_file("Preflight assertions failed");
-            exit(1);
-        }
+        $message = $all_pass
+            ? "Migration looks feasible."
+            : "Migration may not be feasible. Review the failures above.";
+        $human_summary .= "\n{$message}\n";
+        $this->progress->show_lifecycle_line($human_summary);
+        $this->output_progress([
+            "type" => "preflight_assertion",
+            "command" => "preflight-assert",
+            "status" => $all_pass ? "complete" : "error",
+            "checks" => $checks,
+            "message" => $message,
+        ], true);
+
+        $this->write_progress_file($all_pass ? null : "Preflight assertions failed");
+        exit($all_pass ? 0 : 1);
     }
 
     /**
@@ -4515,7 +4522,7 @@ class ImportClient
         }
 
         // Output the summary and manifest as structured JSON for callers,
-        // and print the human-readable summary to stderr.
+        // or print the human-readable terminal summary.
         $this->output_progress([
             "status" => "complete",
             "command" => "apply-runtime",
@@ -4529,18 +4536,15 @@ class ImportClient
             "message" => "apply-runtime complete (runtime: {$runtime})",
         ]);
 
-        if (!$this->progress->is_mode('pipeline')) {
-            fwrite(STDERR, "\n");
-            fwrite(STDERR, "Runtime: {$runtime}\n");
-            fwrite(STDERR, "Source host: {$webhost}\n");
-            if ($target_engine !== null) {
-                fwrite(STDERR, "Target database: {$target_engine}\n");
-            }
-            fwrite(STDERR, "\n");
-            foreach ($summary as $line) {
-                fwrite(STDERR, "{$line}\n");
-            }
+        $human_summary = "\nRuntime: {$runtime}\nSource host: {$webhost}\n";
+        if ($target_engine !== null) {
+            $human_summary .= "Target database: {$target_engine}\n";
         }
+        $human_summary .= "\n";
+        foreach ($summary as $line) {
+            $human_summary .= "{$line}\n";
+        }
+        $this->progress->show_lifecycle_line($human_summary);
     }
 
     /**
@@ -10955,15 +10959,12 @@ class ImportClient
                     $bytes_since_check = $bytes_received - $last_bytes_received;
                     $rate = $bytes_since_check / 5.0; // bytes per second
 
-                    // Only output progress_check in verbose mode or non-TTY
-                    if ($this->verbose_mode || !$this->is_tty) {
-                        fwrite($this->progress_fd, json_encode([
-                            "progress_check" => true,
-                            "bytes_received" => $bytes_received,
-                            "bytes_last_5s" => $bytes_since_check,
-                            "rate_bps" => round($rate),
-                        ]) . "\n");
-                    }
+                    $this->output_progress([
+                        "progress_check" => true,
+                        "bytes_received" => $bytes_received,
+                        "bytes_last_5s" => $bytes_since_check,
+                        "rate_bps" => round($rate),
+                    ], true);
 
                     // If we're receiving less than 1KB/s for 5 seconds, something is wrong
                     if ($bytes_since_check < 1024 && $bytes_received > 0) {
@@ -10977,24 +10978,23 @@ class ImportClient
                     $last_bytes_received = $bytes_received;
                 }
 
-                // Output heartbeat every second (only in verbose/non-TTY mode)
+                // Output a structured heartbeat every second when JSONL or
+                // verbose output is active.
                 if ($now - $last_heartbeat >= 1.0) {
-                    if ($this->verbose_mode || !$this->is_tty) {
-                        $heartbeat = [
-                            "heartbeat" => true,
-                            "bytes_received" => $bytes_received,
-                        ];
-                        // Only emit file counters when the fetch list has
-                        // been counted (fetch phase).  During indexing the
-                        // list doesn't exist yet and emitting files_done:0
-                        // without files_total confuses consumers.
-                        if ($this->fetch_list_total !== null) {
-                            $heartbeat["files_done"] =
-                                ($this->fetch_list_done ?? 0) + $this->files_pulled;
-                            $heartbeat["files_total"] = $this->fetch_list_total;
-                        }
-                        fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
+                    $heartbeat = [
+                        "heartbeat" => true,
+                        "bytes_received" => $bytes_received,
+                    ];
+                    // Only emit file counters when the fetch list has
+                    // been counted (fetch phase).  During indexing the
+                    // list doesn't exist yet and emitting files_done:0
+                    // without files_total confuses consumers.
+                    if ($this->fetch_list_total !== null) {
+                        $heartbeat["files_done"] =
+                            ($this->fetch_list_done ?? 0) + $this->files_pulled;
+                        $heartbeat["files_total"] = $this->fetch_list_total;
                     }
+                    $this->output_progress($heartbeat, true);
                     $last_heartbeat = $now;
                 }
 
@@ -11540,7 +11540,13 @@ class ImportClient
                 "message" => "State saved successfully",
             ], true);
         } catch (Exception $e) {
-            fwrite($this->progress_fd, "Warning: Failed to save state: " . $e->getMessage() . "\n");
+            $message = "Warning: Failed to save state: " . $e->getMessage();
+            $this->progress->print_line($message . "\n");
+            $this->output_progress([
+                "type" => "state_save_error",
+                "error" => $e->getMessage(),
+                "message" => $message,
+            ], true);
         }
 
         $this->progress->show_lifecycle_line("Exiting...\n");

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -210,6 +210,116 @@ class FileBodyStreamingTest extends TestCase
             'Final file must be byte-identical to source after mid-file resume.');
     }
 
+    public function testStreamingHeartbeatsUseTheSelectedProgressOutput(): void
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Streaming progress coverage requires PHP curl and pcntl.');
+        }
+
+        $ttyOutput = $this->fetchSlowResponseWithProgressMode('tty', false);
+        $this->assertSame('', $ttyOutput);
+
+        $jsonlOutput = $this->fetchSlowResponseWithProgressMode('jsonl', true);
+        $records = array_map(
+            static fn(string $line): array => json_decode($line, true, 512, JSON_THROW_ON_ERROR),
+            array_values(array_filter(preg_split('/\R/', trim($jsonlOutput)) ?: []))
+        );
+        $heartbeatRecords = array_values(array_filter(
+            $records,
+            static fn(array $record): bool => ( $record['heartbeat'] ?? false ) === true
+        ));
+        $this->assertNotEmpty($heartbeatRecords, $jsonlOutput);
+    }
+
+    private function fetchSlowResponseWithProgressMode(
+        string $progressMode,
+        bool $progressStreamIsTty
+    ): string {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertNotFalse($listener, $errorMessage);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 5);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_timeout($connection, 5);
+            $request = '';
+            while (strpos($request, "\r\n\r\n") === false) {
+                $requestChunk = fread($connection, 8192);
+                if ($requestChunk === false || $requestChunk === '') {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(3);
+                }
+                $request .= $requestChunk;
+            }
+
+            $boundary = 'progress-output-test';
+            $body = "--{$boundary}\r\n"
+                . "X-Chunk-Type: completion\r\n"
+                . "Content-Length: 0\r\n\r\n\r\n"
+                . "--{$boundary}--\r\n";
+            $headers = "HTTP/1.1 200 OK\r\n"
+                . "Content-Type: multipart/mixed; boundary={$boundary}\r\n"
+                . 'Content-Length: ' . strlen($body) . "\r\n"
+                . "Connection: close\r\n\r\n";
+            $splitAt = (int) floor(strlen($body) / 2);
+            fwrite($connection, $headers . substr($body, 0, $splitAt));
+            fflush($connection);
+            usleep(1200000);
+            fwrite($connection, substr($body, $splitAt));
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        fclose($listener);
+        $output = fopen('php://temp', 'w+');
+        $this->assertIsResource($output);
+        $client = new \ImportClient(
+            'http://' . $address,
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root'
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('is_tty')->setValue($client, $progressStreamIsTty);
+        $reflection->getProperty('progress_output_mode')->setValue($client, $progressMode);
+        $reflection->getProperty('progress_fd')->setValue($client, $output);
+        $progress = $reflection->getProperty('progress')->getValue($client);
+        $progress->set_progress_fd($output);
+        $progress->set_terminal_output_enabled($progressMode === 'tty');
+
+        $context = new StreamingContext();
+        $context->on_chunk = static function (array $chunk) use ($context): void {
+            if (( $chunk['headers']['x-chunk-type'] ?? '' ) === 'completion') {
+                $context->saw_completion = true;
+            }
+        };
+
+        try {
+            $reflection->getMethod('fetch_streaming')->invoke(
+                $client,
+                'http://' . $address . '/stream',
+                null,
+                $context
+            );
+        } finally {
+            pcntl_waitpid($child, $status);
+        }
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        rewind($output);
+        $contents = stream_get_contents($output);
+        fclose($output);
+        $this->assertIsString($contents);
+        return $contents;
+    }
+
     private function buildMultipart(string $boundary, array $parts): string
     {
         $out = '';

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -143,4 +143,63 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->assertStringContainsString("define('DB_FILE'", $runtime);
         $this->assertStringContainsString("Constant already defined", $runtime);
     }
+
+    public function testApplyRuntimeUsesTheSelectedProgressOutput(): void
+    {
+        $this->writeState([]);
+
+        $ttyResult = $this->runApplyRuntimeCli('tty', $this->outputDir . '-tty');
+        $this->assertSame(0, $ttyResult['exit'], $ttyResult['stderr']);
+        $this->assertStringContainsString("Runtime: php-builtin\n", $ttyResult['stdout']);
+        $this->assertStringContainsString("Source host: other\n", $ttyResult['stdout']);
+        $this->assertStringNotContainsString('{"status":', $ttyResult['stdout']);
+        $this->assertSame('', $ttyResult['stderr']);
+
+        $jsonlResult = $this->runApplyRuntimeCli('jsonl', $this->outputDir . '-jsonl');
+        $this->assertSame(0, $jsonlResult['exit'], $jsonlResult['stderr']);
+        $this->assertSame('', $jsonlResult['stderr']);
+        $record = json_decode(trim($jsonlResult['stdout']), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('complete', $record['status'] ?? null);
+        $this->assertSame('apply-runtime', $record['command'] ?? null);
+        $this->assertSame('php-builtin', $record['runtime'] ?? null);
+    }
+
+    /** @return array{exit:int,stdout:string,stderr:string} */
+    private function runApplyRuntimeCli(string $progressMode, string $outputDir): array
+    {
+        $process = proc_open(
+            [
+                PHP_BINARY,
+                __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
+                'apply-runtime',
+                'https://source.example/export.php',
+                '--state-dir=' . $this->stateDir,
+                '--flat-document-root=' . $this->fsRoot,
+                '--output-dir=' . $outputDir,
+                '--runtime=php-builtin',
+                '--progress=' . $progressMode,
+            ],
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                ['pipe', 'w'],
+            ],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+
+        return [
+            'exit' => $exit,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+        ];
+    }
 }

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -37,6 +37,17 @@ describe('Import: Protocol Version Mismatch', () => {
         writeFileSync(stateFilePath(), JSON.stringify(state, null, 2));
     }
 
+    function assertionResult(result) {
+        const records = result.stdout
+            .trim()
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .map((line) => JSON.parse(line));
+        const report = records.find((record) => record.command === 'preflight-assert');
+        assert.ok(report, `Expected preflight-assert result:\n${result.stdout}`);
+        return report;
+    }
+
     beforeAll(async () => {
         await ensureSite(site);
     });
@@ -62,8 +73,11 @@ describe('Import: Protocol Version Mismatch', () => {
         });
 
         assert.equal(result.exitCode, 0, `Expected exit 0:\nstdout: ${result.stdout}`);
-        assert.ok(result.stdout.includes('[PASS] Protocol compatible'), `Expected PASS for protocol check:\n${result.stdout}`);
-        assert.match(result.stdout, /remote v\d+, client v\d+/);
+        const report = assertionResult(result);
+        assert.equal(report.status, 'complete');
+        const protocolCheck = report.checks.find((check) => check.label === 'Protocol compatible');
+        assert.equal(protocolCheck.pass, true);
+        assert.match(protocolCheck.detail, /remote v\d+, client v\d+/);
     });
 
     it('fails when the remote protocol version is lower', () => {
@@ -73,6 +87,7 @@ describe('Import: Protocol Version Mismatch', () => {
 
         const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
             secret: getSiteSecret(site),
+            extraArgs: ['--progress=tty'],
         });
 
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
@@ -91,9 +106,12 @@ describe('Import: Protocol Version Mismatch', () => {
         });
 
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
-        assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('does not match'), `Expected mismatch message:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('Update the Reprint client'), `Expected update instruction:\n${result.stdout}`);
+        const report = assertionResult(result);
+        assert.equal(report.status, 'error');
+        const protocolCheck = report.checks.find((check) => check.label === 'Protocol compatible');
+        assert.equal(protocolCheck.pass, false);
+        assert.match(protocolCheck.detail, /does not match/);
+        assert.match(protocolCheck.detail, /Update the Reprint client/);
     });
 
     it('fails when remote does not report a protocol version', () => {
@@ -106,8 +124,11 @@ describe('Import: Protocol Version Mismatch', () => {
         });
 
         assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
-        assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('does not report a protocol version'), `Expected missing version message:\n${result.stdout}`);
-        assert.ok(result.stdout.includes('Update the export plugin'), `Expected update instruction:\n${result.stdout}`);
+        const report = assertionResult(result);
+        assert.equal(report.status, 'error');
+        const protocolCheck = report.checks.find((check) => check.label === 'Protocol compatible');
+        assert.equal(protocolCheck.pass, false);
+        assert.match(protocolCheck.detail, /does not report a protocol version/);
+        assert.match(protocolCheck.detail, /Update the export plugin/);
     });
 });


### PR DESCRIPTION
`--progress=tty|jsonl` now controls preflight assertion summaries, apply-runtime summaries, streaming heartbeats and checks, and interrupt save failures instead of those paths consulting the physical terminal or writing around the selected presentation.

```console
$ php reprint.phar preflight-assert "$URL" \
    --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" \
    --secret="$SECRET" --progress=jsonl
{"type":"preflight_assertion","command":"preflight-assert","status":"complete","checks":[...],"message":"Migration looks feasible."}
```

Command data results remain unchanged: preflight and pull-metadata JSON, files-stats JSON, db-domains lines, and SQL on stdout are not progress output.

## Testing

Run preflight-assert and apply-runtime with redirected output and `--progress=tty`, then run them in a terminal with `--progress=jsonl`. Confirm each explicit mode overrides terminal detection and JSONL output contains no human summary.
