### PR TITLE
Preserve local files by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,19 +115,14 @@ Symlinks ARE automatically recreated during import. This is safe because all pat
 
 The file indexer (`endpoint_file_index` in `export.php`) prevents duplicate traversal of directories that overlap with configured roots. The `should_skip_index_root()` function checks each directory's `realpath()` against the scheduled root list — if a directory is a duplicate or parent of an already-scheduled root, traversal skips it. This is critical for WP.com Atomic sites where symlinks create overlapping paths (e.g. `/srv/htdocs/srv` → `/srv` creating infinite cycles, or `/wordpress/` and `/srv/htdocs/wordpress/` resolving to the same location).
 
-### Non-Empty fs-root Handling (`--on-fs-root-nonempty`)
+### Local fs-root Preservation
 
-By default, `files-pull` refuses to start if `--fs-root` is non-empty (to prevent accidental overwrites). The `--on-fs-root-nonempty` flag controls this behavior:
-
-- `--on-fs-root-nonempty=error` (default): throw an error and abort.
-- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
-
-In `preserve-local` mode:
+`files-pull` always preserves existing local content:
 - Existing files are never overwritten — if anything (regular file, symlink, directory) already exists at a remote file's path, the remote file is skipped.
 - Pre-existing symlinks in directory paths are kept, and no new content is ever created through them. If any component of a file's directory path is a symlink, the entire operation is skipped. This is critical for hosting environments where plugins, themes, and WP core are symlinked from a shared location — their contents must not be modified.
 - Non-writable directories are skipped gracefully instead of causing errors.
 - All skipped operations are logged to the audit log with a `PRESERVE-LOCAL` prefix.
-- The setting persists in state, so it survives across resume cycles and delta syncs. During delta sync, previously-skipped files remain protected.
+- During delta sync, previously-skipped files remain protected.
 
 ### SQL Dump Batching
 

--- a/README.md
+++ b/README.md
@@ -240,13 +240,11 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
-**Non-empty local fs-root**
+**Existing local files**
 
-By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
-the `--on-fs-root-nonempty` flag controls this behavior. It takes the following values:
-
-- `--on-fs-root-nonempty=error` (default): throw an error and abort.
-- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
+`files-pull` preserves files, symlinks, and directories that already exist in
+`--fs-root`. It skips a remote path that conflicts with local content instead
+of overwriting it.
 
 **Filtering files**
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -9786,26 +9786,6 @@ class ImportClient
             return;
         }
 
