### PR TITLE
[PHP] Make make-identical the default pull intent

### DIFF
--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -110,10 +110,9 @@ sorted path mutations directly and removes an indexed subtree when its root is
 deleted or replaced. Non-empty directories remain implicit. A successful
 initial pull with no local mutations creates an empty local index.
 
-Files-pull has two intents. `--intent=copy-changes` is the default. Explicit
-`--intent=make-identical` uses a resumable `PushPlan` to build a fresh local
-index after the next remote index is complete. The same
-`FileIndexDiffProcessor` used by `PushPlan`
+Files-pull has two intents. `--intent=make-identical` is the default. After
+the next remote index is complete, it uses a resumable `PushPlan` to build a
+fresh local index. The same `FileIndexDiffProcessor` used by `PushPlan`
 compares the retained and fresh local indexes one path at a time. Files-pull
 merges those local differences with the selected next remote index mapped into
 local relative paths. Each locally changed selected root is removed, and every

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -338,7 +338,7 @@ class ImportClient
     private $filter = "none";
 
     /** @var string Whether files-pull copies remote changes or makes selected paths identical. */
-    private $files_pull_intent = "copy-changes";
+    private $files_pull_intent = "make-identical";
 
     /** @var string|null Extra remote directory to include in the export (--extra-directory). */
     private $extra_directory = null;
@@ -865,7 +865,7 @@ class ImportClient
         $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
 
         if (in_array($command, ["pull", "pull-files", "files-pull"], true)) {
-            $this->files_pull_intent = $options["intent"] ?? "copy-changes";
+            $this->files_pull_intent = $options["intent"] ?? "make-identical";
             if (!in_array($this->files_pull_intent, ["copy-changes", "make-identical"], true)) {
                 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option value, never HTML output.
                 throw new InvalidArgumentException(
@@ -2960,7 +2960,7 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
-        $previous_intent = $this->get_state()->files_pull_intent ?? "copy-changes";
+        $previous_intent = $this->get_state()->files_pull_intent ?? "make-identical";
         if ($has_progress && $previous_intent !== $this->files_pull_intent) {
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option values, never HTML output.
             throw new RuntimeException(
@@ -11850,7 +11850,7 @@ if (
             'target' => 'intent',
             'placeholder' => 'INTENT',
             'valid_values' => ['copy-changes', 'make-identical'],
-            'help' => 'Pull intent (copy-changes|make-identical; default: copy-changes)',
+            'help' => 'Pull intent (copy-changes|make-identical; default: make-identical)',
             'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -51,6 +51,7 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('Next remote index', $output);
         $this->assertStringContainsString('--intent=INTENT', $output);
         $this->assertStringContainsString('copy-changes|make-identical', $output);
+        $this->assertStringContainsString('default: make-identical', $output);
     }
 
     public function testFilterOptionIsHiddenFromCommandHelp(): void

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -263,7 +263,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
 
         $this->abortFilesPull();
-        $pull = $this->runFilesPull(['--intent=make-identical']);
+        $pull = $this->runFilesPull();
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
         $this->assertSame('old', file_get_contents($this->localTree . '/edited.txt'));
@@ -292,7 +292,6 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $this->abortFilesPull();
         $pull = $this->runFilesPull([
-            '--intent=make-identical',
             '--include=/var/www/html/selected',
         ]);
 

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -391,6 +391,7 @@ describe('Import: --preserve-local', () => {
 
             const result = runImporter(importUrl(), tempDir, 'files-pull', {
                 secret: getSiteSecret(site),
+                extraArgs: ['--intent=copy-changes'],
             });
             assert.equal(result.exitCode, 0,
                 `Expected exit 0 (delta)\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);


### PR DESCRIPTION
Pull commands now select `make-identical` when `--intent` is omitted. `--intent=copy-changes` remains available for callers which want only the remote-index difference.

The default applies consistently to `files-pull`, `pull-files`, and `pull`. The integration coverage omits the option when checking restoration of local edits, deletions, and local-only paths.

Stacked on #538.

## Testing

- `../vendor/bin/phpunit Import/CliHelpTest.php Import/PullIntentReconciliationTest.php Import/PushPlanTest.php Import/PullStateTest.php`
- `composer analyze -- --memory-limit=1G`
- `composer lint:php:compat`