### PR TITLE
[PHP] Decode streamed file-error paths before recording pull state

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -6320,7 +6320,7 @@ class ImportClient
                 }
                 // @TODO: Cleanup the local file that we may have started downloading.
             } elseif ($chunk_type === "error") {
-                $this->handle_error_chunk($chunk, "files", $context);
+                $this->handle_error_chunk($chunk, "files");
             } elseif ($chunk_type === "progress") {
                 $this->handle_progress($chunk, "files");
             } elseif ($chunk_type === "completion") {
@@ -6684,7 +6684,7 @@ class ImportClient
                             : null,
                 ];
             } elseif ($chunk_type === "error") {
-                $this->handle_error_chunk($chunk, "index", $context);
+                $this->handle_error_chunk($chunk, "index");
             }
         };
 
@@ -8129,7 +8129,7 @@ class ImportClient
                             true,
                         );
                     } elseif ($chunk_type === "error") {
-                        $this->handle_error_chunk($chunk, "sql", $context);
+                        $this->handle_error_chunk($chunk, "sql");
                     }
                 };
 
@@ -8614,7 +8614,7 @@ class ImportClient
                             true,
                         );
                     } elseif ($chunk_type === "error") {
-                        $this->handle_error_chunk($chunk, "db-index", $context);
+                        $this->handle_error_chunk($chunk, "db-index");
                     }
                 };
 
@@ -9963,13 +9963,16 @@ class ImportClient
     }
 
     /**
-     * Handle an error chunk from the server.
+     * Handles an error chunk from the server.
+     *
+     * The exporter encodes error paths as base64 because a remote path can
+     * contain arbitrary bytes. Decode that protocol field before recording
+     * its path in pull state. A source-side read error invalidates remote
+     * state, but does not authorize deleting a local file: a later response
+     * may replay the file's data.
      */
-    private function handle_error_chunk(
-        array $chunk,
-        string $phase,
-        StreamingContext $context
-    ): void {
+    private function handle_error_chunk(array $chunk, string $phase): void
+    {
         $body = $chunk["body"] ?? "";
         $data = json_decode($body, true);
         if (!$data) {
@@ -9982,7 +9985,20 @@ class ImportClient
         }
 
         $error_type = $data["error_type"] ?? "unknown";
-        $path = $data["path"] ?? "";
+        $encoded_path = $data["path"] ?? "";
+        $path = is_string($encoded_path)
+            ? base64_decode($encoded_path, true)
+            : false;
+        if ($path === false) {
+            $observed_path = is_string($encoded_path)
+                ? substr($encoded_path, 0, 100)
+                : gettype($encoded_path);
+            $this->audit_log(
+                "REMOTE ERROR | phase={$phase} | invalid base64 path: {$observed_path}",
+                true,
+            );
+            $path = "";
+        }
         $message = $data["message"] ?? "Error";
 
         $this->audit_log(
@@ -9996,18 +10012,6 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_absolute_path = $this->filesystem_root . $path;
-            if ($context->file_handle && $context->file_path === $local_absolute_path) {
-                fclose($context->file_handle);
-                $context->file_handle = null;
-                $context->file_path = null;
-                $context->file_ctime = null;
-                $context->file_bytes_written = 0;
-            }
-
-            if (file_exists($local_absolute_path)) {
-                @unlink($local_absolute_path);
-            }
             $this->wal_append_remote_index_invalidation($path);
 
             if ($error_type === "file_changed") {

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -130,6 +130,61 @@ class RemapSeamTest extends TestCase
         $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local_absolute_path);
     }
 
+    public function testFileErrorChunkRecordsDecodedRemotePathWithoutDeletingMappedFile(): void
+    {
+        $remote_absolute_path = '/remote-root/file.txt';
+        $mapped_local_path = $this->root . '/mapped-root/file.txt';
+        mkdir(dirname($mapped_local_path), 0755, true);
+        file_put_contents($mapped_local_path, 'mapped');
+
+        $client = $this->clientWithRules(array(
+            '/remote-root' => $this->root . '/mapped-root',
+        ));
+        $this->set($client, 'is_tty', true);
+
+        $this->call($client, 'handle_error_chunk', array(
+            array(
+                'body' => json_encode(array(
+                    'error_type' => 'file_changed',
+                    'path' => base64_encode($remote_absolute_path),
+                    'message' => 'The file changed while the server read it.',
+                ), JSON_THROW_ON_ERROR),
+            ),
+            'files',
+        ));
+
+        $this->assertFileExists($mapped_local_path);
+
+        $reflection = new \ReflectionClass($client);
+        $volatile_files_file = $reflection
+            ->getProperty('volatile_files_file')
+            ->getValue($client);
+        $this->assertSame(
+            array($remote_absolute_path => 1),
+            json_decode((string) file_get_contents($volatile_files_file), true),
+        );
+
+        $pull_index_wal_handle = $reflection
+            ->getProperty('pull_index_wal_handle')
+            ->getValue($client);
+        $this->assertTrue(fflush($pull_index_wal_handle));
+        $pull_index_wal_path = $reflection
+            ->getProperty('pull_index_wal_path')
+            ->getValue($client);
+        $this->assertSame(
+            array(
+                'op' => '-',
+                'remote_absolute_path_b64' => base64_encode($remote_absolute_path),
+            ),
+            json_decode(
+                (string) file_get_contents($pull_index_wal_path),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            ),
+        );
+    }
+
     /**
      * The path-prefix helper underpinning rule matching. A trailing slash on
      * either argument is path-equivalent and must be ignored.


### PR DESCRIPTION
File-error records now use the remote path the exporter sent, rather than its base64 transport encoding.

The exporter serializes an error path as base64 because filenames may contain arbitrary bytes. The importer previously logged and keyed remote-index invalidation and volatile-file state with that encoded token. This decodes the protocol field before recording it, so a changed file is tracked under its actual remote path.

It deliberately leaves local files in place. A source read error says that an export part was not confirmed; it does not confirm that an already downloaded local file is disposable. An interrupted response can be replayed into that file on the next request.