-        // Remove existing file/symlink if present
-        if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
-            if (
-                !$this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)
-            ) {
-                $this->audit_log(
-                    "Failed to remove existing path for symlink: {$local_absolute_path}",
-                    true,
-                );
-                $this->output_progress([
-                    "type" => "symlink_error",
-                    "path" => $path,
-                    "target" => $target_for_local,
-                    "error" => "Failed to replace existing path",
-                    "message" => "Symlink error: {$path} -> {$target}",
-                ]);
-                return;
-            }
-        }
-
         // Create parent directory
         $dir = dirname($local_absolute_path);
         if (!is_dir($dir)) {
@@ -9836,7 +9816,7 @@ class ImportClient
 
         // Create symlink
         $symlink_result = symlink($target_for_local, $local_absolute_path);
-        if (true !== $symlink_result || !is_link($local_absolute_path)) {
+        if (true !== $symlink_result) {
             // Log error and skip this symlink
             $this->audit_log(
                 "Failed to create symlink: {$local_absolute_path} -> {$target_for_local}",

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3737,7 +3737,7 @@ class ImportClient
             $parent = dirname($local_absolute_path);
             if (!is_dir($parent)) {
                 try {
-                    $this->create_directory_if_missing($parent);
+                    $this->create_directory_if_missing($parent, true);
                 } catch (LocalPathConflictException $e) {
                     throw $e;
                 } catch (RuntimeException $e) {
@@ -9365,7 +9365,7 @@ class ImportClient
             if (!is_dir($dir)) {
                 // Check if any component of the path exists as a file and remove it
                 try {
-                    $this->create_directory_if_missing($dir);
+                    $this->create_directory_if_missing($dir, true);
                 } catch (PreserveLocalSkipException $e) {
                     $context->skip_current_file = true;
                     $this->audit_log($e->getMessage(), true);
@@ -9497,6 +9497,19 @@ class ImportClient
         if (is_dir($dir) && !is_writable($dir)) {
             return "PRESERVE-LOCAL skip file (dir not writable): {$remote_absolute_path}";
         }
+        $relative_parent_path = relative_path_under($dir, $this->filesystem_root);
+        if ($relative_parent_path !== null) {
+            $current = $this->filesystem_root;
+            foreach (explode("/", $relative_parent_path) as $part) {
+                if ($part === "") {
+                    continue;
+                }
+                $current = wp_join_unix_paths($current, $part);
+                if (is_file($current)) {
+                    return "PRESERVE-LOCAL skip file (file in path): {$remote_absolute_path}";
+                }
+            }
+        }
         if ($this->path_traverses_symlink($dir)) {
             return "PRESERVE-LOCAL skip file (symlink in path): {$remote_absolute_path}";
         }
@@ -9532,9 +9545,13 @@ class ImportClient
      * Create a directory path when missing, removing blockers.
      *
      * @param string $dir Directory path to create
+     * @param bool $replace_file_blockers Whether this pull already admitted the path.
      * @throws RuntimeException if directory cannot be created or is outside allowed path
      */
-    private function create_directory_if_missing(string $dir): void
+    private function create_directory_if_missing(
+        string $dir,
+        bool $replace_file_blockers = false
+    ): void
     {
         // Security: Ensure path is under the filesystem root
         $real_filesystem_root = $this->filesystem_root;
@@ -9600,11 +9617,25 @@ class ImportClient
                 );
             }
 
-            // Do not replace a file blocking directory creation.
+            // Only entries admitted by the index comparison may replace a
+            // blocker. A caller outside that workflow has a local conflict.
             if (is_file($current)) {
-                throw new LocalPathConflictException(
-                    "Cannot create directory because a local file blocks it: {$current}",
-                );
+                if ($replace_file_blockers) {
+                    $this->audit_log(
+                        "Removing file blocking directory: {$current}",
+                        true,
+                    );
+                    if (!unlink($current)) {
+                        throw new RuntimeException(
+                            "Failed to remove file blocking directory: {$current}",
+                        );
+                    }
+                }
+                if (!$replace_file_blockers) {
+                    throw new LocalPathConflictException(
+                        "Cannot create directory because a local file blocks it: {$current}",
+                    );
+                }
             }
 
             // Create directory if it doesn't exist
@@ -9692,7 +9723,7 @@ class ImportClient
 
         // Create directory, removing any files that block the path
         try {
-            $this->create_directory_if_missing($local_absolute_path);
+            $this->create_directory_if_missing($local_absolute_path, true);
         } catch (PreserveLocalSkipException $e) {
             $this->audit_log($e->getMessage(), true);
             $this->emit_skip_progress($remote_absolute_path);
@@ -9790,7 +9821,7 @@ class ImportClient
         $dir = dirname($local_absolute_path);
         if (!is_dir($dir)) {
             try {
-                $this->create_directory_if_missing($dir);
+                $this->create_directory_if_missing($dir, true);
             } catch (PreserveLocalSkipException $e) {
                 $this->audit_log($e->getMessage(), true);
                 $this->emit_skip_progress($path);

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -9782,15 +9782,18 @@ class ImportClient
             $target,
         );
 
-        // If something already exists at the symlink path, keep it — whether
-        // it's a file, directory, or another symlink.
-        // Also skip if any parent component is a symlink — we never create
-        // new content through symlinked directories.
+        // The index comparison excludes local-owned paths before this handler
+        // runs. An existing path here belongs to an earlier pull and may be
+        // replaced by the incoming symlink.
         if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
-            $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
-            $this->emit_skip_progress($path);
-            return;
+            if (!$this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)) {
+                throw new RuntimeException(
+                    "Failed to replace path with symlink: {$path}",
+                );
+            }
         }
+
+        // Never create new content through symlinked directories.
         if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
             $this->audit_log("PRESERVE-LOCAL skip symlink (symlink in path): {$path} -> {$target}", true);
             $this->emit_skip_progress($path);

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -11,6 +11,7 @@
  */
 
 use Reprint\Importer\CurlTimeoutException;
+use Reprint\Importer\LocalPathConflictException;
 use Reprint\Importer\PreserveLocalSkipException;
 use Reprint\Importer\Pull\PullFailureReportedException;
 use Reprint\Importer\State\DatabaseApplyCommandState;
@@ -266,27 +267,6 @@ class ImportClient
      * with no source).
      */
     private $include_caches = false;
-
-    /**
-     * @var string Controls behavior when the filesystem root is non-empty at pull start.
-     *
-     * 'error' (default): throw an error if the filesystem root is non-empty.
-     * 'preserve-local': preserve existing files, symlinks, and directories in the
-     * filesystem root instead of overwriting them; non-writable directories are skipped
-     * gracefully and logged to the audit log.
-     *
-     * On the first sync, existing filesystem root content is left untouched — any file,
-     * symlink, or directory that already exists at a path the remote tries to write
-     * is skipped and never added to the remote index.
-     *
-     * On subsequent delta syncs, preserved paths survive because the importer compares
-     * the next remote index only with paths it previously added to the remote index.
-     * A preserved local path was never added to that baseline, so its absence from the
-     * next remote index cannot schedule it for deletion.
-     *
-     * Set via --on-fs-root-nonempty, persisted in state so it survives across invocations.
-     */
-    private $fs_root_nonempty_behavior = 'error';
 
     /**
      * Selects a path-filter preset for files-pull.
@@ -939,15 +919,6 @@ class ImportClient
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         $this->include_caches = $options["include_caches"] ?? false;
         $this->extra_directory = $options["extra_directory"] ?? null;
-        if (isset($options["fs_root_nonempty_behavior"])) {
-            $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
-            if (!in_array($this->fs_root_nonempty_behavior, ['error', 'preserve-local'])) {
-                throw new InvalidArgumentException(
-                    "Invalid --on-fs-root-nonempty value: {$this->fs_root_nonempty_behavior}. " .
-                        "Valid values: error, preserve-local",
-                );
-            }
-        }
         $command = $options["command"] ?? null;
 
         // Map accepted command aliases to the canonical command names.
@@ -1051,16 +1022,6 @@ class ImportClient
             $this->follow_symlinks = true;
             $this->get_state()->follow_symlinks = true;
             $this->save_state();
-        }
-
-        // Persist fs_root_nonempty_behavior in state so it survives across invocations.
-        // 'preserve-local' preserves existing local files instead of overwriting
-        // them, and gracefully skips non-writable directories.
-        if (isset($options["fs_root_nonempty_behavior"])) {
-            $this->get_state()->fs_root_nonempty_behavior = $this->fs_root_nonempty_behavior;
-            $this->save_state();
-        } else {
-            $this->fs_root_nonempty_behavior = $this->get_state()->fs_root_nonempty_behavior ?? 'error';
         }
 
         // Persist the path-filter preset in state so it survives across resume cycles.
@@ -3023,16 +2984,6 @@ class ImportClient
                 "message" => "Resuming files-pull (stage: {$stage}, remote index entries: {$remote_index_entry_count})",
             ], true);
         } else {
-            // Starting fresh — validate that the filesystem root is empty.
-            // A delta sync ($is_delta) naturally has a non-empty filesystem root
-            // because we put those files there during the initial sync.
-            if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
-                throw new RuntimeException(
-                    "Filesystem root is not empty and no cursor found. " .
-                        "Either clear the filesystem root, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
-                );
-            }
-
             // The marker blocks files-diff and files-push before the first
             // pull checkpoint can make this lifecycle resumable.
             $this->open_pull_index_wal();
@@ -3069,7 +3020,7 @@ class ImportClient
                 ], true);
             } else {
                 $this->audit_log(
-                    "START files-pull ({$this->fs_root_nonempty_behavior} mode, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
+                    "START files-pull (local preservation, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
                     true,
                 );
 
@@ -3640,6 +3591,8 @@ class ImportClient
             if (!is_dir($parent)) {
                 try {
                     $this->create_directory_if_missing($parent);
+                } catch (LocalPathConflictException $e) {
+                    throw $e;
                 } catch (RuntimeException $e) {
                     $this->audit_log(
                         "INTERMEDIATE SYMLINK SKIP: failed to prepare parent for {$remote_absolute_path}: " .
@@ -6720,12 +6673,12 @@ class ImportClient
                     strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) > 0
                 )
             ) {
-                $preserve_local_skip_reason =
-                    $this->should_skip_for_preserve_local(
+                $local_preservation_skip_reason =
+                    $this->should_skip_for_local_preservation(
                         $next_remote_index_entry["path"],
                     );
-                if ($preserve_local_skip_reason) {
-                    $this->audit_log($preserve_local_skip_reason, true);
+                if ($local_preservation_skip_reason) {
+                    $this->audit_log($local_preservation_skip_reason, true);
                     $this->emit_skip_progress($next_remote_index_entry["path"]);
                 } else {
                     $this->append_to_fetch_list(
@@ -9377,18 +9330,12 @@ class ImportClient
     }
 
     /**
-     * Check whether any component of the path (between the filesystem root
-     * and the remote absolute path) is a symlink. In preserve-local mode this is used
-     * to prevent creating new content through symlinked directories — their
-     * contents belong to shared hosting infrastructure and must not be
-     * modified.
+     * Preserve a local file path instead of overwriting it. A directory
+     * symlink or a non-writable parent is also skipped because its contents
+     * belong to local hosting infrastructure.
      */
-    private function should_skip_for_preserve_local(string $remote_absolute_path): ?string
+    private function should_skip_for_local_preservation(string $remote_absolute_path): ?string
     {
-        if ($this->fs_root_nonempty_behavior !== 'preserve-local') {
-            return null;
-        }
-
         $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
             $remote_absolute_path
         );
@@ -9466,23 +9413,17 @@ class ImportClient
                 $real_check === false ||
                 !path_is_within_root($real_check, $real_filesystem_root)
             ) {
-                // In preserve-local mode, a path that resolves outside the
-                // filesystem root is expected when a directory like wp-content/plugins
-                // is symlinked to a shared hosting location.  Skip gracefully
-                // instead of treating it as a security violation.
-                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-                    throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: path resolves outside filesystem root via symlink: {$dir}",
-                    );
-                }
-                throw new RuntimeException(
-                    "Security: Refusing to create directory outside filesystem root: {$dir}",
+                // A path that resolves outside the filesystem root belongs to
+                // local hosting infrastructure. Skip it rather than following
+                // the symlink into that infrastructure.
+                throw new PreserveLocalSkipException(
+                    "PRESERVE-LOCAL: path resolves outside filesystem root via symlink: {$dir}",
                 );
             }
         }
 
         if (is_dir($dir) && !is_link($dir)) {
-            if ($this->fs_root_nonempty_behavior === 'preserve-local' && !is_writable($dir)) {
+            if (!is_writable($dir)) {
                 throw new PreserveLocalSkipException(
                     "PRESERVE-LOCAL: directory not writable: {$dir}",
                 );
@@ -9509,49 +9450,24 @@ class ImportClient
             $current .= "/" . $part;
 
             if (is_link($current)) {
-                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-                    // Never create directories through symlinks — the symlink
-                    // and its target contents are shared hosting infrastructure
-                    // that must not be modified.
-                    throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: symlink in directory path: {$current}",
-                    );
-                }
-                $this->audit_log(
-                    "Removing symlink blocking directory: {$current}",
-                    true,
+                // Never create directories through symlinks — the symlink
+                // and its target contents are shared hosting infrastructure
+                // that must not be modified.
+                throw new PreserveLocalSkipException(
+                    "PRESERVE-LOCAL: symlink in directory path: {$current}",
                 );
-                if (!unlink($current)) {
-                    throw new RuntimeException(
-                        "Failed to remove symlink blocking directory: {$current}",
-                    );
-                }
-                // Clear cached realpath so the subsequent realpath() check
-                // sees the new directory instead of the removed symlink.
-                clearstatcache(true, $current);
             }
 
-            // Remove file if blocking directory creation
+            // Do not replace a file blocking directory creation.
             if (is_file($current)) {
-                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-                    throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: file blocks directory creation: {$current}",
-                    );
-                }
-                $this->audit_log(
-                    "Removing file blocking directory: {$current}",
-                    true,
+                throw new LocalPathConflictException(
+                    "Cannot create directory because a local file blocks it: {$current}",
                 );
-                if (!unlink($current)) {
-                    throw new RuntimeException(
-                        "Failed to remove file blocking directory: {$current}",
-                    );
-                }
             }
 
             // Create directory if it doesn't exist
             if (is_dir($current)) {
-                if ($this->fs_root_nonempty_behavior === 'preserve-local' && !is_writable($current)) {
+                if (!is_writable($current)) {
                     throw new PreserveLocalSkipException(
                         "PRESERVE-LOCAL: directory not writable: {$current}",
                     );
@@ -9598,27 +9514,25 @@ class ImportClient
             $remote_absolute_path
         );
 
-        // In preserve-local mode, if the directory already exists (as a real
-        // directory or via a symlink to a directory), keep it as-is.
+        // If the directory already exists (as a real directory or via a
+        // symlink to a directory), keep it as-is.
         // Also skip if any parent component is a symlink — we never create
         // new directories through symlinked paths.
-        if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-            if (is_dir($local_absolute_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$remote_absolute_path}", true);
-                $this->emit_skip_progress($remote_absolute_path);
-                if ($ctime > 0) {
-                    $this->upsert_remote_index_entry($remote_absolute_path, $ctime, 0, "dir");
-                }
-                return;
+        if (is_dir($local_absolute_path)) {
+            $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$remote_absolute_path}", true);
+            $this->emit_skip_progress($remote_absolute_path);
+            if ($ctime > 0) {
+                $this->upsert_remote_index_entry($remote_absolute_path, $ctime, 0, "dir");
             }
-            if ($this->path_traverses_symlink($local_absolute_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$remote_absolute_path}", true);
-                $this->emit_skip_progress($remote_absolute_path);
-                if ($ctime > 0) {
-                    $this->upsert_remote_index_entry($remote_absolute_path, $ctime, 0, "dir");
-                }
-                return;
+            return;
+        }
+        if ($this->path_traverses_symlink($local_absolute_path)) {
+            $this->audit_log("PRESERVE-LOCAL skip directory (symlink in path): {$remote_absolute_path}", true);
+            $this->emit_skip_progress($remote_absolute_path);
+            if ($ctime > 0) {
+                $this->upsert_remote_index_entry($remote_absolute_path, $ctime, 0, "dir");
             }
+            return;
         }
 
         if (
@@ -9695,21 +9609,19 @@ class ImportClient
             $target,
         );
 
-        // In preserve-local mode, if something already exists at the symlink
-        // path, keep it — whether it's a file, directory, or another symlink.
+        // If something already exists at the symlink path, keep it — whether
+        // it's a file, directory, or another symlink.
         // Also skip if any parent component is a symlink — we never create
         // new content through symlinked directories.
-        if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-            if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
-                $this->emit_skip_progress($path);
-                return;
-            }
-            if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
-                $this->audit_log("PRESERVE-LOCAL skip symlink (symlink in path): {$path} -> {$target}", true);
-                $this->emit_skip_progress($path);
-                return;
-            }
+        if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
+            $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
+            $this->emit_skip_progress($path);
+            return;
+        }
+        if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
+            $this->audit_log("PRESERVE-LOCAL skip symlink (symlink in path): {$path} -> {$target}", true);
+            $this->emit_skip_progress($path);
+            return;
         }
 
         // Validate that the symlink target doesn't escape the filesystem root.
@@ -9761,6 +9673,8 @@ class ImportClient
                 $this->audit_log($e->getMessage(), true);
                 $this->emit_skip_progress($path);
                 return;
+            } catch (LocalPathConflictException $e) {
+                throw $e;
             } catch (RuntimeException $e) {
                 // Log error and skip this symlink
                 $this->audit_log(
@@ -10954,7 +10868,6 @@ class ImportClient
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;
-        $this->state->fs_root_nonempty_behavior = $previous_state->fs_root_nonempty_behavior;
         $this->state->max_allowed_packet = $previous_state->max_allowed_packet;
         $this->state->resolved_path_mappings_fingerprint = $previous_state->resolved_path_mappings_fingerprint;
         $this->state->pull_pipeline = $previous_state->pull_pipeline;
@@ -11609,16 +11522,6 @@ if (
                 '(a :fs-root: path or an absolute path within --fs-root), nested by source path. ' .
                 'Bare --follow-symlinks is equivalent to --follow-symlinks=:fs-root:.',
             'commands' => ['pull', 'pull-files', 'files-pull'],
-        ],
-        [
-            'name' => 'on-fs-root-nonempty',
-            'type' => 'value',
-            'target' => 'fs_root_nonempty_behavior',
-            'placeholder' => 'MODE',
-            'help' => 'What to do when filesystem root is non-empty (error|preserve-local)',
-            'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'files-pull'],
-            'aliases' => ['on-docroot-nonempty'],
         ],
         [
             'name' => 'include-caches',

--- a/packages/reprint-client/src/lib/import/class-local-path-conflict-exception.php
+++ b/packages/reprint-client/src/lib/import/class-local-path-conflict-exception.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Reprint\Importer;
+
+use RuntimeException;
+
+/** Thrown when a local path type prevents the required directory from existing. */
+class LocalPathConflictException extends RuntimeException {}

--- a/packages/reprint-client/src/lib/import/load.php
+++ b/packages/reprint-client/src/lib/import/load.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/class-streaming-context.php';
 require_once __DIR__ . '/class-preserve-local-skip-exception.php';
+require_once __DIR__ . '/class-local-path-conflict-exception.php';
 require_once __DIR__ . '/class-interrupted-response-exception.php';
 require_once __DIR__ . '/class-transient-interruption-exception.php';
 require_once __DIR__ . '/class-curl-timeout-exception.php';

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -51,7 +51,6 @@ class PullState
     public bool $follow_symlinks = true;
     /** @var string|null Fingerprint of the local followed symlinks root; guards resume. */
     public ?string $local_followed_symlinks_root_fingerprint = null;
-    public string $fs_root_nonempty_behavior = 'error';
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
     public ?string $user_agent = null;
@@ -111,6 +110,10 @@ class PullState
     public static function from_array(array $data): self
     {
         $state = new self();
+        // Older state files selected the non-empty filesystem-root behavior.
+        // Files-pull now always preserves local paths, so that choice no
+        // longer changes resume behavior.
+        unset($data['fs_root_nonempty_behavior']);
         reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->active_resumable_command = ResumableCommandCheckpointState::from_array($data['active_resumable_command']);
         $state->preflight = $data['preflight'];
@@ -119,7 +122,6 @@ class PullState
         $state->webhost = $data['webhost'];
         $state->follow_symlinks = $data['follow_symlinks'];
         $state->local_followed_symlinks_root_fingerprint = $data['local_followed_symlinks_root_fingerprint'];
-        $state->fs_root_nonempty_behavior = $data['fs_root_nonempty_behavior'];
         $state->filter = $data['filter'];
         $state->user_agent = $data['user_agent'];
         $state->max_allowed_packet = $data['max_allowed_packet'];
@@ -223,7 +225,6 @@ class PullState
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
             'local_followed_symlinks_root_fingerprint' => $this->local_followed_symlinks_root_fingerprint,
-            'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,
             'max_allowed_packet' => $this->max_allowed_packet,

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -46,6 +46,14 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('Next remote index', $output);
     }
 
+    public function testFilesPullHelpDoesNotListTheRemovedNonEmptyRootOption(): void
+    {
+        $this->assertStringNotContainsString(
+            '--on-fs-root-nonempty',
+            $this->runHelp('files-pull')
+        );
+    }
+
     public function testFilterOptionIsHiddenFromCommandHelp(): void
     {
         foreach (array('pull', 'pull-files', 'files-pull') as $command) {

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -168,6 +168,29 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
+    public function testPullPreservesAFileBlockingARemoteDescendant(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'node_modules/pulled-package.js' => 'pulled dependency',
+            ],
+        ]);
+        mkdir($this->localTree, 0700, true);
+        file_put_contents($this->localTree . '/node_modules', 'local file');
+
+        $this->completeFilesPull();
+
+        $this->assertSame(
+            'local file',
+            file_get_contents($this->localTree . '/node_modules')
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('node_modules/pulled-package.js'),
+            $index
+        );
+    }
+
     public function testFilesPullRejectsAnUnfinishedFilesPush(): void
     {
         if (PHP_VERSION_ID < 80100 || !function_exists('curl_init')) {

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -352,9 +352,7 @@ final class FilesPullLocalIndexTest extends TestCase
         yield 'filtered files' => [[
             '--filter=essential-files',
         ]];
-        yield 'preserve local files' => [[
-            '--on-fs-root-nonempty=preserve-local',
-        ]];
+        yield 'default local preservation' => [[]];
     }
 
     public function testRemappedPullKeepsUnrelatedLocalIndexEntries(): void

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -120,7 +120,7 @@ class FilesPullStateTest extends TestCase
     }
 
     /**
-     * Set up a client with state loaded and preserve-local mode.
+     * Set up a client with state loaded.
      */
     private function prepareClient(): array
     {
@@ -133,9 +133,6 @@ class FilesPullStateTest extends TestCase
 
         $ttyProperty = $reflection->getProperty('is_tty');
         $ttyProperty->setValue($client, false);
-
-        $behaviorProp = $reflection->getProperty('fs_root_nonempty_behavior');
-        $behaviorProp->setValue($client, 'preserve-local');
 
         return [$client, $reflection];
     }

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -131,7 +131,6 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r = new \ReflectionClass($client);
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
-        $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
         $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
         $r->getProperty('pull_excluded_files_with_path_prefixes')->setValue($client, $pull_excluded_files_with_path_prefixes);
         return [$client, $r];

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -287,7 +287,7 @@ class PullSymlinkTest extends TestCase
         $this->assertEquals(0, $count, 'No symlinks should be created for invalid chunks');
     }
 
-    public function testSymlinkReplacesExistingFile()
+    public function testSymlinkPreservesExistingFile()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -297,7 +297,7 @@ class PullSymlinkTest extends TestCase
         file_put_contents($filePath, 'content');
         $this->assertTrue(is_file($filePath));
 
-        // Create symlink at same location
+        // Receive a symlink at the same location.
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
 
@@ -311,8 +311,8 @@ class PullSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        // Should now be a symlink
-        $this->assertTrue(is_link($filePath), 'File should be replaced with symlink');
-        $this->assertEquals('target', readlink($filePath));
+        // The local file belongs to the user and is preserved.
+        $this->assertTrue(is_file($filePath), 'Local file should be preserved');
+        $this->assertSame('content', file_get_contents($filePath));
     }
 }

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -287,7 +287,7 @@ class PullSymlinkTest extends TestCase
         $this->assertEquals(0, $count, 'No symlinks should be created for invalid chunks');
     }
 
