### PR TITLE
[Tests] Retry E2E preflight calls without an HTTP response

### DIFF
--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -294,7 +294,18 @@ export function runImporter(url, outputDir, command, options = {}) {
             // No state file or invalid JSON — need preflight
         }
         if (needsPreflight) {
-            const preflightResult = runImporterOnce('preflight');
+            let preflightResult;
+            let preflightAttempts = 0;
+            do {
+                preflightResult = runImporterOnce('preflight');
+                preflightAttempts += 1;
+                // Preflight is read-only. Retry only when cURL received no HTTP
+                // response, which is the transient PHP-FPM stall seen in CI.
+            } while (
+                preflightResult.exitCode !== 0 &&
+                preflightAttempts < 3 &&
+                preflightResult.stdout.includes('"http_code":0')
+            );
             if (preflightResult.exitCode !== 0) {
                 return preflightResult;
             }


### PR DESCRIPTION
The E2E suite retries its read-only preflight call when cURL reports no HTTP response, so a transient PHP-FPM stall does not abort dependent tests.

The retry is bounded to two additional attempts and applies only to HTTP 0 results; every HTTP response keeps the existing behavior.