### PR TITLE
[PHP] Name inclusive and strict path ancestry predicates

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -34,7 +34,8 @@ use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\path_is_descendant_of;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
@@ -2254,7 +2255,7 @@ class ImportClient
         $push_state_directory = realpath_with_missing_tail(
             $push_state_directory
         );
-        if (path_is_within_root($push_state_directory, $resolved_local_filesystem_root)) {
+        if (path_is_same_as_or_descendant_of($push_state_directory, $resolved_local_filesystem_root)) {
             throw new InvalidArgumentException(
                 'The local push state directory ' . $push_state_directory
                 . ' must be outside the filesystem root ' . $resolved_local_filesystem_root . '.'
@@ -2578,7 +2579,7 @@ class ImportClient
             if (
                 $content_dir !== null &&
                 $uploads_basedir !== null &&
-                !path_is_within_root($uploads_basedir, $content_dir)
+                !path_is_same_as_or_descendant_of($uploads_basedir, $content_dir)
             ) {
                 $this->audit_log(
                     "NON-STANDARD LAYOUT | uploads at {$uploads_basedir} " .
@@ -3536,7 +3537,7 @@ class ImportClient
             }
             // Skip if this directory is a subdirectory of an already-visited path,
             // since those files were already included in the parent's index.
-            if (path_is_within_root($dir, array_keys($visited))) {
+            if (path_is_same_as_or_descendant_of($dir, array_keys($visited))) {
                 $this->audit_log(
                     "FOLLOW SYMLINK SKIP | {$dir} already covered by a visited parent",
                     true,
@@ -3680,7 +3681,7 @@ class ImportClient
             }
 
             // Check containment: skip if already under a visited root
-            if (path_is_within_root($symlink_target, array_keys($visited))) {
+            if (path_is_same_as_or_descendant_of($symlink_target, array_keys($visited))) {
                 continue;
             }
 
@@ -4735,28 +4736,16 @@ class ImportClient
         $wp_includes_detached = $wp_includes_path !== null
             && $wp_includes_path !== wp_join_unix_paths($abspath, "wp-includes");
         $content_detached = $content_dir !== null
-            && (
-                $content_dir === $abspath
-                || !path_is_within_root($content_dir, $abspath)
-            );
+            && !path_is_descendant_of($content_dir, $abspath);
         $plugins_detached = $plugins_dir !== null
             && $content_dir !== null
-            && (
-                $plugins_dir === $content_dir
-                || !path_is_within_root($plugins_dir, $content_dir)
-            );
+            && !path_is_descendant_of($plugins_dir, $content_dir);
         $mu_plugins_detached = $mu_plugins_dir !== null
             && $content_dir !== null
-            && (
-                $mu_plugins_dir === $content_dir
-                || !path_is_within_root($mu_plugins_dir, $content_dir)
-            );
+            && !path_is_descendant_of($mu_plugins_dir, $content_dir);
         $uploads_detached = $uploads_basedir !== null
             && $content_dir !== null
-            && (
-                $uploads_basedir === $content_dir
-                || !path_is_within_root($uploads_basedir, $content_dir)
-            );
+            && !path_is_descendant_of($uploads_basedir, $content_dir);
 
         // If any sub-component is detached from content_dir, we need to
         // "explode" wp-content into a real directory with individual symlinks
@@ -7334,11 +7323,11 @@ class ImportClient
             $remote_parent_components[] = $missing_remote_path_components[$component_index];
             $path_prefix = wp_join_unix_paths("/", ...$remote_parent_components);
             if (
-                !path_is_within_root(
+                !path_is_same_as_or_descendant_of(
                     $nearest_existing_path_before,
                     $path_prefix,
                 )
-                && !path_is_within_root(
+                && !path_is_same_as_or_descendant_of(
                     $nearest_existing_path_after,
                     $path_prefix,
                 )
@@ -8693,7 +8682,7 @@ class ImportClient
             $resolved = normalize_path(wp_join_unix_paths($symlink_parent_dir, $target));
         }
 
-        if (!path_is_within_root($resolved, $root)) {
+        if (!path_is_same_as_or_descendant_of($resolved, $root)) {
             throw new RuntimeException(
                 "Security: symlink target escapes filesystem root: {$target} " .
                 "(resolves to {$resolved}, root is {$root})"
@@ -8808,7 +8797,7 @@ class ImportClient
                 continue;
             }
             $next_remote_index_entry_path = $next_remote_index_entry["path"];
-            if (path_is_within_root($next_remote_index_entry_path, $remote_absolute_path)) {
+            if (path_is_same_as_or_descendant_of($next_remote_index_entry_path, $remote_absolute_path)) {
                 $path_prefix_found = true;
                 break;
             }
@@ -8963,7 +8952,7 @@ class ImportClient
         $filesystem_root = $this->filesystem_root;
         $directory = $this->resolve_token_path($raw, ["fs-root" => $filesystem_root]);
 
-        if (!path_is_within_root($directory, $filesystem_root)) {
+        if (!path_is_same_as_or_descendant_of($directory, $filesystem_root)) {
             throw new InvalidArgumentException(
                 "--follow-symlinks local followed symlinks root \"{$directory}\" resolves outside --fs-root ({$filesystem_root}); " .
                     "it must stay within the destination root",
@@ -8997,7 +8986,7 @@ class ImportClient
             $source = $this->resolve_token_path($source_raw, $source_tokens);
             $target = $this->resolve_token_path($target_raw, $target_tokens);
 
-            if (!path_is_within_root($target, $filesystem_root)) {
+            if (!path_is_same_as_or_descendant_of($target, $filesystem_root)) {
                 throw new InvalidArgumentException(
                     "--remap target \"{$target}\" resolves outside --fs-root ({$filesystem_root}); " .
                         "targets must stay within the destination root",
@@ -9048,7 +9037,7 @@ class ImportClient
         $directories = [];
         foreach (["wp-plugins" => "plugins", "wp-mu-plugins" => "mu-plugins", "wp-uploads" => "uploads"] as $token => $name) {
             $source = $source_tokens[$token];
-            if ($source !== null && !path_is_within_root($source, $content)) {
+            if ($source !== null && !path_is_same_as_or_descendant_of($source, $content)) {
                 $directories[$name] = $source;
             }
         }
@@ -9107,7 +9096,7 @@ class ImportClient
             $covered = false;
 
             foreach ($sources as $other) {
-                if ($other !== $path && path_is_within_root($path, $other)) {
+                if (path_is_descendant_of($path, $other)) {
                     $covered = true;
                     break;
                 }
@@ -9606,7 +9595,7 @@ class ImportClient
             $real_check = realpath($check_path);
             if (
                 $real_check === false ||
-                !path_is_within_root($real_check, $real_filesystem_root)
+                !path_is_same_as_or_descendant_of($real_check, $real_filesystem_root)
             ) {
                 // In preserve-local mode, a path that resolves outside the
                 // filesystem root is expected when a directory like wp-content/plugins
@@ -9707,7 +9696,7 @@ class ImportClient
             }
 
             $resolved = realpath($current);
-            if ($resolved === false || !path_is_within_root($resolved, $real_filesystem_root)) {
+            if ($resolved === false || !path_is_same_as_or_descendant_of($resolved, $real_filesystem_root)) {
                 throw new RuntimeException(
                     "Security: Refusing to create directory outside filesystem root: {$current}",
                 );
@@ -10102,7 +10091,7 @@ class ImportClient
     private function path_is_within_original_export_scope(string $path): bool
     {
         foreach ($this->get_export_directories() as $root) {
-            if (path_is_within_root($path, $root)) {
+            if (path_is_same_as_or_descendant_of($path, $root)) {
                 return true;
             }
         }
@@ -10185,7 +10174,7 @@ class ImportClient
                 continue;
             }
             // Check if this path is already covered by an existing dir.
-            if (!path_is_within_root($path, $dirs)) {
+            if (!path_is_same_as_or_descendant_of($path, $dirs)) {
                 $dirs[] = $path;
                 $this->audit_log(
                     "DIRECTORY AUTO-DETECT | adding {$label} outside roots: " .

--- a/packages/reprint-client/src/lib/host/functions.php
+++ b/packages/reprint-client/src/lib/host/functions.php
@@ -5,7 +5,7 @@
  * Registry, detection logic, and shared preflight extraction helpers.
  */
 
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
 /**
@@ -112,7 +112,7 @@ function extract_constants(array $preflight_data): array
     if (
         $content_dir !== ''
         && $abspath !== ''
-        && !path_is_within_root($content_dir, $abspath)
+        && !path_is_same_as_or_descendant_of($content_dir, $abspath)
     ) {
         $result['WP_CONTENT_DIR'] = '{fs-root}/wp-content';
     }

--- a/packages/reprint-client/src/lib/local-index-update-functions.php
+++ b/packages/reprint-client/src/lib/local-index-update-functions.php
@@ -2,7 +2,7 @@
 
 namespace Reprint\Importer;
 
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exceptions contain CLI filesystem paths, never HTML output.
 
@@ -153,7 +153,7 @@ function merge_local_index_mutations(
 			 */
 			while (
 				$local_index_entries->valid()
-				&& path_is_within_root(
+				&& path_is_same_as_or_descendant_of(
 					$local_index_entries->current()['path'],
 					$local_index_update_path
 				)

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -3,7 +3,8 @@
 use function Reprint\Importer\sort_index_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\path_is_descendant_of;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
@@ -695,7 +696,7 @@ class PushPlan
                 if ($this->deleted_directory_stack_entry !== null) {
                     $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                     if (
-                        !path_is_within_root(
+                        !path_is_same_as_or_descendant_of(
                             $local_index_entry["path"],
                             $this->deleted_directory_stack_entry["path"]
                         )
@@ -712,8 +713,7 @@ class PushPlan
             if ($path_comparison < 0) {
                 // New files, symlinks, and empty directories need to be pushed.
                 $fresh_local_index_entry_replaces_local_subtree = $local_index_entry !== null
-                    && $local_index_entry["path"] !== $fresh_local_index_entry["path"]
-                    && path_is_within_root(
+                    && path_is_descendant_of(
                         $local_index_entry["path"],
                         $fresh_local_index_entry["path"]
                     );
@@ -1004,10 +1004,10 @@ class PushPlan
         $next_fresh_local_index_entry_path =
             $this->fresh_local_index_entry["path"] ?? "\0";
 
-        return path_is_within_root(
+        return path_is_same_as_or_descendant_of(
             $previous_fresh_local_index_entry_path,
             $local_relative_path
-        ) || path_is_within_root(
+        ) || path_is_same_as_or_descendant_of(
             $next_fresh_local_index_entry_path,
             $local_relative_path
         );
@@ -1171,8 +1171,7 @@ class PushPlan
     private function deleted_directory_stack_covers_path(string $path, ?array $entry): bool
     {
         return $entry !== null
-            && $path !== $entry["path"]
-            && path_is_within_root($path, $entry["path"]);
+            && path_is_descendant_of($path, $entry["path"]);
     }
 
     /**
@@ -1197,8 +1196,8 @@ class PushPlan
         }
         foreach ($this->excluded_paths as $excluded_path) {
             if (
-                path_is_within_root($document_root_relative_path, $excluded_path)
-                || path_is_within_root($excluded_path, $document_root_relative_path)
+                path_is_same_as_or_descendant_of($document_root_relative_path, $excluded_path)
+                || path_is_same_as_or_descendant_of($excluded_path, $document_root_relative_path)
             ) {
                 return true;
             }

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -113,7 +113,7 @@ final class FileIndexProcessor {
         // An ordinary traversal must begin inside a configured root. Following
         // links deliberately relaxes that boundary because a link target may
         // be outside every configured root and still belong in the index.
-        if (!$follow_symlinks && !\WordPress\Reprint\Exporter\path_is_within_root($canonical_index_directory, $directories)) {
+        if (!$follow_symlinks && !\WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of($canonical_index_directory, $directories)) {
             throw new InvalidArgumentException(
                 "list_dir is outside of allowed roots: {$canonical_index_directory}"
             );
@@ -321,7 +321,7 @@ final class FileIndexProcessor {
         }
         if (
             $this->storage_path !== ""
-            && \WordPress\Reprint\Exporter\path_is_within_root($path, $this->storage_path)
+            && \WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of($path, $this->storage_path)
         ) {
             $this->step_status = self::STATUS_SKIPPED;
             return true;
@@ -416,7 +416,7 @@ final class FileIndexProcessor {
             $canonical_directory = realpath($path);
             if (
                 $canonical_directory === false
-                || !\WordPress\Reprint\Exporter\path_is_within_root($this->directories, $canonical_directory)
+                || !\WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of($this->directories, $canonical_directory)
             ) {
                 $this->directory_stack[] = [
                     "dir" => $path,
@@ -653,7 +653,7 @@ final class FileIndexProcessor {
         // boundary, then continue with the remaining stack.
         if (
             !$this->follow_symlinks
-            && !\WordPress\Reprint\Exporter\path_is_within_root($canonical_directory, $this->directories)
+            && !\WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of($canonical_directory, $this->directories)
         ) {
             array_pop($this->directory_stack);
             $this->directory_error = [

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -7,7 +7,7 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 
 /**
@@ -112,7 +112,7 @@ final class Site_Export_Push_Endpoints {
         if ($canonical_docroot === false) {
             $canonical_docroot = normalize_path($docroot);
         }
-        if (path_is_within_root($canonical_reprint_directory, $canonical_docroot)) {
+        if (path_is_same_as_or_descendant_of($canonical_reprint_directory, $canonical_docroot)) {
             throw new InvalidArgumentException(
                 'Push endpoints require reprint_directory ' . json_encode($reprint_directory)
                 . ' to be outside docroot ' . json_encode($docroot) . '; observed it inside that document root.'

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -8,7 +8,7 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\build_pdo_dsn;
 use function WordPress\Reprint\Exporter\json_encode_or_throw;
 use function WordPress\Reprint\Exporter\parse_size;
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
 require_once __DIR__ . '/class-file-index-processor.php';

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -319,42 +319,97 @@ function normalize_excluded_paths(array $excluded_paths): array
 // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
 /**
- * Returns true when one path is equal to or strictly under one root.
+ * Indicates whether a candidate path is the same as or a descendant of an
+ * ancestor.
  *
- * Either argument may be a list. The result is true when any path-and-root
- * pair matches. The filesystem root contains every absolute path, and cannot
- * use the normal root-plus-slash prefix because that would produce `//`.
+ * Either argument may be a list. The result is true when any candidate-and-
+ * ancestor pair matches. The filesystem root matches every absolute path and
+ * cannot use the normal ancestor-plus-slash prefix because that would produce
+ * `//`.
+ *
+ * Examples:
+ *
+ *     path_is_same_as_or_descendant_of('/srv/site', '/srv/site');            // true
+ *     path_is_same_as_or_descendant_of('/srv/site/wp-content', '/srv/site'); // true
+ *     path_is_same_as_or_descendant_of('/srv/site-old', '/srv/site');        // false
+ *     path_is_same_as_or_descendant_of('/', '/');                             // true
  *
  * @param string|list<string> $path Candidate path or paths.
- * @param string|list<string> $root Containing root or roots.
- * @return bool Whether a candidate path belongs to a root.
+ * @param string|list<string> $ancestor Ancestor path or paths.
+ * @return bool Whether a candidate is the same as or a descendant of an
+ *              ancestor.
  * @throws InvalidArgumentException If either scalar value is not a string.
  */
-function path_is_within_root($path, $root): bool
+function path_is_same_as_or_descendant_of($path, $ancestor): bool
 {
     if (is_array($path)) {
         foreach ($path as $candidate_path) {
-            if (path_is_within_root($candidate_path, $root)) {
+            if (path_is_same_as_or_descendant_of($candidate_path, $ancestor)) {
                 return true;
             }
         }
         return false;
     }
-    if (is_array($root)) {
-        foreach ($root as $candidate_root) {
-            if (path_is_within_root($path, $candidate_root)) {
+    if (is_array($ancestor)) {
+        foreach ($ancestor as $candidate_ancestor) {
+            if (path_is_same_as_or_descendant_of($path, $candidate_ancestor)) {
                 return true;
             }
         }
         return false;
     }
-    if (!is_string($path) || !is_string($root)) {
+    if (!is_string($path) || !is_string($ancestor)) {
         throw new InvalidArgumentException('Path containment expects strings or lists of strings.');
     }
-    if ($root === "/") {
+    if ($ancestor === "/") {
         return str_starts_with($path, "/");
     }
-    return $path === $root || str_starts_with($path, $root . "/");
+    return $path === $ancestor || str_starts_with($path, $ancestor . "/");
+}
+
+/**
+ * Indicates whether a candidate path is a descendant of an ancestor.
+ *
+ * Either argument may be a list. The result is true when any candidate-and-
+ * ancestor pair has a component-boundary match below the ancestor. Unlike
+ * path_is_same_as_or_descendant_of(), equal paths do not match. The
+ * filesystem root contains every absolute descendant, but not itself.
+ *
+ * Examples:
+ *
+ *     path_is_descendant_of('/srv/site/wp-content', '/srv/site'); // true
+ *     path_is_descendant_of('/srv/site', '/srv/site');            // false
+ *     path_is_descendant_of('/srv/site-old', '/srv/site');        // false
+ *     path_is_descendant_of('/wp-content', '/');                  // true
+ *     path_is_descendant_of('/', '/');                             // false
+ *
+ * @param string|list<string> $path Candidate path or paths.
+ * @param string|list<string> $ancestor Ancestor path or paths.
+ * @return bool Whether a candidate is a descendant of an ancestor.
+ * @throws InvalidArgumentException If either scalar value is not a string.
+ */
+function path_is_descendant_of($path, $ancestor): bool
+{
+    if (is_array($path)) {
+        foreach ($path as $candidate_path) {
+            if (path_is_descendant_of($candidate_path, $ancestor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (is_array($ancestor)) {
+        foreach ($ancestor as $candidate_ancestor) {
+            if (path_is_descendant_of($path, $candidate_ancestor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (!path_is_same_as_or_descendant_of($path, $ancestor)) {
+        return false;
+    }
+    return $path !== $ancestor;
 }
 
 /**

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -3,7 +3,8 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
-use function WordPress\Reprint\Exporter\path_is_within_root;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\path_is_descendant_of;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
@@ -198,14 +199,14 @@ class RemapSeamTest extends TestCase
     }
 
     /**
-     * @dataProvider providePathWithinRootCases
+     * @dataProvider providePathSameAsOrDescendantOfCases
      */
-    public function testPathIsWithinRoot(bool $expected, string $path, string $root): void
+    public function testPathIsSameAsOrDescendantOf(bool $expected, string $path, string $ancestor): void
     {
-        $this->assertSame($expected, path_is_within_root($path, $root));
+        $this->assertSame($expected, path_is_same_as_or_descendant_of($path, $ancestor));
     }
 
-    public static function providePathWithinRootCases(): array
+    public static function providePathSameAsOrDescendantOfCases(): array
     {
         return array(
             'filesystem root itself' => array(true, '/', '/'),
@@ -217,16 +218,51 @@ class RemapSeamTest extends TestCase
         );
     }
 
-    public function testPathIsWithinRootMatchesAnyPathAndRoot(): void
+    public function testPathIsSameAsOrDescendantOfMatchesAnyPathAndAncestor(): void
     {
-        $this->assertTrue(path_is_within_root('/a/b', ['/elsewhere', '/a']));
-        $this->assertTrue(path_is_within_root(['/elsewhere', '/a/b'], '/a'));
-        $this->assertTrue(path_is_within_root(
+        $this->assertTrue(path_is_same_as_or_descendant_of('/a/b', ['/elsewhere', '/a']));
+        $this->assertTrue(path_is_same_as_or_descendant_of(['/elsewhere', '/a/b'], '/a'));
+        $this->assertTrue(path_is_same_as_or_descendant_of(
             ['/elsewhere', '/a/b'],
             ['/not-this-one', '/a']
         ));
-        $this->assertFalse(path_is_within_root(
+        $this->assertFalse(path_is_same_as_or_descendant_of(
             ['/elsewhere', '/other'],
+            ['/not-this-one', '/a']
+        ));
+    }
+
+    /**
+     * @dataProvider providePathDescendantOfCases
+     */
+    public function testPathIsDescendantOf(bool $expected, string $path, string $ancestor): void
+    {
+        $this->assertSame($expected, path_is_descendant_of($path, $ancestor));
+    }
+
+    public static function providePathDescendantOfCases(): array
+    {
+        return array(
+            'filesystem root itself' => array(false, '/', '/'),
+            'filesystem root child' => array(true, '/child', '/'),
+            'relative path is outside filesystem root' => array(false, 'child', '/'),
+            'exact non-root match' => array(false, '/a', '/a'),
+            'non-root descendant' => array(true, '/a/b', '/a'),
+            'sibling prefix' => array(false, '/ab', '/a'),
+            'relative logical descendant' => array(true, 'a/b', 'a'),
+        );
+    }
+
+    public function testPathIsDescendantOfMatchesAnyPathAndAncestor(): void
+    {
+        $this->assertTrue(path_is_descendant_of('/a/b', ['/elsewhere', '/a']));
+        $this->assertTrue(path_is_descendant_of(['/elsewhere', '/a/b'], '/a'));
+        $this->assertTrue(path_is_descendant_of(
+            ['/elsewhere', '/a/b'],
+            ['/not-this-one', '/a']
+        ));
+        $this->assertFalse(path_is_descendant_of(
+            ['/elsewhere', '/a'],
             ['/not-this-one', '/a']
         ));
     }


### PR DESCRIPTION
Path ancestry checks now state whether equality counts, so a caller can select the intended relation without an extra comparison.

`path_is_same_as_or_descendant_of()` replaces the inclusive predicate, and `path_is_descendant_of()` excludes an equal path. Both retain the component-boundary, list, and filesystem-root behavior of the previous predicate. The flat-document-root, selected-source, and push-plan callers use the strict relation where an equal path must not match.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php Import/RemapResolveTest.php Import/PushPlanTest.php Import/LocalIndexUpdateFunctionsTest.php Import/FlatDocrootWpConfigTest.php Import/WpcloudHostAnalyzerTest.php PushEndpointsTest.php FileIndexProcessorTest.php --testdox --colors=never`; PHPStan; PHP 7.2/7.4 compatibility checks.