-    public function testSymlinkPreservesExistingFile()
+    public function testSymlinkReplacesExistingFile()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -297,7 +297,7 @@ class PullSymlinkTest extends TestCase
         file_put_contents($filePath, 'content');
         $this->assertTrue(is_file($filePath));
 
-        // Receive a symlink at the same location.
+        // Create symlink at same location
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
 
@@ -311,8 +311,8 @@ class PullSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        // The local file belongs to the user and is preserved.
-        $this->assertTrue(is_file($filePath), 'Local file should be preserved');
-        $this->assertSame('content', file_get_contents($filePath));
+        // Should now be a symlink
+        $this->assertTrue(is_link($filePath), 'File should be replaced with symlink');
+        $this->assertEquals('target', readlink($filePath));
     }
 }

--- a/tests/Import/TypeSwapTest.php
+++ b/tests/Import/TypeSwapTest.php
@@ -57,10 +57,8 @@ class TypeSwapTest extends TestCase
         rmdir($dir);
     }
 
-    /**
-     * create_directory_if_missing should remove a symlink that blocks directory creation.
-     */
-    public function testEnsureDirectoryPathRemovesBlockingSymlink()
+    /** create_directory_if_missing should keep a symlink that blocks directory creation. */
+    public function testEnsureDirectoryPathKeepsBlockingSymlink()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -78,12 +76,23 @@ class TypeSwapTest extends TestCase
         symlink($targetDir, $symlinkPath);
         $this->assertTrue(is_link($symlinkPath), 'Precondition: symlink exists');
 
