### PR TITLE
[CLI] Use --include for scoped file pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ The presets use the same repeatable path-prefix options available directly on
 
 ```bash
 php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
-    --only=:wp-content: --exclude=:wp-uploads:
+    --include=:wp-content: --exclude=:wp-uploads:
 ```
 
-`--only=SOURCE` supplies an included source prefix and `--exclude=SOURCE`
+`--include=SOURCE` supplies an included source prefix and `--exclude=SOURCE`
 supplies an excluded source prefix. Both accept WordPress path tokens or
 absolute source paths, and exclusions win when the prefixes overlap. Switching
 filters after a completed run starts a new filtered delta against the shared
@@ -311,11 +311,11 @@ php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT"
 
 It accepts the `pull` file filters (`--filter=none` and
 `--filter=essential-files`) plus the same path selection options as
-`files-pull`, including repeated `--only` and `--exclude` values:
+`files-pull`, including repeated `--include` and `--exclude` values:
 
 ```bash
 php reprint.phar pull-files "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
-    --only=:wp-content: --exclude=:wp-uploads:
+    --include=:wp-content: --exclude=:wp-uploads:
 ```
 
 #### Pull only the database.

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -296,7 +296,7 @@ class ImportClient
      *   "skipped-earlier"  — download only uploads
      *
      * The presets are translated into the same include and exclude path
-     * prefixes used by --only and --exclude. Set via --filter=<value> and
+     * prefixes used by --include and --exclude. Set via --filter=<value> and
      * persisted in state so it survives across resume cycles within the same
      * run.
      */
@@ -313,7 +313,7 @@ class ImportClient
     private $resolved_path_mappings = [];
 
     /**
-     * @var array<int,string> Resolved `--only` file paths: a list of real source
+     * @var array<int,string> Resolved `--include` file paths: a list of real source
      * absolute path prefixes the files-pull command is restricted to. Empty = full sync
      * (every detected root).
      */
@@ -734,9 +734,9 @@ class ImportClient
             $this->resolved_path_mappings = $this->resolve_remap($remap_raw);
         }
 
