### PR TITLE
[PHP] Use cautious URL replacement in text leaves

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -1,7 +1,6 @@
 <?php
 
 use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
-use WordPress\DataLiberation\URL\URLInTextProcessor;
 use WordPress\DataLiberation\URL\WPURL;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
@@ -19,14 +18,17 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → BlockMarkupUrlProcessor (block_markup hint) or
- *    URLInTextProcessor (default)
+ * 4. A `data-settings` HTML attribute containing valid JSON → recurse on its
+ *    JSON string leaves
+ * 5. Leaf text → BlockMarkupUrlProcessor (block_markup hint) or
+ *    URLInPotentiallyStructuredTextProcessor (default)
  *
- * HTML is never auto-detected — the caller must explicitly pass
- * content_type='block_markup' for values known to contain HTML/block markup.
- * The hint propagates through recursive calls so that leaf strings inside
- * serialized PHP, JSON, or base64 eventually reach the same block-markup
- * parser.
+ * HTML is not broadly auto-detected. The narrow `data-settings` case is safe
+ * to recognize because both the HTML attribute and its JSON value must parse
+ * before this rewriter enters either layer. Other HTML/block markup requires
+ * content_type='block_markup'. The hint propagates through recursive calls so
+ * that leaf strings inside serialized PHP, JSON, or base64 eventually reach
+ * the same block-markup parser.
  */
 class StructuredDataUrlRewriter
 {
@@ -63,6 +65,9 @@ class StructuredDataUrlRewriter
     /** @var string Cache namespace for this rewriter's URL mapping. */
     private string $mapping_cache_key;
 
+    /** @var array<string, string> Source URL base => target URL base. */
+    private array $url_mapping;
+
     /** @var array<string, array{content_type: string, input: string, output: string}> */
     private array $structured_rewrite_cache = [];
 
@@ -84,6 +89,8 @@ class StructuredDataUrlRewriter
      */
     public function __construct(array $url_mapping)
     {
+        $this->url_mapping = $url_mapping;
+
         // Extract unique source domains for the quick-reject check.
         $domains = [];
         foreach (array_keys($url_mapping) as $from_url) {
@@ -134,7 +141,27 @@ class StructuredDataUrlRewriter
             $content_type = self::PLAIN_TEXT;
         }
 
-        $structured_cache_key = sha1($content_type . "\0" . $value);
+        return $this->rewrite_value($value, $content_type, false);
+    }
+
+    /**
+     * Rewrite a value, distinguishing top-level input from a string that an
+     * enclosing parser has already accepted.
+     *
+     * A malformed top-level PHP serialization or JSON value stays untouched:
+     * its enclosing escaping rules are unknown. A malformed nested candidate
+     * is instead ordinary text within a parser-confirmed string leaf, and may
+     * take the cautious opaque-text path.
+     */
+    private function rewrite_value(string $value, string $content_type, bool $is_parser_confirmed_string_leaf): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        $structured_cache_key = sha1(
+            $content_type . "\0" . ( $is_parser_confirmed_string_leaf ? 'leaf' : 'top-level' ) . "\0" . $value
+        );
         $cached = $this->get_cached_structured_rewrite($structured_cache_key, $content_type, $value);
         if ($cached !== null) {
             return $cached;
@@ -154,18 +181,21 @@ class StructuredDataUrlRewriter
         // cannot expose serialized string values for rewriting.
         if ($this->could_be_php_serialization_with_strings($value)) {
             $p = new PhpSerializationProcessor($value);
-            if (!$p->is_malformed()) {
-                while ($p->next_value()) {
-                    $original = $p->get_value();
-                    $rewritten = $this->rewrite($original, $content_type);
-                    if ($rewritten !== $original) {
-                        $p->set_value($rewritten);
-                    }
-                }
-                $rewritten_value = $p->get_updated_serialization();
-                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
-                return $rewritten_value;
+            if ($p->is_malformed()) {
+                return $is_parser_confirmed_string_leaf
+                    ? $this->rewrite_leaf_text($value, $content_type)
+                    : $value;
             }
+            while ($p->next_value()) {
+                $original = $p->get_value();
+                $rewritten = $this->rewrite_value($original, $content_type, true);
+                if ($rewritten !== $original) {
+                    $p->set_value($rewritten);
+                }
+            }
+            $rewritten_value = $p->get_updated_serialization();
+            $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+            return $rewritten_value;
         }
 
         // Performance guard: avoid calling json_decode() for ordinary URL
@@ -173,19 +203,20 @@ class StructuredDataUrlRewriter
         // once entered; this gate only skips first non-whitespace bytes that
         // cannot start a JSON value containing string leaves.
         if ($this->could_be_json_with_strings($value)) {
-            $iter = new JsonStringIterator($value);
-            if (!$iter->is_malformed()) {
-                while ($iter->next_value()) {
-                    $original = $iter->get_value();
-                    $rewritten = $this->rewrite($original, $content_type);
-                    if ($rewritten !== $original) {
-                        $iter->set_value($rewritten);
-                    }
-                }
-                $rewritten_value = $iter->get_result();
-                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
-                return $rewritten_value;
+            $rewritten_value = $this->rewrite_json_value($value, $content_type);
+            if ($rewritten_value === null) {
+                return $is_parser_confirmed_string_leaf
+                    ? $this->rewrite_leaf_text($value, $content_type)
+                    : $value;
             }
+            $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+            return $rewritten_value;
+        }
+
+        $rewritten_value = $this->rewrite_json_in_data_settings_attributes($value, $content_type);
+        if ($rewritten_value !== null) {
+            $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+            return $rewritten_value;
         }
 
         // Base64 decoding is temporarily disabled for performance.
@@ -193,9 +224,112 @@ class StructuredDataUrlRewriter
         // Base64ValueScanner in SqlStatementRewriter — this block
         // was for base64-within-base64 nesting which is rare in practice.
 
-        $rewritten_value = $this->rewrite_urls($value, $content_type);
+        $rewritten_value = $this->rewrite_leaf_text($value, $content_type);
         $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
         return $rewritten_value;
+    }
+
+    /**
+     * Rewrite valid JSON while preserving its enclosing JSON representation.
+     *
+     * @return string|null Updated JSON, or null when the JSON is malformed.
+     */
+    private function rewrite_json_value(string $value, string $content_type): ?string
+    {
+        $iter = new JsonStringIterator($value);
+        if ($iter->is_malformed()) {
+            return null;
+        }
+
+        while ($iter->next_value()) {
+            $original = $iter->get_value();
+            $rewritten = $this->rewrite_value($original, $content_type, true);
+            if ($rewritten !== $original) {
+                $iter->set_value($rewritten);
+            }
+        }
+
+        return $iter->get_result();
+    }
+
+    /**
+     * Rewrite JSON stored in the page-builder `data-settings` HTML attribute.
+     *
+     * The tag processor must recognize the attribute and the JSON parser must
+     * accept its value. An invalid JSON value is deliberately left unchanged;
+     * this method still reports that it handled the surrounding structured
+     * value so the opaque-text path cannot guess at its escape rules.
+     *
+     * @return string|null Updated HTML, or null when no `data-settings` HTML
+     *                     attribute was found.
+     */
+    private function rewrite_json_in_data_settings_attributes(string $value, string $content_type): ?string
+    {
+        if (stripos($value, 'data-settings') === false) {
+            return null;
+        }
+
+        $processor = new WP_HTML_PHP_Tag_Processor($value);
+        $found_data_settings = false;
+        while ($processor->next_tag()) {
+            $original = $processor->get_attribute('data-settings');
+            if (!is_string($original)) {
+                continue;
+            }
+
+            $found_data_settings = true;
+            $rewritten = $this->rewrite_json_value($original, $content_type);
+            if ($rewritten !== null && $rewritten !== $original) {
+                $processor->set_attribute('data-settings', $rewritten);
+            }
+        }
+
+        return $found_data_settings ? $processor->get_updated_html() : null;
+    }
+
+    private function rewrite_leaf_text(string $value, string $content_type): string
+    {
+        $rewritten_value = $this->rewrite_urls($value, $content_type);
+
+        if ($content_type === self::BLOCK_MARKUP) {
+            return $this->rewrite_json_ld_script_elements($rewritten_value, $content_type);
+        }
+
+        return $rewritten_value;
+    }
+
+    /**
+     * Rewrite valid JSON-LD script contents without treating other scripts as
+     * structured data. JSON-LD is identified by the MIME type's essence, so a
+     * charset parameter does not prevent rewriting.
+     */
+    private function rewrite_json_ld_script_elements(string $value, string $content_type): string
+    {
+        if (stripos($value, 'application/ld+json') === false) {
+            return $value;
+        }
+
+        $processor = new WP_HTML_PHP_Tag_Processor($value);
+        while ($processor->next_token()) {
+            if ($processor->get_token_type() !== '#tag'
+                || $processor->get_tag() !== 'SCRIPT') {
+                continue;
+            }
+
+            $type = $processor->get_attribute('type');
+            if (!is_string($type)
+                || strtolower(trim(explode(';', $type, 2)[0])) !== 'application/ld+json') {
+                continue;
+            }
+
+            $original = $processor->get_modifiable_text();
+            $rewritten = $this->rewrite_json_value($original, $content_type);
+            if ($rewritten !== null && $rewritten !== $original) {
+                $processor->set_modifiable_text($rewritten);
+            }
+        }
+
+        return $processor->get_updated_html();
     }
 
     /**
@@ -244,9 +378,11 @@ class StructuredDataUrlRewriter
      *
      * This is a speed guard before constructing JsonStringIterator, whose
      * constructor calls json_decode(). Objects and arrays can contain nested
-     * string leaves, and JSON string scalars can themselves be rewritten. The
-     * iterator remains responsible for full JSON validation after this coarse
-     * first-byte check passes.
+     * string leaves, and JSON string scalars can themselves be rewritten. An
+     * array also checks its first non-whitespace value byte: a shortcode name
+     * such as `[vc_row ...]` cannot start JSON, while JSON's `true`, `false`,
+     * and `null` literals remain valid starts. The iterator remains
+     * responsible for full JSON validation after this syntax gate passes.
      */
     private function could_be_json_with_strings(string $value): bool
     {
@@ -257,7 +393,31 @@ class StructuredDataUrlRewriter
                 continue;
             }
 
-            return $byte === '{' || $byte === '[' || $byte === '"';
+            if ($byte !== '[') {
+                return $byte === '{' || $byte === '"';
+            }
+
+            for (++$i; $i < $length; $i++) {
+                $first_array_value_byte = $value[$i];
+                if ($first_array_value_byte === ' '
+                    || $first_array_value_byte === "\n"
+                    || $first_array_value_byte === "\r"
+                    || $first_array_value_byte === "\t") {
+                    continue;
+                }
+
+                return $first_array_value_byte === ']'
+                    || $first_array_value_byte === '{'
+                    || $first_array_value_byte === '['
+                    || $first_array_value_byte === '"'
+                    || $first_array_value_byte === '-'
+                    || ($first_array_value_byte >= '0' && $first_array_value_byte <= '9')
+                    || $first_array_value_byte === 't'
+                    || $first_array_value_byte === 'f'
+                    || $first_array_value_byte === 'n';
+            }
+
+            return true;
         }
 
         return false;
@@ -484,44 +644,9 @@ class StructuredDataUrlRewriter
                 return $p->get_updated_html();
 
             case self::PLAIN_TEXT:
-                $p = new URLInTextProcessor( $content, $base_url );
+                $p = new URLInPotentiallyStructuredTextProcessor($content, $this->url_mapping);
                 while ( $p->next_url() ) {
-                    $raw_url = $p->get_raw_url();
-                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url;
-                    $cached = $this->get_cached_rewrite_result($cache_key);
-                    if ($cached !== null) {
-                        if ($cached !== false) {
-                            $p->set_raw_url($cached['raw_url']);
-                        }
-                        continue;
-                    }
-
-                    $parsed_url = $p->get_parsed_url();
-                    $converted = false;
-                    foreach ( $parsed_mapping as $mapping ) {
-                        if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $converted = WPURL::replace_base_url(
-                                $parsed_url,
-                                array(
-                                    'old_base_url' => $base_url,
-                                    'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $p->get_raw_url(),
-                                    'is_relative'  => false,
-                                )
-                            );
-                            break;
-                        }
-                    }
-
-                    $cache_value = false;
-                    if ($converted !== false) {
-                        $cache_value = [
-                            'raw_url'    => (string) $converted,
-                            'parsed_url' => $converted->new_url,
-                        ];
-                        $p->set_raw_url($cache_value['raw_url']);
-                    }
-                    $this->set_cached_rewrite_result($cache_key, $cache_value);
+                    $p->replace_url_base();
                 }
 
                 return $p->get_updated_text();

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -21,7 +21,7 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * 4. A `data-settings` HTML attribute containing valid JSON → recurse on its
  *    JSON string leaves
  * 5. Leaf text → BlockMarkupUrlProcessor (block_markup hint) or
- *    URLInPotentiallyStructuredTextProcessor (default)
+ *    LimitedURLBaseInOpaqueTextProcessor (default)
  *
  * HTML is not broadly auto-detected. The narrow `data-settings` case is safe
  * to recognize because both the HTML attribute and its JSON value must parse
@@ -644,7 +644,7 @@ class StructuredDataUrlRewriter
                 return $p->get_updated_html();
 
             case self::PLAIN_TEXT:
-                $p = new URLInPotentiallyStructuredTextProcessor($content, $this->url_mapping);
+                $p = new LimitedURLBaseInOpaqueTextProcessor($content, $this->url_mapping);
                 while ( $p->next_url() ) {
                     $p->replace_url_base();
                 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,12 +26,6 @@ parameters:
         -
             message: '#^Call to an undefined method WordPress\\DataLiberation\\BlockMarkup\\BlockMarkupUrlProcessor::get_tag\(\)\.$#'
             path: packages/reprint-client/src/lib/url-rewrite/class-domain-collector.php
-        -
-            message: '#^Class WordPress\\DataLiberation\\URL\\URLInTextProcessor does not have a constructor and must be instantiated without any parameters\.$#'
-            path: packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
-        -
-            message: '#^Call to an undefined method WordPress\\DataLiberation\\URL\\URLInTextProcessor::(next_url|get_parsed_url|get_raw_url|set_raw_url|get_updated_text)\(\)\.$#'
-            path: packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
     treatPhpDocTypesAsCertain: false
     scanDirectories:
         - packages/reprint-server/src

--- a/tests/UrlRewriting/StructuredDataUrlRewriterExportCorpusTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterExportCorpusTest.php
@@ -1,0 +1,236 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.php';
+
+class StructuredDataUrlRewriterExportCorpusTest extends TestCase {
+    private const SOURCE_URL = 'https://source.example/wp-content/uploads';
+    private const TARGET_URL = 'https://destination.example/wp-content/uploads';
+
+    /**
+     * @dataProvider structuredSiteBuilderExports
+     *
+     * @param array<int, string> $suffixes
+     */
+    public function testRewritesUrlsInKnownStructuredSiteBuilderExports(
+        string $format,
+        string $input,
+        array $suffixes,
+        ?string $content_type = null
+    ): void {
+        $output = $this->createRewriter()->rewrite($input, $content_type);
+
+        $value_to_inspect = $output;
+
+        if ($format === 'json') {
+            $this->assertNotNull(json_decode($output, true));
+        }
+
+        if ($format === 'serialized_php') {
+            $unserialized = @unserialize($output);
+            $this->assertNotFalse($unserialized);
+            $value_to_inspect = json_encode($unserialized, JSON_UNESCAPED_SLASHES);
+        }
+
+        $this->assertStringNotContainsString('source.example', $value_to_inspect);
+        $this->assertSame(
+            count($suffixes),
+            substr_count($value_to_inspect, 'destination.example')
+        );
+        foreach ($suffixes as $suffix) {
+            $this->assertStringContainsString(
+                substr($suffix, strrpos($suffix, '/') + 1),
+                $value_to_inspect
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, string, array<int, string>, string|null}>
+     */
+    public static function structuredSiteBuilderExports(): iterable
+    {
+        yield 'Elementor document with image and background controls' => [
+            'json',
+            '{"title":"Home","type":"page","version":"0.4","content":['
+            . '{"id":"a1b2c3","elType":"section","settings":{'
+            . '"background_background":"classic","background_image":{'
+            . '"url":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/hero.jpg?ver=1"}}},'
+            . '{"id":"d4e5f6","elType":"widget","widgetType":"image","settings":{'
+            . '"image":{"url":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/logo.svg#mark"}}}]}',
+            ['/wp-content/uploads/2026/01/hero.jpg?ver=1', '/wp-content/uploads/2026/01/logo.svg#mark'],
+            null,
+        ];
+
+        yield 'Elementor JSON containing a WPBakery shortcode leaf' => [
+            'json',
+            '{"content":"[vc_row css=\\".vc_custom{background:url(https:\\\\/\\\\/source.example\\\\/wp-content\\\\/uploads\\\\/2026\\\\/01\\\\/hero.jpg)}\\"]"}',
+            ['/wp-content/uploads/2026/01/hero.jpg'],
+            null,
+        ];
+
+        yield 'top-level WPBakery shortcode' => [
+            'shortcode',
+            '[read_more_button url="https://source.example/wp-content/uploads/2026/01/read-more/" top_margin="page_margin_top"]',
+            ['/wp-content/uploads/2026/01/read-more/'],
+            null,
+        ];
+
+        yield 'JSON array beginning with null before a URL string' => [
+            'json',
+            '[null,"https://source.example/wp-content/uploads/2026/01/read-more/"]',
+            ['/wp-content/uploads/2026/01/read-more/'],
+            null,
+        ];
+
+        yield 'HTML data-settings attribute containing JSON Unicode escapes' => [
+            'html',
+            '<div data-settings=\'{"image":"https:\\u002F\\u002Fsource.example\\u002Fwp-content\\u002Fuploads\\u002F2026\\u002F01\\u002Fhero.jpg"}\'></div>',
+            ['/wp-content/uploads/2026/01/hero.jpg'],
+            null,
+        ];
+
+        yield 'JSON-LD script in block markup' => [
+            'block_markup',
+            '<script type="application/ld+json; charset=utf-8">'
+            . '{"@context":"https://source.example/wp-content/uploads/schema",'
+            . '"image":{"url":"https://source.example/wp-content/uploads/2026/01/hero.jpg"}}'
+            . '</script>',
+            ['/wp-content/uploads/schema', '/wp-content/uploads/2026/01/hero.jpg'],
+            StructuredDataUrlRewriter::BLOCK_MARKUP,
+        ];
+
+        yield 'Breakdance style JSON with a nested CSS declaration' => [
+            'json',
+            '{"data":{"tree":{"root":{"type":"section","properties":{'
+            . '"background":{"image":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/cover.webp"},'
+            . '"custom_css":".root{mask:url(https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/mask.svg#shape)}"}}}}}',
+            ['/wp-content/uploads/2026/01/cover.webp', '/wp-content/uploads/2026/01/mask.svg#shape'],
+            null,
+        ];
+
+        yield 'SiteOrigin style widget configuration' => [
+            'json',
+            '{"widgets":[{"panels_info":{"class":"SiteOrigin_Widget_Image_Widget"},'
+            . '"image":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/panel.jpg"},'
+            . '{"panels_info":{"class":"SiteOrigin_Widget_Hero_Widget"},'
+            . '"frames":[{"background":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/frame.jpg"}]}]}',
+            ['/wp-content/uploads/2026/01/panel.jpg', '/wp-content/uploads/2026/01/frame.jpg'],
+            null,
+        ];
+
+        yield 'Beaver Builder serialized layout with nested module settings' => [
+            'serialized_php',
+            serialize([
+                'nodes' => [
+                    'node-a' => [
+                        'type' => 'photo',
+                        'settings' => [
+                            'photo_src' => 'https://source.example/wp-content/uploads/2026/01/photo.jpg',
+                            'link_url' => 'https://source.example/wp-content/uploads/2026/01/read-more.pdf?download=1',
+                        ],
+                    ],
+                    'node-b' => [
+                        'type' => 'html',
+                        'settings' => [
+                            'html' => '<div style="background:url(https:\/\/source.example\/wp-content\/uploads\/2026\/01\/texture.png);"></div>',
+                        ],
+                    ],
+                ],
+            ]),
+            [
+                '/wp-content/uploads/2026/01/photo.jpg',
+                '/wp-content/uploads/2026/01/read-more.pdf?download=1',
+                '/wp-content/uploads/2026/01/texture.png',
+            ],
+            null,
+        ];
+
+        yield 'Avada serialized options containing raw CSS' => [
+            'serialized_php',
+            serialize([
+                'fusion_builder' => [
+                    'background_image' => 'https://source.example/wp-content/uploads/2026/01/cover.jpg',
+                    'custom_css' => '.fusion-builder-row{background-image:url(https://source.example/wp-content/uploads/2026/01/row.jpg);}',
+                ],
+            ]),
+            ['/wp-content/uploads/2026/01/cover.jpg', '/wp-content/uploads/2026/01/row.jpg'],
+            null,
+        ];
+
+        yield 'Gutenberg block markup with HTML image and JSON block attributes' => [
+            'block_markup',
+            '<!-- wp:cover {"url":"https://source.example/wp-content/uploads/2026/01/cover.jpg",'
+            . '"id":42,"dimRatio":50} --><div class="wp-block-cover">'
+            . '<img src="https://source.example/wp-content/uploads/2026/01/cover.jpg" alt="">'
+            . '</div><!-- /wp:cover -->',
+            ['/wp-content/uploads/2026/01/cover.jpg', '/wp-content/uploads/2026/01/cover.jpg'],
+            StructuredDataUrlRewriter::BLOCK_MARKUP,
+        ];
+
+        yield 'serialized Gutenberg markup retained as a string leaf' => [
+            'serialized_php',
+            serialize([
+                'post_content' => '<!-- wp:image {"id":12} --><figure class="wp-block-image">'
+                    . '<img src="https://source.example/wp-content/uploads/2026/01/photo.jpg" alt="">'
+                    . '</figure><!-- /wp:image -->',
+            ]),
+            ['/wp-content/uploads/2026/01/photo.jpg'],
+            StructuredDataUrlRewriter::BLOCK_MARKUP,
+        ];
+    }
+
+    public function testLeavesMalformedBuilderPayloadsByteIdentical(): void
+    {
+        $rewriter = $this->createRewriter();
+        $values = [
+            '{"content":[{"settings":{"image":{"url":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/hero.jpg"}}},]}',
+            'a:1:{s:7:"content";s:999:"https://source.example/wp-content/uploads/2026/01/hero.jpg";}',
+        ];
+
+        foreach ($values as $value) {
+            $this->assertSame($value, $rewriter->rewrite($value));
+        }
+    }
+
+    public function testLeavesMalformedJsonInADataSettingsAttributeByteIdentical(): void
+    {
+        $input = '<div data-settings=\'{"image":"https:\\u002F\\u002Fsource.example\\u002Fwp-content\\u002Fuploads\\u002F2026\\u002F01\\u002Fhero.jpg",}\'></div>';
+
+        $this->assertSame($input, $this->createRewriter()->rewrite($input));
+    }
+
+    public function testLeavesMalformedJsonLdScriptByteIdentical(): void
+    {
+        $input = '<script type="application/ld+json">'
+            . '{"@context":"https://source.example/wp-content/uploads/schema",}'
+            . '</script>';
+
+        $this->assertSame(
+            $input,
+            $this->createRewriter()->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+    }
+
+    public function testWritesUnicodeDestinationDomainsAsPunycodeInAnElementorDocument(): void
+    {
+        $input = '{"content":[{"settings":{"image":{"url":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/logo.png"}}}]}';
+        $output = ( new StructuredDataUrlRewriter([
+            self::SOURCE_URL => 'https://xn--bcher-kva.example/wp-content/uploads',
+        ]) )->rewrite($input);
+
+        $this->assertStringContainsString('xn--bcher-kva.example', $output);
+        $this->assertStringNotContainsString('bücher.example', $output);
+        $this->assertSame(
+            'https://xn--bcher-kva.example/wp-content/uploads/2026/01/logo.png',
+            json_decode($output, true)['content'][0]['settings']['image']['url']
+        );
+    }
+
+    private function createRewriter(): StructuredDataUrlRewriter
+    {
+        return new StructuredDataUrlRewriter([self::SOURCE_URL => self::TARGET_URL]);
+    }
+}

--- a/tests/UrlRewriting/StructuredDataUrlRewriterExportCorpusTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterExportCorpusTest.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.
 
 class StructuredDataUrlRewriterExportCorpusTest extends TestCase {
     private const SOURCE_URL = 'https://source.example/wp-content/uploads';
-    private const TARGET_URL = 'https://destination.example/wp-content/uploads';
+    private const TARGET_URL = 'https://destination.example';
 
     /**
      * @dataProvider structuredSiteBuilderExports
@@ -218,7 +218,7 @@ class StructuredDataUrlRewriterExportCorpusTest extends TestCase {
     {
         $input = '{"content":[{"settings":{"image":{"url":"https:\\/\\/source.example\\/wp-content\\/uploads\\/2026\\/01\\/logo.png"}}}]}';
         $output = ( new StructuredDataUrlRewriter([
-            self::SOURCE_URL => 'https://xn--bcher-kva.example/wp-content/uploads',
+            self::SOURCE_URL => 'https://xn--bcher-kva.example',
         ]) )->rewrite($input);
 
         $this->assertStringContainsString('xn--bcher-kva.example', $output);

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -71,12 +71,15 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertEquals($input, $result);
     }
 
-    public function testDoesNotRewriteQueryString(): void
+    public function testRewritesUrlValuedQueryString(): void
     {
         $rewriter = $this->createRewriter();
         $input = 'Visit us at https://webarchive.org?url=https://old-site.com/about for more info.';
         $result = $rewriter->rewrite($input);
-        $this->assertEquals($input, $result);
+        $this->assertSame(
+            'Visit us at https://webarchive.org?url=https://new-site.com/about for more info.',
+            $result
+        );
     }
 
     // --- JSON content ---
@@ -197,16 +200,24 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($input, $result, 'Serialized PHP with no matching URLs should be byte-identical');
     }
 
-    public function testMalformedSerializedPhpFallsBackToText(): void
+    public function testMalformedSerializedPhpRemainsOpaque(): void
     {
         $rewriter = $this->createRewriter();
-        // SerializedPhpFormat::is_serialized() triggers on 's:...' ending with ';'
-        // but this is truncated/malformed — the walker will return false,
-        // falling back to text rewriting
+        // This resembles serialized PHP but is truncated/malformed. Replacing
+        // its quoted bytes could make a length-prefixed value inconsistent.
         $input = 's:999:"https://old-site.com";';
         $result = $rewriter->rewrite($input);
-        // Should have attempted text rewriting, replacing the URL
-        $this->assertStringContainsString('new-site.com', $result);
+        $this->assertSame($input, $result);
+    }
+
+    public function testMalformedJsonRemainsOpaque(): void
+    {
+        $rewriter = $this->createRewriter();
+        // This is not a complete JSON document. Replacing its quoted bytes
+        // would assume escape and string-boundary rules that were not parsed.
+        $input = '{"url":"https:\\/\\/old-site.com\\/page",}';
+
+        $this->assertSame($input, $rewriter->rewrite($input));
     }
 
     // --- Base64 ---

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -24,7 +24,8 @@ describe('Import: URL Rewriting', () => {
     let tempDir;
     // Derive source domain from site registry so the port stays in sync
     const SOURCE_DOMAIN = new URL(getSiteUrl(site)).origin;
-    const TARGET_DOMAIN = 'https://target.example.com';
+    const TARGET_BASE_URL = 'https://target.example.com';
+    const EXPECTED_TARGET_URL = `${new URL(SOURCE_DOMAIN).protocol}//target.example.com`;
 
     beforeAll(async () => {
         await ensureSite(site, {
@@ -124,7 +125,7 @@ describe('Import: URL Rewriting', () => {
                 `--target-user=e2e_admin`,
                 `--target-pass=e2e_password`,
                 `--target-db=${importDb}`,
-                `--rewrite-url`, SOURCE_DOMAIN, TARGET_DOMAIN,
+                `--rewrite-url`, SOURCE_DOMAIN, TARGET_BASE_URL,
             ],
         });
 
@@ -203,13 +204,12 @@ describe('Import: URL Rewriting', () => {
             val.startsWith('a:'),
             `Expected serialized PHP format, got: ${val.substring(0, 10)}`
         );
-        // Verify s:N: byte lengths are correct for the target domain URL.
-        // The rewriter preserves the original URL's trailing-slash style,
-        // so a bare origin like "https://target.example.com" stays without
-        // a trailing slash.
-        const targetLen = TARGET_DOMAIN.length;
+        // The opaque-text processor changes only the authority. It keeps the
+        // source protocol, so the destination mapping's https scheme is not
+        // copied into this http source value.
+        const targetLen = EXPECTED_TARGET_URL.length;
         assert.ok(
-            val.includes(`s:${targetLen}:"${TARGET_DOMAIN}"`),
+            val.includes(`s:${targetLen}:"${EXPECTED_TARGET_URL}"`),
             `Expected correct s:N: prefix for target URL (s:${targetLen}:), got: ${val}`
         );
     });

--- a/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
+++ b/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
@@ -12,8 +12,9 @@ import { ensureSite } from '../lib/site-setup.js';
 describe('Import: SQLite db-apply target', () => {
     const site = 'basic';
     const targetDb = 'wp_sqlite_import';
-    const targetDomain = 'https://sqlite-target.example.com';
+    const targetBaseUrl = 'https://sqlite-target.example.com';
     const sourceDomain = new URL(getSiteUrl(site)).origin;
+    const expectedTargetUrl = `${new URL(sourceDomain).protocol}//sqlite-target.example.com`;
     let tempDir;
     let sqlitePath;
 
@@ -48,7 +49,7 @@ describe('Import: SQLite db-apply target', () => {
                 '--target-engine=sqlite',
                 `--target-sqlite-path=${sqlitePath}`,
                 `--target-db=${targetDb}`,
-                '--rewrite-url', sourceDomain, targetDomain,
+                '--rewrite-url', sourceDomain, targetBaseUrl,
             ],
         });
 
@@ -74,7 +75,7 @@ describe('Import: SQLite db-apply target', () => {
         assert.equal(options.length, 2, `Expected siteurl/home rows, got: ${JSON.stringify(options)}`);
         for (const row of options) {
             assert.ok(
-                row.option_value.includes(targetDomain),
+                row.option_value.includes(expectedTargetUrl),
                 `Expected rewritten target domain in ${row.option_name}, got: ${row.option_value}`,
             );
             assert.ok(


### PR DESCRIPTION
Uses URLInPotentiallyStructuredTextProcessor for text leaves after structured values have been parsed. The opaque path changes only the configured source authority, preserving protocol and suffix bytes rather than rendering a complete replacement URL.

Depends on #550.