-        // create_directory_if_missing for a child should replace the symlink with a real dir
+        $this->expectException(\Reprint\Importer\PreserveLocalSkipException::class);
         $method->invoke($client, $fsRoot . '/some-dir/child');
+    }
 
-        $this->assertFalse(is_link($symlinkPath), 'Symlink should be removed');
-        $this->assertTrue(is_dir($symlinkPath), 'Should be a real directory now');
-        $this->assertTrue(is_dir($fsRoot . '/some-dir/child'), 'Child directory should exist');
+    /** create_directory_if_missing should report a file that blocks a directory. */
+    public function testEnsureDirectoryPathReportsBlockingFileConflict()
+    {
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
+
+        $reflection = new \ReflectionClass($client);
+        $method = $reflection->getMethod('create_directory_if_missing');
+        $fsRoot = realpath($this->tempDir . '/fs-root');
+        $blockingFile = $fsRoot . '/some-dir';
+        file_put_contents($blockingFile, 'local file');
+
+        $this->expectException(\Reprint\Importer\LocalPathConflictException::class);
+        $method->invoke($client, $fsRoot . '/some-dir/child');
     }
 
     /**
@@ -130,10 +139,8 @@ class TypeSwapTest extends TestCase
         $this->assertEquals('hello', file_get_contents($symlinkPath));
     }
 
-    /**
-     * A directory chunk should replace a symlink-to-file with a real directory.
-     */
-    public function testDirectoryChunkReplacesSymlinkToFile()
+    /** A directory chunk should keep a symlink-to-file. */
+    public function testDirectoryChunkKeepsSymlinkToFile()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -159,17 +166,12 @@ class TypeSwapTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $this->assertFalse(is_link($symlinkPath), 'Symlink should be removed');
-        $this->assertTrue(is_dir($symlinkPath), 'Should be a real directory now');
+        $this->assertTrue(is_link($symlinkPath), 'Symlink should remain');
+        $this->assertSame($realFile, readlink($symlinkPath));
     }
 