-        $only_raw = $options["only"] ?? [];
-        if (is_string($only_raw)) {
-            $only_raw = [$only_raw];
+        $include_raw = $options["include"] ?? $options["only"] ?? [];
+        if (is_string($include_raw)) {
+            $include_raw = [$include_raw];
         }
         $excluded_raw = $options["exclude"] ?? [];
         if (is_string($excluded_raw)) {
@@ -746,14 +746,14 @@ class ImportClient
         if ($this->filter === "essential-files") {
             $excluded_raw[] = ":wp-uploads:";
         } elseif ($this->filter === "skipped-earlier") {
-            $only_raw[] = ":wp-uploads:";
+            $include_raw[] = ":wp-uploads:";
         }
 
         $this->pull_only_files_with_path_prefixes = [];
         $this->pull_excluded_files_with_path_prefixes = [];
-        if (!empty($only_raw)) {
+        if (!empty($include_raw)) {
             $this->pull_only_files_with_path_prefixes =
-                $this->resolve_remote_paths($only_raw, "only");
+                $this->resolve_remote_paths($include_raw, "include");
         }
         if (!empty($excluded_raw)) {
             $this->pull_excluded_files_with_path_prefixes =
@@ -3370,8 +3370,8 @@ class ImportClient
     private function discover_symlink_targets(): void
     {
         // Seed "already covered" from the dirs actually enumerated this run (the
-        // --only prefixes when scoped), not the full preflight roots — otherwise a
-        // narrow --only skips a target under a root but outside its scope.
+        // --include prefixes when scoped), not the full preflight roots — otherwise a
+        // narrow --include skips a target under a root but outside its scope.
         $roots = $this->get_export_directories();
 
         // Collect all indexed directory real paths for containment checks
@@ -6376,11 +6376,11 @@ class ImportClient
         if ($cursor === null) {
             $start = $roots[0];
             if (!empty($this->pull_only_files_with_path_prefixes)) {
-                // With --only, get_export_directories() returns only the resolved
+                // With --include, get_export_directories() returns only the resolved
                 // file path prefixes, and those become the request's directory[]
                 // allowlist. The exporter rejects list_dir unless it is inside
                 // that allowlist, so $roots[0] may no longer be valid. Start from
-                // the first --only file path prefix; the exporter still traverses
+                // the first --include file path prefix; the exporter still traverses
                 // the remaining directory[] entries.
                 $start = $export_dirs[0] ?? $roots[0];
             }
@@ -8728,7 +8728,7 @@ class ImportClient
     /**
      * Refuse to resume a files-pull after changing its path selection.
      *
-     * --only determines the next remote index traversal, while --exclude determines
+     * --include determines the next remote index traversal, while --exclude determines
      * which entries enter the later fetch list. Keep both fixed for the complete
      * in-progress lifecycle rather than allowing a resumed stage to cross a path-
      * selection boundary. Completed runs may use a different selection because the
@@ -8745,7 +8745,7 @@ class ImportClient
 
         if ($previous !== $fingerprint) {
             throw new RuntimeException(
-                "Cannot change --only or --exclude while resuming files-pull. " .
+                "Cannot change --include or --exclude while resuming files-pull. " .
                     "Use the original path selections, or use --abort to start a new files-pull.",
             );
         }
@@ -8980,11 +8980,11 @@ class ImportClient
     }
 
     /**
-     * Whether a path is selected by the active --only and --exclude prefixes.
+     * Whether a path is selected by the active --include and --exclude prefixes.
      *
-     * The exporter has already applied --only to entries in the next remote
-     * index, including followed symlink targets outside an --only prefix. Other
-     * paths are checked against --only locally. An included root itself is not
+     * The exporter has already applied --include to entries in the next remote
+     * index, including followed symlink targets outside an --include prefix. Other
+     * paths are checked against --include locally. An included root itself is not
      * selected because the next remote index lists its contents, not the root
      * entry. Exclusions always win.
      *
@@ -9068,7 +9068,7 @@ class ImportClient
     }
 
     /**
-     * Resolve a --remap/--only/--exclude path argument into an absolute path.
+     * Resolve a --remap/--include/--exclude path argument into an absolute path.
      *
      * Substitutes a known leading `:token:` (see the token tables in
      * resolve_remap and resolve_remote_paths) with its
@@ -9953,7 +9953,7 @@ class ImportClient
 
     /**
      * Whether $path falls under one of the ORIGINAL export directories (the
-     * --only prefixes, or the base roots without --only) — i.e. it was going to
+     * --include prefixes, or the base roots without --include) — i.e. it was going to
      * be pulled anyway. Evaluated against the pre-follow scope; a followed
      * target outside all of these is "escaping" and eligible for symlink bundling.
      */
@@ -9979,13 +9979,13 @@ class ImportClient
      */
     private function get_export_directories(): array
     {
-        // Memoized: The inputs (pull_only, remap, preflight) are all set before
+        // Memoized: The inputs (include, remap, preflight) are all set before
         // the first caller and never change mid-run, so cache on first use.
         if ($this->export_directories_cache !== null) {
             return $this->export_directories_cache;
         }
 
-        // With --only, files-pull should enumerate only the selected source path
+        // With --include, files-pull should enumerate only the selected source path
         // prefixes. Do not add the default roots, remap sources, document root, or
         // auto-prepend/append directories below.
         if (!empty($this->pull_only_files_with_path_prefixes)) {
@@ -11840,14 +11840,15 @@ if (
             'commands' => ['pull-files', 'files-pull'],
         ],
         [
-            'name' => 'only',
+            'name' => 'include',
             'type' => 'value-or-next',
-            'target' => 'only',
+            'target' => 'include',
             'placeholder' => 'SOURCE',
             'repeatable' => true,
             'help' => 'Restrict the file pull to SOURCE (a :token: like :wp-content: or :wp-uploads:, or an absolute path); ' .
                 'repeat for several. Default pulls everything',
             'commands' => ['pull-files', 'files-pull'],
+            'aliases' => ['only'],
         ],
         [
             'name' => 'exclude',
@@ -12403,7 +12404,7 @@ if (
                 "\n" .
                 "  reprint pull-files https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
-                "    --only=:wp-content: --exclude=:wp-uploads:\n",
+                "    --include=:wp-content: --exclude=:wp-uploads:\n",
         ],
         "pull-db" => [
             "level" => "high",
@@ -12484,7 +12485,7 @@ if (
                 "Runs files-index internally to write the next remote index.\n",
             "extra" =>
                 "Path selection:\n" .
-                "  --only=SOURCE      Include only this source path prefix; repeatable.\n" .
+                "  --include=SOURCE   Include only this source path prefix; repeatable.\n" .
                 "  --exclude=SOURCE   Exclude this source path prefix; repeatable.\n" .
                 "  Exclusions win when include and exclude prefixes overlap.\n" .
                 "\n" .

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -20,7 +20,8 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--state-dir=DIR', $output);
         $this->assertStringContainsString('--fs-root=DIR', $output);
         $this->assertStringContainsString('--remap SOURCE TARGET', $output);
-        $this->assertStringContainsString('--only=SOURCE', $output);
+        $this->assertStringContainsString('--include=SOURCE', $output);
+        $this->assertStringNotContainsString('--only', $output);
         $this->assertStringContainsString('--exclude=SOURCE', $output);
     }
 

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -347,7 +347,7 @@ final class FilesPullLocalIndexTest extends TestCase
     public static function partialPullProvider(): iterable
     {
         yield 'selected directory' => [[
-            '--only=/var/www/html/selected',
+            '--include=/var/www/html/selected',
         ]];
         yield 'filtered files' => [[
             '--filter=essential-files',
@@ -404,7 +404,7 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $this->abortFilesPull();
         $pull = $this->runFilesPull([
-            '--only=/var/www/html/folder',
+            '--include=/var/www/html/folder',
         ]);
 
         $this->assertSame(0, $pull['exit'], $pull['output']);

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -119,7 +119,7 @@ class FollowedSymlinksRootTest extends TestCase
 
     /**
      * @param string|null $followedSymlinksRootSub Root suffix under fs-root (null = filesystem root).
-     * @param array<int,string> $scopePrefixes Original export scope (--only prefixes).
+     * @param array<int,string> $scopePrefixes Original export scope (--include prefixes).
      * @param array<string,string> $remapRules source => absolute target.
      */
     private function placeClient(?string $followedSymlinksRootSub, array $scopePrefixes, array $remapRules = []): \ImportClient

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -5,7 +5,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 
 /**
- * --only and --exclude reuse the existing `value-or-next` option type (like
+ * --include and --exclude reuse the existing `value-or-next` option type (like
  * --new-site-url), but are repeatable because commas are valid path bytes. The
  * parser lives inside the CLI bootstrap guard (not require-able), so this
  * exercises the real binary.
@@ -190,7 +190,7 @@ PHP, var_export($requestsLog, true)));
         );
     }
 
-    public function testOnlyOptionIsRecognizedAsRepeatableInBothForms(): void
+    public function testIncludeOptionIsRecognizedAsRepeatableInBothForms(): void
     {
         $tail = array(
             '--state-dir=' . $this->tempDir . '/state',
@@ -199,6 +199,27 @@ PHP, var_export($requestsLog, true)));
         );
         // Both forms fail later (unreachable host) but must not be rejected as
         // an unknown option.
+        $equals = $this->runCli(array_merge(
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--include=:wp-content:', '--include=:wp-uploads:/2025'),
+            $tail
+        ));
+        $this->assertStringNotContainsString('Unknown option', $equals);
+
+        $space = $this->runCli(array_merge(
+            array('files-pull', 'http://fake.invalid/?site-export-api', '--include', ':wp-content:', '--include', ':wp-uploads:/2025'),
+            $tail
+        ));
+        $this->assertStringNotContainsString('Unknown option', $space);
+    }
+
+    public function testOnlyAliasIsRecognizedAsRepeatableInBothForms(): void
+    {
+        $tail = array(
+            '--state-dir=' . $this->tempDir . '/state',
+            '--fs-root=' . $this->tempDir . '/fs',
+            '--secret=x',
+        );
+
         $equals = $this->runCli(array_merge(
             array('files-pull', 'http://fake.invalid/?site-export-api', '--only=:wp-content:', '--only=:wp-uploads:/2025'),
             $tail
@@ -212,10 +233,9 @@ PHP, var_export($requestsLog, true)));
         $this->assertStringNotContainsString('Unknown option', $space);
     }
 
-
-    public function testRepeatedOnlyOptionsAreAllPreserved(): void
+    public function testRepeatedIncludeOptionsAreAllPreserved(): void
     {
-        // If repeated --only values are collapsed to the last one, this would
+        // If repeated --include values are collapsed to the last one, this would
         // succeed because :wp-content: is resolvable. Preserving both values
         // forces resolution of :abspath:, which this preflight intentionally
         // omits.
@@ -224,9 +244,9 @@ PHP, var_export($requestsLog, true)));
         $output = $this->runCli(array(
             'files-pull',
             'http://fake.invalid/?site-export-api',
-            '--only',
+            '--include',
             ':abspath:/wp-admin',
-            '--only',
+            '--include',
             ':wp-content:',
             '--abort',
             '--state-dir=' . $this->tempDir . '/state',
@@ -304,7 +324,7 @@ PHP, var_export($requestsLog, true)));
         $this->assertStringNotContainsString('PullFailureReportedException', $output);
     }
 
-    public function testRepeatedOnlyOptionsAreUsedByFilesPull(): void
+    public function testIncludeAndOnlyAliasValuesAreUsedByFilesPull(): void
     {
         $requestsLog = $this->tempDir . '/requests.jsonl';
         $remoteReprintApiUrl = $this->startDirectoryCaptureServer($requestsLog);
@@ -313,9 +333,9 @@ PHP, var_export($requestsLog, true)));
         $output = $this->runCli(array(
             'files-pull',
             $remoteReprintApiUrl,
-            '--only',
+            '--include',
             ':wp-content:/plugins',
-            '--only',
+            '--include',
             ':wp-uploads:/2025',
             '--only',
             ':wp-content:/themes',
@@ -372,16 +392,16 @@ PHP, var_export($requestsLog, true)));
         $this->assertNull($fileIndexRequest['exclude_path'] ?? null);
     }
 
-    public function testOnlyOptionKeepsCommaInsideSourcePath(): void
+    public function testIncludeOptionKeepsCommaInsideSourcePath(): void
     {
-        // --abort runs after --only resolution, avoiding a network request while
+        // --abort runs after --include resolution, avoiding a network request while
         // still proving the CLI did not split the SOURCE at the comma.
         $this->writePreflightState('http://fake.invalid/?site-export-api');
 
         $output = $this->runCli(array(
             'files-pull',
             'http://fake.invalid/?site-export-api',
-            '--only',
+            '--include',
             ':wp-content:/plugins,custom',
             '--abort',
             '--state-dir=' . $this->tempDir . '/state',

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
 /**
  * Path selection: the diff must reconcile only within the selected path
- * prefixes. --only scopes the downloaded next remote index, while --exclude
+ * prefixes. --include scopes the downloaded next remote index, while --exclude
  * is applied locally to that index. The delete drains in
  * compare_remote_indexes_and_build_fetch_list() must keep unselected local
  * files and remote index entries while still deleting selected orphans.
@@ -140,9 +140,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     public function testOnlyFilesPrefixDiffKeepsUnselectedAndDeletesSelectedOrphan(): void
     {
         // Remote index (sorted): an unselected entry, a matched selected file,
-        // and a selected orphan absent from the --only next remote index. The
-        // delete drains must reconcile only within the --only file prefixes, so the remote index
-        // accumulates as a union across files-pull --only runs.
+        // and a selected orphan absent from the --include next remote index. The
+        // delete drains must reconcile only within the --include file prefixes, so the remote index
+        // accumulates as a union across files-pull --include runs.
         $this->writeIndex('remote-index.jsonl',
             $this->indexLine('/wp-config.php', 1000, 10)               // unselected
             . $this->indexLine('/wp-content/keep.txt', 1000, 10)       // matched
@@ -228,9 +228,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     public function testRemoteFollowedPathOutsideOnlyScopeIsFetched(): void
     {
-        // The exporter applies the --only roots before building this index, but
+        // The exporter applies the --include roots before building this index, but
         // following a selected symlink may add its target outside those roots.
-        // The importer must fetch that target while still using --only to scope
+        // The importer must fetch that target while still using --include to scope
         // deletions from the prior remote index.
         $this->writeIndex('remote-index.jsonl', '');
         $this->writeIndex(
@@ -253,8 +253,8 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
     public function testOnlyRootItselfSurvivesTheDeleteDrains(): void
     {
-        // A next remote index built with --only lists each selected directory's
-        // *contents* but never the directory itself, so the --only roots
+        // A next remote index built with --include lists each selected directory's
+        // *contents* but never the directory itself, so the --include roots
         // always look deleted-on-remote to the diff. The drains must not
         // delete them: that would recursively remove the very directories
         // the user asked to pull, while the matched children keep the

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -11,9 +11,9 @@ require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
  *   - resolve_remote_paths(): :token: templates / absolute paths → remote absolute
  *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
  *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
- *   - is_selected_for_pulling(): per-path --only/--exclude membership.
- *   - get_export_directories(): with --only, a *replace* of the export roots.
- * Orthogonal to --remap (--only file prefixes decide what gets pulled, not where it lands).
+ *   - is_selected_for_pulling(): per-path --include/--exclude membership.
+ *   - get_export_directories(): with --include, a *replace* of the export roots.
+ * Orthogonal to --remap (--include file prefixes decide what gets pulled, not where it lands).
  */
 class OnlyFilesPathPrefixTest extends TestCase
 {
@@ -78,7 +78,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         return $c;
     }
 
-    /** Preflight carrying only the wp paths_urls needed by the --only file-prefix helpers. */
+    /** Preflight carrying only the wp paths_urls needed by the --include file-prefix helpers. */
     private function withPaths(array $pathsUrls): \ImportClient
     {
         return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
@@ -155,7 +155,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testResolvePullOnlyFilesPrefixAddsDirectoriesOutsideWpContent(): void
     {
-        // Selecting :wp-content: with --only yields WP_CONTENT_DIR plus any plugins,
+        // Selecting :wp-content: with --include yields WP_CONTENT_DIR plus any plugins,
         // mu-plugins, or uploads directory outside it (uploads here); a nested
         // directory is already covered.
         $c = $this->withPaths(array(
@@ -163,7 +163,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'plugins_dir' => '/var/www/html/wp-content/plugins', // nested → not added
             'uploads' => array('basedir' => '/mnt/uploads'),     // outside WP_CONTENT_DIR → added
         ));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:'), 'only'));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:'), 'include'));
         sort($pull_only_files_with_path_prefixes);
         $this->assertSame(array('/mnt/uploads', '/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
@@ -173,7 +173,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         // :wp-content:/plugins is nested under :wp-content: → dropped, so the
         // exporter never walks the subtree twice.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ':wp-content:/plugins'), 'only'));
+        $pull_only_files_with_path_prefixes = $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ':wp-content:/plugins'), 'include'));
         $this->assertSame(array('/var/www/html/wp-content'), $pull_only_files_with_path_prefixes);
     }
 
@@ -193,7 +193,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         ))));
         $this->assertSame(
             array('/custom/plugins/woocommerce'),
-            $this->call($c, 'resolve_remote_paths', array(array(':wp-plugins:/woocommerce'), 'only'))
+            $this->call($c, 'resolve_remote_paths', array(array(':wp-plugins:/woocommerce'), 'include'))
         );
     }
 
@@ -203,17 +203,17 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->assertSame(
             array('/var/custom/data'),
-            $this->call($c, 'resolve_remote_paths', array(array('/var/custom/data'), 'only'))
+            $this->call($c, 'resolve_remote_paths', array(array('/var/custom/data'), 'include'))
         );
     }
 
     public function testResolvePullOnlyFilesPrefixRejectsBlankSource(): void
     {
-        // Strict input hygiene: a blank source (e.g. `--only ""`) is an error,
+        // Strict input hygiene: a blank source (e.g. `--include ""`) is an error,
         // not silently ignored.
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
-        $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ''), 'only'));
+        $this->call($c, 'resolve_remote_paths', array(array(':wp-content:', ''), 'include'));
     }
 
     public function testResolvePullOnlyFilesPrefixRejectsUnavailableToken(): void
@@ -223,13 +223,13 @@ class OnlyFilesPathPrefixTest extends TestCase
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
-        $this->call($c, 'resolve_remote_paths', array(array(':abspath:/wp-admin'), 'only'));
+        $this->call($c, 'resolve_remote_paths', array(array(':abspath:/wp-admin'), 'include'));
     }
 
     public function testPullOnlyFilesPrefixSelectionDefaultsToTrueAndIsSlashAware(): void
     {
         $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        // No --only: every file path is selected (keeps the diff deleting orphans).
+        // No --include: every file path is selected (keeps the diff deleting orphans).
         $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/anything/at/all.php', false)));
 
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
@@ -283,7 +283,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->expectExceptionMessage('Cannot change --include or --exclude while resuming files-pull');
         $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(true));
     }
 
