### PR TITLE
[PHP] Centralize document-root-relative path validation

### DIFF
--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -3,6 +3,7 @@
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Push errors become authenticated API JSON, never HTML output.
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_relative_path;
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\relative_path_under;
@@ -2445,9 +2446,6 @@ final class Site_Export_Push_Session {
      * @param string $path Document-root-relative raw path bytes.
      */
     private function assert_path_not_reserved(string $path): void {
-        if ($path === '') {
-            throw new InvalidArgumentException('Document-root-relative path must not be empty.');
-        }
         $path_bytes = strlen($path);
         if ($path_bytes > self::MAX_PATH_BYTES) {
             throw new InvalidArgumentException(
@@ -2455,26 +2453,7 @@ final class Site_Export_Push_Session {
                 . self::MAX_PATH_BYTES . ' bytes; observed ' . $path_bytes . '.'
             );
         }
-        if ($path[0] === '/') {
-            throw new InvalidArgumentException('Document-root-relative path must not be absolute: ' . base64_encode($path) . '.');
-        }
-        if (strpos($path, "\0") !== false) {
-            throw new InvalidArgumentException('Document-root-relative path must not contain a NUL byte: ' . base64_encode($path) . '.');
-        }
-        if (strpos($path, '\\') !== false) {
-            throw new InvalidArgumentException('Document-root-relative path must not contain a backslash: ' . base64_encode($path) . '.');
-        }
-        foreach (explode('/', $path) as $segment) {
-            if ($segment === '') {
-                throw new InvalidArgumentException('Document-root-relative path must not contain an empty component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '.') {
-                throw new InvalidArgumentException('Document-root-relative path must not contain a dot component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '..') {
-                throw new InvalidArgumentException('Document-root-relative path must not contain a parent component: ' . base64_encode($path) . '.');
-            }
-        }
+        assert_valid_relative_path($path, 'Document-root-relative path');
         if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
             throw new InvalidArgumentException('The WordPress maintenance marker path is reserved: ' . base64_encode($path) . '.');
         }

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -280,29 +280,10 @@ function normalize_excluded_paths(array $excluded_paths): array
         if (!is_string($path)) {
             throw new InvalidArgumentException('Each excluded path must be a string; observed ' . gettype($path) . '.');
         }
-        if ($path === '') {
-            throw new InvalidArgumentException('Excluded path must not be empty.');
-        }
-        if ($path[0] === '/') {
+        if ($path !== '' && $path[0] === '/') {
             throw new InvalidArgumentException('Excluded path must be document-root-relative: ' . base64_encode($path) . '.');
         }
-        if (strpos($path, "\0") !== false) {
-            throw new InvalidArgumentException('Excluded path must not contain a NUL byte: ' . base64_encode($path) . '.');
-        }
-        if (strpos($path, '\\') !== false) {
-            throw new InvalidArgumentException('Excluded path must not contain a backslash: ' . base64_encode($path) . '.');
-        }
-        foreach (explode('/', $path) as $segment) {
-            if ($segment === '') {
-                throw new InvalidArgumentException('Excluded path must not contain an empty component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '.') {
-                throw new InvalidArgumentException('Excluded path must not contain a dot component: ' . base64_encode($path) . '.');
-            }
-            if ($segment === '..') {
-                throw new InvalidArgumentException('Excluded path must not contain a parent component: ' . base64_encode($path) . '.');
-            }
-        }
+        assert_valid_relative_path($path, 'Excluded path');
         $normalized_excluded_paths[] = $path;
     }
     sort($normalized_excluded_paths, SORT_STRING);
@@ -315,6 +296,51 @@ function normalize_excluded_paths(array $excluded_paths): array
         );
     }
     return $normalized_excluded_paths;
+}
+
+/**
+ * Validates a document-root-relative path carried as raw bytes.
+ *
+ * A valid path has one or more slash-delimited components. It cannot be
+ * absolute, use Windows separators, include a NUL byte, or contain empty,
+ * current-directory, or parent-directory components. It deliberately does
+ * not trim whitespace: spaces and other non-reserved bytes are valid file
+ * name bytes.
+ *
+ * Examples:
+ *
+ *     assert_valid_relative_path('wp-content/plugins', 'Excluded path');
+ *     assert_valid_relative_path('index.php', 'Document-root-relative path');
+ *
+ * @param string $path Raw path bytes to validate.
+ * @param string $label Human-readable name at the start of validation errors.
+ * @throws InvalidArgumentException When the path has a reserved form.
+ */
+function assert_valid_relative_path(string $path, string $label): void
+{
+    if ($path === '') {
+        throw new InvalidArgumentException("{$label} must not be empty.");
+    }
+    if ($path[0] === '/') {
+        throw new InvalidArgumentException("{$label} must not be absolute: " . base64_encode($path) . '.');
+    }
+    if (strpos($path, "\0") !== false) {
+        throw new InvalidArgumentException("{$label} must not contain a NUL byte: " . base64_encode($path) . '.');
+    }
+    if (strpos($path, '\\') !== false) {
+        throw new InvalidArgumentException("{$label} must not contain a backslash: " . base64_encode($path) . '.');
+    }
+    foreach (explode('/', $path) as $component) {
+        if ($component === '') {
+            throw new InvalidArgumentException("{$label} must not contain an empty component: " . base64_encode($path) . '.');
+        }
+        if ($component === '.') {
+            throw new InvalidArgumentException("{$label} must not contain a dot component: " . base64_encode($path) . '.');
+        }
+        if ($component === '..') {
+            throw new InvalidArgumentException("{$label} must not contain a parent component: " . base64_encode($path) . '.');
+        }
+    }
 }
 // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -3,8 +3,9 @@
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
-use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\assert_valid_relative_path;
 use function WordPress\Reprint\Exporter\path_is_descendant_of;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
@@ -152,6 +153,39 @@ class RemapSeamTest extends TestCase
             'trailing slash on path' => array('', '/home/adam/', '/home/adam'),
             'trailing slash on both' => array('', '/home/adam/', '/home/adam/'),
             'under, prefix has trailing slash' => array('/c', '/a/b/c', '/a/b/'),
+        );
+    }
+
+    public function testAssertValidRelativePathAllowsDocumentRootDescendants(): void
+    {
+        foreach (array('index.php', 'wp-content/plugins/example.php', 'leading space/file') as $path) {
+            assert_valid_relative_path($path, 'Document-root-relative path');
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider provideInvalidRelativePathCases
+     */
+    public function testAssertValidRelativePathRejectsReservedForms(string $path, string $message): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        assert_valid_relative_path($path, 'Document-root-relative path');
+    }
+
+    public static function provideInvalidRelativePathCases(): array
+    {
+        return array(
+            'empty path' => array('', 'Document-root-relative path must not be empty.'),
+            'absolute path' => array('/index.php', 'Document-root-relative path must not be absolute: L2luZGV4LnBocA==.'),
+            'NUL byte' => array("nul\0byte", 'Document-root-relative path must not contain a NUL byte: bnVsAGJ5dGU=.'),
+            'backslash' => array('windows\\path', 'Document-root-relative path must not contain a backslash: d2luZG93c1xwYXRo.'),
+            'empty component' => array('wp-content//plugins', 'Document-root-relative path must not contain an empty component: d3AtY29udGVudC8vcGx1Z2lucw==.'),
+            'dot component' => array('./index.php', 'Document-root-relative path must not contain a dot component: Li9pbmRleC5waHA=.'),
+            'parent component' => array('wp-content/../index.php', 'Document-root-relative path must not contain a parent component: d3AtY29udGVudC8uLi9pbmRleC5waHA=.'),
         );
     }
 


### PR DESCRIPTION
Push endpoint configuration and multipart document-root paths now reject the same malformed forms while keeping their caller-specific limits, reservations, and error wording.

`assert_valid_relative_path()` owns the shared raw-byte grammar: nonempty, relative, slash-delimited paths without NUL bytes, backslashes, empty components, or dot components. It documents valid examples and intentionally does not trim filename bytes.

Excluded-path normalization retains its configuration-specific absolute-path message. The push session retains its 4096-byte limit and `.maintenance` reservation.

Tests: `cd tests && ../vendor/bin/phpunit Import/RemapSeamTest.php PushEndpointsTest.php PushSessionTest.php Import/SortIndexFileTest.php --testdox --colors=never`; `vendor/bin/phpstan analyse --memory-limit=1G`; PHP 7.2/7.4 compatibility checks.