### PR TITLE
[PHP] Use path helpers for runtime and pull artifacts

### DIFF
--- a/packages/reprint-client/src/lib/import/functions.php
+++ b/packages/reprint-client/src/lib/import/functions.php
@@ -5,6 +5,8 @@ namespace Reprint\Importer;
 use PDO;
 use RuntimeException;
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * If the ALL_PROXY environment variable is set, apply it to the cURL
  * handle via CURLOPT_PROXY.
@@ -90,7 +92,7 @@ function resolve_sqlite_integration_path(string $suffix = ''): string
 {
 	$source_directory = dirname(__DIR__, 2);
 	foreach (array(dirname($source_directory, 3), dirname($source_directory, 4)) as $project_root) {
-		$candidate = $project_root . '/lib/sqlite-database-integration' . $suffix;
+		$candidate = wp_join_unix_paths($project_root, 'lib/sqlite-database-integration', $suffix);
 		if (file_exists($candidate)) {
 			return $candidate;
 		}
@@ -110,8 +112,8 @@ function resolve_sqlite_integration_plugin_path(): string
 {
 	$source_directory = dirname(__DIR__, 2);
 	foreach (array(dirname($source_directory, 3), dirname($source_directory, 4)) as $project_root) {
-		$root    = $project_root . '/lib/sqlite-database-integration';
-		$package = $root . '/packages/plugin-sqlite-database-integration';
+		$root    = wp_join_unix_paths($project_root, 'lib/sqlite-database-integration');
+		$package = wp_join_unix_paths($root, 'packages/plugin-sqlite-database-integration');
 		if (is_dir($package)) {
 			return $package;
 		}

--- a/packages/reprint-client/src/lib/import/functions.php
+++ b/packages/reprint-client/src/lib/import/functions.php
@@ -5,8 +5,6 @@ namespace Reprint\Importer;
 use PDO;
 use RuntimeException;
 
-use function WordPress\Filesystem\wp_join_unix_paths;
-
 /**
  * If the ALL_PROXY environment variable is set, apply it to the cURL
  * handle via CURLOPT_PROXY.
@@ -92,7 +90,9 @@ function resolve_sqlite_integration_path(string $suffix = ''): string
 {
 	$source_directory = dirname(__DIR__, 2);
 	foreach (array(dirname($source_directory, 3), dirname($source_directory, 4)) as $project_root) {
-		$candidate = wp_join_unix_paths($project_root, 'lib/sqlite-database-integration', $suffix);
+		// The packaged CLI has a phar:// project root. Joining it with the
+		// Unix filesystem helper would collapse the scheme's required `:///`.
+		$candidate = $project_root . '/lib/sqlite-database-integration' . $suffix;
 		if (file_exists($candidate)) {
 			return $candidate;
 		}
@@ -112,8 +112,9 @@ function resolve_sqlite_integration_plugin_path(): string
 {
 	$source_directory = dirname(__DIR__, 2);
 	foreach (array(dirname($source_directory, 3), dirname($source_directory, 4)) as $project_root) {
-		$root    = wp_join_unix_paths($project_root, 'lib/sqlite-database-integration');
-		$package = wp_join_unix_paths($root, 'packages/plugin-sqlite-database-integration');
+		// Keep the phar:// scheme intact when this runs from the packaged CLI.
+		$root    = $project_root . '/lib/sqlite-database-integration';
+		$package = $root . '/packages/plugin-sqlite-database-integration';
 		if (is_dir($package)) {
 			return $package;
 		}

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -466,7 +466,7 @@ class Pull
                         $this->client->run_db_sync();
                     });
                 }
-                $sql_file = $this->client->state_dir . "/db.sql";
+                $sql_file = wp_join_unix_paths($this->client->state_dir, 'db.sql');
                 $size = null;
                 if (file_exists($sql_file)) {
                     $bytes = filesize($sql_file);
@@ -825,13 +825,13 @@ class Pull
 
         $paths = [];
         if ($reset_file_transfer_state) {
-            $paths[] = $pull_state_directory . "/remote-index.next.jsonl";
-            $paths[] = $pull_state_directory . "/fetch-list.jsonl";
+            $paths[] = wp_join_unix_paths($pull_state_directory, 'remote-index.next.jsonl');
+            $paths[] = wp_join_unix_paths($pull_state_directory, 'fetch-list.jsonl');
         }
         if ($reset_db_state) {
-            $paths[] = $state_dir . "/db.sql";
-            $paths[] = $state_dir . "/db-tables.jsonl";
-            $paths[] = $pull_state_directory . "/domains.json";
+            $paths[] = wp_join_unix_paths($state_dir, 'db.sql');
+            $paths[] = wp_join_unix_paths($state_dir, 'db-tables.jsonl');
+            $paths[] = wp_join_unix_paths($pull_state_directory, 'domains.json');
         }
 
         foreach ($paths as $path) {

--- a/packages/reprint-client/src/lib/target-runtime/class-nginx-fpm-applier.php
+++ b/packages/reprint-client/src/lib/target-runtime/class-nginx-fpm-applier.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Runtime applier for nginx + PHP-FPM (also works with Apache + PHP-FPM).
  *
@@ -22,13 +25,13 @@ class NginxFpmApplier implements RuntimeApplier
         $summary = [];
 
         // 1. Write runtime.php
-        $runtime_path = $output_dir . '/runtime.php';
+        $runtime_path = wp_join_unix_paths($output_dir, 'runtime.php');
         $runtime = generate_runtime_php($manifest, $filesystem_root);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write nginx.conf (includes auto_prepend_file + INI directives)
-        $nginx_conf_path = $output_dir . '/nginx.conf';
+        $nginx_conf_path = wp_join_unix_paths($output_dir, 'nginx.conf');
         $nginx_conf = $this->generate_nginx_conf($manifest, $filesystem_root, $runtime_path, $host, $port);
         write_runtime_file($nginx_conf_path, $nginx_conf);
         $summary[] = "Wrote {$nginx_conf_path}";

--- a/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Runtime applier for PHP's built-in development server.
  *
@@ -24,14 +27,14 @@ class PhpBuiltinApplier implements RuntimeApplier
         $summary = [];
 
         // 1. Write runtime.php (base layers + CLI-server routing)
-        $runtime_path = $output_dir . '/runtime.php';
+        $runtime_path = wp_join_unix_paths($output_dir, 'runtime.php');
         $runtime = generate_runtime_php($manifest, $filesystem_root);
         $runtime .= $this->generate_cli_server_routing($options);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write start.sh
-        $start_path = $output_dir . '/start.sh';
+        $start_path = wp_join_unix_paths($output_dir, 'start.sh');
         $start_script = $this->generate_start_script($manifest, $filesystem_root, $runtime_path, $host, $port);
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);

--- a/packages/reprint-client/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-client/src/lib/target-runtime/class-playground-cli-applier.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Runtime applier for WordPress Playground CLI (@wp-playground/cli).
  *
@@ -58,7 +61,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // 1. Write runtime.php using the VFS path (/wordpress) as fs-root.
         //    Inside Playground, the host's fs-root is mounted at /wordpress,
         //    so all resolved {fs-root} paths must reference /wordpress.
-        $runtime_path = $output_dir . '/runtime.php';
+        $runtime_path = wp_join_unix_paths($output_dir, 'runtime.php');
         $runtime = generate_runtime_php($manifest, self::VFS_ROOT);
 
         // Suppress display of PHP warnings and deprecation notices.
@@ -79,13 +82,13 @@ class PlaygroundCliApplier implements RuntimeApplier
         $manifest->sqlite = $saved_sqlite;
 
         // 2. Write blueprint.json (minimal — most config is in start.sh flags)
-        $blueprint_path = $output_dir . '/blueprint.json';
+        $blueprint_path = wp_join_unix_paths($output_dir, 'blueprint.json');
         $blueprint = $this->generate_blueprint();
         write_runtime_file($blueprint_path, json_encode($blueprint, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
         $summary[] = "Wrote {$blueprint_path}";
 
         // 3. Write start.sh
-        $start_path = $output_dir . '/start.sh';
+        $start_path = wp_join_unix_paths($output_dir, 'start.sh');
         $start_script = $this->generate_start_script(
             $manifest,
             $filesystem_root,
@@ -102,7 +105,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         // 4. Write start.json — structured config for programmatic consumers
         // (e.g. Studio). The source paths are as seen by this PHP process;
         // callers running inside a VFS must map them to host paths.
-        $config_path = $output_dir . '/start.json';
+        $config_path = wp_join_unix_paths($output_dir, 'start.json');
         $config = $this->generate_start_config(
             $filesystem_root,
             $output_dir,
@@ -213,12 +216,12 @@ class PlaygroundCliApplier implements RuntimeApplier
             // document root. Three mounts assemble the standard layout.
             $mounts[] = $wordpress_core_dir . ':/wordpress';
 
-            $wp_content = $real_fs_root . '/wp-content';
+            $wp_content = wp_join_unix_paths($real_fs_root, 'wp-content');
             if (is_dir($wp_content)) {
                 $mounts[] = $wp_content . ':/wordpress/wp-content';
             }
 
-            $wp_config = $real_fs_root . '/wp-config.php';
+            $wp_config = wp_join_unix_paths($real_fs_root, 'wp-config.php');
             if (file_exists($wp_config)) {
                 $mounts[] = $wp_config . ':/wordpress/wp-config.php';
             }
@@ -250,7 +253,7 @@ class PlaygroundCliApplier implements RuntimeApplier
             'document_root' => self::VFS_ROOT,
             'mounts_before_install' => [],
             'mounts' => [],
-            'blueprint' => $output_dir . '/blueprint.json',
+            'blueprint' => wp_join_unix_paths($output_dir, 'blueprint.json'),
             'port' => $port,
             'follow_symlinks' => true,
             'wordpress_install_mode' => 'do-not-attempt-installing',

--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -263,13 +263,15 @@ function ensure_sqlite_plugin_database_driver(string $source_dir, string $target
 
 function sqlite_plugin_database_driver_source(string $source_dir): string
 {
+    // The packaged CLI passes a phar:// source directory. The Unix filesystem
+    // helper would collapse the scheme's required `:///` separator.
     $candidates = [
-        wp_join_unix_paths($source_dir, 'wp-includes/database'),
-        wp_join_unix_paths(dirname($source_dir), 'mysql-on-sqlite/src'),
+        $source_dir . '/wp-includes/database',
+        dirname($source_dir) . '/mysql-on-sqlite/src',
     ];
 
     foreach ($candidates as $candidate) {
-        if (is_file(wp_join_unix_paths($candidate, 'version.php'))) {
+        if (is_file($candidate . '/version.php')) {
             return realpath($candidate) ?: $candidate;
         }
     }

--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -1,4 +1,7 @@
 <?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+
 /**
  * Target runtime functions.
  *
@@ -225,7 +228,7 @@ function copy_sqlite_plugin(string $source_dir, string $output_dir): string
         );
     }
 
-    $target_dir = $output_dir . '/sqlite-database-integration';
+    $target_dir = wp_join_unix_paths($output_dir, 'sqlite-database-integration');
 
     if (!is_dir($target_dir)) {
         copy_directory_recursive($source_dir, $target_dir);
@@ -247,8 +250,8 @@ function copy_sqlite_plugin(string $source_dir, string $output_dir): string
  */
 function ensure_sqlite_plugin_database_driver(string $source_dir, string $target_dir): void
 {
-    $target_database_dir = $target_dir . '/wp-includes/database';
-    if (is_file($target_database_dir . '/version.php') && !is_link($target_database_dir)) {
+    $target_database_dir = wp_join_unix_paths($target_dir, 'wp-includes/database');
+    if (is_file(wp_join_unix_paths($target_database_dir, 'version.php')) && !is_link($target_database_dir)) {
         return;
     }
 
@@ -261,12 +264,12 @@ function ensure_sqlite_plugin_database_driver(string $source_dir, string $target
 function sqlite_plugin_database_driver_source(string $source_dir): string
 {
     $candidates = [
-        $source_dir . '/wp-includes/database',
-        dirname($source_dir) . '/mysql-on-sqlite/src',
+        wp_join_unix_paths($source_dir, 'wp-includes/database'),
+        wp_join_unix_paths(dirname($source_dir), 'mysql-on-sqlite/src'),
     ];
 
     foreach ($candidates as $candidate) {
-        if (is_file($candidate . '/version.php')) {
+        if (is_file(wp_join_unix_paths($candidate, 'version.php'))) {
             return realpath($candidate) ?: $candidate;
         }
     }
@@ -315,7 +318,7 @@ function copy_directory_recursive(string $source, string $dest): void
         RecursiveIteratorIterator::SELF_FIRST,
     );
     foreach ($iterator as $item) {
-        $target = $dest . '/' . $iterator->getSubPathname();
+        $target = wp_join_unix_paths($dest, $iterator->getSubPathname());
         if ($item->isDir()) {
             if (!is_dir($target)) {
                 mkdir($target, 0755, true);

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -738,7 +738,7 @@ function normalize_path_list(array $paths): array
         }
         $real = realpath($path);
         $final = $real !== false ? $real : $path;
-        $final = $final === "/" ? "/" : rtrim($final, "/");
+        $final = trim_right_slash($final);
         if ($final === "") {
             continue;
         }

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -103,4 +103,26 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         $this->assertContains($this->pullStateFile, $mount_sources);
         $this->assertContains('/tmp/reprint/state.json', $mount_targets);
     }
+
+    public function testPlaygroundConfigNormalizesATrailingOutputDirectorySlash(): void
+    {
+        $manifest = new \RuntimeManifest('other');
+        $applier = new \PlaygroundCliApplier();
+        $applier->apply($manifest, $this->fsRoot, $this->outputDir . '/', [
+            'wordpress_index_php' => $this->fsRoot . '/index.php',
+        ]);
+
+        $config = json_decode(
+            file_get_contents($this->outputDir . '/start.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertSame($this->outputDir . '/blueprint.json', $config['blueprint']);
+        $this->assertSame(
+            $this->outputDir . '/runtime.php',
+            $config['mounts'][0]['source'],
+        );
+    }
 }

--- a/tests/Import/SqliteRuntimePluginCopyTest.php
+++ b/tests/Import/SqliteRuntimePluginCopyTest.php
@@ -71,4 +71,15 @@ class SqliteRuntimePluginCopyTest extends TestCase
         $this->assertFileExists($copied . '/wp-includes/database/version.php');
         $this->assertFileExists($copied . '/wp-includes/database/load.php');
     }
+
+    public function testCopyNormalizesATrailingOutputDirectorySlash(): void
+    {
+        $copied = \copy_sqlite_plugin($this->pluginSource(), $this->tempDir . '/');
+
+        $this->assertSame(
+            $this->tempDir . '/sqlite-database-integration',
+            $copied,
+        );
+        $this->assertFileExists($copied . '/wp-includes/database/version.php');
+    }
 }


### PR DESCRIPTION
Runtime and pull artifacts now use the existing path helpers, so a trailing output-directory slash produces stable artifact paths instead of duplicate separators.

The change routes host-side artifact and state paths through `wp_join_unix_paths()` and routes export list normalization through `trim_right_slash()`. SQLite integration lookup paths remain direct because the packaged CLI uses `phar://` URIs, whose required `:///` separator the Unix filesystem helper would collapse. Generated runtime URI code and bootstrap loader paths also remain direct because they do not share the same filesystem-path contract or helper availability.

Tests: `cd tests && ../vendor/bin/phpunit Import/SqliteRuntimePluginCopyTest.php Import/NewSiteUrlSqliteTest.php Import/DeactivateHostPluginsTest.php Import/PlaygroundRemoteUploadProxyRuntimeTest.php --testdox --colors=never`; PHPStan; PHP compatibility checks.