@@ -297,7 +297,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/plugins'));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->expectExceptionMessage('Cannot change --include or --exclude while resuming files-pull');
         $this->call($c, 'assert_files_pull_path_selection_unchanged_while_resuming', array(true));
     }
 
@@ -320,8 +320,8 @@ class OnlyFilesPathPrefixTest extends TestCase
         ));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
-        $this->runFilesPull(array('only' => array(':wp-uploads:')));
+        $this->expectExceptionMessage('Cannot change --include or --exclude while resuming files-pull');
+        $this->runFilesPull(array('include' => array(':wp-uploads:')));
     }
 
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
@@ -331,7 +331,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
-        $this->runFilesPull(array('only' => array(':wp-content:/plugins')));
+        $this->runFilesPull(array('include' => array(':wp-content:/plugins')));
 
         $state = $this->readState();
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
@@ -351,7 +351,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
-        $this->runFilesPull(array('only' => array(':wp-uploads:')));
+        $this->runFilesPull(array('include' => array(':wp-uploads:')));
 
         $state = $this->readState();
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);
@@ -364,7 +364,7 @@ class OnlyFilesPathPrefixTest extends TestCase
         ));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot change --only or --exclude while resuming files-pull');
+        $this->expectExceptionMessage('Cannot change --include or --exclude while resuming files-pull');
         $this->runFilesPull(array('exclude' => array(':wp-uploads:')));
     }
 