-    /**
-     * After replacing a symlink with a directory, nested files should be writable.
-     *
-     * Simulates the scenario: symlink at path A is replaced by a directory chunk,
-     * then a file chunk arrives at A/sub/file.txt.
-     */
-    public function testFileChunkUnderFormerSymlink()
+    /** A directory chunk should keep a symlink that blocks a nested path. */
+    public function testDirectoryChunkKeepsSymlinkBlockingNestedPath()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -184,7 +186,7 @@ class TypeSwapTest extends TestCase
 
         $reflection = new \ReflectionClass($client);
 
-        // Step 1: directory chunk replaces the symlink
+        // A directory chunk cannot replace the symlink.
         $dirMethod = $reflection->getMethod('handle_directory_chunk');
         $dirMethod->invoke($client, [
             'headers' => [
@@ -193,36 +195,12 @@ class TypeSwapTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue(is_dir($symlinkPath), 'Should be a real directory after dir chunk');
-
-        // Step 2: file chunk writes a nested file
-        $fileMethod = $reflection->getMethod('handle_file_chunk');
-        $context = new StreamingContext();
-        $fileMethod->invoke($client, [
-            'headers' => [
-                'x-file-path' => base64_encode('/parent/sub/file.txt'),
-                'x-first-chunk' => '1',
-                'x-last-chunk' => '1',
-                'x-file-ctime' => '1234567890',
-                'x-file-size' => '7',
-            ],
-            'body' => 'content',
-        ], $context);
-
-        if ($context->file_handle) {
-            fclose($context->file_handle);
-        }
-
-        $nestedFile = $fsRoot . '/parent/sub/file.txt';
-        $this->assertTrue(file_exists($nestedFile), 'Nested file should exist');
-        $this->assertEquals('content', file_get_contents($nestedFile));
+        $this->assertTrue(is_link($symlinkPath), 'Symlink should remain');
+        $this->assertFalse(file_exists($fsRoot . '/parent/sub/file.txt'));
     }
 
-    /**
-     * create_directory_if_missing should replace a symlink with a full real directory
-     * hierarchy when creating deeply nested paths.
-     */
-    public function testNestedFileUnderExistingSymlinkViaEnsureDirectory()
+    /** create_directory_if_missing should keep a symlink blocking nested paths. */
+    public function testEnsureDirectoryPathKeepsNestedBlockingSymlink()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
@@ -237,14 +215,10 @@ class TypeSwapTest extends TestCase
         symlink($targetDir, $symlinkPath);
         $this->assertTrue(is_link($symlinkPath), 'Precondition: symlink exists');
 
-        // Call create_directory_if_missing for a deeply nested path
+        // A deeply nested path cannot replace the symlink.
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('create_directory_if_missing');
+        $this->expectException(\Reprint\Importer\PreserveLocalSkipException::class);
         $method->invoke($client, $fsRoot . '/top/sub/deep');
-
-        $this->assertFalse(is_link($symlinkPath), 'Symlink should be removed');
-        $this->assertTrue(is_dir($symlinkPath), 'top should be a real directory');
-        $this->assertTrue(is_dir($fsRoot . '/top/sub'), 'sub should exist');
-        $this->assertTrue(is_dir($fsRoot . '/top/sub/deep'), 'deep should exist');
     }
 }

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -1,5 +1,5 @@
 /**
- * Test 37: --preserve-local mode
+ * Test 37: default local preservation
  *
  * Tests importing into a pre-existing WordPress hosting environment that uses
  * symlinks for shared infrastructure: WP core, plugins, themes, drop-ins, and
@@ -45,7 +45,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
 
-describe('Import: --preserve-local', () => {
+describe('Import: local preservation', () => {
     const site = 'preserve-local';
     let siteDir;
 
@@ -97,9 +97,9 @@ describe('Import: --preserve-local', () => {
     }
 
     // ------------------------------------------------------------------
-    // Test: non-empty directory without --preserve-local errors
+    // Test: non-empty directory preserves local content by default
     // ------------------------------------------------------------------
-    describe('non-empty directory without --preserve-local errors', () => {
+    describe('non-empty directory preserves local content by default', () => {
         let tempDir;
 
         beforeAll(() => {
@@ -112,25 +112,21 @@ describe('Import: --preserve-local', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('errors on non-empty directory without --preserve-local', () => {
+        it('completes without a local-preservation option', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 autoResume: false,
             });
-            assert.equal(result.exitCode, 1,
-                `Expected exit code 1, got ${result.exitCode}\n` +
+            assert.equal(result.exitCode, 0,
+                `Expected exit code 0, got ${result.exitCode}\n` +
                 `signal: ${result.signal}, killed: ${result.killed}, errorCode: ${result.errorCode}\n` +
                 `stdout (${result.stdout.length} bytes): ${result.stdout}\n` +
                 `stderr (${result.stderr.length} bytes): ${result.stderr}`);
-            assert.ok(
-                result.stderr.includes('not empty'),
-                `Expected error about non-empty directory, got: ${result.stderr}`,
-            );
         });
     });
 
     // ------------------------------------------------------------------
-    // Test: realistic hosting import with --preserve-local
+    // Test: realistic hosting import with default local preservation
     // ------------------------------------------------------------------
     describe('hosting environment with symlinked infrastructure', () => {
         let tempDir;
@@ -149,10 +145,9 @@ describe('Import: --preserve-local', () => {
             cleanupTempDir(tempDir);
         });
 
-        it('files-pull completes with --preserve-local', () => {
+        it('files-pull completes with default local preservation', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(
                 result.exitCode, 0,
@@ -160,11 +155,10 @@ describe('Import: --preserve-local', () => {
             );
         });
 
-        it('state shows complete with preserve_local persisted', () => {
+        it('state shows complete', () => {
             const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.active_resumable_command.completion_state, 'complete');
-            assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
 
         // -- file symlinks preserved ----------------------------------
@@ -295,9 +289,9 @@ describe('Import: --preserve-local', () => {
     });
 
     // ------------------------------------------------------------------
-    // Test: --preserve-local survives resume
+    // Test: local preservation survives resume
     // ------------------------------------------------------------------
-    describe('--preserve-local survives resume', () => {
+    describe('local preservation survives resume', () => {
         let tempDir;
         let wpShared;
         let localSiteRoot;
@@ -317,7 +311,7 @@ describe('Import: --preserve-local', () => {
         it('completes after forced resume with --max-exec=3', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-fs-root-nonempty=preserve-local', '--max-exec=3'],
+                extraArgs: ['--max-exec=3'],
                 timeout: 120000,
             });
             assert.equal(
@@ -333,19 +327,18 @@ describe('Import: --preserve-local', () => {
             assert.ok(lstatSync(join(localSiteRoot, 'wp-content', 'object-cache.php')).isSymbolicLink());
         });
 
-        it('state preserves preserve_local across resume cycles', () => {
+        it('state remains complete across resume cycles', () => {
             const state = JSON.parse(readFileSync(
                 join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
                 'utf-8',
             ));
-            assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
     });
 
     // ------------------------------------------------------------------
     // Test: delta sync preserves hosting symlinks
     // ------------------------------------------------------------------
-    describe('delta sync after --preserve-local', () => {
+    describe('delta sync after local preservation', () => {
         let tempDir;
         let wpShared;
         let localSiteRoot;
@@ -365,7 +358,6 @@ describe('Import: --preserve-local', () => {
         it('initial import completes', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(result.exitCode, 0,
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -381,7 +373,7 @@ describe('Import: --preserve-local', () => {
 
         it('delta sync completes', () => {
             // Abort previous completion, then re-run — triggers delta.
-            // preserve_local is restored from persisted state.
+            // Local preservation is part of every files-pull run.
             const abort = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: ['--abort'],
@@ -485,7 +477,6 @@ describe('Import: --preserve-local', () => {
         it('files-pull completes without security errors', () => {
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(
                 result.exitCode, 0,

--- a/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
+++ b/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
@@ -6,7 +6,7 @@
  * invocation —
  *
  *   files-pull --only :wp-content: --remap :wp-content: :fs-root:/wp-content \
- *     --on-fs-root-nonempty=preserve-local --no-follow-symlinks
+ *     --no-follow-symlinks
  *
  * — against a fs-root pre-populated with the realistic managed hosting layout
  * (shared read-only wordpress/ tree + hosting symlinks; see
@@ -107,9 +107,9 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
         return `${getSiteUrl(site)}&directory=${siteDir}`;
     }
 
-    // Shared remap + preserve flags; the --only scope varies per run.
+    // Shared remap and symlink flags; the --only scope varies per run.
     const remap = ['--remap', ':wp-content:', ':fs-root:/wp-content'];
-    const preserve = ['--on-fs-root-nonempty=preserve-local', '--no-follow-symlinks'];
+    const symlinkOptions = ['--no-follow-symlinks'];
 
     let tempDir;
     let fsRoot;
@@ -134,10 +134,10 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     // ================================================================
     // Phase 1 — first migration: --only :wp-content:
     // ================================================================
-    it('files-pull completes with --only + --remap + preserve-local', () => {
+    it('files-pull completes with --only + --remap and default local preservation', () => {
         const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
-            extraArgs: ['--only', ':wp-content:', ...remap, ...preserve],
+            extraArgs: ['--only', ':wp-content:', ...remap, ...symlinkOptions],
         });
         assert.equal(
             result.exitCode, 0,
@@ -231,7 +231,7 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     it('scoped delta re-sync completes (--only :wp-content:/plugins)', () => {
         const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
-            extraArgs: ['--only', ':wp-content:/plugins', ...remap, ...preserve],
+            extraArgs: ['--only', ':wp-content:/plugins', ...remap, ...symlinkOptions],
         });
         assert.equal(
             result.exitCode, 0,


### PR DESCRIPTION
files-pull now preserves existing local content by default, so imports can start in a non-empty filesystem root without an option.

The non-empty-root option has been removed from the CLI help and documentation. A local file that blocks a required directory now fails the pull with a path-type conflict instead of being treated as a skipped local path.