@@ -395,7 +395,7 @@ class OnlyFilesPathPrefixTest extends TestCase
 
     public function testPullOnlyFilesPrefixesReplaceRootsAndIgnoreUnselectedRemap(): void
     {
-        // With --only, export roots ARE the selected file prefixes: core/abspath/document_root
+        // With --include, export roots ARE the selected file prefixes: core/abspath/document_root
         // are dropped, and an unselected --remap source stays inert.
         $c = $this->client(array(
             'wp_detect' => array('roots' => array(array('path' => '/var/www/html'))),

--- a/tests/e2e/lib/atomic-hosting-fixture.js
+++ b/tests/e2e/lib/atomic-hosting-fixture.js
@@ -3,7 +3,7 @@
  * core, plugins, themes, drop-ins, and mu-plugins live in a shared, read-only
  * directory and are symlinked into the site root.
  *
- * Used by the preserve-local tests (import-37) and the --only/--remap managed
+ * Used by the preserve-local tests (import-37) and the --include/--remap managed
  * composition test (import-51).
  *
  * Layout produced (relative to `siteRoot`):

--- a/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
+++ b/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
@@ -1,11 +1,11 @@
 /**
- * Test 51: --only + --remap onto a managed Atomic docroot (v1 composition)
+ * Test 51: --include + --remap onto a managed Atomic docroot (v1 composition)
  *
  * The committed Docker twin of the real "first migration onto a managed Atomic
  * site" flow, plus the scoped re-sync that follows it. It exercises the v1
  * invocation —
  *
- *   files-pull --only :wp-content: --remap :wp-content: :fs-root:/wp-content \
+ *   files-pull --include :wp-content: --remap :wp-content: :fs-root:/wp-content \
  *     --on-fs-root-nonempty=preserve-local --no-follow-symlinks
  *
  * — against a fs-root pre-populated with the realistic managed hosting layout
@@ -19,9 +19,9 @@
  * :fs-root:/wp-content` flattens it to fs-root/wp-content — which is why the
  * managed fixture here lives at the fs-root ROOT (the docroot), unlike test 37.
  *
- * Phase 1 — first migration (--only :wp-content:). Verifies the four contracts
+ * Phase 1 — first migration (--include :wp-content:). Verifies the four contracts
  * of the composition:
- *   1. Core excluded (--only)        — no wp-admin/wp-includes pulled.
+ *   1. Core excluded (--include)        — no wp-admin/wp-includes pulled.
  *   2. Direct placement (--remap)    — wp-content at fs-root/wp-content, no nesting.
  *   3. Managed layer preserved       — hosting symlinks intact, read-only dirs
  *                                      don't crash, shared content untouched.
@@ -29,7 +29,7 @@
  *                                      files colliding with the managed layer
  *                                      are skipped (target wins).
  *
- * Phase 2 — scoped delta re-sync (--only :wp-content:/plugins). Verifies the
+ * Phase 2 — scoped delta re-sync (--include :wp-content:/plugins). Verifies the
  * re-sync behavior against the same managed target:
  *   A. Delta-delete   — a file the SOURCE removed that is IN the current scope
  *                       and was previously synced is deleted on the target.
@@ -54,7 +54,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 import { buildAtomicHostingFixture, unlockSharedDir } from '../lib/atomic-hosting-fixture.js';
 
-describe('Import: --only + --remap onto a managed Atomic docroot', () => {
+describe('Import: --include + --remap onto a managed Atomic docroot', () => {
     const site = 'only-remap-managed';
     let siteDir;
 
@@ -107,7 +107,7 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
         return `${getSiteUrl(site)}&directory=${siteDir}`;
     }
 
-    // Shared remap + preserve flags; the --only scope varies per run.
+    // Shared remap + preserve flags; the --include scope varies per run.
     const remap = ['--remap', ':wp-content:', ':fs-root:/wp-content'];
     const preserve = ['--on-fs-root-nonempty=preserve-local', '--no-follow-symlinks'];
 
@@ -132,12 +132,12 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     const tgtTheme = (name) => join(fsRoot, 'wp-content', 'themes', name);
 
     // ================================================================
-    // Phase 1 — first migration: --only :wp-content:
+    // Phase 1 — first migration: --include :wp-content:
     // ================================================================
-    it('files-pull completes with --only + --remap + preserve-local', () => {
+    it('files-pull completes with --include + --remap + preserve-local', () => {
         const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
-            extraArgs: ['--only', ':wp-content:', ...remap, ...preserve],
+            extraArgs: ['--include', ':wp-content:', ...remap, ...preserve],
         });
         assert.equal(
             result.exitCode, 0,
@@ -145,12 +145,12 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
         );
     });
 
-    // -- 1. Core excluded (--only) --------------------------------
+    // -- 1. Core excluded (--include) --------------------------------
     it('source WP core is never pulled', () => {
         assert.ok(!existsSync(join(fsRoot, 'wp-admin')),
-            'wp-admin should not be pulled (--only :wp-content:)');
+            'wp-admin should not be pulled (--include :wp-content:)');
         assert.ok(!existsSync(join(fsRoot, 'wp-includes')),
-            'wp-includes should not be pulled (--only :wp-content:)');
+            'wp-includes should not be pulled (--include :wp-content:)');
     });
 
     // -- 2. Direct placement (--remap) ----------------------------
@@ -212,7 +212,7 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
     });
 
     // ================================================================
-    // Phase 2 — scoped delta re-sync: --only :wp-content:/plugins
+    // Phase 2 — scoped delta re-sync: --include :wp-content:/plugins
     // ================================================================
     it('removes custom-plugin from source, then aborts to force a fresh delta', () => {
         // The source tree is owned by nginx:nginx (site-setup chowns it), so
@@ -228,10 +228,10 @@ describe('Import: --only + --remap onto a managed Atomic docroot', () => {
         assert.equal(abort.exitCode, 0, `abort expected exit 0\nstderr: ${abort.stderr}`);
     });
 
-    it('scoped delta re-sync completes (--only :wp-content:/plugins)', () => {
+    it('scoped delta re-sync completes (--include :wp-content:/plugins)', () => {
         const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
-            extraArgs: ['--only', ':wp-content:/plugins', ...remap, ...preserve],
+            extraArgs: ['--include', ':wp-content:/plugins', ...remap, ...preserve],
         });
         assert.equal(
             result.exitCode, 0,

--- a/tests/e2e/tests/import-52-followed-symlinks-root.test.js
+++ b/tests/e2e/tests/import-52-followed-symlinks-root.test.js
@@ -2,11 +2,11 @@
  * Test 52: followed symlinks root — --follow-symlinks=<dir> places escaping paths under a local root (ARC-1814).
  *
  * Covers the {in-scope, escaping} x {relative, absolute} matrix of directory
- * symlinks under --only + --remap: escaping targets are consolidated into the
+ * symlinks under --include + --remap: escaping targets are consolidated into the
  * local followed symlinks root (nested by source path, deduped), in-scope paths are left in place.
  * (Escaping *file* symlinks are a known limitation — not covered here.)
  *
- * Run: files-pull --only :wp-content: --remap :wp-content: :fs-root:/wp-content
+ * Run: files-pull --include :wp-content: --remap :wp-content: :fs-root:/wp-content
  *                 --follow-symlinks=:fs-root:/.followed-symlinks-root
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -60,9 +60,9 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
                     rmSync(p, { recursive: true, force: true });
                     symlinkSync(target, p);
                 }
-                // A plugin that symlinks into themes — for the narrow `--only
+                // A plugin that symlinks into themes — for the narrow `--include
                 // :wp-content:/plugins` run, themes/indice-real is OUTSIDE the
-                // --only scope but INSIDE the remapped wp-content, so remap (checked
+                // --include scope but INSIDE the remapped wp-content, so remap (checked
                 // before the local followed symlinks root) should place it at wp-content/themes.
                 const plugin = join(siteDir, 'wp-content', 'plugins', 'cross-plugin');
                 mkdirSync(plugin, { recursive: true });
@@ -90,7 +90,7 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
         const result = runImporter(importUrl(), tempDir, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
-                '--only', ':wp-content:',
+                '--include', ':wp-content:',
                 '--remap', ':wp-content:', ':fs-root:/wp-content',
                 '--follow-symlinks=:fs-root:/.followed-symlinks-root',
             ],
@@ -140,15 +140,15 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
             'in-scope paths must not use the local followed symlinks root');
     });
 
-    // ── Narrow --only: a plugin symlinks into themes (in wp-content, out of --only) ──
-    // themes is OUTSIDE --only :wp-content:/plugins but INSIDE the remapped
+    // ── Narrow --include: a plugin symlinks into themes (in wp-content, out of --include) ──
+    // themes is OUTSIDE --include :wp-content:/plugins but INSIDE the remapped
     // wp-content, so remap (checked before followed-symlink placement) must place it
     // at wp-content/themes for both relative and absolute spellings.
-    it('narrow --only :wp-content:/plugins files-pull completes', () => {
+    it('narrow --include :wp-content:/plugins files-pull completes', () => {
         const result = runImporter(importUrl(), tempDir2, 'files-pull', {
             secret: getSiteSecret(site),
             extraArgs: [
-                '--only', ':wp-content:/plugins',
+                '--include', ':wp-content:/plugins',
                 '--remap', ':wp-content:', ':fs-root:/wp-content',
                 '--follow-symlinks=:fs-root:/.followed-symlinks-root',
             ],
@@ -157,7 +157,7 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
     });
 
     it('cross-scope theme path lands under wp-content/themes through remap', () => {
-        // Followed from a plugin symlink; themes is out of --only but in wp-content.
+        // Followed from a plugin symlink; themes is out of --include but in wp-content.
         const themeStyle = join(fsRoot2(), 'wp-content', 'themes', 'indice-real', 'style.css');
         assert.ok(existsSync(themeStyle), `expected remapped theme at ${themeStyle}`);
         assert.ok(readFileSync(themeStyle, 'utf-8').includes('in-scope local theme'));
@@ -175,9 +175,9 @@ describe('Import: local followed symlinks root (--follow-symlinks=<dir>) places 
         }
     });
 
-    it('narrow --only pulls only plugins — unfollowed themes are absent', () => {
+    it('narrow --include pulls only plugins — unfollowed themes are absent', () => {
         // themes/indice-real is present (followed via the plugin symlink), but the
-        // other themes (indice, esc-rel, …) live outside --only=plugins and are not
+        // other themes (indice, esc-rel, …) live outside --include=plugins and are not
         // reachable, so they must not be pulled.
         assert.ok(existsSync(join(fsRoot2(), 'wp-content', 'themes', 'indice-real')),
             'the followed theme is present');


### PR DESCRIPTION
files-pull and pull-files now advertise --include for source path selection. Existing scripts can keep using --only as a hidden alias.\n\nTests: focused PHPUnit suite; PHPStan; PHP and JavaScript syntax checks; git diff --check.