### PR TITLE
[PHP] Add FileIndexDiffProcessor to share file-index comparison logic between push and pull

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -31,10 +31,10 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * `next_path()` selects the first unconsumed path found in either index. That
  * selected path becomes the **current path**. The current path can have:
  *
- * - an old entry and no new entry, meaning the path disappeared;
- * - no old entry and a new entry, meaning the path appeared; or
- * - an entry in both indexes, meaning the caller must compare their recorded
- *   information to decide whether the path changed.
+ * - an old entry and no new entry, making the path `deleted`;
+ * - no old entry and a new entry, making the path `added`; or
+ * - an entry in both indexes, making the path `modified` when its recorded
+ *   type, size, or ctime differs and `unchanged` otherwise.
  *
  * For example, while `wp-content/a.txt` is current, its old entry is the
  * record for `wp-content/a.txt` in the old index. It is not the record for
@@ -42,9 +42,9 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * `wp-content/a.txt`, the current path has no old entry and
  * `get_path_type_in_old_index()` returns null.
  *
- * This class only aligns the two indexes. It does not classify a change or
- * decide whether to copy, remove, or preserve a path. The caller makes that
- * decision from the information exposed for the current path.
+ * The processor labels that snapshot difference through `get_path_change()`.
+ * It does not decide whether to copy, remove, or preserve a path. That policy
+ * remains with the caller.
  *
  * ## Current, preceding, and following paths
  *
@@ -83,8 +83,7 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *     while ($has_path) {
  *         apply_path_operation(
  *             $processor->get_path(),
- *             $processor->get_path_type_in_old_index(),
- *             $processor->get_path_type_in_new_index()
+ *             $processor->get_path_change()
  *         );
  *         $has_path = $processor->next_path();
  *         save_cursor($processor->get_cursor());
@@ -337,6 +336,40 @@ final class FileIndexDiffProcessor
         return $this->current_path_found_in === "new"
             ? $this->new_index_entry["path"]
             : $this->old_index_entry["path"];
+    }
+
+    /**
+     * Returns how the current path differs between the two snapshots.
+     *
+     * A path is `added` when it occurs only in the new index and `deleted` when
+     * it occurs only in the old index. A path present in both is `modified`
+     * when its recorded type, size, or ctime differs; otherwise it is
+     * `unchanged`. The label describes the indexes, not the operation a caller
+     * should perform.
+     *
+     * @return string One of `added`, `modified`, `deleted`, or `unchanged`.
+     * @phpstan-return 'added'|'modified'|'deleted'|'unchanged'
+     */
+    public function get_path_change(): string
+    {
+        $this->assert_current_path();
+        if ($this->current_path_found_in === "new") {
+            return "added";
+        }
+        if ($this->current_path_found_in === "old") {
+            return "deleted";
+        }
+
+        $old_index_entry = $this->get_required_old_index_entry();
+        $new_index_entry = $this->get_required_new_index_entry();
+        if (
+            $old_index_entry["type"] !== $new_index_entry["type"]
+            || $old_index_entry["size"] !== $new_index_entry["size"]
+            || $old_index_entry["ctime"] !== $new_index_entry["ctime"]
+        ) {
+            return "modified";
+        }
+        return "unchanged";
     }
 
     /**

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -20,69 +20,69 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *
  * This processor opens two such lists:
  *
- * - The **earlier index** describes the tree at the starting point.
- * - The **later index** describes the tree at the ending point.
+ * - The **old index** describes the tree at the starting point.
+ * - The **new index** describes the tree at the ending point.
  *
- * "Earlier" and "later" therefore identify the snapshot which supplied an
- * entry. They do not mean the previously or subsequently visited path. This
- * class uses "previous" only for traversal history.
+ * "Old" and "new" identify the snapshot which supplied an entry. They do not
+ * describe traversal order within either index.
  *
  * ## How paths are compared
  *
  * `next_path()` selects the first unconsumed path found in either index. That
  * selected path becomes the **current path**. The current path can have:
  *
- * - an earlier entry and no later entry, meaning the path disappeared;
- * - no earlier entry and a later entry, meaning the path appeared; or
+ * - an old entry and no new entry, meaning the path disappeared;
+ * - no old entry and a new entry, meaning the path appeared; or
  * - an entry in both indexes, meaning the caller must compare their recorded
  *   information to decide whether the path changed.
  *
- * For example, while `wp-content/a.txt` is current, its earlier entry is the
- * record for `wp-content/a.txt` in the earlier index. It is not the record for
- * the path visited immediately before it. If the earlier index does not contain
- * `wp-content/a.txt`, the current path has no earlier entry and
- * `get_earlier_path_type()` returns null.
+ * For example, while `wp-content/a.txt` is current, its old entry is the
+ * record for `wp-content/a.txt` in the old index. It is not the record for
+ * the path visited immediately before it. If the old index does not contain
+ * `wp-content/a.txt`, the current path has no old entry and
+ * `get_path_type_in_old_index()` returns null.
  *
  * This class only aligns the two indexes. It does not classify a change or
  * decide whether to copy, remove, or preserve a path. The caller makes that
  * decision from the information exposed for the current path.
  *
- * ## Current entries and lookahead entries
+ * ## Current, preceding, and following paths
  *
  * The indexes are already sorted, so they can be merged in a single pass. The
  * processor retains at most one unread entry from each index and compares their
- * decoded path bytes. The earlier and later retained entries do not always name
- * the same path.
+ * decoded path bytes. The retained old and new entries do not always name the
+ * same path.
  *
- * Suppose the earlier index's retained entry is `b.txt` and the later index's
+ * Suppose the old index's retained entry is `b.txt` and the new index's
  * retained entry is `a.txt`. `a.txt` becomes the current path because it sorts
- * first. It has no earlier entry. The retained `b.txt` entry remains available
- * as the earlier lookahead path for callers which need to reason about what
- * follows without moving either stream.
+ * first. It has no old entry. Relative to `a.txt`, `b.txt` is the following path
+ * in the old index.
  *
- * Therefore the information getters and lookahead getters answer different
- * questions:
+ * Current-path information and neighboring paths answer different questions:
  *
- * - `get_earlier_path_type()` describes the current path in the earlier
- *   snapshot, or returns null when that snapshot has no such path.
- * - `get_earlier_lookahead_path()` returns the path of the entry retained from
- *   the earlier stream, even when that entry belongs to a future current path.
+ * - `get_path_type_in_old_index()` describes the current path in the old index,
+ *   or returns null when that index has no such path.
+ * - When the current path is absent from the old index,
+ *   `get_following_path_in_old_index()` returns the first old-index path which
+ *   sorts after it.
  *
- * The corresponding later getters make the same distinction for the later
- * index. `get_previous_later_path()` is different again: it returns the last
- * path already consumed from the later index. Earlier-only paths may have been
- * selected since then.
+ * The corresponding new-index getters make the same distinction.
+ * `get_preceding_path_in_new_index()` returns the closest new-index path which
+ * sorts before the current path. `get_following_path_in_new_index()` returns the
+ * closest new-index path which sorts after a current path absent from that
+ * index. Together they bracket the position where that missing path would
+ * appear in the new index.
  *
  * ## Selection and consumption
  *
  * A caller selects, inspects, processes, and then consumes one path:
  *
- *     $processor = FileIndexDiffProcessor::start($earlier_index, $later_index);
+ *     $processor = FileIndexDiffProcessor::start($old_index, $new_index);
  *     while ($processor->next_path()) {
  *         apply_path_operation(
  *             $processor->get_path(),
- *             $processor->get_earlier_path_type(),
- *             $processor->get_later_path_type()
+ *             $processor->get_path_type_in_old_index(),
+ *             $processor->get_path_type_in_new_index()
  *         );
  *         $processor->consume_current_path();
  *         save_cursor($processor->get_cursor());
@@ -97,52 +97,53 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * ## Resume boundaries
  *
  * The cursor records the byte offset after the last consumed entry in each
- * index and the last consumed later-index path. A selected but unconsumed entry
- * is deliberately not included. If a process stops before storing the consumed
- * cursor, `resume()` selects that path again. Work performed for one path must
+ * index and the new-index path preceding the next merge position. A selected
+ * but unconsumed entry is deliberately not included. If a process stops before
+ * storing the consumed cursor, `resume()` selects that path again. Work
+ * performed for one path must
  * therefore tolerate replay, or its caller must store a separate durable
  * confirmation.
  *
  * Both JSONL indexes must remain immutable and sorted by decoded path bytes,
  * not by their base64 representation. The cursor identifies byte positions in
- * those same files; it does not identify or validate their contents. The later
- * index must exist. A missing earlier index represents an empty starting tree.
+ * those same files; it does not identify or validate their contents. The new
+ * index must exist. A missing old index represents an empty starting tree.
  *
  * Selecting a path may move the private file handles beyond the public cursor
- * while the processor retains lookahead. Only the cursor returned after
+ * while the processor retains unread entries. Only the cursor returned after
  * `consume_current_path()` is a continuation boundary.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
- * @phpstan-type Cursor array{earlier_index_byte_offset:int,later_index_byte_offset:int,previous_later_index_entry_path_b64:string|null}
+ * @phpstan-type Cursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor
 {
     /** @var resource|null Stream containing the starting tree, or null for an empty tree. */
-    private $earlier_index_handle = null;
+    private $old_index_handle = null;
 
     /** @var resource|null Stream containing the ending tree. */
-    private $later_index_handle = null;
+    private $new_index_handle = null;
 
-    /** @var IndexEntry|null Unconsumed earlier entry, which may be current or lookahead. */
-    private ?array $earlier_index_entry = null;
+    /** @var IndexEntry|null Unconsumed old entry, which may be current or following. */
+    private ?array $old_index_entry = null;
 
-    /** Whether the earlier entry has been read, including an EOF result. */
-    private bool $earlier_index_entry_loaded = false;
+    /** Whether the old entry has been read, including an EOF result. */
+    private bool $old_index_entry_loaded = false;
 
-    /** @var IndexEntry|null Unconsumed later entry, which may be current or lookahead. */
-    private ?array $later_index_entry = null;
+    /** @var IndexEntry|null Unconsumed new entry, which may be current or following. */
+    private ?array $new_index_entry = null;
 
-    /** Whether the later entry has been read, including an EOF result. */
-    private bool $later_index_entry_loaded = false;
+    /** Whether the new entry has been read, including an EOF result. */
+    private bool $new_index_entry_loaded = false;
 
     /** @var Cursor Positions immediately after the entries consumed for the last current path. */
     private array $cursor;
 
-    /** @var 'earlier'|'later'|'both'|null Indexes which contain the current path. */
-    private ?string $current_path_order = null;
+    /** @var 'old'|'new'|'both'|null Indexes which contain the current path. */
+    private ?string $current_path_membership = null;
 
-    /** Later-index path consumed most recently before the current path. */
-    private ?string $previous_later_path = null;
+    /** Closest consumed new-index path which sorts before the current path. */
+    private ?string $preceding_path_in_new_index = null;
 
     /** Whether both indexes reached EOF. */
     private bool $complete = false;
@@ -153,23 +154,23 @@ final class FileIndexDiffProcessor
     /**
      * Opens two filesystem indexes and starts before their first paths.
      *
-     * The earlier file describes the starting tree and may be absent, which is
-     * equivalent to an empty tree. The later file describes the ending tree and
+     * The old file describes the starting tree and may be absent, which is
+     * equivalent to an empty tree. The new file describes the ending tree and
      * must be readable. Both files remain open until `close()`.
      *
-     * @param string $earlier_index_file Earlier index, or a missing path for an empty index.
-     * @param string $later_index_file   Later index.
+     * @param string $old_index_file Old index, or a missing path for an empty index.
+     * @param string $new_index_file New index.
      * @return self Open processor positioned before either index's first path.
      */
-    public static function start(string $earlier_index_file, string $later_index_file): self
+    public static function start(string $old_index_file, string $new_index_file): self
     {
         return self::resume(
-            $earlier_index_file,
-            $later_index_file,
+            $old_index_file,
+            $new_index_file,
             [
-                "earlier_index_byte_offset" => 0,
-                "later_index_byte_offset" => 0,
-                "previous_later_index_entry_path_b64" => null,
+                "old_index_byte_offset" => 0,
+                "new_index_byte_offset" => 0,
+                "preceding_new_index_entry_path_b64" => null,
             ]
         );
     }
@@ -178,53 +179,53 @@ final class FileIndexDiffProcessor
      * Reopens the two filesystem indexes at the positions recorded by a cursor.
      *
      * Each byte offset points to the next entry not represented by the stored
-     * cursor. The previous later-index path restores the traversal information
-     * returned by `get_previous_later_path()`. An entry selected before an
+     * cursor. The preceding new-index path restores the lower neighbor returned
+     * by `get_preceding_path_in_new_index()`. An entry selected before an
      * interruption but not consumed is deliberately selected again.
      *
      * The caller must provide the same immutable index contents used to produce
      * the cursor. This method restores positions; it does not fingerprint the
      * files or check that they still describe the same snapshots.
      *
-     * @param string $earlier_index_file Earlier index, or a missing path for an empty index.
-     * @param string $later_index_file   Later index.
+     * @param string $old_index_file Old index, or a missing path for an empty index.
+     * @param string $new_index_file New index.
      * @param array  $cursor {
      *     Cursor returned by get_cursor().
      *
-     *     @type int         $earlier_index_byte_offset            Next byte in the earlier index.
-     *     @type int         $later_index_byte_offset              Next byte in the later index.
-     *     @type string|null $previous_later_index_entry_path_b64  Last consumed later-index path.
+     *     @type int         $old_index_byte_offset              Next byte in the old index.
+     *     @type int         $new_index_byte_offset              Next byte in the new index.
+     *     @type string|null $preceding_new_index_entry_path_b64 New-index path before the next position.
      * }
      * @phpstan-param Cursor $cursor
      * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
-        string $earlier_index_file,
-        string $later_index_file,
+        string $old_index_file,
+        string $new_index_file,
         array $cursor
     ): self {
         $processor = new self();
         $processor->cursor = $cursor;
-        if (is_file($earlier_index_file)) {
-            $processor->earlier_index_handle = @fopen($earlier_index_file, "rb");
-            if (!is_resource($processor->earlier_index_handle)) {
-                throw new RuntimeException("Failed to open the earlier file index: {$earlier_index_file}.");
+        if (is_file($old_index_file)) {
+            $processor->old_index_handle = @fopen($old_index_file, "rb");
+            if (!is_resource($processor->old_index_handle)) {
+                throw new RuntimeException("Failed to open the old file index: {$old_index_file}.");
             }
         }
-        $processor->later_index_handle = @fopen($later_index_file, "rb");
-        if (!is_resource($processor->later_index_handle)) {
+        $processor->new_index_handle = @fopen($new_index_file, "rb");
+        if (!is_resource($processor->new_index_handle)) {
             $processor->close();
-            throw new RuntimeException("Failed to open the later file index: {$later_index_file}.");
+            throw new RuntimeException("Failed to open the new file index: {$new_index_file}.");
         }
         if (
-            ( is_resource($processor->earlier_index_handle)
+            ( is_resource($processor->old_index_handle)
                 && fseek(
-                    $processor->earlier_index_handle,
-                    $cursor["earlier_index_byte_offset"]
+                    $processor->old_index_handle,
+                    $cursor["old_index_byte_offset"]
                 ) !== 0 )
             || fseek(
-                $processor->later_index_handle,
-                $cursor["later_index_byte_offset"]
+                $processor->new_index_handle,
+                $cursor["new_index_byte_offset"]
             ) !== 0
         ) {
             $processor->close();
@@ -238,17 +239,17 @@ final class FileIndexDiffProcessor
      *
      * This method retains at most one unread entry from each index, compares
      * their paths, and makes the first path in decoded-byte order current. The
-     * current path may occur in the earlier index, the later index, or both.
+     * current path may occur in the old index, the new index, or both.
      * Information getters may be called only after this method returns true.
      * The caller must consume the current path before selecting another one.
-     * False means both indexes reached EOF and remains false on later calls.
+     * False means both indexes reached EOF and remains false on subsequent calls.
      *
      * @return bool Whether a path was selected.
      */
     public function next_path(): bool
     {
         $this->assert_open();
-        if ($this->current_path_order !== null) {
+        if ($this->current_path_membership !== null) {
             throw new LogicException(
                 "Cannot select another file-index path before consuming the current path."
             );
@@ -256,50 +257,50 @@ final class FileIndexDiffProcessor
         if ($this->complete) {
             return false;
         }
-        if (!$this->earlier_index_entry_loaded) {
-            $this->earlier_index_entry = $this->read_next_index_entry(
-                $this->earlier_index_handle
+        if (!$this->old_index_entry_loaded) {
+            $this->old_index_entry = $this->read_next_index_entry(
+                $this->old_index_handle
             );
-            $this->earlier_index_entry_loaded = true;
+            $this->old_index_entry_loaded = true;
         }
-        if (!$this->later_index_entry_loaded) {
-            $this->later_index_entry = $this->read_next_index_entry(
-                $this->later_index_handle
+        if (!$this->new_index_entry_loaded) {
+            $this->new_index_entry = $this->read_next_index_entry(
+                $this->new_index_handle
             );
-            $this->later_index_entry_loaded = true;
+            $this->new_index_entry_loaded = true;
         }
-        if ($this->earlier_index_entry === null && $this->later_index_entry === null) {
+        if ($this->old_index_entry === null && $this->new_index_entry === null) {
             $this->complete = true;
             return false;
         }
 
-        if ($this->earlier_index_entry === null) {
-            $current_path_order = "later";
-        } elseif ($this->later_index_entry === null) {
-            $current_path_order = "earlier";
+        if ($this->old_index_entry === null) {
+            $current_path_membership = "new";
+        } elseif ($this->new_index_entry === null) {
+            $current_path_membership = "old";
         } else {
             // Base64 text order does not preserve arbitrary path-byte order.
             $path_comparison = strcmp(
-                $this->later_index_entry["path"],
-                $this->earlier_index_entry["path"]
+                $this->new_index_entry["path"],
+                $this->old_index_entry["path"]
             );
-            $current_path_order = $path_comparison < 0
-                ? "later"
-                : ( $path_comparison > 0 ? "earlier" : "both" );
+            $current_path_membership = $path_comparison < 0
+                ? "new"
+                : ( $path_comparison > 0 ? "old" : "both" );
         }
 
-        $previous_later_path = null;
-        if ($this->cursor["previous_later_index_entry_path_b64"] !== null) {
-            $previous_later_path = base64_decode(
-                $this->cursor["previous_later_index_entry_path_b64"],
+        $preceding_path_in_new_index = null;
+        if ($this->cursor["preceding_new_index_entry_path_b64"] !== null) {
+            $preceding_path_in_new_index = base64_decode(
+                $this->cursor["preceding_new_index_entry_path_b64"],
                 true
             );
-            if ($previous_later_path === false) {
-                throw new RuntimeException("The file-index diff cursor has an invalid previous path.");
+            if ($preceding_path_in_new_index === false) {
+                throw new RuntimeException("The file-index diff cursor has an invalid preceding new-index path.");
             }
         }
-        $this->current_path_order = $current_path_order;
-        $this->previous_later_path = $previous_later_path;
+        $this->current_path_membership = $current_path_membership;
+        $this->preceding_path_in_new_index = $preceding_path_in_new_index;
         return true;
     }
 
@@ -312,186 +313,193 @@ final class FileIndexDiffProcessor
     public function get_path(): string
     {
         $this->assert_current_path();
-        return $this->current_path_order === "later"
-            ? $this->later_index_entry["path"]
-            : $this->earlier_index_entry["path"];
+        return $this->current_path_membership === "new"
+            ? $this->new_index_entry["path"]
+            : $this->old_index_entry["path"];
     }
 
     /**
      * Returns the current path's type in the starting tree.
      *
-     * Null means the earlier index has no entry for the current path: the path
-     * did not exist in the starting tree. A retained earlier lookahead entry for
+     * Null means the old index has no entry for the current path: the path
+     * did not exist in the starting tree. A retained following old entry for
      * another path does not affect this result.
      */
-    public function get_earlier_path_type(): ?string
+    public function get_path_type_in_old_index(): ?string
     {
-        $entry = $this->get_earlier_index_entry_for_current_path();
+        $entry = $this->get_old_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
     /**
      * Returns the current path's type in the ending tree.
      *
-     * Null means the later index has no entry for the current path: the path no
-     * longer exists in the ending tree. A retained later lookahead entry for
+     * Null means the new index has no entry for the current path: the path no
+     * longer exists in the ending tree. A retained following new entry for
      * another path does not affect this result.
      */
-    public function get_later_path_type(): ?string
+    public function get_path_type_in_new_index(): ?string
     {
-        $entry = $this->get_later_index_entry_for_current_path();
+        $entry = $this->get_new_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
     /**
      * Returns the size recorded for the current path in the starting tree.
      *
-     * The current path must have an earlier entry. Call
-     * `get_earlier_path_type()` first when its presence is not already known.
+     * The current path must have an old entry. Call
+     * `get_path_type_in_old_index()` first when its presence is not already known.
      */
-    public function get_earlier_size(): int
+    public function get_size_in_old_index(): int
     {
-        return $this->get_required_earlier_index_entry()["size"];
+        return $this->get_required_old_index_entry()["size"];
     }
 
     /**
      * Returns the size recorded for the current path in the ending tree.
      *
-     * The current path must have a later entry. Call `get_later_path_type()`
+     * The current path must have a new entry. Call `get_path_type_in_new_index()`
      * first when its presence is not already known.
      */
-    public function get_later_size(): int
+    public function get_size_in_new_index(): int
     {
-        return $this->get_required_later_index_entry()["size"];
+        return $this->get_required_new_index_entry()["size"];
     }
 
     /**
      * Returns the ctime recorded for the current path in the starting tree.
      *
-     * The current path must have an earlier entry. Call
-     * `get_earlier_path_type()` first when its presence is not already known.
+     * The current path must have an old entry. Call
+     * `get_path_type_in_old_index()` first when its presence is not already known.
      */
-    public function get_earlier_ctime(): int
+    public function get_ctime_in_old_index(): int
     {
-        return $this->get_required_earlier_index_entry()["ctime"];
+        return $this->get_required_old_index_entry()["ctime"];
     }
 
     /**
      * Returns the ctime recorded for the current path in the ending tree.
      *
-     * The current path must have a later entry. Call `get_later_path_type()`
+     * The current path must have a new entry. Call `get_path_type_in_new_index()`
      * first when its presence is not already known.
      */
-    public function get_later_ctime(): int
+    public function get_ctime_in_new_index(): int
     {
-        return $this->get_required_later_index_entry()["ctime"];
+        return $this->get_required_new_index_entry()["ctime"];
     }
 
     /**
      * Returns whether the current path was an empty directory in the starting tree.
      *
-     * Null means either that the current path has no earlier entry or that its
-     * earlier entry does not carry the optional empty-directory marker. Inspect
-     * `get_earlier_path_type()` when those cases need to be distinguished.
+     * Null means either that the current path has no old entry or that its
+     * old entry does not carry the optional empty-directory marker. Inspect
+     * `get_path_type_in_old_index()` when those cases need to be distinguished.
      */
-    public function get_earlier_directory_is_empty(): ?bool
+    public function get_directory_is_empty_in_old_index(): ?bool
     {
-        $entry = $this->get_earlier_index_entry_for_current_path();
+        $entry = $this->get_old_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
     /**
      * Returns whether the current path is an empty directory in the ending tree.
      *
-     * Null means either that the current path has no later entry or that its
-     * later entry does not carry the optional empty-directory marker. Inspect
-     * `get_later_path_type()` when those cases need to be distinguished.
+     * Null means either that the current path has no new entry or that its
+     * new entry does not carry the optional empty-directory marker. Inspect
+     * `get_path_type_in_new_index()` when those cases need to be distinguished.
      */
-    public function get_later_directory_is_empty(): ?bool
+    public function get_directory_is_empty_in_new_index(): ?bool
     {
-        $entry = $this->get_later_index_entry_for_current_path();
+        $entry = $this->get_new_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
     /**
-     * Returns the path of the entry retained from the earlier index.
+     * Returns the old-index path immediately following the current path.
      *
-     * This is stream lookahead, not necessarily information about the current
-     * path. When only the later index contains the current path, the earlier
-     * retained entry names a path which sorts after it. Null means the earlier
-     * stream has no retained entry because it reached EOF or was absent.
+     * The current path must be absent from the old index. Its insertion position
+     * then falls immediately before the retained old entry. Null means no old
+     * path follows it because the old index reached EOF or was absent.
      */
-    public function get_earlier_lookahead_path(): ?string
+    public function get_following_path_in_old_index(): ?string
     {
         $this->assert_current_path();
-        return $this->earlier_index_entry["path"] ?? null;
+        if ($this->current_path_membership !== "new") {
+            throw new LogicException(
+                "The current path occurs in the old index, so its following old-index path has not been read."
+            );
+        }
+        return $this->old_index_entry["path"] ?? null;
     }
 
     /**
-     * Returns the path of the entry retained from the later index.
+     * Returns the new-index path immediately following the current path.
      *
-     * This is stream lookahead, not necessarily information about the current
-     * path. When only the earlier index contains the current path, the later
-     * retained entry names a path which sorts after it. Null means the later
-     * stream has reached EOF.
+     * The current path must be absent from the new index. Its insertion position
+     * then falls immediately before the retained new entry. Null means no new
+     * path follows it because the new index reached EOF.
      */
-    public function get_later_lookahead_path(): ?string
+    public function get_following_path_in_new_index(): ?string
     {
         $this->assert_current_path();
-        return $this->later_index_entry["path"] ?? null;
+        if ($this->current_path_membership !== "old") {
+            throw new LogicException(
+                "The current path occurs in the new index, so its following new-index path has not been read."
+            );
+        }
+        return $this->new_index_entry["path"] ?? null;
     }
 
     /**
-     * Returns the last path consumed from the later index before the current path.
+     * Returns the new-index path immediately preceding the current path.
      *
-     * This reports traversal history, not an entry from the earlier snapshot.
-     * Consuming an earlier-only path leaves this value unchanged, so it may not
-     * be the path selected immediately before the current one. Null means no
-     * later-index path has been consumed yet.
+     * This is the closest new-index path which sorts before the current path,
+     * not necessarily the path selected immediately before it. Null means the
+     * current path sorts before every path in the new index.
      */
-    public function get_previous_later_path(): ?string
+    public function get_preceding_path_in_new_index(): ?string
     {
         $this->assert_current_path();
-        return $this->previous_later_path;
+        return $this->preceding_path_in_new_index;
     }
 
     /**
      * Records that the caller finished processing the current path.
      *
-     * An earlier-only or later-only path consumes the entry from that index. A
-     * path present in both indexes consumes both entries. Retained lookahead for
-     * a future path is not consumed. The cursor is updated only after the file
-     * positions of the consumed entries are known. Consuming a later entry also
-     * makes the current path the next result's `get_previous_later_path()`.
+     * An old-only or new-only path consumes the entry from that index. A path
+     * present in both indexes consumes both entries. A retained following entry
+     * is not consumed. The cursor is updated only after the file positions of
+     * the consumed entries are known. Consuming a new entry also
+     * makes the current path a subsequent result's preceding new-index path.
      *
      * Calling this method after both indexes reached EOF is a logic error.
      */
     public function consume_current_path(): void
     {
         $this->assert_current_path();
-        if ($this->current_path_order !== "later") {
-            $earlier_index_byte_offset = ftell($this->earlier_index_handle);
-            if (!is_int($earlier_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the earlier file-index byte offset.");
+        if ($this->current_path_membership !== "new") {
+            $old_index_byte_offset = ftell($this->old_index_handle);
+            if (!is_int($old_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the old file-index byte offset.");
             }
-            $this->cursor["earlier_index_byte_offset"] = $earlier_index_byte_offset;
-            $this->earlier_index_entry = null;
-            $this->earlier_index_entry_loaded = false;
+            $this->cursor["old_index_byte_offset"] = $old_index_byte_offset;
+            $this->old_index_entry = null;
+            $this->old_index_entry_loaded = false;
         }
-        if ($this->current_path_order !== "earlier") {
-            $later_index_byte_offset = ftell($this->later_index_handle);
-            if (!is_int($later_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the later file-index byte offset.");
+        if ($this->current_path_membership !== "old") {
+            $new_index_byte_offset = ftell($this->new_index_handle);
+            if (!is_int($new_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the new file-index byte offset.");
             }
-            $this->cursor["later_index_byte_offset"] = $later_index_byte_offset;
-            $this->cursor["previous_later_index_entry_path_b64"] = base64_encode(
-                $this->later_index_entry["path"]
+            $this->cursor["new_index_byte_offset"] = $new_index_byte_offset;
+            $this->cursor["preceding_new_index_entry_path_b64"] = base64_encode(
+                $this->new_index_entry["path"]
             );
-            $this->later_index_entry = null;
-            $this->later_index_entry_loaded = false;
+            $this->new_index_entry = null;
+            $this->new_index_entry_loaded = false;
         }
-        $this->current_path_order = null;
-        $this->previous_later_path = null;
+        $this->current_path_membership = null;
+        $this->preceding_path_in_new_index = null;
     }
 
     /**
@@ -506,9 +514,9 @@ final class FileIndexDiffProcessor
      * @return array {
      *     Cursor for `resume()`.
      *
-     *     @type int         $earlier_index_byte_offset            Next byte in the earlier index.
-     *     @type int         $later_index_byte_offset              Next byte in the later index.
-     *     @type string|null $previous_later_index_entry_path_b64  Last consumed later-index path.
+     *     @type int         $old_index_byte_offset              Next byte in the old index.
+     *     @type int         $new_index_byte_offset              Next byte in the new index.
+     *     @type string|null $preceding_new_index_entry_path_b64 New-index path before the next position.
      * }
      *
      * @phpstan-return Cursor
@@ -526,17 +534,17 @@ final class FileIndexDiffProcessor
      */
     public function close(): void
     {
-        if (is_resource($this->earlier_index_handle)) {
-            fclose($this->earlier_index_handle);
+        if (is_resource($this->old_index_handle)) {
+            fclose($this->old_index_handle);
         }
-        if (is_resource($this->later_index_handle)) {
-            fclose($this->later_index_handle);
+        if (is_resource($this->new_index_handle)) {
+            fclose($this->new_index_handle);
         }
-        $this->earlier_index_handle = null;
-        $this->earlier_index_entry = null;
-        $this->later_index_entry = null;
-        $this->current_path_order = null;
-        $this->previous_later_path = null;
+        $this->old_index_handle = null;
+        $this->old_index_entry = null;
+        $this->new_index_entry = null;
+        $this->current_path_membership = null;
+        $this->preceding_path_in_new_index = null;
         $this->closed = true;
     }
 
@@ -552,7 +560,7 @@ final class FileIndexDiffProcessor
     private function assert_current_path(): void
     {
         $this->assert_open();
-        if ($this->current_path_order === null) {
+        if ($this->current_path_membership === null) {
             throw new LogicException("No current file-index path. Call next_path() first.");
         }
     }
@@ -560,61 +568,61 @@ final class FileIndexDiffProcessor
     /**
      * Returns the current path's entry from the starting tree, when it has one.
      *
-     * The retained earlier entry may instead be lookahead for a future path.
-     * In that case the current path exists only in the later index and this
-     * method returns null rather than exposing the unrelated retained entry.
+     * The retained old entry may instead be the path following a current path
+     * found only in the new index. In that case this method returns null rather
+     * than exposing the unrelated retained entry.
      *
      * @phpstan-return IndexEntry|null
      */
-    private function get_earlier_index_entry_for_current_path(): ?array
+    private function get_old_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_order === "later"
+        return $this->current_path_membership === "new"
             ? null
-            : $this->earlier_index_entry;
+            : $this->old_index_entry;
     }
 
     /**
      * Returns the current path's entry from the ending tree, when it has one.
      *
-     * The retained later entry may instead be lookahead for a future path. In
-     * that case the current path exists only in the earlier index and this
-     * method returns null rather than exposing the unrelated retained entry.
+     * The retained new entry may instead be the path following a current path
+     * found only in the old index. In that case this method returns null rather
+     * than exposing the unrelated retained entry.
      *
      * @phpstan-return IndexEntry|null
      */
-    private function get_later_index_entry_for_current_path(): ?array
+    private function get_new_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_order === "earlier"
+        return $this->current_path_membership === "old"
             ? null
-            : $this->later_index_entry;
+            : $this->new_index_entry;
     }
 
     /**
-     * Returns the current path's earlier entry when its presence is required.
+     * Returns the current path's old entry when its presence is required.
      *
      * @phpstan-return IndexEntry
      */
-    private function get_required_earlier_index_entry(): array
+    private function get_required_old_index_entry(): array
     {
-        $entry = $this->get_earlier_index_entry_for_current_path();
+        $entry = $this->get_old_index_entry_for_current_path();
         if ($entry === null) {
-            throw new LogicException("The current path has no earlier-index entry.");
+            throw new LogicException("The current path has no old-index entry.");
         }
         return $entry;
     }
 
     /**
-     * Returns the current path's later entry when its presence is required.
+     * Returns the current path's new entry when its presence is required.
      *
      * @phpstan-return IndexEntry
      */
-    private function get_required_later_index_entry(): array
+    private function get_required_new_index_entry(): array
     {
-        $entry = $this->get_later_index_entry_for_current_path();
+        $entry = $this->get_new_index_entry_for_current_path();
         if ($entry === null) {
-            throw new LogicException("The current path has no later-index entry.");
+            throw new LogicException("The current path has no new-index entry.");
         }
         return $entry;
     }

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -21,12 +21,12 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *
  * A caller performs its work before consuming the current path:
  *
- *     $processor = FileIndexDiffProcessor::start($before_index, $after_index);
+ *     $processor = FileIndexDiffProcessor::start($earlier_index, $later_index);
  *     while ($processor->next_path()) {
  *         apply_path_operation(
  *             $processor->get_path(),
- *             $processor->get_before_path_type(),
- *             $processor->get_after_path_type()
+ *             $processor->get_earlier_path_type(),
+ *             $processor->get_later_path_type()
  *         );
  *         $processor->consume_current_path();
  *         save_cursor($processor->get_cursor());
@@ -44,30 +44,30 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *
  * Each selected path has one of three relationships:
  *
- * | Before path type | After path type | Meaning                         |
- * |------------------|-----------------|---------------------------------|
- * | non-null         | null            | The path occurs only before.    |
- * | null             | non-null        | The path occurs only after.     |
+ * | Earlier path type | Later path type | Meaning                         |
+ * |-------------------|-----------------|---------------------------------|
+ * | non-null          | null            | Only the earlier index has it.  |
+ * | null              | non-null        | Only the later index has it.    |
  * | non-null         | non-null        | Both indexes contain the path.  |
  *
  * The two lookahead-path getters expose the entries currently retained from
  * the underlying streams even when one belongs to a later path. For example,
- * an after-only path may retain the next before-side path as lookahead. Callers
+ * a later-only path may retain the next earlier-index path as lookahead. Callers
  * use this to recognize subtree replacements without reading ahead or moving
  * either cursor themselves.
  *
- * `previous_after_path` is the most recently consumed path from the after
- * index. Consuming a before-only path does not change it. This gives callers
- * the preceding after-side path while they process gaps in sparse indexes.
+ * `previous_later_path` is the most recently consumed path from the later
+ * index. Consuming an earlier-only path does not change it. This gives callers
+ * the preceding later-index path while they process gaps in sparse indexes.
  *
  * ## Index and cursor requirements
  *
  * Both JSONL indexes must be sorted by decoded path bytes, not by their base64
- * representation. The after index must exist. A missing before index represents
+ * representation. The later index must exist. A missing earlier index represents
  * an empty earlier snapshot.
  *
  * The cursor contains the byte offset after the last consumed entry in each
- * index and the previous consumed after-side path. It identifies positions
+ * index and the previous consumed later-index path. It identifies positions
  * within the same immutable index files; it does not identify or validate the
  * files themselves. A caller which resumes with different index contents has
  * violated the processor contract.
@@ -78,36 +78,36 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * cursor returned after `consume_current_path()` is a continuation boundary.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
- * @phpstan-type Cursor array{before_index_byte_offset:int,after_index_byte_offset:int,previous_after_index_entry_path_b64:string|null}
+ * @phpstan-type Cursor array{earlier_index_byte_offset:int,later_index_byte_offset:int,previous_later_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor
 {
     /** @var resource|null Open earlier index, or null when the earlier index is absent. */
-    private $before_index_handle = null;
+    private $earlier_index_handle = null;
 
     /** @var resource|null Open later index. */
-    private $after_index_handle = null;
+    private $later_index_handle = null;
 
     /** @var IndexEntry|null Earlier entry retained until its aligned path is consumed. */
-    private ?array $before_index_entry = null;
+    private ?array $earlier_index_entry = null;
 
     /** Whether the earlier entry has been read, including an EOF result. */
-    private bool $before_index_entry_loaded = false;
+    private bool $earlier_index_entry_loaded = false;
 
     /** @var IndexEntry|null Later entry retained until its aligned path is consumed. */
-    private ?array $after_index_entry = null;
+    private ?array $later_index_entry = null;
 
     /** Whether the later entry has been read, including an EOF result. */
-    private bool $after_index_entry_loaded = false;
+    private bool $later_index_entry_loaded = false;
 
     /** @var Cursor Position immediately after the last consumed aligned path. */
     private array $cursor;
 
-    /** @var 'before'|'after'|'both'|null Relationship of the selected path. */
+    /** @var 'earlier'|'later'|'both'|null Relationship of the selected path. */
     private ?string $current_path_order = null;
 
-    /** Most recently consumed after-side path restored for the selected path. */
-    private ?string $previous_after_path = null;
+    /** Most recently consumed later-index path restored for the selected path. */
+    private ?string $previous_later_path = null;
 
     /** Whether both indexes reached EOF. */
     private bool $complete = false;
@@ -118,23 +118,23 @@ final class FileIndexDiffProcessor
     /**
      * Starts a new comparison at the beginning of both indexes.
      *
-     * The before index may be absent, which is equivalent to an empty earlier
-     * snapshot. The after index must be an existing readable file. Both files
+     * The earlier index may be absent, which is equivalent to an empty earlier
+     * snapshot. The later index must be an existing readable file. Both files
      * remain open until `close()`.
      *
-     * @param string $before_index_file Earlier index, or a missing path for an empty index.
-     * @param string $after_index_file  Later index.
+     * @param string $earlier_index_file Earlier index, or a missing path for an empty index.
+     * @param string $later_index_file   Later index.
      * @return self Open processor positioned before the first aligned path.
      */
-    public static function start(string $before_index_file, string $after_index_file): self
+    public static function start(string $earlier_index_file, string $later_index_file): self
     {
         return self::resume(
-            $before_index_file,
-            $after_index_file,
+            $earlier_index_file,
+            $later_index_file,
             [
-                "before_index_byte_offset" => 0,
-                "after_index_byte_offset" => 0,
-                "previous_after_index_entry_path_b64" => null,
+                "earlier_index_byte_offset" => 0,
+                "later_index_byte_offset" => 0,
+                "previous_later_index_entry_path_b64" => null,
             ]
         );
     }
@@ -142,53 +142,53 @@ final class FileIndexDiffProcessor
     /**
      * Resumes a comparison after the last consumed aligned path.
      *
-     * The byte offsets address the next unread entries. The previous after-side
-     * path restores the context returned as `previous_after_path`. Entries read
+     * The byte offsets address the next unread entries. The previous later-index
+     * path restores the context returned as `previous_later_path`. Entries read
      * before an interruption but not consumed are deliberately read again.
      *
      * The caller must provide the same immutable index contents used to produce
      * the cursor. This method restores positions; it does not fingerprint the
      * files or check that they still describe the same snapshots.
      *
-     * @param string $before_index_file Earlier index, or a missing path for an empty index.
-     * @param string $after_index_file  Later index.
+     * @param string $earlier_index_file Earlier index, or a missing path for an empty index.
+     * @param string $later_index_file   Later index.
      * @param array  $cursor {
      *     Cursor returned by get_cursor().
      *
-     *     @type int         $before_index_byte_offset             Next byte in the earlier index.
-     *     @type int         $after_index_byte_offset              Next byte in the later index.
-     *     @type string|null $previous_after_index_entry_path_b64  Last consumed later-index path.
+     *     @type int         $earlier_index_byte_offset            Next byte in the earlier index.
+     *     @type int         $later_index_byte_offset              Next byte in the later index.
+     *     @type string|null $previous_later_index_entry_path_b64  Last consumed later-index path.
      * }
      * @phpstan-param Cursor $cursor
      * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
-        string $before_index_file,
-        string $after_index_file,
+        string $earlier_index_file,
+        string $later_index_file,
         array $cursor
     ): self {
         $processor = new self();
         $processor->cursor = $cursor;
-        if (is_file($before_index_file)) {
-            $processor->before_index_handle = @fopen($before_index_file, "rb");
-            if (!is_resource($processor->before_index_handle)) {
-                throw new RuntimeException("Failed to open the before file index: {$before_index_file}.");
+        if (is_file($earlier_index_file)) {
+            $processor->earlier_index_handle = @fopen($earlier_index_file, "rb");
+            if (!is_resource($processor->earlier_index_handle)) {
+                throw new RuntimeException("Failed to open the earlier file index: {$earlier_index_file}.");
             }
         }
-        $processor->after_index_handle = @fopen($after_index_file, "rb");
-        if (!is_resource($processor->after_index_handle)) {
+        $processor->later_index_handle = @fopen($later_index_file, "rb");
+        if (!is_resource($processor->later_index_handle)) {
             $processor->close();
-            throw new RuntimeException("Failed to open the after file index: {$after_index_file}.");
+            throw new RuntimeException("Failed to open the later file index: {$later_index_file}.");
         }
         if (
-            ( is_resource($processor->before_index_handle)
+            ( is_resource($processor->earlier_index_handle)
                 && fseek(
-                    $processor->before_index_handle,
-                    $cursor["before_index_byte_offset"]
+                    $processor->earlier_index_handle,
+                    $cursor["earlier_index_byte_offset"]
                 ) !== 0 )
             || fseek(
-                $processor->after_index_handle,
-                $cursor["after_index_byte_offset"]
+                $processor->later_index_handle,
+                $cursor["later_index_byte_offset"]
             ) !== 0
         ) {
             $processor->close();
@@ -218,50 +218,50 @@ final class FileIndexDiffProcessor
         if ($this->complete) {
             return false;
         }
-        if (!$this->before_index_entry_loaded) {
-            $this->before_index_entry = $this->read_next_index_entry(
-                $this->before_index_handle
+        if (!$this->earlier_index_entry_loaded) {
+            $this->earlier_index_entry = $this->read_next_index_entry(
+                $this->earlier_index_handle
             );
-            $this->before_index_entry_loaded = true;
+            $this->earlier_index_entry_loaded = true;
         }
-        if (!$this->after_index_entry_loaded) {
-            $this->after_index_entry = $this->read_next_index_entry(
-                $this->after_index_handle
+        if (!$this->later_index_entry_loaded) {
+            $this->later_index_entry = $this->read_next_index_entry(
+                $this->later_index_handle
             );
-            $this->after_index_entry_loaded = true;
+            $this->later_index_entry_loaded = true;
         }
-        if ($this->before_index_entry === null && $this->after_index_entry === null) {
+        if ($this->earlier_index_entry === null && $this->later_index_entry === null) {
             $this->complete = true;
             return false;
         }
 
-        if ($this->before_index_entry === null) {
-            $current_path_order = "after";
-        } elseif ($this->after_index_entry === null) {
-            $current_path_order = "before";
+        if ($this->earlier_index_entry === null) {
+            $current_path_order = "later";
+        } elseif ($this->later_index_entry === null) {
+            $current_path_order = "earlier";
         } else {
             // Base64 text order does not preserve arbitrary path-byte order.
             $path_comparison = strcmp(
-                $this->after_index_entry["path"],
-                $this->before_index_entry["path"]
+                $this->later_index_entry["path"],
+                $this->earlier_index_entry["path"]
             );
             $current_path_order = $path_comparison < 0
-                ? "after"
-                : ( $path_comparison > 0 ? "before" : "both" );
+                ? "later"
+                : ( $path_comparison > 0 ? "earlier" : "both" );
         }
 
-        $previous_after_path = null;
-        if ($this->cursor["previous_after_index_entry_path_b64"] !== null) {
-            $previous_after_path = base64_decode(
-                $this->cursor["previous_after_index_entry_path_b64"],
+        $previous_later_path = null;
+        if ($this->cursor["previous_later_index_entry_path_b64"] !== null) {
+            $previous_later_path = base64_decode(
+                $this->cursor["previous_later_index_entry_path_b64"],
                 true
             );
-            if ($previous_after_path === false) {
+            if ($previous_later_path === false) {
                 throw new RuntimeException("The file-index diff cursor has an invalid previous path.");
             }
         }
         $this->current_path_order = $current_path_order;
-        $this->previous_after_path = $previous_after_path;
+        $this->previous_later_path = $previous_later_path;
         return true;
     }
 
@@ -269,120 +269,120 @@ final class FileIndexDiffProcessor
     public function get_path(): string
     {
         $this->assert_current_path();
-        return $this->current_path_order === "after"
-            ? $this->after_index_entry["path"]
-            : $this->before_index_entry["path"];
+        return $this->current_path_order === "later"
+            ? $this->later_index_entry["path"]
+            : $this->earlier_index_entry["path"];
     }
 
-    /** Returns the earlier local path type, or null when the path occurs only after. */
-    public function get_before_path_type(): ?string
+    /** Returns the earlier local path type, or null when only the later index has the path. */
+    public function get_earlier_path_type(): ?string
     {
-        $entry = $this->get_before_entry();
+        $entry = $this->get_earlier_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
-    /** Returns the later local path type, or null when the path occurs only before. */
-    public function get_after_path_type(): ?string
+    /** Returns the later local path type, or null when only the earlier index has the path. */
+    public function get_later_path_type(): ?string
     {
-        $entry = $this->get_after_entry();
+        $entry = $this->get_later_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
-    /** Returns the earlier size. The selected path must occur in the before index. */
-    public function get_before_size(): int
+    /** Returns the earlier size. The selected path must occur in the earlier index. */
+    public function get_earlier_size(): int
     {
-        return $this->get_required_before_entry()["size"];
+        return $this->get_required_earlier_index_entry()["size"];
     }
 
-    /** Returns the later size. The selected path must occur in the after index. */
-    public function get_after_size(): int
+    /** Returns the later size. The selected path must occur in the later index. */
+    public function get_later_size(): int
     {
-        return $this->get_required_after_entry()["size"];
+        return $this->get_required_later_index_entry()["size"];
     }
 
-    /** Returns the earlier ctime. The selected path must occur in the before index. */
-    public function get_before_ctime(): int
+    /** Returns the earlier ctime. The selected path must occur in the earlier index. */
+    public function get_earlier_ctime(): int
     {
-        return $this->get_required_before_entry()["ctime"];
+        return $this->get_required_earlier_index_entry()["ctime"];
     }
 
-    /** Returns the later ctime. The selected path must occur in the after index. */
-    public function get_after_ctime(): int
+    /** Returns the later ctime. The selected path must occur in the later index. */
+    public function get_later_ctime(): int
     {
-        return $this->get_required_after_entry()["ctime"];
+        return $this->get_required_later_index_entry()["ctime"];
     }
 
     /** Returns the earlier directory empty marker, or null when it is not recorded. */
-    public function get_before_directory_is_empty(): ?bool
+    public function get_earlier_directory_is_empty(): ?bool
     {
-        $entry = $this->get_before_entry();
+        $entry = $this->get_earlier_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
     /** Returns the later directory empty marker, or null when it is not recorded. */
-    public function get_after_directory_is_empty(): ?bool
+    public function get_later_directory_is_empty(): ?bool
     {
-        $entry = $this->get_after_entry();
+        $entry = $this->get_later_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
     /** Returns the earlier entry retained as lookahead, which may follow the selected path. */
-    public function get_before_lookahead_path(): ?string
+    public function get_earlier_lookahead_path(): ?string
     {
         $this->assert_current_path();
-        return $this->before_index_entry["path"] ?? null;
+        return $this->earlier_index_entry["path"] ?? null;
     }
 
     /** Returns the later entry retained as lookahead, which may follow the selected path. */
-    public function get_after_lookahead_path(): ?string
+    public function get_later_lookahead_path(): ?string
     {
         $this->assert_current_path();
-        return $this->after_index_entry["path"] ?? null;
+        return $this->later_index_entry["path"] ?? null;
     }
 
     /** Returns the most recently consumed later-index path. */
-    public function get_previous_after_path(): ?string
+    public function get_previous_later_path(): ?string
     {
         $this->assert_current_path();
-        return $this->previous_after_path;
+        return $this->previous_later_path;
     }
 
     /**
      * Consumes the current path after its caller completes the associated work.
      *
-     * A before-only or after-only path advances one index. A path present in
+     * An earlier-only or later-only path advances one index. A path present in
      * both indexes advances both. The cursor is updated only after the relevant
-     * file positions are known, and consuming an after-side entry also records
-     * that entry as the next result's `previous_after_path`.
+     * file positions are known, and consuming a later-index entry also records
+     * that entry as the next result's `previous_later_path`.
      *
      * Calling this method after both indexes reached EOF is a logic error.
      */
     public function consume_current_path(): void
     {
         $this->assert_current_path();
-        if ($this->current_path_order !== "after") {
-            $before_index_byte_offset = ftell($this->before_index_handle);
-            if (!is_int($before_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the before file-index byte offset.");
+        if ($this->current_path_order !== "later") {
+            $earlier_index_byte_offset = ftell($this->earlier_index_handle);
+            if (!is_int($earlier_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the earlier file-index byte offset.");
             }
-            $this->cursor["before_index_byte_offset"] = $before_index_byte_offset;
-            $this->before_index_entry = null;
-            $this->before_index_entry_loaded = false;
+            $this->cursor["earlier_index_byte_offset"] = $earlier_index_byte_offset;
+            $this->earlier_index_entry = null;
+            $this->earlier_index_entry_loaded = false;
         }
-        if ($this->current_path_order !== "before") {
-            $after_index_byte_offset = ftell($this->after_index_handle);
-            if (!is_int($after_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the after file-index byte offset.");
+        if ($this->current_path_order !== "earlier") {
+            $later_index_byte_offset = ftell($this->later_index_handle);
+            if (!is_int($later_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the later file-index byte offset.");
             }
-            $this->cursor["after_index_byte_offset"] = $after_index_byte_offset;
-            $this->cursor["previous_after_index_entry_path_b64"] = base64_encode(
-                $this->after_index_entry["path"]
+            $this->cursor["later_index_byte_offset"] = $later_index_byte_offset;
+            $this->cursor["previous_later_index_entry_path_b64"] = base64_encode(
+                $this->later_index_entry["path"]
             );
-            $this->after_index_entry = null;
-            $this->after_index_entry_loaded = false;
+            $this->later_index_entry = null;
+            $this->later_index_entry_loaded = false;
         }
         $this->current_path_order = null;
-        $this->previous_after_path = null;
+        $this->previous_later_path = null;
     }
 
     /**
@@ -395,9 +395,9 @@ final class FileIndexDiffProcessor
      * @return array {
      *     Cursor for `resume()`.
      *
-     *     @type int         $before_index_byte_offset            Next byte in the earlier index.
-     *     @type int         $after_index_byte_offset             Next byte in the later index.
-     *     @type string|null $previous_after_index_entry_path_b64 Last consumed later-index path.
+     *     @type int         $earlier_index_byte_offset            Next byte in the earlier index.
+     *     @type int         $later_index_byte_offset              Next byte in the later index.
+     *     @type string|null $previous_later_index_entry_path_b64  Last consumed later-index path.
      * }
      *
      * @phpstan-return Cursor
@@ -415,17 +415,17 @@ final class FileIndexDiffProcessor
      */
     public function close(): void
     {
-        if (is_resource($this->before_index_handle)) {
-            fclose($this->before_index_handle);
+        if (is_resource($this->earlier_index_handle)) {
+            fclose($this->earlier_index_handle);
         }
-        if (is_resource($this->after_index_handle)) {
-            fclose($this->after_index_handle);
+        if (is_resource($this->later_index_handle)) {
+            fclose($this->later_index_handle);
         }
-        $this->before_index_handle = null;
-        $this->before_index_entry = null;
-        $this->after_index_entry = null;
+        $this->earlier_index_handle = null;
+        $this->earlier_index_entry = null;
+        $this->later_index_entry = null;
         $this->current_path_order = null;
-        $this->previous_after_path = null;
+        $this->previous_later_path = null;
         $this->closed = true;
     }
 
@@ -447,39 +447,39 @@ final class FileIndexDiffProcessor
     }
 
     /** @phpstan-return IndexEntry|null */
-    private function get_before_entry(): ?array
+    private function get_earlier_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_order === "after"
+        return $this->current_path_order === "later"
             ? null
-            : $this->before_index_entry;
+            : $this->earlier_index_entry;
     }
 
     /** @phpstan-return IndexEntry|null */
-    private function get_after_entry(): ?array
+    private function get_later_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_order === "before"
+        return $this->current_path_order === "earlier"
             ? null
-            : $this->after_index_entry;
+            : $this->later_index_entry;
     }
 
     /** @phpstan-return IndexEntry */
-    private function get_required_before_entry(): array
+    private function get_required_earlier_index_entry(): array
     {
-        $entry = $this->get_before_entry();
+        $entry = $this->get_earlier_index_entry_for_current_path();
         if ($entry === null) {
-            throw new LogicException("The current path has no before-index entry.");
+            throw new LogicException("The current path has no earlier-index entry.");
         }
         return $entry;
     }
 
     /** @phpstan-return IndexEntry */
-    private function get_required_after_entry(): array
+    private function get_required_later_index_entry(): array
     {
-        $entry = $this->get_after_entry();
+        $entry = $this->get_later_index_entry_for_current_path();
         if ($entry === null) {
-            throw new LogicException("The current path has no after-index entry.");
+            throw new LogicException("The current path has no later-index entry.");
         }
         return $entry;
     }

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -42,7 +42,7 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * `wp-content/a.txt`, the current path has no old entry and
  * `get_path_type_in_old_index()` returns null.
  *
- * The processor labels that snapshot difference through `get_path_change()`.
+ * The processor labels that snapshot difference through `get_path_transition()`.
  * It does not decide whether to copy, remove, or preserve a path. That policy
  * remains with the caller.
  *
@@ -83,7 +83,7 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *     while ($has_path) {
  *         apply_path_operation(
  *             $processor->get_path(),
- *             $processor->get_path_change()
+ *             $processor->get_path_transition()
  *         );
  *         $has_path = $processor->next_path();
  *         save_cursor($processor->get_cursor());
@@ -339,7 +339,7 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns how the current path differs between the two snapshots.
+     * Returns the current path's transition from the old to the new snapshot.
      *
      * A path is `added` when it occurs only in the new index and `deleted` when
      * it occurs only in the old index. A path present in both is `modified`
@@ -350,7 +350,7 @@ final class FileIndexDiffProcessor
      * @return string One of `added`, `modified`, `deleted`, or `unchanged`.
      * @phpstan-return 'added'|'modified'|'deleted'|'unchanged'
      */
-    public function get_path_change(): string
+    public function get_path_transition(): string
     {
         $this->assert_current_path();
         if ($this->current_path_found_in === "new") {

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -1,0 +1,264 @@
+<?php
+
+use function Reprint\Importer\decode_local_index_entry;
+
+require_once __DIR__ . '/../local-index-update-functions.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint processor classes use domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing processor classes.
+
+/**
+ * Retains the current path from two sorted file indexes.
+ *
+ * Callers inspect one aligned before/after pair with get_current_path(), perform
+ * their operation for that path, then call consume_current_path(). The cursor
+ * advances only when the caller confirms that operation completed. A resumed
+ * processor therefore presents an unconfirmed path again.
+ *
+ * The indexes must use decoded-path byte order. A missing before index is an
+ * empty index. The processor retains only one entry from each index.
+ *
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
+ * @phpstan-type CurrentPath array{order:'before'|'after'|'both',before:IndexEntry|null,after:IndexEntry|null,before_lookahead:IndexEntry|null,after_lookahead:IndexEntry|null,previous_after_path:string|null}
+ * @phpstan-type Cursor array{before_index_byte_offset:int,after_index_byte_offset:int,previous_after_index_entry_path_b64:string|null}
+ */
+final class FileIndexDiffProcessor
+{
+    /** @var resource|null */
+    private $before_index_handle = null;
+
+    /** @var resource|null */
+    private $after_index_handle = null;
+
+    /** @var IndexEntry|null */
+    private ?array $before_index_entry = null;
+
+    private bool $before_index_entry_loaded = false;
+
+    /** @var IndexEntry|null */
+    private ?array $after_index_entry = null;
+
+    private bool $after_index_entry_loaded = false;
+
+    /** @var Cursor */
+    private array $cursor;
+
+    private bool $closed = false;
+
+    /**
+     * Opens two sorted indexes at their beginning.
+     *
+     * @param string $before_index_file Earlier index, or a missing path for an empty index.
+     * @param string $after_index_file  Later index.
+     */
+    public static function start(string $before_index_file, string $after_index_file): self
+    {
+        return self::resume(
+            $before_index_file,
+            $after_index_file,
+            [
+                "before_index_byte_offset" => 0,
+                "after_index_byte_offset" => 0,
+                "previous_after_index_entry_path_b64" => null,
+            ]
+        );
+    }
+
+    /**
+     * Reopens two sorted indexes at the last consumed path.
+     *
+     * @param string $before_index_file Earlier index, or a missing path for an empty index.
+     * @param string $after_index_file  Later index.
+     * @param array  $cursor {
+     *     Cursor returned by get_cursor().
+     *
+     *     @type int         $before_index_byte_offset             Next byte in the earlier index.
+     *     @type int         $after_index_byte_offset              Next byte in the later index.
+     *     @type string|null $previous_after_index_entry_path_b64  Last consumed later-index path.
+     * }
+     * @phpstan-param Cursor $cursor
+     */
+    public static function resume(
+        string $before_index_file,
+        string $after_index_file,
+        array $cursor
+    ): self {
+        $processor = new self();
+        $processor->cursor = $cursor;
+        if (is_file($before_index_file)) {
+            $processor->before_index_handle = fopen($before_index_file, "rb");
+            if (!is_resource($processor->before_index_handle)) {
+                throw new RuntimeException("Failed to open the before file index: {$before_index_file}.");
+            }
+        }
+        $processor->after_index_handle = fopen($after_index_file, "rb");
+        if (!is_resource($processor->after_index_handle)) {
+            $processor->close();
+            throw new RuntimeException("Failed to open the after file index: {$after_index_file}.");
+        }
+        if (
+            ( is_resource($processor->before_index_handle)
+                && fseek(
+                    $processor->before_index_handle,
+                    $cursor["before_index_byte_offset"]
+                ) !== 0 )
+            || fseek(
+                $processor->after_index_handle,
+                $cursor["after_index_byte_offset"]
+            ) !== 0
+        ) {
+            $processor->close();
+            throw new RuntimeException("Failed to restore the file-index diff cursor.");
+        }
+        return $processor;
+    }
+
+    /**
+     * Returns the next aligned path without consuming it.
+     *
+     * `before` is an earlier index entry and `after` is its desired or current
+     * replacement. Null means that side has no entry at this path.
+     *
+     * @phpstan-return CurrentPath|null
+     */
+    public function get_current_path(): ?array
+    {
+        $this->assert_open();
+        if (!$this->before_index_entry_loaded) {
+            $this->before_index_entry = $this->read_next_index_entry(
+                $this->before_index_handle
+            );
+            $this->before_index_entry_loaded = true;
+        }
+        if (!$this->after_index_entry_loaded) {
+            $this->after_index_entry = $this->read_next_index_entry(
+                $this->after_index_handle
+            );
+            $this->after_index_entry_loaded = true;
+        }
+        if ($this->before_index_entry === null && $this->after_index_entry === null) {
+            return null;
+        }
+
+        if ($this->before_index_entry === null) {
+            $order = "after";
+        } elseif ($this->after_index_entry === null) {
+            $order = "before";
+        } else {
+            // Base64 does not preserve byte order ('0' sorts before 'A'
+            // in ASCII but encodes a higher value), so compare decoded paths.
+            $path_comparison = strcmp(
+                $this->after_index_entry["path"],
+                $this->before_index_entry["path"]
+            );
+            $order = $path_comparison < 0
+                ? "after"
+                : ( $path_comparison > 0 ? "before" : "both" );
+        }
+
+        $previous_after_path = null;
+        if ($this->cursor["previous_after_index_entry_path_b64"] !== null) {
+            $previous_after_path = base64_decode(
+                $this->cursor["previous_after_index_entry_path_b64"],
+                true
+            );
+            if ($previous_after_path === false) {
+                throw new RuntimeException("The file-index diff cursor has an invalid previous path.");
+            }
+        }
+
+        return [
+            "order" => $order,
+            "before" => $order === "after" ? null : $this->before_index_entry,
+            "after" => $order === "before" ? null : $this->after_index_entry,
+            "before_lookahead" => $this->before_index_entry,
+            "after_lookahead" => $this->after_index_entry,
+            "previous_after_path" => $previous_after_path,
+        ];
+    }
+
+    /** Consumes the current aligned path after the caller completes its operation. */
+    public function consume_current_path(): void
+    {
+        $current_path = $this->get_current_path();
+        if ($current_path === null) {
+            throw new LogicException("Cannot consume a completed file-index diff.");
+        }
+        if ($current_path["order"] !== "after") {
+            $before_index_byte_offset = ftell($this->before_index_handle);
+            if (!is_int($before_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the before file-index byte offset.");
+            }
+            $this->cursor["before_index_byte_offset"] = $before_index_byte_offset;
+            $this->before_index_entry = null;
+            $this->before_index_entry_loaded = false;
+        }
+        if ($current_path["order"] !== "before") {
+            $after_index_byte_offset = ftell($this->after_index_handle);
+            if (!is_int($after_index_byte_offset)) {
+                throw new RuntimeException("Failed to read the after file-index byte offset.");
+            }
+            $this->cursor["after_index_byte_offset"] = $after_index_byte_offset;
+            $this->cursor["previous_after_index_entry_path_b64"] = base64_encode(
+                $current_path["after"]["path"]
+            );
+            $this->after_index_entry = null;
+            $this->after_index_entry_loaded = false;
+        }
+    }
+
+    /**
+     * Returns the cursor after the last consumed path.
+     *
+     * @phpstan-return Cursor
+     */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Idempotently closes both index handles. */
+    public function close(): void
+    {
+        if (is_resource($this->before_index_handle)) {
+            fclose($this->before_index_handle);
+        }
+        if (is_resource($this->after_index_handle)) {
+            fclose($this->after_index_handle);
+        }
+        $this->before_index_handle = null;
+        $this->before_index_entry = null;
+        $this->after_index_entry = null;
+        $this->closed = true;
+    }
+
+    /** Rejects work after close(). */
+    private function assert_open(): void
+    {
+        if ($this->closed) {
+            throw new LogicException("Cannot use a closed file-index diff processor.");
+        }
+    }
+
+    /**
+     * Reads one index entry and decodes its path.
+     *
+     * @param resource|null $index_handle Open index or null for an empty index.
+     * @phpstan-return IndexEntry|null
+     */
+    private function read_next_index_entry($index_handle): ?array
+    {
+        if (!is_resource($index_handle)) {
+            return null;
+        }
+        $line = fgets($index_handle);
+        if ($line === false) {
+            if (!feof($index_handle)) {
+                throw new RuntimeException("Failed to read a file-index entry.");
+            }
+            return null;
+        }
+        return decode_local_index_entry($line);
+    }
+}

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -22,34 +22,39 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * A caller performs its work before consuming the current path:
  *
  *     $processor = FileIndexDiffProcessor::start($before_index, $after_index);
- *     while ($current_path = $processor->get_current_path()) {
- *         apply_path_operation($current_path);
+ *     while ($processor->next_path()) {
+ *         apply_path_operation(
+ *             $processor->get_path(),
+ *             $processor->get_before_path_type(),
+ *             $processor->get_after_path_type()
+ *         );
  *         $processor->consume_current_path();
  *         save_cursor($processor->get_cursor());
  *     }
  *     $processor->close();
  *
- * `get_current_path()` is idempotent. It continues to return the same path
- * until `consume_current_path()` advances the processor. If the process stops
- * after applying an operation but before storing the new cursor, `resume()`
- * presents that path again. The operation associated with one path therefore
- * needs to tolerate replay, or the caller needs its own durable confirmation.
+ * `next_path()` is the only path-selection method which reads from the index
+ * handles. The `get_*()` methods only inspect the selected path. If the process
+ * stops after applying an operation but before storing the consumed cursor,
+ * `resume()` selects that path again. The operation associated with one path
+ * therefore needs to tolerate replay, or the caller needs its own durable
+ * confirmation.
  *
  * ## Alignment
  *
- * Each current path has one of three orders:
+ * Each selected path has one of three relationships:
  *
- * | Order    | Before entry | After entry | Meaning                         |
- * |----------|--------------|-------------|---------------------------------|
- * | `before` | present      | null        | The path occurs only before.    |
- * | `after`  | null         | present     | The path occurs only after.     |
- * | `both`   | present      | present     | Both indexes contain the path.  |
+ * | Before path type | After path type | Meaning                         |
+ * |------------------|-----------------|---------------------------------|
+ * | non-null         | null            | The path occurs only before.    |
+ * | null             | non-null        | The path occurs only after.     |
+ * | non-null         | non-null        | Both indexes contain the path.  |
  *
- * The two `*_lookahead` values expose the entries currently retained from the
- * underlying streams even when one belongs to a later path. For example, an
- * `after` result may include the next `before` entry as `before_lookahead`.
- * Callers use this to recognize subtree replacements without reading ahead or
- * moving either cursor themselves.
+ * The two lookahead-path getters expose the entries currently retained from
+ * the underlying streams even when one belongs to a later path. For example,
+ * an after-only path may retain the next before-side path as lookahead. Callers
+ * use this to recognize subtree replacements without reading ahead or moving
+ * either cursor themselves.
  *
  * `previous_after_path` is the most recently consumed path from the after
  * index. Consuming a before-only path does not change it. This gives callers
@@ -67,13 +72,12 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * files themselves. A caller which resumes with different index contents has
  * violated the processor contract.
  *
- * The processor keeps one current entry from each index in memory. Reading a
- * current path may move the file handles beyond the public cursor because the
- * retained entries are not consumed yet. Only the cursor returned after
- * `consume_current_path()` is a continuation boundary.
+ * The processor keeps one current entry from each index in memory. Selecting a
+ * path may move the file handles beyond the public cursor because the retained
+ * entries are not consumed yet. Getter calls never move the handles. Only the
+ * cursor returned after `consume_current_path()` is a continuation boundary.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
- * @phpstan-type CurrentPath array{order:'before'|'after'|'both',before:IndexEntry|null,after:IndexEntry|null,before_lookahead:IndexEntry|null,after_lookahead:IndexEntry|null,previous_after_path:string|null}
  * @phpstan-type Cursor array{before_index_byte_offset:int,after_index_byte_offset:int,previous_after_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor
@@ -98,6 +102,15 @@ final class FileIndexDiffProcessor
 
     /** @var Cursor Position immediately after the last consumed aligned path. */
     private array $cursor;
+
+    /** @var 'before'|'after'|'both'|null Relationship of the selected path. */
+    private ?string $current_path_order = null;
+
+    /** Most recently consumed after-side path restored for the selected path. */
+    private ?string $previous_after_path = null;
+
+    /** Whether both indexes reached EOF. */
+    private bool $complete = false;
 
     /** Whether close() has made this processor terminal. */
     private bool $closed = false;
@@ -185,33 +198,26 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns the current aligned path without consuming it.
+     * Selects the next aligned path from the two indexes.
      *
-     * The first call reads at most one retained entry from each index. Later
-     * calls return the same result until `consume_current_path()` advances one
-     * or both streams. Null means both indexes reached EOF and remains stable
-     * until the processor is closed.
+     * This method reads at most one retained entry from each index. It returns
+     * true when the per-information getters may inspect a selected path. The
+     * caller must consume that path before selecting another one. False means
+     * both indexes reached EOF and remains false on later calls.
      *
-     * `before` and `after` describe the aligned path. A null value means that
-     * side has no entry at the path. The lookahead values describe the retained
-     * stream entries and may therefore refer to different paths.
-     *
-     * @return array|null {
-     *     Current aligned path, or null after both indexes reach EOF.
-     *
-     *     @type string     $order               `before`, `after`, or `both`.
-     *     @type array|null $before              Entry at this path in the earlier index.
-     *     @type array|null $after               Entry at this path in the later index.
-     *     @type array|null $before_lookahead    Current retained earlier-index entry.
-     *     @type array|null $after_lookahead     Current retained later-index entry.
-     *     @type string|null $previous_after_path Last consumed later-index path.
-     * }
-     *
-     * @phpstan-return CurrentPath|null
+     * @return bool Whether a path was selected.
      */
-    public function get_current_path(): ?array
+    public function next_path(): bool
     {
         $this->assert_open();
+        if ($this->current_path_order !== null) {
+            throw new LogicException(
+                "Cannot select another file-index path before consuming the current path."
+            );
+        }
+        if ($this->complete) {
+            return false;
+        }
         if (!$this->before_index_entry_loaded) {
             $this->before_index_entry = $this->read_next_index_entry(
                 $this->before_index_handle
@@ -225,21 +231,21 @@ final class FileIndexDiffProcessor
             $this->after_index_entry_loaded = true;
         }
         if ($this->before_index_entry === null && $this->after_index_entry === null) {
-            return null;
+            $this->complete = true;
+            return false;
         }
 
         if ($this->before_index_entry === null) {
-            $order = "after";
+            $current_path_order = "after";
         } elseif ($this->after_index_entry === null) {
-            $order = "before";
+            $current_path_order = "before";
         } else {
-            // Base64 does not preserve byte order ('0' sorts before 'A'
-            // in ASCII but encodes a higher value), so compare decoded paths.
+            // Base64 text order does not preserve arbitrary path-byte order.
             $path_comparison = strcmp(
                 $this->after_index_entry["path"],
                 $this->before_index_entry["path"]
             );
-            $order = $path_comparison < 0
+            $current_path_order = $path_comparison < 0
                 ? "after"
                 : ( $path_comparison > 0 ? "before" : "both" );
         }
@@ -254,15 +260,91 @@ final class FileIndexDiffProcessor
                 throw new RuntimeException("The file-index diff cursor has an invalid previous path.");
             }
         }
+        $this->current_path_order = $current_path_order;
+        $this->previous_after_path = $previous_after_path;
+        return true;
+    }
 
-        return [
-            "order" => $order,
-            "before" => $order === "after" ? null : $this->before_index_entry,
-            "after" => $order === "before" ? null : $this->after_index_entry,
-            "before_lookahead" => $this->before_index_entry,
-            "after_lookahead" => $this->after_index_entry,
-            "previous_after_path" => $previous_after_path,
-        ];
+    /** Returns the selected local relative path. */
+    public function get_path(): string
+    {
+        $this->assert_current_path();
+        return $this->current_path_order === "after"
+            ? $this->after_index_entry["path"]
+            : $this->before_index_entry["path"];
+    }
+
+    /** Returns the earlier local path type, or null when the path occurs only after. */
+    public function get_before_path_type(): ?string
+    {
+        $entry = $this->get_before_entry();
+        return $entry["type"] ?? null;
+    }
+
+    /** Returns the later local path type, or null when the path occurs only before. */
+    public function get_after_path_type(): ?string
+    {
+        $entry = $this->get_after_entry();
+        return $entry["type"] ?? null;
+    }
+
+    /** Returns the earlier size. The selected path must occur in the before index. */
+    public function get_before_size(): int
+    {
+        return $this->get_required_before_entry()["size"];
+    }
+
+    /** Returns the later size. The selected path must occur in the after index. */
+    public function get_after_size(): int
+    {
+        return $this->get_required_after_entry()["size"];
+    }
+
+    /** Returns the earlier ctime. The selected path must occur in the before index. */
+    public function get_before_ctime(): int
+    {
+        return $this->get_required_before_entry()["ctime"];
+    }
+
+    /** Returns the later ctime. The selected path must occur in the after index. */
+    public function get_after_ctime(): int
+    {
+        return $this->get_required_after_entry()["ctime"];
+    }
+
+    /** Returns the earlier directory empty marker, or null when it is not recorded. */
+    public function get_before_directory_is_empty(): ?bool
+    {
+        $entry = $this->get_before_entry();
+        return $entry["empty"] ?? null;
+    }
+
+    /** Returns the later directory empty marker, or null when it is not recorded. */
+    public function get_after_directory_is_empty(): ?bool
+    {
+        $entry = $this->get_after_entry();
+        return $entry["empty"] ?? null;
+    }
+
+    /** Returns the earlier entry retained as lookahead, which may follow the selected path. */
+    public function get_before_lookahead_path(): ?string
+    {
+        $this->assert_current_path();
+        return $this->before_index_entry["path"] ?? null;
+    }
+
+    /** Returns the later entry retained as lookahead, which may follow the selected path. */
+    public function get_after_lookahead_path(): ?string
+    {
+        $this->assert_current_path();
+        return $this->after_index_entry["path"] ?? null;
+    }
+
+    /** Returns the most recently consumed later-index path. */
+    public function get_previous_after_path(): ?string
+    {
+        $this->assert_current_path();
+        return $this->previous_after_path;
     }
 
     /**
@@ -277,11 +359,8 @@ final class FileIndexDiffProcessor
      */
     public function consume_current_path(): void
     {
-        $current_path = $this->get_current_path();
-        if ($current_path === null) {
-            throw new LogicException("Cannot consume a completed file-index diff.");
-        }
-        if ($current_path["order"] !== "after") {
+        $this->assert_current_path();
+        if ($this->current_path_order !== "after") {
             $before_index_byte_offset = ftell($this->before_index_handle);
             if (!is_int($before_index_byte_offset)) {
                 throw new RuntimeException("Failed to read the before file-index byte offset.");
@@ -290,26 +369,28 @@ final class FileIndexDiffProcessor
             $this->before_index_entry = null;
             $this->before_index_entry_loaded = false;
         }
-        if ($current_path["order"] !== "before") {
+        if ($this->current_path_order !== "before") {
             $after_index_byte_offset = ftell($this->after_index_handle);
             if (!is_int($after_index_byte_offset)) {
                 throw new RuntimeException("Failed to read the after file-index byte offset.");
             }
             $this->cursor["after_index_byte_offset"] = $after_index_byte_offset;
             $this->cursor["previous_after_index_entry_path_b64"] = base64_encode(
-                $current_path["after"]["path"]
+                $this->after_index_entry["path"]
             );
             $this->after_index_entry = null;
             $this->after_index_entry_loaded = false;
         }
+        $this->current_path_order = null;
+        $this->previous_after_path = null;
     }
 
     /**
      * Returns the continuation boundary after the last consumed path.
      *
-     * Reading through `get_current_path()` does not change this cursor. A caller
-     * should first complete its work for the current path, then consume the path,
-     * make its own output durable, and finally store this cursor.
+     * Selecting a path and reading its information does not change this cursor.
+     * A caller should first complete its work for the current path, then consume
+     * the path, make its own output durable, and finally store this cursor.
      *
      * @return array {
      *     Cursor for `resume()`.
@@ -343,6 +424,8 @@ final class FileIndexDiffProcessor
         $this->before_index_handle = null;
         $this->before_index_entry = null;
         $this->after_index_entry = null;
+        $this->current_path_order = null;
+        $this->previous_after_path = null;
         $this->closed = true;
     }
 
@@ -352,6 +435,53 @@ final class FileIndexDiffProcessor
         if ($this->closed) {
             throw new LogicException("Cannot use a closed file-index diff processor.");
         }
+    }
+
+    /** Rejects information requests when next_path() has not selected a path. */
+    private function assert_current_path(): void
+    {
+        $this->assert_open();
+        if ($this->current_path_order === null) {
+            throw new LogicException("No current file-index path. Call next_path() first.");
+        }
+    }
+
+    /** @phpstan-return IndexEntry|null */
+    private function get_before_entry(): ?array
+    {
+        $this->assert_current_path();
+        return $this->current_path_order === "after"
+            ? null
+            : $this->before_index_entry;
+    }
+
+    /** @phpstan-return IndexEntry|null */
+    private function get_after_entry(): ?array
+    {
+        $this->assert_current_path();
+        return $this->current_path_order === "before"
+            ? null
+            : $this->after_index_entry;
+    }
+
+    /** @phpstan-return IndexEntry */
+    private function get_required_before_entry(): array
+    {
+        $entry = $this->get_before_entry();
+        if ($entry === null) {
+            throw new LogicException("The current path has no before-index entry.");
+        }
+        return $entry;
+    }
+
+    /** @phpstan-return IndexEntry */
+    private function get_required_after_entry(): array
+    {
+        $entry = $this->get_after_entry();
+        if ($entry === null) {
+            throw new LogicException("The current path has no after-index entry.");
+        }
+        return $entry;
     }
 
     /**

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -73,36 +73,36 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * index. Together they bracket the position where that missing path would
  * appear in the new index.
  *
- * ## Selection and consumption
+ * ## Traversal
  *
- * A caller selects, inspects, processes, and then consumes one path:
+ * The first call to `next_path()` selects a path. Each subsequent call consumes
+ * the current path, advances the cursor, and selects the following path:
  *
- *     $processor = FileIndexDiffProcessor::start($old_index, $new_index);
- *     while ($processor->next_path()) {
+ *     $processor = FileIndexDiffProcessor::create($old_index, $new_index);
+ *     $has_path = $processor->next_path();
+ *     while ($has_path) {
  *         apply_path_operation(
  *             $processor->get_path(),
  *             $processor->get_path_type_in_old_index(),
  *             $processor->get_path_type_in_new_index()
  *         );
- *         $processor->consume_current_path();
+ *         $has_path = $processor->next_path();
  *         save_cursor($processor->get_cursor());
  *     }
  *     $processor->close();
  *
  * `next_path()` is the only public method which reads index entries. Information
  * getters do not move either file handle and return stable values until the
- * current path is consumed. `consume_current_path()` advances the public cursor
- * past the index entries which supplied the current path.
+ * next call to `next_path()`.
  *
  * ## Resume boundaries
  *
  * The cursor records the byte offset after the last consumed entry in each
  * index and the new-index path preceding the next merge position. A selected
  * but unconsumed entry is deliberately not included. If a process stops before
- * storing the consumed cursor, `resume()` selects that path again. Work
- * performed for one path must
- * therefore tolerate replay, or its caller must store a separate durable
- * confirmation.
+ * advancing and storing the cursor, `resume()` selects that path again. Work
+ * performed for one path must therefore tolerate replay, or its caller must
+ * store a separate durable confirmation.
  *
  * Both JSONL indexes must remain immutable and sorted by decoded path bytes,
  * not by their base64 representation. The cursor identifies byte positions in
@@ -110,8 +110,8 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * index must exist. A missing old index represents an empty starting tree.
  *
  * Selecting a path may move the private file handles beyond the public cursor
- * while the processor retains unread entries. Only the cursor returned after
- * `consume_current_path()` is a continuation boundary.
+ * while the processor retains unread entries. The cursor still names only
+ * consumed entries and can always be passed to `resume()`.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
  * @phpstan-type Cursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
@@ -140,7 +140,7 @@ final class FileIndexDiffProcessor
     private array $cursor;
 
     /** @var 'old'|'new'|'both'|null Indexes which contain the current path. */
-    private ?string $current_path_membership = null;
+    private ?string $current_path_found_in = null;
 
     /** Closest consumed new-index path which sorts before the current path. */
     private ?string $preceding_path_in_new_index = null;
@@ -152,7 +152,7 @@ final class FileIndexDiffProcessor
     private bool $closed = false;
 
     /**
-     * Opens two filesystem indexes and starts before their first paths.
+     * Creates a processor positioned before either index's first path.
      *
      * The old file describes the starting tree and may be absent, which is
      * equivalent to an empty tree. The new file describes the ending tree and
@@ -162,7 +162,7 @@ final class FileIndexDiffProcessor
      * @param string $new_index_file New index.
      * @return self Open processor positioned before either index's first path.
      */
-    public static function start(string $old_index_file, string $new_index_file): self
+    public static function create(string $old_index_file, string $new_index_file): self
     {
         return self::resume(
             $old_index_file,
@@ -237,22 +237,43 @@ final class FileIndexDiffProcessor
     /**
      * Selects the next unconsumed path found in either snapshot.
      *
-     * This method retains at most one unread entry from each index, compares
-     * their paths, and makes the first path in decoded-byte order current. The
-     * current path may occur in the old index, the new index, or both.
-     * Information getters may be called only after this method returns true.
-     * The caller must consume the current path before selecting another one.
-     * False means both indexes reached EOF and remains false on subsequent calls.
+     * If a path is already current, this method first records it as consumed and
+     * advances the public cursor past the entries which supplied it. It then
+     * retains at most one unread entry from each index, compares their paths,
+     * and makes the first path in decoded-byte order current. The current path
+     * may occur in the old index, the new index, or both. Information getters
+     * may be called only after this method returns true. False means both indexes
+     * reached EOF and remains false on subsequent calls.
      *
      * @return bool Whether a path was selected.
      */
     public function next_path(): bool
     {
         $this->assert_open();
-        if ($this->current_path_membership !== null) {
-            throw new LogicException(
-                "Cannot select another file-index path before consuming the current path."
-            );
+        if ($this->current_path_found_in !== null) {
+            if ($this->current_path_found_in !== "new") {
+                $old_index_byte_offset = ftell($this->old_index_handle);
+                if (!is_int($old_index_byte_offset)) {
+                    throw new RuntimeException("Failed to read the old file-index byte offset.");
+                }
+                $this->cursor["old_index_byte_offset"] = $old_index_byte_offset;
+                $this->old_index_entry = null;
+                $this->old_index_entry_loaded = false;
+            }
+            if ($this->current_path_found_in !== "old") {
+                $new_index_byte_offset = ftell($this->new_index_handle);
+                if (!is_int($new_index_byte_offset)) {
+                    throw new RuntimeException("Failed to read the new file-index byte offset.");
+                }
+                $this->cursor["new_index_byte_offset"] = $new_index_byte_offset;
+                $this->cursor["preceding_new_index_entry_path_b64"] = base64_encode(
+                    $this->new_index_entry["path"]
+                );
+                $this->new_index_entry = null;
+                $this->new_index_entry_loaded = false;
+            }
+            $this->current_path_found_in = null;
+            $this->preceding_path_in_new_index = null;
         }
         if ($this->complete) {
             return false;
@@ -275,16 +296,16 @@ final class FileIndexDiffProcessor
         }
 
         if ($this->old_index_entry === null) {
-            $current_path_membership = "new";
+            $current_path_found_in = "new";
         } elseif ($this->new_index_entry === null) {
-            $current_path_membership = "old";
+            $current_path_found_in = "old";
         } else {
             // Base64 text order does not preserve arbitrary path-byte order.
             $path_comparison = strcmp(
                 $this->new_index_entry["path"],
                 $this->old_index_entry["path"]
             );
-            $current_path_membership = $path_comparison < 0
+            $current_path_found_in = $path_comparison < 0
                 ? "new"
                 : ( $path_comparison > 0 ? "old" : "both" );
         }
@@ -299,7 +320,7 @@ final class FileIndexDiffProcessor
                 throw new RuntimeException("The file-index diff cursor has an invalid preceding new-index path.");
             }
         }
-        $this->current_path_membership = $current_path_membership;
+        $this->current_path_found_in = $current_path_found_in;
         $this->preceding_path_in_new_index = $preceding_path_in_new_index;
         return true;
     }
@@ -308,12 +329,12 @@ final class FileIndexDiffProcessor
      * Returns the local relative path selected by next_path().
      *
      * This method does not read either index. The returned path remains current
-     * until `consume_current_path()`.
+     * until the next call to `next_path()`.
      */
     public function get_path(): string
     {
         $this->assert_current_path();
-        return $this->current_path_membership === "new"
+        return $this->current_path_found_in === "new"
             ? $this->new_index_entry["path"]
             : $this->old_index_entry["path"];
     }
@@ -424,7 +445,7 @@ final class FileIndexDiffProcessor
     public function get_following_path_in_old_index(): ?string
     {
         $this->assert_current_path();
-        if ($this->current_path_membership !== "new") {
+        if ($this->current_path_found_in !== "new") {
             throw new LogicException(
                 "The current path occurs in the old index, so its following old-index path has not been read."
             );
@@ -442,7 +463,7 @@ final class FileIndexDiffProcessor
     public function get_following_path_in_new_index(): ?string
     {
         $this->assert_current_path();
-        if ($this->current_path_membership !== "old") {
+        if ($this->current_path_found_in !== "old") {
             throw new LogicException(
                 "The current path occurs in the new index, so its following new-index path has not been read."
             );
@@ -464,52 +485,13 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Records that the caller finished processing the current path.
-     *
-     * An old-only or new-only path consumes the entry from that index. A path
-     * present in both indexes consumes both entries. A retained following entry
-     * is not consumed. The cursor is updated only after the file positions of
-     * the consumed entries are known. Consuming a new entry also
-     * makes the current path a subsequent result's preceding new-index path.
-     *
-     * Calling this method after both indexes reached EOF is a logic error.
-     */
-    public function consume_current_path(): void
-    {
-        $this->assert_current_path();
-        if ($this->current_path_membership !== "new") {
-            $old_index_byte_offset = ftell($this->old_index_handle);
-            if (!is_int($old_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the old file-index byte offset.");
-            }
-            $this->cursor["old_index_byte_offset"] = $old_index_byte_offset;
-            $this->old_index_entry = null;
-            $this->old_index_entry_loaded = false;
-        }
-        if ($this->current_path_membership !== "old") {
-            $new_index_byte_offset = ftell($this->new_index_handle);
-            if (!is_int($new_index_byte_offset)) {
-                throw new RuntimeException("Failed to read the new file-index byte offset.");
-            }
-            $this->cursor["new_index_byte_offset"] = $new_index_byte_offset;
-            $this->cursor["preceding_new_index_entry_path_b64"] = base64_encode(
-                $this->new_index_entry["path"]
-            );
-            $this->new_index_entry = null;
-            $this->new_index_entry_loaded = false;
-        }
-        $this->current_path_membership = null;
-        $this->preceding_path_in_new_index = null;
-    }
-
-    /**
      * Returns the positions from which another processor can continue.
      *
      * Each offset points immediately after the last entry consumed from its
      * index. Selecting a path and inspecting its information does not change
      * these offsets, even though private handles may have read retained entries.
-     * A caller should finish its work for the current path, consume the path,
-     * make its own output durable, and then store this cursor.
+     * Calling `next_path()` again advances the cursor past the current path
+     * before selecting another one.
      *
      * @return array {
      *     Cursor for `resume()`.
@@ -543,12 +525,12 @@ final class FileIndexDiffProcessor
         $this->old_index_handle = null;
         $this->old_index_entry = null;
         $this->new_index_entry = null;
-        $this->current_path_membership = null;
+        $this->current_path_found_in = null;
         $this->preceding_path_in_new_index = null;
         $this->closed = true;
     }
 
-    /** Rejects attempts to inspect or consume paths after close(). */
+    /** Rejects attempts to select or inspect paths after close(). */
     private function assert_open(): void
     {
         if ($this->closed) {
@@ -560,7 +542,7 @@ final class FileIndexDiffProcessor
     private function assert_current_path(): void
     {
         $this->assert_open();
-        if ($this->current_path_membership === null) {
+        if ($this->current_path_found_in === null) {
             throw new LogicException("No current file-index path. Call next_path() first.");
         }
     }
@@ -577,7 +559,7 @@ final class FileIndexDiffProcessor
     private function get_old_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_membership === "new"
+        return $this->current_path_found_in === "new"
             ? null
             : $this->old_index_entry;
     }
@@ -594,7 +576,7 @@ final class FileIndexDiffProcessor
     private function get_new_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
-        return $this->current_path_membership === "old"
+        return $this->current_path_found_in === "old"
             ? null
             : $this->new_index_entry;
     }
@@ -631,7 +613,7 @@ final class FileIndexDiffProcessor
      * Reads and decodes one entry, or returns null at EOF or for an absent index.
      *
      * The file handle advances when a line is read, but the public cursor does
-     * not advance until the caller consumes the current path containing it.
+     * does not advance until `next_path()` moves past the current path.
      *
      * @param resource|null $index_handle Open index or null for an empty index.
      * @phpstan-return IndexEntry|null

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -9,15 +9,68 @@ require_once __DIR__ . '/../local-index-update-functions.php';
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing processor classes.
 
 /**
- * Retains the current path from two sorted file indexes.
+ * Aligns entries from two path-sorted file indexes without loading either index.
  *
- * Callers inspect one aligned before/after pair with get_current_path(), perform
- * their operation for that path, then call consume_current_path(). The cursor
- * advances only when the caller confirms that operation completed. A resumed
- * processor therefore presents an unconfirmed path again.
+ * `FileIndexDiffProcessor` provides the traversal shared by operations which
+ * compare an earlier filesystem snapshot with a later one. It does not decide
+ * whether two entries differ or what should happen to a path. Instead, it
+ * presents the next path from the union of both indexes and lets its caller
+ * inspect the entry from either side.
  *
- * The indexes must use decoded-path byte order. A missing before index is an
- * empty index. The processor retains only one entry from each index.
+ * ## Usage
+ *
+ * A caller performs its work before consuming the current path:
+ *
+ *     $processor = FileIndexDiffProcessor::start($before_index, $after_index);
+ *     while ($current_path = $processor->get_current_path()) {
+ *         apply_path_operation($current_path);
+ *         $processor->consume_current_path();
+ *         save_cursor($processor->get_cursor());
+ *     }
+ *     $processor->close();
+ *
+ * `get_current_path()` is idempotent. It continues to return the same path
+ * until `consume_current_path()` advances the processor. If the process stops
+ * after applying an operation but before storing the new cursor, `resume()`
+ * presents that path again. The operation associated with one path therefore
+ * needs to tolerate replay, or the caller needs its own durable confirmation.
+ *
+ * ## Alignment
+ *
+ * Each current path has one of three orders:
+ *
+ * | Order    | Before entry | After entry | Meaning                         |
+ * |----------|--------------|-------------|---------------------------------|
+ * | `before` | present      | null        | The path occurs only before.    |
+ * | `after`  | null         | present     | The path occurs only after.     |
+ * | `both`   | present      | present     | Both indexes contain the path.  |
+ *
+ * The two `*_lookahead` values expose the entries currently retained from the
+ * underlying streams even when one belongs to a later path. For example, an
+ * `after` result may include the next `before` entry as `before_lookahead`.
+ * Callers use this to recognize subtree replacements without reading ahead or
+ * moving either cursor themselves.
+ *
+ * `previous_after_path` is the most recently consumed path from the after
+ * index. Consuming a before-only path does not change it. This gives callers
+ * the preceding after-side path while they process gaps in sparse indexes.
+ *
+ * ## Index and cursor requirements
+ *
+ * Both JSONL indexes must be sorted by decoded path bytes, not by their base64
+ * representation. The after index must exist. A missing before index represents
+ * an empty earlier snapshot.
+ *
+ * The cursor contains the byte offset after the last consumed entry in each
+ * index and the previous consumed after-side path. It identifies positions
+ * within the same immutable index files; it does not identify or validate the
+ * files themselves. A caller which resumes with different index contents has
+ * violated the processor contract.
+ *
+ * The processor keeps one current entry from each index in memory. Reading a
+ * current path may move the file handles beyond the public cursor because the
+ * retained entries are not consumed yet. Only the cursor returned after
+ * `consume_current_path()` is a continuation boundary.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
  * @phpstan-type CurrentPath array{order:'before'|'after'|'both',before:IndexEntry|null,after:IndexEntry|null,before_lookahead:IndexEntry|null,after_lookahead:IndexEntry|null,previous_after_path:string|null}
@@ -25,32 +78,40 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  */
 final class FileIndexDiffProcessor
 {
-    /** @var resource|null */
+    /** @var resource|null Open earlier index, or null when the earlier index is absent. */
     private $before_index_handle = null;
 
-    /** @var resource|null */
+    /** @var resource|null Open later index. */
     private $after_index_handle = null;
 
-    /** @var IndexEntry|null */
+    /** @var IndexEntry|null Earlier entry retained until its aligned path is consumed. */
     private ?array $before_index_entry = null;
 
+    /** Whether the earlier entry has been read, including an EOF result. */
     private bool $before_index_entry_loaded = false;
 
-    /** @var IndexEntry|null */
+    /** @var IndexEntry|null Later entry retained until its aligned path is consumed. */
     private ?array $after_index_entry = null;
 
+    /** Whether the later entry has been read, including an EOF result. */
     private bool $after_index_entry_loaded = false;
 
-    /** @var Cursor */
+    /** @var Cursor Position immediately after the last consumed aligned path. */
     private array $cursor;
 
+    /** Whether close() has made this processor terminal. */
     private bool $closed = false;
 
     /**
-     * Opens two sorted indexes at their beginning.
+     * Starts a new comparison at the beginning of both indexes.
+     *
+     * The before index may be absent, which is equivalent to an empty earlier
+     * snapshot. The after index must be an existing readable file. Both files
+     * remain open until `close()`.
      *
      * @param string $before_index_file Earlier index, or a missing path for an empty index.
      * @param string $after_index_file  Later index.
+     * @return self Open processor positioned before the first aligned path.
      */
     public static function start(string $before_index_file, string $after_index_file): self
     {
@@ -66,7 +127,15 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Reopens two sorted indexes at the last consumed path.
+     * Resumes a comparison after the last consumed aligned path.
+     *
+     * The byte offsets address the next unread entries. The previous after-side
+     * path restores the context returned as `previous_after_path`. Entries read
+     * before an interruption but not consumed are deliberately read again.
+     *
+     * The caller must provide the same immutable index contents used to produce
+     * the cursor. This method restores positions; it does not fingerprint the
+     * files or check that they still describe the same snapshots.
      *
      * @param string $before_index_file Earlier index, or a missing path for an empty index.
      * @param string $after_index_file  Later index.
@@ -78,6 +147,7 @@ final class FileIndexDiffProcessor
      *     @type string|null $previous_after_index_entry_path_b64  Last consumed later-index path.
      * }
      * @phpstan-param Cursor $cursor
+     * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
         string $before_index_file,
@@ -87,12 +157,12 @@ final class FileIndexDiffProcessor
         $processor = new self();
         $processor->cursor = $cursor;
         if (is_file($before_index_file)) {
-            $processor->before_index_handle = fopen($before_index_file, "rb");
+            $processor->before_index_handle = @fopen($before_index_file, "rb");
             if (!is_resource($processor->before_index_handle)) {
                 throw new RuntimeException("Failed to open the before file index: {$before_index_file}.");
             }
         }
-        $processor->after_index_handle = fopen($after_index_file, "rb");
+        $processor->after_index_handle = @fopen($after_index_file, "rb");
         if (!is_resource($processor->after_index_handle)) {
             $processor->close();
             throw new RuntimeException("Failed to open the after file index: {$after_index_file}.");
@@ -115,10 +185,27 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns the next aligned path without consuming it.
+     * Returns the current aligned path without consuming it.
      *
-     * `before` is an earlier index entry and `after` is its desired or current
-     * replacement. Null means that side has no entry at this path.
+     * The first call reads at most one retained entry from each index. Later
+     * calls return the same result until `consume_current_path()` advances one
+     * or both streams. Null means both indexes reached EOF and remains stable
+     * until the processor is closed.
+     *
+     * `before` and `after` describe the aligned path. A null value means that
+     * side has no entry at the path. The lookahead values describe the retained
+     * stream entries and may therefore refer to different paths.
+     *
+     * @return array|null {
+     *     Current aligned path, or null after both indexes reach EOF.
+     *
+     *     @type string     $order               `before`, `after`, or `both`.
+     *     @type array|null $before              Entry at this path in the earlier index.
+     *     @type array|null $after               Entry at this path in the later index.
+     *     @type array|null $before_lookahead    Current retained earlier-index entry.
+     *     @type array|null $after_lookahead     Current retained later-index entry.
+     *     @type string|null $previous_after_path Last consumed later-index path.
+     * }
      *
      * @phpstan-return CurrentPath|null
      */
@@ -178,7 +265,16 @@ final class FileIndexDiffProcessor
         ];
     }
 
-    /** Consumes the current aligned path after the caller completes its operation. */
+    /**
+     * Consumes the current path after its caller completes the associated work.
+     *
+     * A before-only or after-only path advances one index. A path present in
+     * both indexes advances both. The cursor is updated only after the relevant
+     * file positions are known, and consuming an after-side entry also records
+     * that entry as the next result's `previous_after_path`.
+     *
+     * Calling this method after both indexes reached EOF is a logic error.
+     */
     public function consume_current_path(): void
     {
         $current_path = $this->get_current_path();
@@ -209,7 +305,19 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns the cursor after the last consumed path.
+     * Returns the continuation boundary after the last consumed path.
+     *
+     * Reading through `get_current_path()` does not change this cursor. A caller
+     * should first complete its work for the current path, then consume the path,
+     * make its own output durable, and finally store this cursor.
+     *
+     * @return array {
+     *     Cursor for `resume()`.
+     *
+     *     @type int         $before_index_byte_offset            Next byte in the earlier index.
+     *     @type int         $after_index_byte_offset             Next byte in the later index.
+     *     @type string|null $previous_after_index_entry_path_b64 Last consumed later-index path.
+     * }
      *
      * @phpstan-return Cursor
      */
@@ -218,7 +326,12 @@ final class FileIndexDiffProcessor
         return $this->cursor;
     }
 
-    /** Idempotently closes both index handles. */
+    /**
+     * Idempotently closes both index handles and makes this instance terminal.
+     *
+     * Closing does not consume a retained path or alter the cursor. To continue,
+     * create another instance with `resume()` and the last stored cursor.
+     */
     public function close(): void
     {
         if (is_resource($this->before_index_handle)) {
@@ -233,7 +346,7 @@ final class FileIndexDiffProcessor
         $this->closed = true;
     }
 
-    /** Rejects work after close(). */
+    /** Rejects attempts to inspect or consume paths after close(). */
     private function assert_open(): void
     {
         if ($this->closed) {
@@ -242,7 +355,10 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Reads one index entry and decodes its path.
+     * Reads and decodes one entry, or returns null at EOF or for an absent index.
+     *
+     * The file handle advances when a line is read, but the public cursor does
+     * not advance until the caller consumes the aligned path containing it.
      *
      * @param resource|null $index_handle Open index or null for an empty index.
      * @phpstan-return IndexEntry|null

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -9,17 +9,73 @@ require_once __DIR__ . '/../local-index-update-functions.php';
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing processor classes.
 
 /**
- * Aligns entries from two path-sorted file indexes without loading either index.
+ * Walks two filesystem indexes together in path order.
  *
- * `FileIndexDiffProcessor` provides the traversal shared by operations which
- * compare an earlier filesystem snapshot with a later one. It does not decide
- * whether two entries differ or what should happen to a path. Instead, it
- * presents the next path from the union of both indexes and lets its caller
- * inspect the entry from either side.
+ * ## What the indexes represent
  *
- * ## Usage
+ * A filesystem index is a path-sorted list describing a filesystem tree at one
+ * point in time. Each index entry records one local relative path, whether that
+ * path is a file, link, or directory, its size, its inode change time (ctime),
+ * and, for some directories, whether it was empty.
  *
- * A caller performs its work before consuming the current path:
+ * This processor opens two such lists:
+ *
+ * - The **earlier index** describes the tree at the starting point.
+ * - The **later index** describes the tree at the ending point.
+ *
+ * "Earlier" and "later" therefore identify the snapshot which supplied an
+ * entry. They do not mean the previously or subsequently visited path. This
+ * class uses "previous" only for traversal history.
+ *
+ * ## How paths are compared
+ *
+ * `next_path()` selects the first unconsumed path found in either index. That
+ * selected path becomes the **current path**. The current path can have:
+ *
+ * - an earlier entry and no later entry, meaning the path disappeared;
+ * - no earlier entry and a later entry, meaning the path appeared; or
+ * - an entry in both indexes, meaning the caller must compare their recorded
+ *   information to decide whether the path changed.
+ *
+ * For example, while `wp-content/a.txt` is current, its earlier entry is the
+ * record for `wp-content/a.txt` in the earlier index. It is not the record for
+ * the path visited immediately before it. If the earlier index does not contain
+ * `wp-content/a.txt`, the current path has no earlier entry and
+ * `get_earlier_path_type()` returns null.
+ *
+ * This class only aligns the two indexes. It does not classify a change or
+ * decide whether to copy, remove, or preserve a path. The caller makes that
+ * decision from the information exposed for the current path.
+ *
+ * ## Current entries and lookahead entries
+ *
+ * The indexes are already sorted, so they can be merged in a single pass. The
+ * processor retains at most one unread entry from each index and compares their
+ * decoded path bytes. The earlier and later retained entries do not always name
+ * the same path.
+ *
+ * Suppose the earlier index's retained entry is `b.txt` and the later index's
+ * retained entry is `a.txt`. `a.txt` becomes the current path because it sorts
+ * first. It has no earlier entry. The retained `b.txt` entry remains available
+ * as the earlier lookahead path for callers which need to reason about what
+ * follows without moving either stream.
+ *
+ * Therefore the information getters and lookahead getters answer different
+ * questions:
+ *
+ * - `get_earlier_path_type()` describes the current path in the earlier
+ *   snapshot, or returns null when that snapshot has no such path.
+ * - `get_earlier_lookahead_path()` returns the path of the entry retained from
+ *   the earlier stream, even when that entry belongs to a future current path.
+ *
+ * The corresponding later getters make the same distinction for the later
+ * index. `get_previous_later_path()` is different again: it returns the last
+ * path already consumed from the later index. Earlier-only paths may have been
+ * selected since then.
+ *
+ * ## Selection and consumption
+ *
+ * A caller selects, inspects, processes, and then consumes one path:
  *
  *     $processor = FileIndexDiffProcessor::start($earlier_index, $later_index);
  *     while ($processor->next_path()) {
@@ -33,80 +89,59 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  *     }
  *     $processor->close();
  *
- * `next_path()` is the only path-selection method which reads from the index
- * handles. The `get_*()` methods only inspect the selected path. If the process
- * stops after applying an operation but before storing the consumed cursor,
- * `resume()` selects that path again. The operation associated with one path
- * therefore needs to tolerate replay, or the caller needs its own durable
+ * `next_path()` is the only public method which reads index entries. Information
+ * getters do not move either file handle and return stable values until the
+ * current path is consumed. `consume_current_path()` advances the public cursor
+ * past the index entries which supplied the current path.
+ *
+ * ## Resume boundaries
+ *
+ * The cursor records the byte offset after the last consumed entry in each
+ * index and the last consumed later-index path. A selected but unconsumed entry
+ * is deliberately not included. If a process stops before storing the consumed
+ * cursor, `resume()` selects that path again. Work performed for one path must
+ * therefore tolerate replay, or its caller must store a separate durable
  * confirmation.
  *
- * ## Alignment
+ * Both JSONL indexes must remain immutable and sorted by decoded path bytes,
+ * not by their base64 representation. The cursor identifies byte positions in
+ * those same files; it does not identify or validate their contents. The later
+ * index must exist. A missing earlier index represents an empty starting tree.
  *
- * Each selected path has one of three relationships:
- *
- * | Earlier path type | Later path type | Meaning                         |
- * |-------------------|-----------------|---------------------------------|
- * | non-null          | null            | Only the earlier index has it.  |
- * | null              | non-null        | Only the later index has it.    |
- * | non-null         | non-null        | Both indexes contain the path.  |
- *
- * The two lookahead-path getters expose the entries currently retained from
- * the underlying streams even when one belongs to a later path. For example,
- * a later-only path may retain the next earlier-index path as lookahead. Callers
- * use this to recognize subtree replacements without reading ahead or moving
- * either cursor themselves.
- *
- * `previous_later_path` is the most recently consumed path from the later
- * index. Consuming an earlier-only path does not change it. This gives callers
- * the preceding later-index path while they process gaps in sparse indexes.
- *
- * ## Index and cursor requirements
- *
- * Both JSONL indexes must be sorted by decoded path bytes, not by their base64
- * representation. The later index must exist. A missing earlier index represents
- * an empty earlier snapshot.
- *
- * The cursor contains the byte offset after the last consumed entry in each
- * index and the previous consumed later-index path. It identifies positions
- * within the same immutable index files; it does not identify or validate the
- * files themselves. A caller which resumes with different index contents has
- * violated the processor contract.
- *
- * The processor keeps one current entry from each index in memory. Selecting a
- * path may move the file handles beyond the public cursor because the retained
- * entries are not consumed yet. Getter calls never move the handles. Only the
- * cursor returned after `consume_current_path()` is a continuation boundary.
+ * Selecting a path may move the private file handles beyond the public cursor
+ * while the processor retains lookahead. Only the cursor returned after
+ * `consume_current_path()` is a continuation boundary.
  *
  * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
  * @phpstan-type Cursor array{earlier_index_byte_offset:int,later_index_byte_offset:int,previous_later_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor
 {
-    /** @var resource|null Open earlier index, or null when the earlier index is absent. */
+    /** @var resource|null Stream containing the starting tree, or null for an empty tree. */
     private $earlier_index_handle = null;
 
-    /** @var resource|null Open later index. */
+    /** @var resource|null Stream containing the ending tree. */
     private $later_index_handle = null;
 
-    /** @var IndexEntry|null Earlier entry retained until its aligned path is consumed. */
+    /** @var IndexEntry|null Unconsumed earlier entry, which may be current or lookahead. */
     private ?array $earlier_index_entry = null;
 
     /** Whether the earlier entry has been read, including an EOF result. */
     private bool $earlier_index_entry_loaded = false;
 
-    /** @var IndexEntry|null Later entry retained until its aligned path is consumed. */
+    /** @var IndexEntry|null Unconsumed later entry, which may be current or lookahead. */
     private ?array $later_index_entry = null;
 
     /** Whether the later entry has been read, including an EOF result. */
     private bool $later_index_entry_loaded = false;
 
-    /** @var Cursor Position immediately after the last consumed aligned path. */
+    /** @var Cursor Positions immediately after the entries consumed for the last current path. */
     private array $cursor;
 
-    /** @var 'earlier'|'later'|'both'|null Relationship of the selected path. */
+    /** @var 'earlier'|'later'|'both'|null Indexes which contain the current path. */
     private ?string $current_path_order = null;
 
-    /** Most recently consumed later-index path restored for the selected path. */
+    /** Later-index path consumed most recently before the current path. */
     private ?string $previous_later_path = null;
 
     /** Whether both indexes reached EOF. */
@@ -116,15 +151,15 @@ final class FileIndexDiffProcessor
     private bool $closed = false;
 
     /**
-     * Starts a new comparison at the beginning of both indexes.
+     * Opens two filesystem indexes and starts before their first paths.
      *
-     * The earlier index may be absent, which is equivalent to an empty earlier
-     * snapshot. The later index must be an existing readable file. Both files
-     * remain open until `close()`.
+     * The earlier file describes the starting tree and may be absent, which is
+     * equivalent to an empty tree. The later file describes the ending tree and
+     * must be readable. Both files remain open until `close()`.
      *
      * @param string $earlier_index_file Earlier index, or a missing path for an empty index.
      * @param string $later_index_file   Later index.
-     * @return self Open processor positioned before the first aligned path.
+     * @return self Open processor positioned before either index's first path.
      */
     public static function start(string $earlier_index_file, string $later_index_file): self
     {
@@ -140,11 +175,12 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Resumes a comparison after the last consumed aligned path.
+     * Reopens the two filesystem indexes at the positions recorded by a cursor.
      *
-     * The byte offsets address the next unread entries. The previous later-index
-     * path restores the context returned as `previous_later_path`. Entries read
-     * before an interruption but not consumed are deliberately read again.
+     * Each byte offset points to the next entry not represented by the stored
+     * cursor. The previous later-index path restores the traversal information
+     * returned by `get_previous_later_path()`. An entry selected before an
+     * interruption but not consumed is deliberately selected again.
      *
      * The caller must provide the same immutable index contents used to produce
      * the cursor. This method restores positions; it does not fingerprint the
@@ -198,12 +234,14 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Selects the next aligned path from the two indexes.
+     * Selects the next unconsumed path found in either snapshot.
      *
-     * This method reads at most one retained entry from each index. It returns
-     * true when the per-information getters may inspect a selected path. The
-     * caller must consume that path before selecting another one. False means
-     * both indexes reached EOF and remains false on later calls.
+     * This method retains at most one unread entry from each index, compares
+     * their paths, and makes the first path in decoded-byte order current. The
+     * current path may occur in the earlier index, the later index, or both.
+     * Information getters may be called only after this method returns true.
+     * The caller must consume the current path before selecting another one.
+     * False means both indexes reached EOF and remains false on later calls.
      *
      * @return bool Whether a path was selected.
      */
@@ -265,7 +303,12 @@ final class FileIndexDiffProcessor
         return true;
     }
 
-    /** Returns the selected local relative path. */
+    /**
+     * Returns the local relative path selected by next_path().
+     *
+     * This method does not read either index. The returned path remains current
+     * until `consume_current_path()`.
+     */
     public function get_path(): string
     {
         $this->assert_current_path();
@@ -274,73 +317,138 @@ final class FileIndexDiffProcessor
             : $this->earlier_index_entry["path"];
     }
 
-    /** Returns the earlier local path type, or null when only the later index has the path. */
+    /**
+     * Returns the current path's type in the starting tree.
+     *
+     * Null means the earlier index has no entry for the current path: the path
+     * did not exist in the starting tree. A retained earlier lookahead entry for
+     * another path does not affect this result.
+     */
     public function get_earlier_path_type(): ?string
     {
         $entry = $this->get_earlier_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
-    /** Returns the later local path type, or null when only the earlier index has the path. */
+    /**
+     * Returns the current path's type in the ending tree.
+     *
+     * Null means the later index has no entry for the current path: the path no
+     * longer exists in the ending tree. A retained later lookahead entry for
+     * another path does not affect this result.
+     */
     public function get_later_path_type(): ?string
     {
         $entry = $this->get_later_index_entry_for_current_path();
         return $entry["type"] ?? null;
     }
 
-    /** Returns the earlier size. The selected path must occur in the earlier index. */
+    /**
+     * Returns the size recorded for the current path in the starting tree.
+     *
+     * The current path must have an earlier entry. Call
+     * `get_earlier_path_type()` first when its presence is not already known.
+     */
     public function get_earlier_size(): int
     {
         return $this->get_required_earlier_index_entry()["size"];
     }
 
-    /** Returns the later size. The selected path must occur in the later index. */
+    /**
+     * Returns the size recorded for the current path in the ending tree.
+     *
+     * The current path must have a later entry. Call `get_later_path_type()`
+     * first when its presence is not already known.
+     */
     public function get_later_size(): int
     {
         return $this->get_required_later_index_entry()["size"];
     }
 
-    /** Returns the earlier ctime. The selected path must occur in the earlier index. */
+    /**
+     * Returns the ctime recorded for the current path in the starting tree.
+     *
+     * The current path must have an earlier entry. Call
+     * `get_earlier_path_type()` first when its presence is not already known.
+     */
     public function get_earlier_ctime(): int
     {
         return $this->get_required_earlier_index_entry()["ctime"];
     }
 
-    /** Returns the later ctime. The selected path must occur in the later index. */
+    /**
+     * Returns the ctime recorded for the current path in the ending tree.
+     *
+     * The current path must have a later entry. Call `get_later_path_type()`
+     * first when its presence is not already known.
+     */
     public function get_later_ctime(): int
     {
         return $this->get_required_later_index_entry()["ctime"];
     }
 
-    /** Returns the earlier directory empty marker, or null when it is not recorded. */
+    /**
+     * Returns whether the current path was an empty directory in the starting tree.
+     *
+     * Null means either that the current path has no earlier entry or that its
+     * earlier entry does not carry the optional empty-directory marker. Inspect
+     * `get_earlier_path_type()` when those cases need to be distinguished.
+     */
     public function get_earlier_directory_is_empty(): ?bool
     {
         $entry = $this->get_earlier_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
-    /** Returns the later directory empty marker, or null when it is not recorded. */
+    /**
+     * Returns whether the current path is an empty directory in the ending tree.
+     *
+     * Null means either that the current path has no later entry or that its
+     * later entry does not carry the optional empty-directory marker. Inspect
+     * `get_later_path_type()` when those cases need to be distinguished.
+     */
     public function get_later_directory_is_empty(): ?bool
     {
         $entry = $this->get_later_index_entry_for_current_path();
         return $entry["empty"] ?? null;
     }
 
-    /** Returns the earlier entry retained as lookahead, which may follow the selected path. */
+    /**
+     * Returns the path of the entry retained from the earlier index.
+     *
+     * This is stream lookahead, not necessarily information about the current
+     * path. When only the later index contains the current path, the earlier
+     * retained entry names a path which sorts after it. Null means the earlier
+     * stream has no retained entry because it reached EOF or was absent.
+     */
     public function get_earlier_lookahead_path(): ?string
     {
         $this->assert_current_path();
         return $this->earlier_index_entry["path"] ?? null;
     }
 
-    /** Returns the later entry retained as lookahead, which may follow the selected path. */
+    /**
+     * Returns the path of the entry retained from the later index.
+     *
+     * This is stream lookahead, not necessarily information about the current
+     * path. When only the earlier index contains the current path, the later
+     * retained entry names a path which sorts after it. Null means the later
+     * stream has reached EOF.
+     */
     public function get_later_lookahead_path(): ?string
     {
         $this->assert_current_path();
         return $this->later_index_entry["path"] ?? null;
     }
 
-    /** Returns the most recently consumed later-index path. */
+    /**
+     * Returns the last path consumed from the later index before the current path.
+     *
+     * This reports traversal history, not an entry from the earlier snapshot.
+     * Consuming an earlier-only path leaves this value unchanged, so it may not
+     * be the path selected immediately before the current one. Null means no
+     * later-index path has been consumed yet.
+     */
     public function get_previous_later_path(): ?string
     {
         $this->assert_current_path();
@@ -348,12 +456,13 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Consumes the current path after its caller completes the associated work.
+     * Records that the caller finished processing the current path.
      *
-     * An earlier-only or later-only path advances one index. A path present in
-     * both indexes advances both. The cursor is updated only after the relevant
-     * file positions are known, and consuming a later-index entry also records
-     * that entry as the next result's `previous_later_path`.
+     * An earlier-only or later-only path consumes the entry from that index. A
+     * path present in both indexes consumes both entries. Retained lookahead for
+     * a future path is not consumed. The cursor is updated only after the file
+     * positions of the consumed entries are known. Consuming a later entry also
+     * makes the current path the next result's `get_previous_later_path()`.
      *
      * Calling this method after both indexes reached EOF is a logic error.
      */
@@ -386,11 +495,13 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns the continuation boundary after the last consumed path.
+     * Returns the positions from which another processor can continue.
      *
-     * Selecting a path and reading its information does not change this cursor.
-     * A caller should first complete its work for the current path, then consume
-     * the path, make its own output durable, and finally store this cursor.
+     * Each offset points immediately after the last entry consumed from its
+     * index. Selecting a path and inspecting its information does not change
+     * these offsets, even though private handles may have read retained entries.
+     * A caller should finish its work for the current path, consume the path,
+     * make its own output durable, and then store this cursor.
      *
      * @return array {
      *     Cursor for `resume()`.
@@ -446,7 +557,15 @@ final class FileIndexDiffProcessor
         }
     }
 
-    /** @phpstan-return IndexEntry|null */
+    /**
+     * Returns the current path's entry from the starting tree, when it has one.
+     *
+     * The retained earlier entry may instead be lookahead for a future path.
+     * In that case the current path exists only in the later index and this
+     * method returns null rather than exposing the unrelated retained entry.
+     *
+     * @phpstan-return IndexEntry|null
+     */
     private function get_earlier_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
@@ -455,7 +574,15 @@ final class FileIndexDiffProcessor
             : $this->earlier_index_entry;
     }
 
-    /** @phpstan-return IndexEntry|null */
+    /**
+     * Returns the current path's entry from the ending tree, when it has one.
+     *
+     * The retained later entry may instead be lookahead for a future path. In
+     * that case the current path exists only in the earlier index and this
+     * method returns null rather than exposing the unrelated retained entry.
+     *
+     * @phpstan-return IndexEntry|null
+     */
     private function get_later_index_entry_for_current_path(): ?array
     {
         $this->assert_current_path();
@@ -464,7 +591,11 @@ final class FileIndexDiffProcessor
             : $this->later_index_entry;
     }
 
-    /** @phpstan-return IndexEntry */
+    /**
+     * Returns the current path's earlier entry when its presence is required.
+     *
+     * @phpstan-return IndexEntry
+     */
     private function get_required_earlier_index_entry(): array
     {
         $entry = $this->get_earlier_index_entry_for_current_path();
@@ -474,7 +605,11 @@ final class FileIndexDiffProcessor
         return $entry;
     }
 
-    /** @phpstan-return IndexEntry */
+    /**
+     * Returns the current path's later entry when its presence is required.
+     *
+     * @phpstan-return IndexEntry
+     */
     private function get_required_later_index_entry(): array
     {
         $entry = $this->get_later_index_entry_for_current_path();
@@ -488,7 +623,7 @@ final class FileIndexDiffProcessor
      * Reads and decodes one entry, or returns null at EOF or for an absent index.
      *
      * The file handle advances when a line is read, but the public cursor does
-     * not advance until the caller consumes the aligned path containing it.
+     * not advance until the caller consumes the current path containing it.
      *
      * @param resource|null $index_handle Open index or null for an empty index.
      * @phpstan-return IndexEntry|null

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -650,7 +650,7 @@ class PushPlan
         $local_relative_path = $this->index_diff->get_path();
         $local_index_path_type = $this->index_diff->get_path_type_in_old_index();
         $fresh_local_index_path_type = $this->index_diff->get_path_type_in_new_index();
-        $local_path_change = $this->index_diff->get_path_change();
+        $local_path_transition = $this->index_diff->get_path_transition();
         $fresh_local_index_entry_shape = $fresh_local_index_path_type === null
             ? null
             : $this->index_entry_shape($fresh_local_index_path_type);
@@ -681,7 +681,7 @@ class PushPlan
             }
         }
 
-        if ($local_path_change === "added") {
+        if ($local_path_transition === "added") {
             // New files, symlinks, and empty directories need to be pushed.
             // A NUL byte cannot occur in an indexed path, so it cannot match
             // when the old index has no following path.
@@ -723,7 +723,7 @@ class PushPlan
                     $local_file_bytes_to_push += $fresh_local_index_size;
                 }
             }
-        } elseif ($local_path_change === "deleted") {
+        } elseif ($local_path_transition === "deleted") {
             $local_empty_directory_is_implied_by_fresh_descendant =
                 $local_index_entry_shape === "empty_directory"
                 && $this->fresh_index_contains_path_or_descendant(
@@ -769,7 +769,7 @@ class PushPlan
             // size. Only modified files and symlinks need to be uploaded.
             $changed_file_or_symlink_needs_push =
                 $fresh_local_index_entry_is_file_or_symlink
-                && $local_path_change === "modified";
+                && $local_path_transition === "modified";
             $needs_delete =
                 $fresh_local_index_entry_is_file_or_symlink
                 !== $local_index_entry_is_file_or_symlink;

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -65,7 +65,7 @@ require_once __DIR__ . '/../index/class-file-index-diff-processor.php';
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null,deleted_directory_stack_top_byte_offset:int|null,previous_fresh_local_index_entry_path:string|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null,deleted_directory_stack_top_byte_offset:int|null,preceding_fresh_local_index_entry_path:string|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
@@ -424,12 +424,12 @@ class PushPlan
             $this->local_index_file,
             $this->fresh_local_index_file,
             [
-                "earlier_index_byte_offset" => $cursor["byte_offset_in_local_index"],
-                "later_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
-                "previous_later_index_entry_path_b64" =>
-                    $cursor["previous_fresh_local_index_entry_path"] === null
+                "old_index_byte_offset" => $cursor["byte_offset_in_local_index"],
+                "new_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
+                "preceding_new_index_entry_path_b64" =>
+                    $cursor["preceding_fresh_local_index_entry_path"] === null
                         ? null
-                        : base64_encode($cursor["previous_fresh_local_index_entry_path"]),
+                        : base64_encode($cursor["preceding_fresh_local_index_entry_path"]),
             ]
         );
         $fresh_local_index_bytes = filesize($this->fresh_local_index_file);
@@ -550,7 +550,7 @@ class PushPlan
             "local_paths_to_push_count" => 0,
             "local_file_bytes_to_push" => 0,
             "deleted_directory_stack_top_byte_offset" => null,
-            "previous_fresh_local_index_entry_path" => null,
+            "preceding_fresh_local_index_entry_path" => null,
         ];
         $this->open_plan_files();
     }
@@ -648,8 +648,8 @@ class PushPlan
         $this->index_diff_path_selected = true;
 
         $local_relative_path = $this->index_diff_processor->get_path();
-        $local_index_path_type = $this->index_diff_processor->get_earlier_path_type();
-        $fresh_local_index_path_type = $this->index_diff_processor->get_later_path_type();
+        $local_index_path_type = $this->index_diff_processor->get_path_type_in_old_index();
+        $fresh_local_index_path_type = $this->index_diff_processor->get_path_type_in_new_index();
         $path_comparison = $local_index_path_type === null
             ? -1
             : ( $fresh_local_index_path_type === null ? 1 : 0 );
@@ -685,13 +685,12 @@ class PushPlan
 
         if ($path_comparison < 0) {
             // New files, symlinks, and empty directories need to be pushed.
-            $local_index_lookahead_path =
-                $this->index_diff_processor->get_earlier_lookahead_path();
+            $following_local_index_path =
+                $this->index_diff_processor->get_following_path_in_old_index();
             $fresh_local_index_entry_replaces_local_subtree =
-                $local_index_lookahead_path !== null
-                && $local_index_lookahead_path !== $local_relative_path
+                $following_local_index_path !== null
                 && path_is_within_root(
-                    $local_index_lookahead_path,
+                    $following_local_index_path,
                     $local_relative_path
                 );
             if (
@@ -710,12 +709,12 @@ class PushPlan
                     );
             }
             if (!$this->path_conflicts_with_excluded_paths($local_relative_path)) {
-                $fresh_local_index_size = $this->index_diff_processor->get_later_size();
+                $fresh_local_index_size = $this->index_diff_processor->get_size_in_new_index();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_later_ctime()
+                    $this->index_diff_processor->get_ctime_in_new_index()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -728,24 +727,24 @@ class PushPlan
                 }
             }
         } elseif ($path_comparison > 0) {
-            $previous_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_previous_later_path();
-            $next_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_later_lookahead_path();
+            $preceding_fresh_local_index_entry_path =
+                $this->index_diff_processor->get_preceding_path_in_new_index();
+            $following_fresh_local_index_entry_path =
+                $this->index_diff_processor->get_following_path_in_new_index();
             $local_empty_directory_is_implied_by_fresh_descendant =
                 $local_index_entry_shape === "empty_directory"
                 && $this->fresh_index_contains_path_or_descendant(
                     $local_relative_path,
-                    $previous_fresh_local_index_entry_path,
-                    $next_fresh_local_index_entry_path
+                    $preceding_fresh_local_index_entry_path,
+                    $following_fresh_local_index_entry_path
                 );
             $local_path_to_delete = $this->local_path_to_delete(
                 $local_relative_path,
-                $previous_fresh_local_index_entry_path,
-                $next_fresh_local_index_entry_path
+                $preceding_fresh_local_index_entry_path,
+                $following_fresh_local_index_entry_path
             );
             // A sparse index entry derives one deleted root, covering its
-            // later descendant entries.
+            // following descendant entries.
             if (
                 !$local_empty_directory_is_implied_by_fresh_descendant
                 && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
@@ -778,10 +777,10 @@ class PushPlan
             $changed_file_or_symlink_needs_push =
                 $fresh_local_index_entry_is_file_or_symlink
                 && (
-                    $this->index_diff_processor->get_later_ctime()
-                        !== $this->index_diff_processor->get_earlier_ctime()
-                    || $this->index_diff_processor->get_later_size()
-                        !== $this->index_diff_processor->get_earlier_size()
+                    $this->index_diff_processor->get_ctime_in_new_index()
+                        !== $this->index_diff_processor->get_ctime_in_old_index()
+                    || $this->index_diff_processor->get_size_in_new_index()
+                        !== $this->index_diff_processor->get_size_in_old_index()
                     || $fresh_local_index_path_type !== $local_index_path_type
                 );
             $needs_delete =
@@ -804,12 +803,12 @@ class PushPlan
                 $this->append_local_path_to_delete($local_relative_path);
             }
             if ($needs_push && !$path_is_excluded) {
-                $fresh_local_index_size = $this->index_diff_processor->get_later_size();
+                $fresh_local_index_size = $this->index_diff_processor->get_size_in_new_index();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_later_ctime()
+                    $this->index_diff_processor->get_ctime_in_new_index()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -839,14 +838,14 @@ class PushPlan
             $this->deleted_directory_stack_entry = null;
         }
         $index_diff_cursor = $this->index_diff_processor->get_cursor();
-        $previous_fresh_local_index_entry_path = null;
-        if ($index_diff_cursor["previous_later_index_entry_path_b64"] !== null) {
-            $previous_fresh_local_index_entry_path = base64_decode(
-                $index_diff_cursor["previous_later_index_entry_path_b64"],
+        $preceding_fresh_local_index_entry_path = null;
+        if ($index_diff_cursor["preceding_new_index_entry_path_b64"] !== null) {
+            $preceding_fresh_local_index_entry_path = base64_decode(
+                $index_diff_cursor["preceding_new_index_entry_path_b64"],
                 true
             );
-            if ($previous_fresh_local_index_entry_path === false) {
-                throw new RuntimeException("The local-index diff cursor has an invalid previous path.");
+            if ($preceding_fresh_local_index_entry_path === false) {
+                throw new RuntimeException("The local-index diff cursor has an invalid preceding path.");
             }
         }
         $this->cursor["position"] = $complete
@@ -858,9 +857,9 @@ class PushPlan
             : [
                 "phase" => "diffing",
                 "byte_offset_in_fresh_local_index" =>
-                    $index_diff_cursor["later_index_byte_offset"],
+                    $index_diff_cursor["new_index_byte_offset"],
                 "byte_offset_in_local_index" =>
-                    $index_diff_cursor["earlier_index_byte_offset"],
+                    $index_diff_cursor["old_index_byte_offset"],
                 "byte_offset_in_local_paths_to_push" =>
                     ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" =>
@@ -869,8 +868,8 @@ class PushPlan
                 "local_file_bytes_to_push" => $local_file_bytes_to_push,
                 "deleted_directory_stack_top_byte_offset" =>
                     $deleted_directory_stack_top_byte_offset,
-                "previous_fresh_local_index_entry_path" =>
-                    $previous_fresh_local_index_entry_path,
+                "preceding_fresh_local_index_entry_path" =>
+                    $preceding_fresh_local_index_entry_path,
             ];
         return !$complete;
     }
@@ -956,16 +955,16 @@ class PushPlan
     /**
      * Returns the highest deleted directory without a fresh entry below it.
      *
-     * Only the previous fresh entry and the current lookahead can neighbor a
-     * path in byte order, so this derives one subtree root without retaining
-     * the tree.
+     * Only the preceding and following fresh entries can neighbor a path in
+     * byte order, so this derives one subtree root without retaining the tree.
      *
-     * @param string|null $next_fresh_local_index_entry_path Next fresh path, or null at EOF.
+     * @param string|null $preceding_fresh_local_index_entry_path Path immediately before this position.
+     * @param string|null $following_fresh_local_index_entry_path Path immediately after this position.
      */
     private function local_path_to_delete(
         string $local_relative_path,
-        ?string $previous_fresh_local_index_entry_path,
-        ?string $next_fresh_local_index_entry_path
+        ?string $preceding_fresh_local_index_entry_path,
+        ?string $following_fresh_local_index_entry_path
     ): string
     {
         $local_relative_path_components = wp_unix_path_segments($local_relative_path);
@@ -978,8 +977,8 @@ class PushPlan
             if (
                 !$this->fresh_index_contains_path_or_descendant(
                     $candidate_local_relative_path,
-                    $previous_fresh_local_index_entry_path,
-                    $next_fresh_local_index_entry_path
+                    $preceding_fresh_local_index_entry_path,
+                    $following_fresh_local_index_entry_path
                 )
             ) {
                 return $candidate_local_relative_path;
@@ -991,26 +990,27 @@ class PushPlan
     /**
      * Checks the adjacent fresh entries for a path or one of its descendants.
      *
-     * @param string|null $next_fresh_local_index_entry_path Next fresh path, or null at EOF.
+     * @param string|null $preceding_fresh_local_index_entry_path Path immediately before this position.
+     * @param string|null $following_fresh_local_index_entry_path Path immediately after this position.
      */
     private function fresh_index_contains_path_or_descendant(
         string $local_relative_path,
-        ?string $previous_fresh_local_index_entry_path,
-        ?string $next_fresh_local_index_entry_path
+        ?string $preceding_fresh_local_index_entry_path,
+        ?string $following_fresh_local_index_entry_path
     ): bool
     {
         // Use an invalid path that cannot match an indexed local relative path
         // so both comparisons below always receive strings.
-        $previous_fresh_local_index_entry_path =
-            $previous_fresh_local_index_entry_path ?? "\0";
-        $next_fresh_local_index_entry_path =
-            $next_fresh_local_index_entry_path ?? "\0";
+        $preceding_fresh_local_index_entry_path =
+            $preceding_fresh_local_index_entry_path ?? "\0";
+        $following_fresh_local_index_entry_path =
+            $following_fresh_local_index_entry_path ?? "\0";
 
         return path_is_within_root(
-            $previous_fresh_local_index_entry_path,
+            $preceding_fresh_local_index_entry_path,
             $local_relative_path
         ) || path_is_within_root(
-            $next_fresh_local_index_entry_path,
+            $following_fresh_local_index_entry_path,
             $local_relative_path
         );
     }

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -7,6 +7,8 @@ use function WordPress\Reprint\Exporter\path_is_within_root;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
+require_once __DIR__ . '/../index/class-file-index-diff-processor.php';
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
 /**
@@ -19,9 +21,9 @@ use function WordPress\Reprint\Exporter\trim_right_slash;
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
- * FileIndexProcessor, the fresh local index, the index diff, the meaning of
- * its cursor, and the two completed path lists. A caller which resumes across
- * processes stores the cursor returned by get_cursor().
+ * FileIndexProcessor, FileIndexDiffProcessor, the fresh local index, the
+ * meaning of its cursor, and the two completed path lists. A caller which
+ * resumes across processes stores the cursor returned by get_cursor().
  *
  * ## Durable boundary
  *
@@ -110,28 +112,14 @@ class PushPlan
     /** @var FileIndexProcessor Fresh local index traversal retained during indexing. */
     private FileIndexProcessor $file_index_processor;
 
-    /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
-    private ?array $fresh_local_index_entry = null;
-
-    /** @var bool Whether $fresh_local_index_entry has been read, including EOF. */
-    private bool $fresh_local_index_entry_loaded = false;
-
-    /** @var string|null Path of the fresh entry consumed before the lookahead entry. */
-    private ?string $previous_fresh_local_index_entry_path = null;
-
-    /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null */
-    private ?array $local_index_lookahead_entry = null;
-
-    /** @var bool Whether $local_index_lookahead_entry has been read, including EOF. */
-    private bool $local_index_lookahead_entry_loaded = false;
+    /** Sorted local-index comparison retained during the diff phase. */
+    private FileIndexDiffProcessor $index_diff_processor;
 
     /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
     private ?array $deleted_directory_stack_entry = null;
 
-    /** @var resource|null Open fresh local index retained during indexing or the index diff. */
+    /** @var resource|null Open fresh local index retained during indexing. */
     private $fresh_local_index_handle = null;
-    /** @var resource|null */
-    private $local_index_file_handle = null;
     /** @var resource|null */
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
@@ -420,12 +408,6 @@ class PushPlan
     {
         /** @var IndexDiffCursor $cursor */
         $cursor = $this->cursor["position"];
-        $this->fresh_local_index_entry = null;
-        $this->fresh_local_index_entry_loaded = false;
-        $this->previous_fresh_local_index_entry_path =
-            $cursor["previous_fresh_local_index_entry_path"];
-        $this->local_index_lookahead_entry = null;
-        $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->local_paths_to_push_handle = $this->open_push_plan_output_file_at_byte_offset(
             $this->local_paths_to_push,
@@ -435,36 +417,24 @@ class PushPlan
             $this->local_paths_to_delete,
             $cursor["byte_offset_in_local_paths_to_delete"]
         );
-        $this->fresh_local_index_handle = fopen($this->fresh_local_index_file, "rb");
-        if (!is_resource($this->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to open the retained fresh local index: {$this->fresh_local_index_file}");
-        }
-
-        if (is_file($this->local_index_file)) {
-            $this->local_index_file_handle = fopen($this->local_index_file, "rb");
-            if (!is_resource($this->local_index_file_handle)) {
-                throw new RuntimeException("Failed to open the local index: {$this->local_index_file}");
-            }
-        }
-        $fresh_local_index_stat = fstat($this->fresh_local_index_handle);
-        $local_index_stat = is_resource($this->local_index_file_handle)
-            ? fstat($this->local_index_file_handle)
-            : ["size" => 0];
-        if (is_array($fresh_local_index_stat) && is_array($local_index_stat)) {
-            $this->index_bytes_total = (int) $fresh_local_index_stat["size"]
-                + (int) $local_index_stat["size"];
-        }
-        $this->seek_index_file_to_byte_offset(
-            $this->fresh_local_index_handle,
-            $cursor["byte_offset_in_fresh_local_index"],
-            "fresh local index"
+        $this->index_diff_processor = FileIndexDiffProcessor::resume(
+            $this->local_index_file,
+            $this->fresh_local_index_file,
+            [
+                "before_index_byte_offset" => $cursor["byte_offset_in_local_index"],
+                "after_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
+                "previous_after_index_entry_path_b64" =>
+                    $cursor["previous_fresh_local_index_entry_path"] === null
+                        ? null
+                        : base64_encode($cursor["previous_fresh_local_index_entry_path"]),
+            ]
         );
-        if ($this->local_index_file_handle) {
-            $this->seek_index_file_to_byte_offset(
-                $this->local_index_file_handle,
-                $cursor["byte_offset_in_local_index"],
-                "local index"
-            );
+        $fresh_local_index_bytes = filesize($this->fresh_local_index_file);
+        $local_index_bytes = is_file($this->local_index_file)
+            ? filesize($this->local_index_file)
+            : 0;
+        if (is_int($fresh_local_index_bytes) && is_int($local_index_bytes)) {
+            $this->index_bytes_total = $fresh_local_index_bytes + $local_index_bytes;
         }
         $this->deleted_directories_stack_handle = fopen($this->deleted_directories_stack, "a+b");
         if (!is_resource($this->deleted_directories_stack_handle)) {
@@ -648,45 +618,28 @@ class PushPlan
     {
         /** @var IndexDiffCursor $cursor */
         $cursor = $this->cursor["position"];
-
-        $byte_offset_in_fresh_local_index = $cursor["byte_offset_in_fresh_local_index"];
-        $byte_offset_in_local_index = $cursor["byte_offset_in_local_index"];
         $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
         $local_file_bytes_to_push = $cursor["local_file_bytes_to_push"];
-        $deleted_directory_stack_top_byte_offset = $cursor["deleted_directory_stack_top_byte_offset"];
+        $deleted_directory_stack_top_byte_offset =
+            $cursor["deleted_directory_stack_top_byte_offset"];
+        $current_path = $this->index_diff_processor->get_current_path();
 
-        if (!$this->fresh_local_index_entry_loaded) {
-            $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
-            $this->fresh_local_index_entry_loaded = true;
-        }
-        if (!$this->local_index_lookahead_entry_loaded) {
-            $this->local_index_lookahead_entry = $this->read_next_index_entry(
-                $this->local_index_file_handle
-            );
-            $this->local_index_lookahead_entry_loaded = true;
-        }
-        $fresh_local_index_entry = $this->fresh_local_index_entry;
-        $local_index_entry = $this->local_index_lookahead_entry;
-
-        if ($fresh_local_index_entry !== null || $local_index_entry !== null) {
-            // Base64 does not preserve byte order ('0' sorts before 'A'
-            // in ASCII but encodes a higher value), so ordering uses the
-            // decoded path bytes.
-            if ($local_index_entry === null) {
-                $path_comparison = -1;
-            } elseif ($fresh_local_index_entry === null) {
-                $path_comparison = 1;
-            } else {
-                $path_comparison = strcmp($fresh_local_index_entry["path"], $local_index_entry["path"]);
-            }
+        if ($current_path !== null) {
+            $fresh_local_index_entry = $current_path["after"];
+            $local_index_entry = $current_path["before"];
+            $path_comparison = $current_path["order"] === "after"
+                ? -1
+                : ( $current_path["order"] === "before" ? 1 : 0 );
 
             $fresh_local_index_entry_shape = null;
-            if ($path_comparison <= 0) {
-                $fresh_local_index_entry_shape = $this->index_entry_shape($fresh_local_index_entry);
+            if ($fresh_local_index_entry !== null) {
+                $fresh_local_index_entry_shape = $this->index_entry_shape(
+                    $fresh_local_index_entry
+                );
             }
 
             $local_index_entry_shape = null;
-            if ($path_comparison >= 0) {
+            if ($local_index_entry !== null) {
                 $local_index_entry_shape = $this->index_entry_shape($local_index_entry);
 
                 // Byte sorting can put a sibling such as `a-other` before
@@ -701,20 +654,24 @@ class PushPlan
                         )
                         && strcmp($local_index_entry["path"], $descendant_prefix) > 0
                     ) {
-                        $deleted_directory_stack_top_byte_offset = $this->deleted_directory_stack_entry["previous_byte_offset"];
-                        $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-                            $deleted_directory_stack_top_byte_offset
-                        );
+                        $deleted_directory_stack_top_byte_offset =
+                            $this->deleted_directory_stack_entry["previous_byte_offset"];
+                        $this->deleted_directory_stack_entry =
+                            $this->read_deleted_directory_stack_entry(
+                                $deleted_directory_stack_top_byte_offset
+                            );
                     }
                 }
             }
 
             if ($path_comparison < 0) {
                 // New files, symlinks, and empty directories need to be pushed.
-                $fresh_local_index_entry_replaces_local_subtree = $local_index_entry !== null
-                    && $local_index_entry["path"] !== $fresh_local_index_entry["path"]
+                $local_index_lookahead_entry = $current_path["before_lookahead"];
+                $fresh_local_index_entry_replaces_local_subtree =
+                    $local_index_lookahead_entry !== null
+                    && $local_index_lookahead_entry["path"] !== $fresh_local_index_entry["path"]
                     && path_is_within_root(
-                        $local_index_entry["path"],
+                        $local_index_lookahead_entry["path"],
                         $fresh_local_index_entry["path"]
                     );
                 if (
@@ -748,10 +705,14 @@ class PushPlan
                 $local_empty_directory_is_implied_by_fresh_descendant =
                     $local_index_entry_shape === "empty_directory"
                     && $this->fresh_index_contains_path_or_descendant(
-                        $local_index_entry["path"]
+                        $local_index_entry["path"],
+                        $current_path["previous_after_path"],
+                        $current_path["after_lookahead"]
                     );
                 $local_path_to_delete = $this->local_path_to_delete(
-                    $local_index_entry["path"]
+                    $local_index_entry["path"],
+                    $current_path["previous_after_path"],
+                    $current_path["after_lookahead"]
                 );
                 // A sparse index entry derives one deleted root, covering its
                 // later descendant entries.
@@ -765,32 +726,40 @@ class PushPlan
                 ) {
                     $this->append_local_path_to_delete($local_path_to_delete);
                     if ($local_path_to_delete !== $local_index_entry["path"]) {
-                        $deleted_directory_stack_top_byte_offset = $this->append_deleted_directory_stack_entry(
-                            $local_path_to_delete,
-                            $deleted_directory_stack_top_byte_offset
-                        );
+                        $deleted_directory_stack_top_byte_offset =
+                            $this->append_deleted_directory_stack_entry(
+                                $local_path_to_delete,
+                                $deleted_directory_stack_top_byte_offset
+                            );
                     }
                 }
             } else {
-                $fresh_local_index_entry_is_file_or_symlink = $fresh_local_index_entry_shape === "file"
+                $fresh_local_index_entry_is_file_or_symlink =
+                    $fresh_local_index_entry_shape === "file"
                     || $fresh_local_index_entry_shape === "symlink";
-                $local_index_entry_is_file_or_symlink = $local_index_entry_shape === "file"
+                $local_index_entry_is_file_or_symlink =
+                    $local_index_entry_shape === "file"
                     || $local_index_entry_shape === "symlink";
-                $empty_directory_needs_push = $fresh_local_index_entry_shape === "empty_directory"
+                $empty_directory_needs_push =
+                    $fresh_local_index_entry_shape === "empty_directory"
                     && $local_index_entry_shape !== "empty_directory";
                 // File and symlink changes are defined by type, ctime, and
                 // size. Other index values do not select a path for upload.
-                $changed_file_or_symlink_needs_push = $fresh_local_index_entry_is_file_or_symlink
+                $changed_file_or_symlink_needs_push =
+                    $fresh_local_index_entry_is_file_or_symlink
                     && (
                         $fresh_local_index_entry["ctime"] !== $local_index_entry["ctime"]
                         || $fresh_local_index_entry["size"] !== $local_index_entry["size"]
                         || $fresh_local_index_entry["type"] !== $local_index_entry["type"]
                     );
                 $needs_delete =
-                    $fresh_local_index_entry_is_file_or_symlink !== $local_index_entry_is_file_or_symlink;
+                    $fresh_local_index_entry_is_file_or_symlink
+                    !== $local_index_entry_is_file_or_symlink;
                 $needs_push = $empty_directory_needs_push
                     || $changed_file_or_symlink_needs_push;
-                $path_is_excluded = $this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"]);
+                $path_is_excluded = $this->path_conflicts_with_excluded_paths(
+                    $fresh_local_index_entry["path"]
+                );
 
                 if (
                     $needs_delete
@@ -816,22 +785,10 @@ class PushPlan
                 }
             }
 
-            if ($path_comparison <= 0) {
-                $byte_offset_in_fresh_local_index = ftell($this->fresh_local_index_handle);
-                $this->previous_fresh_local_index_entry_path =
-                    $fresh_local_index_entry["path"];
-                $this->fresh_local_index_entry = $this->read_next_index_entry($this->fresh_local_index_handle);
-            }
-            if ($path_comparison >= 0) {
-                $byte_offset_in_local_index = ftell($this->local_index_file_handle);
-                $this->local_index_lookahead_entry = $this->read_next_index_entry(
-                    $this->local_index_file_handle
-                );
-            }
+            $this->index_diff_processor->consume_current_path();
         }
 
-        $complete = $this->fresh_local_index_entry === null
-            && $this->local_index_lookahead_entry === null;
+        $complete = $this->index_diff_processor->get_current_path() === null;
         if ($complete) {
             if (
                 !fflush($this->local_paths_to_push_handle)
@@ -843,7 +800,18 @@ class PushPlan
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
         }
-        $cursor_after_step = $complete
+        $index_diff_cursor = $this->index_diff_processor->get_cursor();
+        $previous_fresh_local_index_entry_path = null;
+        if ($index_diff_cursor["previous_after_index_entry_path_b64"] !== null) {
+            $previous_fresh_local_index_entry_path = base64_decode(
+                $index_diff_cursor["previous_after_index_entry_path_b64"],
+                true
+            );
+            if ($previous_fresh_local_index_entry_path === false) {
+                throw new RuntimeException("The local-index diff cursor has an invalid previous path.");
+            }
+        }
+        $this->cursor["position"] = $complete
             ? [
                 "phase" => "complete",
                 "local_paths_to_push_count" => $local_paths_to_push_count,
@@ -851,17 +819,21 @@ class PushPlan
             ]
             : [
                 "phase" => "diffing",
-                "byte_offset_in_fresh_local_index" => $byte_offset_in_fresh_local_index,
-                "byte_offset_in_local_index" => $byte_offset_in_local_index,
-                "byte_offset_in_local_paths_to_push" => ftell($this->local_paths_to_push_handle),
-                "byte_offset_in_local_paths_to_delete" => ftell($this->local_paths_to_delete_handle),
+                "byte_offset_in_fresh_local_index" =>
+                    $index_diff_cursor["after_index_byte_offset"],
+                "byte_offset_in_local_index" =>
+                    $index_diff_cursor["before_index_byte_offset"],
+                "byte_offset_in_local_paths_to_push" =>
+                    ftell($this->local_paths_to_push_handle),
+                "byte_offset_in_local_paths_to_delete" =>
+                    ftell($this->local_paths_to_delete_handle),
                 "local_paths_to_push_count" => $local_paths_to_push_count,
                 "local_file_bytes_to_push" => $local_file_bytes_to_push,
-                "deleted_directory_stack_top_byte_offset" => $deleted_directory_stack_top_byte_offset,
+                "deleted_directory_stack_top_byte_offset" =>
+                    $deleted_directory_stack_top_byte_offset,
                 "previous_fresh_local_index_entry_path" =>
-                    $this->previous_fresh_local_index_entry_path,
+                    $previous_fresh_local_index_entry_path,
             ];
-        $this->cursor["position"] = $cursor_after_step;
         return !$complete;
     }
 
@@ -877,10 +849,10 @@ class PushPlan
         if (isset($this->file_index_processor)) {
             $this->file_index_processor->close();
         }
-        $this->close_fresh_local_index_handle();
-        if (is_resource($this->local_index_file_handle)) {
-            fclose($this->local_index_file_handle);
+        if (isset($this->index_diff_processor)) {
+            $this->index_diff_processor->close();
         }
+        $this->close_fresh_local_index_handle();
         if (is_resource($this->local_paths_to_push_handle)) {
             fclose($this->local_paths_to_push_handle);
         }
@@ -890,15 +862,9 @@ class PushPlan
         if (is_resource($this->deleted_directories_stack_handle)) {
             fclose($this->deleted_directories_stack_handle);
         }
-        $this->local_index_file_handle = null;
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
         $this->deleted_directories_stack_handle = null;
-        $this->fresh_local_index_entry = null;
-        $this->fresh_local_index_entry_loaded = false;
-        $this->previous_fresh_local_index_entry_path = null;
-        $this->local_index_lookahead_entry = null;
-        $this->local_index_lookahead_entry_loaded = false;
         $this->deleted_directory_stack_entry = null;
         $this->closed = true;
     }
@@ -949,34 +915,28 @@ class PushPlan
     }
 
     /**
-     * Positions an index file handle at its durable byte offset.
-     *
-     * The plan owns immutable index files, and records their consumed byte
-     * offsets only after finishing the corresponding step.
-     *
-     * @param resource $index_file_handle Open index file handle to position.
-     * @param int      $byte_offset       Durable byte offset saved in the cursor.
-     * @param string   $index_description Human-readable index name used in failures.
-     */
-    private function seek_index_file_to_byte_offset(
-        $index_file_handle,
-        int $byte_offset,
-        string $index_description
-    ): void
-    {
-        if (fseek($index_file_handle, $byte_offset) !== 0) {
-            throw new RuntimeException("Failed to seek the {$index_description} to byte {$byte_offset}.");
-        }
-    }
-
-    /**
      * Returns the highest deleted directory without a fresh entry below it.
      *
      * Only the previous fresh entry and the current lookahead can neighbor a
      * path in byte order, so this derives one subtree root without retaining
      * the tree.
+     *
+     * @param array|null $next_fresh_local_index_entry {
+     *     Next fresh index entry, or null at EOF.
+     *
+     *     @type string $path  Decoded local relative path.
+     *     @type string $type  Entry type: `file`, `link`, or `dir`.
+     *     @type int    $ctime Indexed change timestamp.
+     *     @type int    $size  Indexed size.
+     *     @type bool   $empty Whether a directory is empty. Present for directories.
+     * }
+     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null $next_fresh_local_index_entry
      */
-    private function local_path_to_delete(string $local_relative_path): string
+    private function local_path_to_delete(
+        string $local_relative_path,
+        ?string $previous_fresh_local_index_entry_path,
+        ?array $next_fresh_local_index_entry
+    ): string
     {
         $local_relative_path_components = wp_unix_path_segments($local_relative_path);
         $candidate_local_relative_path_components = [];
@@ -985,7 +945,13 @@ class PushPlan
             $candidate_local_relative_path = wp_join_unix_paths(
                 ...$candidate_local_relative_path_components
             );
-            if (!$this->fresh_index_contains_path_or_descendant($candidate_local_relative_path)) {
+            if (
+                !$this->fresh_index_contains_path_or_descendant(
+                    $candidate_local_relative_path,
+                    $previous_fresh_local_index_entry_path,
+                    $next_fresh_local_index_entry
+                )
+            ) {
                 return $candidate_local_relative_path;
             }
         }
@@ -994,15 +960,30 @@ class PushPlan
 
     /**
      * Checks the adjacent fresh entries for a path or one of its descendants.
+     *
+     * @param array|null $next_fresh_local_index_entry {
+     *     Next fresh index entry, or null at EOF.
+     *
+     *     @type string $path  Decoded local relative path.
+     *     @type string $type  Entry type: `file`, `link`, or `dir`.
+     *     @type int    $ctime Indexed change timestamp.
+     *     @type int    $size  Indexed size.
+     *     @type bool   $empty Whether a directory is empty. Present for directories.
+     * }
+     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null $next_fresh_local_index_entry
      */
-    private function fresh_index_contains_path_or_descendant(string $local_relative_path): bool
+    private function fresh_index_contains_path_or_descendant(
+        string $local_relative_path,
+        ?string $previous_fresh_local_index_entry_path,
+        ?array $next_fresh_local_index_entry
+    ): bool
     {
         // Use an invalid path that cannot match an indexed local relative path
         // so both comparisons below always receive strings.
         $previous_fresh_local_index_entry_path =
-            $this->previous_fresh_local_index_entry_path ?? "\0";
+            $previous_fresh_local_index_entry_path ?? "\0";
         $next_fresh_local_index_entry_path =
-            $this->fresh_local_index_entry["path"] ?? "\0";
+            $next_fresh_local_index_entry["path"] ?? "\0";
 
         return path_is_within_root(
             $previous_fresh_local_index_entry_path,
@@ -1232,58 +1213,6 @@ class PushPlan
             $excluded_paths[] = $excluded_path;
         }
         return $excluded_paths;
-    }
-
-    /**
-     * Reads and decodes the next index entry.
-     *
-     * A null index file handle represents a missing local index.
-     * The indexer's entry schema is trusted; only file reads, JSON decoding,
-     * and base64 path decoding are handled here as fallible operations.
-     *
-     * @param resource|null $index_file_handle Open index file handle, or null when no local index exists.
-     * @return array|null {
-     *     Decoded index entry, or null at EOF or when the handle is null.
-     *
-     *     @type string $path  Decoded filesystem path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size used for change detection.
-     *     @type bool   $empty Whether a directory is empty. Present for directory entries.
-     * }
-     * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null
-     */
-    private function read_next_index_entry($index_file_handle): ?array
-    {
-        if (!$index_file_handle) {
-            return null;
-        }
-        $index_entry_json = fgets($index_file_handle);
-        if ($index_entry_json === false) {
-            if (!feof($index_file_handle)) {
-                throw new RuntimeException("Failed to read an index line.");
-            }
-            return null;
-        }
-
-        try {
-            $index_entry = json_decode($index_entry_json, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException(
-                "Unexpected index line, it is not valid JSON: " . substr($index_entry_json, 0, 120),
-                0,
-                $exception
-            );
-        }
-        /** @var array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $index_entry */
-        $local_relative_path = base64_decode($index_entry["path"], true);
-        if ($local_relative_path === false) {
-            throw new RuntimeException(
-                "The index path is not valid base64: " . substr($index_entry_json, 0, 120)
-            );
-        }
-        $index_entry["path"] = $local_relative_path;
-        return $index_entry;
     }
 
 }

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -424,9 +424,9 @@ class PushPlan
             $this->local_index_file,
             $this->fresh_local_index_file,
             [
-                "before_index_byte_offset" => $cursor["byte_offset_in_local_index"],
-                "after_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
-                "previous_after_index_entry_path_b64" =>
+                "earlier_index_byte_offset" => $cursor["byte_offset_in_local_index"],
+                "later_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
+                "previous_later_index_entry_path_b64" =>
                     $cursor["previous_fresh_local_index_entry_path"] === null
                         ? null
                         : base64_encode($cursor["previous_fresh_local_index_entry_path"]),
@@ -648,8 +648,8 @@ class PushPlan
         $this->index_diff_path_selected = true;
 
         $local_relative_path = $this->index_diff_processor->get_path();
-        $local_index_path_type = $this->index_diff_processor->get_before_path_type();
-        $fresh_local_index_path_type = $this->index_diff_processor->get_after_path_type();
+        $local_index_path_type = $this->index_diff_processor->get_earlier_path_type();
+        $fresh_local_index_path_type = $this->index_diff_processor->get_later_path_type();
         $path_comparison = $local_index_path_type === null
             ? -1
             : ( $fresh_local_index_path_type === null ? 1 : 0 );
@@ -686,7 +686,7 @@ class PushPlan
         if ($path_comparison < 0) {
             // New files, symlinks, and empty directories need to be pushed.
             $local_index_lookahead_path =
-                $this->index_diff_processor->get_before_lookahead_path();
+                $this->index_diff_processor->get_earlier_lookahead_path();
             $fresh_local_index_entry_replaces_local_subtree =
                 $local_index_lookahead_path !== null
                 && $local_index_lookahead_path !== $local_relative_path
@@ -710,12 +710,12 @@ class PushPlan
                     );
             }
             if (!$this->path_conflicts_with_excluded_paths($local_relative_path)) {
-                $fresh_local_index_size = $this->index_diff_processor->get_after_size();
+                $fresh_local_index_size = $this->index_diff_processor->get_later_size();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_after_ctime()
+                    $this->index_diff_processor->get_later_ctime()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -729,9 +729,9 @@ class PushPlan
             }
         } elseif ($path_comparison > 0) {
             $previous_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_previous_after_path();
+                $this->index_diff_processor->get_previous_later_path();
             $next_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_after_lookahead_path();
+                $this->index_diff_processor->get_later_lookahead_path();
             $local_empty_directory_is_implied_by_fresh_descendant =
                 $local_index_entry_shape === "empty_directory"
                 && $this->fresh_index_contains_path_or_descendant(
@@ -778,10 +778,10 @@ class PushPlan
             $changed_file_or_symlink_needs_push =
                 $fresh_local_index_entry_is_file_or_symlink
                 && (
-                    $this->index_diff_processor->get_after_ctime()
-                        !== $this->index_diff_processor->get_before_ctime()
-                    || $this->index_diff_processor->get_after_size()
-                        !== $this->index_diff_processor->get_before_size()
+                    $this->index_diff_processor->get_later_ctime()
+                        !== $this->index_diff_processor->get_earlier_ctime()
+                    || $this->index_diff_processor->get_later_size()
+                        !== $this->index_diff_processor->get_earlier_size()
                     || $fresh_local_index_path_type !== $local_index_path_type
                 );
             $needs_delete =
@@ -804,12 +804,12 @@ class PushPlan
                 $this->append_local_path_to_delete($local_relative_path);
             }
             if ($needs_push && !$path_is_excluded) {
-                $fresh_local_index_size = $this->index_diff_processor->get_after_size();
+                $fresh_local_index_size = $this->index_diff_processor->get_later_size();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_after_ctime()
+                    $this->index_diff_processor->get_later_ctime()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -840,9 +840,9 @@ class PushPlan
         }
         $index_diff_cursor = $this->index_diff_processor->get_cursor();
         $previous_fresh_local_index_entry_path = null;
-        if ($index_diff_cursor["previous_after_index_entry_path_b64"] !== null) {
+        if ($index_diff_cursor["previous_later_index_entry_path_b64"] !== null) {
             $previous_fresh_local_index_entry_path = base64_decode(
-                $index_diff_cursor["previous_after_index_entry_path_b64"],
+                $index_diff_cursor["previous_later_index_entry_path_b64"],
                 true
             );
             if ($previous_fresh_local_index_entry_path === false) {
@@ -858,9 +858,9 @@ class PushPlan
             : [
                 "phase" => "diffing",
                 "byte_offset_in_fresh_local_index" =>
-                    $index_diff_cursor["after_index_byte_offset"],
+                    $index_diff_cursor["later_index_byte_offset"],
                 "byte_offset_in_local_index" =>
-                    $index_diff_cursor["before_index_byte_offset"],
+                    $index_diff_cursor["earlier_index_byte_offset"],
                 "byte_offset_in_local_paths_to_push" =>
                     ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" =>

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -113,7 +113,7 @@ class PushPlan
     private FileIndexProcessor $file_index_processor;
 
     /** Sorted local-index comparison retained during the diff phase. */
-    private FileIndexDiffProcessor $index_diff_processor;
+    private FileIndexDiffProcessor $index_diff;
 
     /** Whether the diff processor already selected the path for the next step. */
     private bool $index_diff_path_selected = false;
@@ -420,7 +420,7 @@ class PushPlan
             $this->local_paths_to_delete,
             $cursor["byte_offset_in_local_paths_to_delete"]
         );
-        $this->index_diff_processor = FileIndexDiffProcessor::resume(
+        $this->index_diff = FileIndexDiffProcessor::resume(
             $this->local_index_file,
             $this->fresh_local_index_file,
             [
@@ -627,7 +627,7 @@ class PushPlan
             $cursor["deleted_directory_stack_top_byte_offset"];
         if (
             !$this->index_diff_path_selected
-            && !$this->index_diff_processor->next_path()
+            && !$this->index_diff->next_path()
         ) {
             if (
                 !fflush($this->local_paths_to_push_handle)
@@ -647,9 +647,9 @@ class PushPlan
         }
         $this->index_diff_path_selected = true;
 
-        $local_relative_path = $this->index_diff_processor->get_path();
-        $local_index_path_type = $this->index_diff_processor->get_path_type_in_old_index();
-        $fresh_local_index_path_type = $this->index_diff_processor->get_path_type_in_new_index();
+        $local_relative_path = $this->index_diff->get_path();
+        $local_index_path_type = $this->index_diff->get_path_type_in_old_index();
+        $fresh_local_index_path_type = $this->index_diff->get_path_type_in_new_index();
         $path_comparison = $local_index_path_type === null
             ? -1
             : ( $fresh_local_index_path_type === null ? 1 : 0 );
@@ -685,12 +685,11 @@ class PushPlan
 
         if ($path_comparison < 0) {
             // New files, symlinks, and empty directories need to be pushed.
-            $following_local_index_path =
-                $this->index_diff_processor->get_following_path_in_old_index();
+            // A NUL byte cannot occur in an indexed path, so it cannot match
+            // when the old index has no following path.
             $fresh_local_index_entry_replaces_local_subtree =
-                $following_local_index_path !== null
-                && path_is_within_root(
-                    $following_local_index_path,
+                path_is_within_root(
+                    $this->index_diff->get_following_path_in_old_index() ?? "\0",
                     $local_relative_path
                 );
             if (
@@ -709,12 +708,12 @@ class PushPlan
                     );
             }
             if (!$this->path_conflicts_with_excluded_paths($local_relative_path)) {
-                $fresh_local_index_size = $this->index_diff_processor->get_size_in_new_index();
+                $fresh_local_index_size = $this->index_diff->get_size_in_new_index();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_ctime_in_new_index()
+                    $this->index_diff->get_ctime_in_new_index()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -727,21 +726,17 @@ class PushPlan
                 }
             }
         } elseif ($path_comparison > 0) {
-            $preceding_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_preceding_path_in_new_index();
-            $following_fresh_local_index_entry_path =
-                $this->index_diff_processor->get_following_path_in_new_index();
             $local_empty_directory_is_implied_by_fresh_descendant =
                 $local_index_entry_shape === "empty_directory"
                 && $this->fresh_index_contains_path_or_descendant(
                     $local_relative_path,
-                    $preceding_fresh_local_index_entry_path,
-                    $following_fresh_local_index_entry_path
+                    $this->index_diff->get_preceding_path_in_new_index(),
+                    $this->index_diff->get_following_path_in_new_index()
                 );
             $local_path_to_delete = $this->local_path_to_delete(
                 $local_relative_path,
-                $preceding_fresh_local_index_entry_path,
-                $following_fresh_local_index_entry_path
+                $this->index_diff->get_preceding_path_in_new_index(),
+                $this->index_diff->get_following_path_in_new_index()
             );
             // A sparse index entry derives one deleted root, covering its
             // following descendant entries.
@@ -777,10 +772,10 @@ class PushPlan
             $changed_file_or_symlink_needs_push =
                 $fresh_local_index_entry_is_file_or_symlink
                 && (
-                    $this->index_diff_processor->get_ctime_in_new_index()
-                        !== $this->index_diff_processor->get_ctime_in_old_index()
-                    || $this->index_diff_processor->get_size_in_new_index()
-                        !== $this->index_diff_processor->get_size_in_old_index()
+                    $this->index_diff->get_ctime_in_new_index()
+                        !== $this->index_diff->get_ctime_in_old_index()
+                    || $this->index_diff->get_size_in_new_index()
+                        !== $this->index_diff->get_size_in_old_index()
                     || $fresh_local_index_path_type !== $local_index_path_type
                 );
             $needs_delete =
@@ -803,12 +798,12 @@ class PushPlan
                 $this->append_local_path_to_delete($local_relative_path);
             }
             if ($needs_push && !$path_is_excluded) {
-                $fresh_local_index_size = $this->index_diff_processor->get_size_in_new_index();
+                $fresh_local_index_size = $this->index_diff->get_size_in_new_index();
                 $this->append_local_path_to_push(
                     $local_relative_path,
                     $fresh_local_index_path_type,
                     $fresh_local_index_size,
-                    $this->index_diff_processor->get_ctime_in_new_index()
+                    $this->index_diff->get_ctime_in_new_index()
                 );
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
@@ -822,9 +817,7 @@ class PushPlan
             }
         }
 
-        $this->index_diff_processor->consume_current_path();
-        $this->index_diff_path_selected = false;
-        $complete = !$this->index_diff_processor->next_path();
+        $complete = !$this->index_diff->next_path();
         $this->index_diff_path_selected = !$complete;
         if ($complete) {
             if (
@@ -837,7 +830,7 @@ class PushPlan
             $deleted_directory_stack_top_byte_offset = null;
             $this->deleted_directory_stack_entry = null;
         }
-        $index_diff_cursor = $this->index_diff_processor->get_cursor();
+        $index_diff_cursor = $this->index_diff->get_cursor();
         $preceding_fresh_local_index_entry_path = null;
         if ($index_diff_cursor["preceding_new_index_entry_path_b64"] !== null) {
             $preceding_fresh_local_index_entry_path = base64_decode(
@@ -886,8 +879,8 @@ class PushPlan
         if (isset($this->file_index_processor)) {
             $this->file_index_processor->close();
         }
-        if (isset($this->index_diff_processor)) {
-            $this->index_diff_processor->close();
+        if (isset($this->index_diff)) {
+            $this->index_diff->close();
         }
         $this->close_fresh_local_index_handle();
         if (is_resource($this->local_paths_to_push_handle)) {

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -115,6 +115,9 @@ class PushPlan
     /** Sorted local-index comparison retained during the diff phase. */
     private FileIndexDiffProcessor $index_diff_processor;
 
+    /** Whether the diff processor already selected the path for the next step. */
+    private bool $index_diff_path_selected = false;
+
     /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
     private ?array $deleted_directory_stack_entry = null;
 
@@ -622,173 +625,208 @@ class PushPlan
         $local_file_bytes_to_push = $cursor["local_file_bytes_to_push"];
         $deleted_directory_stack_top_byte_offset =
             $cursor["deleted_directory_stack_top_byte_offset"];
-        $current_path = $this->index_diff_processor->get_current_path();
-
-        if ($current_path !== null) {
-            $fresh_local_index_entry = $current_path["after"];
-            $local_index_entry = $current_path["before"];
-            $path_comparison = $current_path["order"] === "after"
-                ? -1
-                : ( $current_path["order"] === "before" ? 1 : 0 );
-
-            $fresh_local_index_entry_shape = null;
-            if ($fresh_local_index_entry !== null) {
-                $fresh_local_index_entry_shape = $this->index_entry_shape(
-                    $fresh_local_index_entry
-                );
+        if (
+            !$this->index_diff_path_selected
+            && !$this->index_diff_processor->next_path()
+        ) {
+            if (
+                !fflush($this->local_paths_to_push_handle)
+                || !fflush($this->local_paths_to_delete_handle)
+                || !fflush($this->deleted_directories_stack_handle)
+            ) {
+                throw new RuntimeException("Failed to flush a push-plan output.");
             }
+            $deleted_directory_stack_top_byte_offset = null;
+            $this->deleted_directory_stack_entry = null;
+            $this->cursor["position"] = [
+                "phase" => "complete",
+                "local_paths_to_push_count" => $local_paths_to_push_count,
+                "local_file_bytes_to_push" => $local_file_bytes_to_push,
+            ];
+            return false;
+        }
+        $this->index_diff_path_selected = true;
 
-            $local_index_entry_shape = null;
-            if ($local_index_entry !== null) {
-                $local_index_entry_shape = $this->index_entry_shape($local_index_entry);
+        $local_relative_path = $this->index_diff_processor->get_path();
+        $local_index_path_type = $this->index_diff_processor->get_before_path_type();
+        $fresh_local_index_path_type = $this->index_diff_processor->get_after_path_type();
+        $path_comparison = $local_index_path_type === null
+            ? -1
+            : ( $fresh_local_index_path_type === null ? 1 : 0 );
+        $fresh_local_index_entry_shape = $fresh_local_index_path_type === null
+            ? null
+            : $this->index_entry_shape($fresh_local_index_path_type);
+        $local_index_entry_shape = $local_index_path_type === null
+            ? null
+            : $this->index_entry_shape($local_index_path_type);
 
-                // Byte sorting can put a sibling such as `a-other` before
-                // `a/child`. Keep a deleted root while local index entries
-                // remain within that root's descendants.
-                if ($this->deleted_directory_stack_entry !== null) {
-                    $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
-                    if (
-                        !path_is_within_root(
-                            $local_index_entry["path"],
-                            $this->deleted_directory_stack_entry["path"]
-                        )
-                        && strcmp($local_index_entry["path"], $descendant_prefix) > 0
-                    ) {
-                        $deleted_directory_stack_top_byte_offset =
-                            $this->deleted_directory_stack_entry["previous_byte_offset"];
-                        $this->deleted_directory_stack_entry =
-                            $this->read_deleted_directory_stack_entry(
-                                $deleted_directory_stack_top_byte_offset
-                            );
-                    }
-                }
-            }
-
-            if ($path_comparison < 0) {
-                // New files, symlinks, and empty directories need to be pushed.
-                $local_index_lookahead_entry = $current_path["before_lookahead"];
-                $fresh_local_index_entry_replaces_local_subtree =
-                    $local_index_lookahead_entry !== null
-                    && $local_index_lookahead_entry["path"] !== $fresh_local_index_entry["path"]
-                    && path_is_within_root(
-                        $local_index_lookahead_entry["path"],
-                        $fresh_local_index_entry["path"]
-                    );
+        if ($local_index_path_type !== null) {
+            // Byte sorting can put a sibling such as `a-other` before
+            // `a/child`. Keep a deleted root while local index entries
+            // remain within that root's descendants.
+            if ($this->deleted_directory_stack_entry !== null) {
+                $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
                 if (
-                    $fresh_local_index_entry_replaces_local_subtree
-                    && !$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])
-                    && !$this->deleted_directory_stack_covers_path(
-                        $fresh_local_index_entry["path"],
-                        $this->deleted_directory_stack_entry
+                    !path_is_within_root(
+                        $local_relative_path,
+                        $this->deleted_directory_stack_entry["path"]
                     )
+                    && strcmp($local_relative_path, $descendant_prefix) > 0
                 ) {
-                    $this->append_local_path_to_delete($fresh_local_index_entry["path"]);
                     $deleted_directory_stack_top_byte_offset =
-                        $this->append_deleted_directory_stack_entry(
-                            $fresh_local_index_entry["path"],
+                        $this->deleted_directory_stack_entry["previous_byte_offset"];
+                    $this->deleted_directory_stack_entry =
+                        $this->read_deleted_directory_stack_entry(
                             $deleted_directory_stack_top_byte_offset
                         );
                 }
-                if (!$this->path_conflicts_with_excluded_paths($fresh_local_index_entry["path"])) {
-                    $this->append_local_path_to_push($fresh_local_index_entry);
-                    if ($local_paths_to_push_count !== null) {
-                        ++$local_paths_to_push_count;
-                    }
-                    if (
-                        $local_file_bytes_to_push !== null
-                        && $fresh_local_index_entry["type"] === "file"
-                    ) {
-                        $local_file_bytes_to_push += $fresh_local_index_entry["size"];
-                    }
-                }
-            } elseif ($path_comparison > 0) {
-                $local_empty_directory_is_implied_by_fresh_descendant =
-                    $local_index_entry_shape === "empty_directory"
-                    && $this->fresh_index_contains_path_or_descendant(
-                        $local_index_entry["path"],
-                        $current_path["previous_after_path"],
-                        $current_path["after_lookahead"]
-                    );
-                $local_path_to_delete = $this->local_path_to_delete(
-                    $local_index_entry["path"],
-                    $current_path["previous_after_path"],
-                    $current_path["after_lookahead"]
-                );
-                // A sparse index entry derives one deleted root, covering its
-                // later descendant entries.
-                if (
-                    !$local_empty_directory_is_implied_by_fresh_descendant
-                    && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
-                    && !$this->deleted_directory_stack_covers_path(
-                        $local_index_entry["path"],
-                        $this->deleted_directory_stack_entry
-                    )
-                ) {
-                    $this->append_local_path_to_delete($local_path_to_delete);
-                    if ($local_path_to_delete !== $local_index_entry["path"]) {
-                        $deleted_directory_stack_top_byte_offset =
-                            $this->append_deleted_directory_stack_entry(
-                                $local_path_to_delete,
-                                $deleted_directory_stack_top_byte_offset
-                            );
-                    }
-                }
-            } else {
-                $fresh_local_index_entry_is_file_or_symlink =
-                    $fresh_local_index_entry_shape === "file"
-                    || $fresh_local_index_entry_shape === "symlink";
-                $local_index_entry_is_file_or_symlink =
-                    $local_index_entry_shape === "file"
-                    || $local_index_entry_shape === "symlink";
-                $empty_directory_needs_push =
-                    $fresh_local_index_entry_shape === "empty_directory"
-                    && $local_index_entry_shape !== "empty_directory";
-                // File and symlink changes are defined by type, ctime, and
-                // size. Other index values do not select a path for upload.
-                $changed_file_or_symlink_needs_push =
-                    $fresh_local_index_entry_is_file_or_symlink
-                    && (
-                        $fresh_local_index_entry["ctime"] !== $local_index_entry["ctime"]
-                        || $fresh_local_index_entry["size"] !== $local_index_entry["size"]
-                        || $fresh_local_index_entry["type"] !== $local_index_entry["type"]
-                    );
-                $needs_delete =
-                    $fresh_local_index_entry_is_file_or_symlink
-                    !== $local_index_entry_is_file_or_symlink;
-                $needs_push = $empty_directory_needs_push
-                    || $changed_file_or_symlink_needs_push;
-                $path_is_excluded = $this->path_conflicts_with_excluded_paths(
-                    $fresh_local_index_entry["path"]
-                );
-
-                if (
-                    $needs_delete
-                    && !$path_is_excluded
-                    && !$this->deleted_directory_stack_covers_path(
-                        $local_index_entry["path"],
-                        $this->deleted_directory_stack_entry
-                    )
-                ) {
-                    $this->append_local_path_to_delete($local_index_entry["path"]);
-                }
-                if ($needs_push && !$path_is_excluded) {
-                    $this->append_local_path_to_push($fresh_local_index_entry);
-                    if ($local_paths_to_push_count !== null) {
-                        ++$local_paths_to_push_count;
-                    }
-                    if (
-                        $local_file_bytes_to_push !== null
-                        && $fresh_local_index_entry["type"] === "file"
-                    ) {
-                        $local_file_bytes_to_push += $fresh_local_index_entry["size"];
-                    }
-                }
             }
-
-            $this->index_diff_processor->consume_current_path();
         }
 
-        $complete = $this->index_diff_processor->get_current_path() === null;
+        if ($path_comparison < 0) {
+            // New files, symlinks, and empty directories need to be pushed.
+            $local_index_lookahead_path =
+                $this->index_diff_processor->get_before_lookahead_path();
+            $fresh_local_index_entry_replaces_local_subtree =
+                $local_index_lookahead_path !== null
+                && $local_index_lookahead_path !== $local_relative_path
+                && path_is_within_root(
+                    $local_index_lookahead_path,
+                    $local_relative_path
+                );
+            if (
+                $fresh_local_index_entry_replaces_local_subtree
+                && !$this->path_conflicts_with_excluded_paths($local_relative_path)
+                && !$this->deleted_directory_stack_covers_path(
+                    $local_relative_path,
+                    $this->deleted_directory_stack_entry
+                )
+            ) {
+                $this->append_local_path_to_delete($local_relative_path);
+                $deleted_directory_stack_top_byte_offset =
+                    $this->append_deleted_directory_stack_entry(
+                        $local_relative_path,
+                        $deleted_directory_stack_top_byte_offset
+                    );
+            }
+            if (!$this->path_conflicts_with_excluded_paths($local_relative_path)) {
+                $fresh_local_index_size = $this->index_diff_processor->get_after_size();
+                $this->append_local_path_to_push(
+                    $local_relative_path,
+                    $fresh_local_index_path_type,
+                    $fresh_local_index_size,
+                    $this->index_diff_processor->get_after_ctime()
+                );
+                if ($local_paths_to_push_count !== null) {
+                    ++$local_paths_to_push_count;
+                }
+                if (
+                    $local_file_bytes_to_push !== null
+                    && $fresh_local_index_path_type === "file"
+                ) {
+                    $local_file_bytes_to_push += $fresh_local_index_size;
+                }
+            }
+        } elseif ($path_comparison > 0) {
+            $previous_fresh_local_index_entry_path =
+                $this->index_diff_processor->get_previous_after_path();
+            $next_fresh_local_index_entry_path =
+                $this->index_diff_processor->get_after_lookahead_path();
+            $local_empty_directory_is_implied_by_fresh_descendant =
+                $local_index_entry_shape === "empty_directory"
+                && $this->fresh_index_contains_path_or_descendant(
+                    $local_relative_path,
+                    $previous_fresh_local_index_entry_path,
+                    $next_fresh_local_index_entry_path
+                );
+            $local_path_to_delete = $this->local_path_to_delete(
+                $local_relative_path,
+                $previous_fresh_local_index_entry_path,
+                $next_fresh_local_index_entry_path
+            );
+            // A sparse index entry derives one deleted root, covering its
+            // later descendant entries.
+            if (
+                !$local_empty_directory_is_implied_by_fresh_descendant
+                && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
+                && !$this->deleted_directory_stack_covers_path(
+                    $local_relative_path,
+                    $this->deleted_directory_stack_entry
+                )
+            ) {
+                $this->append_local_path_to_delete($local_path_to_delete);
+                if ($local_path_to_delete !== $local_relative_path) {
+                    $deleted_directory_stack_top_byte_offset =
+                        $this->append_deleted_directory_stack_entry(
+                            $local_path_to_delete,
+                            $deleted_directory_stack_top_byte_offset
+                        );
+                }
+            }
+        } else {
+            $fresh_local_index_entry_is_file_or_symlink =
+                $fresh_local_index_entry_shape === "file"
+                || $fresh_local_index_entry_shape === "symlink";
+            $local_index_entry_is_file_or_symlink =
+                $local_index_entry_shape === "file"
+                || $local_index_entry_shape === "symlink";
+            $empty_directory_needs_push =
+                $fresh_local_index_entry_shape === "empty_directory"
+                && $local_index_entry_shape !== "empty_directory";
+            // File and symlink changes are defined by type, ctime, and
+            // size. Other index values do not select a path for upload.
+            $changed_file_or_symlink_needs_push =
+                $fresh_local_index_entry_is_file_or_symlink
+                && (
+                    $this->index_diff_processor->get_after_ctime()
+                        !== $this->index_diff_processor->get_before_ctime()
+                    || $this->index_diff_processor->get_after_size()
+                        !== $this->index_diff_processor->get_before_size()
+                    || $fresh_local_index_path_type !== $local_index_path_type
+                );
+            $needs_delete =
+                $fresh_local_index_entry_is_file_or_symlink
+                !== $local_index_entry_is_file_or_symlink;
+            $needs_push = $empty_directory_needs_push
+                || $changed_file_or_symlink_needs_push;
+            $path_is_excluded = $this->path_conflicts_with_excluded_paths(
+                $local_relative_path
+            );
+
+            if (
+                $needs_delete
+                && !$path_is_excluded
+                && !$this->deleted_directory_stack_covers_path(
+                    $local_relative_path,
+                    $this->deleted_directory_stack_entry
+                )
+            ) {
+                $this->append_local_path_to_delete($local_relative_path);
+            }
+            if ($needs_push && !$path_is_excluded) {
+                $fresh_local_index_size = $this->index_diff_processor->get_after_size();
+                $this->append_local_path_to_push(
+                    $local_relative_path,
+                    $fresh_local_index_path_type,
+                    $fresh_local_index_size,
+                    $this->index_diff_processor->get_after_ctime()
+                );
+                if ($local_paths_to_push_count !== null) {
+                    ++$local_paths_to_push_count;
+                }
+                if (
+                    $local_file_bytes_to_push !== null
+                    && $fresh_local_index_path_type === "file"
+                ) {
+                    $local_file_bytes_to_push += $fresh_local_index_size;
+                }
+            }
+        }
+
+        $this->index_diff_processor->consume_current_path();
+        $this->index_diff_path_selected = false;
+        $complete = !$this->index_diff_processor->next_path();
+        $this->index_diff_path_selected = !$complete;
         if ($complete) {
             if (
                 !fflush($this->local_paths_to_push_handle)
@@ -866,6 +904,7 @@ class PushPlan
         $this->local_paths_to_delete_handle = null;
         $this->deleted_directories_stack_handle = null;
         $this->deleted_directory_stack_entry = null;
+        $this->index_diff_path_selected = false;
         $this->closed = true;
     }
 
@@ -921,21 +960,12 @@ class PushPlan
      * path in byte order, so this derives one subtree root without retaining
      * the tree.
      *
-     * @param array|null $next_fresh_local_index_entry {
-     *     Next fresh index entry, or null at EOF.
-     *
-     *     @type string $path  Decoded local relative path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size.
-     *     @type bool   $empty Whether a directory is empty. Present for directories.
-     * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null $next_fresh_local_index_entry
+     * @param string|null $next_fresh_local_index_entry_path Next fresh path, or null at EOF.
      */
     private function local_path_to_delete(
         string $local_relative_path,
         ?string $previous_fresh_local_index_entry_path,
-        ?array $next_fresh_local_index_entry
+        ?string $next_fresh_local_index_entry_path
     ): string
     {
         $local_relative_path_components = wp_unix_path_segments($local_relative_path);
@@ -949,7 +979,7 @@ class PushPlan
                 !$this->fresh_index_contains_path_or_descendant(
                     $candidate_local_relative_path,
                     $previous_fresh_local_index_entry_path,
-                    $next_fresh_local_index_entry
+                    $next_fresh_local_index_entry_path
                 )
             ) {
                 return $candidate_local_relative_path;
@@ -961,21 +991,12 @@ class PushPlan
     /**
      * Checks the adjacent fresh entries for a path or one of its descendants.
      *
-     * @param array|null $next_fresh_local_index_entry {
-     *     Next fresh index entry, or null at EOF.
-     *
-     *     @type string $path  Decoded local relative path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size.
-     *     @type bool   $empty Whether a directory is empty. Present for directories.
-     * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}|null $next_fresh_local_index_entry
+     * @param string|null $next_fresh_local_index_entry_path Next fresh path, or null at EOF.
      */
     private function fresh_index_contains_path_or_descendant(
         string $local_relative_path,
         ?string $previous_fresh_local_index_entry_path,
-        ?array $next_fresh_local_index_entry
+        ?string $next_fresh_local_index_entry_path
     ): bool
     {
         // Use an invalid path that cannot match an indexed local relative path
@@ -983,7 +1004,7 @@ class PushPlan
         $previous_fresh_local_index_entry_path =
             $previous_fresh_local_index_entry_path ?? "\0";
         $next_fresh_local_index_entry_path =
-            $next_fresh_local_index_entry["path"] ?? "\0";
+            $next_fresh_local_index_entry_path ?? "\0";
 
         return path_is_within_root(
             $previous_fresh_local_index_entry_path,
@@ -997,24 +1018,15 @@ class PushPlan
     /**
      * Returns the logical entry kind used by the transition table.
      *
-     * @param array $index_entry {
-     *     Parsed index entry.
-     *
-     *     @type string $path  Decoded filesystem path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $ctime Indexed change timestamp.
-     *     @type int    $size  Indexed size used for change detection.
-     *     @type bool   $empty Whether a directory is empty. Present for directory entries.
-     * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $index_entry
+     * @param string $path_type Entry type: `file`, `link`, or `dir`.
      * @return 'file'|'symlink'|'empty_directory'
      */
-    private function index_entry_shape(array $index_entry): string
+    private function index_entry_shape(string $path_type): string
     {
-        if ($index_entry["type"] === "file") {
+        if ($path_type === "file") {
             return "file";
         }
-        if ($index_entry["type"] === "link") {
+        if ($path_type === "link") {
             return "symlink";
         }
         return "empty_directory";
@@ -1025,26 +1037,25 @@ class PushPlan
      *
      * Base64 keeps arbitrary filesystem path bytes representable in JSON.
      *
-     * @param array $fresh_local_index_entry {
-     *     Fresh local index entry selected for push.
-     *
-     *     @type string $path  Decoded filesystem path.
-     *     @type string $type  Entry type: `file`, `link`, or `dir`.
-     *     @type int    $size  Indexed size used for change detection.
-     *     @type int    $ctime Indexed change timestamp.
-     * }
-     * @phpstan-param array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool} $fresh_local_index_entry
+     * @param string $local_relative_path Local relative path selected for push.
+     * @param string $path_type           Entry type: `file`, `link`, or `dir`.
+     * @param int    $size                Indexed size used for change detection.
+     * @param int    $ctime               Indexed change timestamp.
      */
-    private function append_local_path_to_push(array $fresh_local_index_entry): void
-    {
+    private function append_local_path_to_push(
+        string $local_relative_path,
+        string $path_type,
+        int $size,
+        int $ctime
+    ): void {
         $local_path_to_push_json_line = json_encode(
             [
-                "path" => base64_encode($fresh_local_index_entry["path"]),
-                "type" => $fresh_local_index_entry["type"] === "link"
+                "path" => base64_encode($local_relative_path),
+                "type" => $path_type === "link"
                     ? "symlink"
-                    : ($fresh_local_index_entry["type"] === "dir" ? "directory" : "file"),
-                "size" => $fresh_local_index_entry["size"],
-                "ctime" => $fresh_local_index_entry["ctime"],
+                    : ($path_type === "dir" ? "directory" : "file"),
+                "size" => $size,
+                "ctime" => $ctime,
             ],
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         ) . "\n";

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -650,9 +650,7 @@ class PushPlan
         $local_relative_path = $this->index_diff->get_path();
         $local_index_path_type = $this->index_diff->get_path_type_in_old_index();
         $fresh_local_index_path_type = $this->index_diff->get_path_type_in_new_index();
-        $path_comparison = $local_index_path_type === null
-            ? -1
-            : ( $fresh_local_index_path_type === null ? 1 : 0 );
+        $local_path_change = $this->index_diff->get_path_change();
         $fresh_local_index_entry_shape = $fresh_local_index_path_type === null
             ? null
             : $this->index_entry_shape($fresh_local_index_path_type);
@@ -683,7 +681,7 @@ class PushPlan
             }
         }
 
-        if ($path_comparison < 0) {
+        if ($local_path_change === "added") {
             // New files, symlinks, and empty directories need to be pushed.
             // A NUL byte cannot occur in an indexed path, so it cannot match
             // when the old index has no following path.
@@ -725,7 +723,7 @@ class PushPlan
                     $local_file_bytes_to_push += $fresh_local_index_size;
                 }
             }
-        } elseif ($path_comparison > 0) {
+        } elseif ($local_path_change === "deleted") {
             $local_empty_directory_is_implied_by_fresh_descendant =
                 $local_index_entry_shape === "empty_directory"
                 && $this->fresh_index_contains_path_or_descendant(
@@ -767,17 +765,11 @@ class PushPlan
             $empty_directory_needs_push =
                 $fresh_local_index_entry_shape === "empty_directory"
                 && $local_index_entry_shape !== "empty_directory";
-            // File and symlink changes are defined by type, ctime, and
-            // size. Other index values do not select a path for upload.
+            // The diff processor defines modification by type, ctime, and
+            // size. Only modified files and symlinks need to be uploaded.
             $changed_file_or_symlink_needs_push =
                 $fresh_local_index_entry_is_file_or_symlink
-                && (
-                    $this->index_diff->get_ctime_in_new_index()
-                        !== $this->index_diff->get_ctime_in_old_index()
-                    || $this->index_diff->get_size_in_new_index()
-                        !== $this->index_diff->get_size_in_old_index()
-                    || $fresh_local_index_path_type !== $local_index_path_type
-                );
+                && $local_path_change === "modified";
             $needs_delete =
                 $fresh_local_index_entry_is_file_or_symlink
                 !== $local_index_entry_is_file_or_symlink;

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -71,6 +71,42 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
     }
 
+    public function testClassifiesAddedDeletedModifiedAndUnchangedPaths(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('b-deleted.txt'),
+            $this->entry('c-type-changed', 1, 1, 'file'),
+            $this->entry('d-size-changed.txt', 1, 10),
+            $this->entry('e-ctime-changed.txt', 10, 1),
+            $this->entry('f-unchanged.txt', 10, 20),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('a-added.txt'),
+            $this->entry('c-type-changed', 1, 1, 'dir'),
+            $this->entry('d-size-changed.txt', 1, 20),
+            $this->entry('e-ctime-changed.txt', 20, 1),
+            $this->entry('f-unchanged.txt', 10, 20),
+        ]);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
+
+        foreach (
+            [
+                'a-added.txt' => 'added',
+                'b-deleted.txt' => 'deleted',
+                'c-type-changed' => 'modified',
+                'd-size-changed.txt' => 'modified',
+                'e-ctime-changed.txt' => 'modified',
+                'f-unchanged.txt' => 'unchanged',
+            ] as $path => $change
+        ) {
+            $this->assertTrue($processor->next_path());
+            $this->assertSame($path, $processor->get_path());
+            $this->assertSame($change, $processor->get_path_change());
+        }
+        $this->assertFalse($processor->next_path());
+        $processor->close();
+    }
+
     public function testComparesDecodedPathBytesInsteadOfBase64Text(): void
     {
         $old_index_file = $this->write_index('old.jsonl', [

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -97,11 +97,11 @@ final class FileIndexDiffProcessorTest extends TestCase
                 'd-size-changed.txt' => 'modified',
                 'e-ctime-changed.txt' => 'modified',
                 'f-unchanged.txt' => 'unchanged',
-            ] as $path => $change
+            ] as $path => $transition
         ) {
             $this->assertTrue($processor->next_path());
             $this->assertSame($path, $processor->get_path());
-            $this->assertSame($change, $processor->get_path_change());
+            $this->assertSame($transition, $processor->get_path_transition());
         }
         $this->assertFalse($processor->next_path());
         $processor->close();

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -39,33 +39,33 @@ final class FileIndexDiffProcessorTest extends TestCase
         parent::tearDown();
     }
 
-    public function testAlignsBeforeAfterAndSharedPaths(): void
+    public function testAlignsEarlierLaterAndSharedPaths(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
-            $this->entry('before-only.txt', 10),
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
+            $this->entry('b-earlier-only.txt', 10),
             $this->entry('shared.txt', 20),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('after-only.txt', 30),
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('a-later-only.txt', 30),
             $this->entry('shared.txt', 40),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
 
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['after-only.txt', null, 'file', 'before-only.txt', 'after-only.txt', null],
+            ['a-later-only.txt', null, 'file', 'b-earlier-only.txt', 'a-later-only.txt', null],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['before-only.txt', 'file', null, 'before-only.txt', 'shared.txt', 'after-only.txt'],
+            ['b-earlier-only.txt', 'file', null, 'b-earlier-only.txt', 'shared.txt', 'a-later-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['shared.txt', 'file', 'file', 'shared.txt', 'shared.txt', 'after-only.txt'],
+            ['shared.txt', 'file', 'file', 'shared.txt', 'shared.txt', 'a-later-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
@@ -77,40 +77,40 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testComparesDecodedPathBytesInsteadOfBase64Text(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
-            $this->entry("\xD0-before"),
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
+            $this->entry("\xD0-earlier"),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('A-after'),
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('A-later'),
         ]);
         $this->assertLessThan(
             0,
-            strcmp(base64_encode("\xD0-before"), base64_encode('A-after'))
+            strcmp(base64_encode("\xD0-earlier"), base64_encode('A-later'))
         );
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('A-after', $processor->get_path());
-        $this->assertNull($processor->get_before_path_type());
-        $this->assertSame('file', $processor->get_after_path_type());
+        $this->assertSame('A-later', $processor->get_path());
+        $this->assertNull($processor->get_earlier_path_type());
+        $this->assertSame('file', $processor->get_later_path_type());
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
-        $this->assertSame("\xD0-before", $processor->get_path());
-        $this->assertSame('file', $processor->get_before_path_type());
-        $this->assertNull($processor->get_after_path_type());
+        $this->assertSame("\xD0-earlier", $processor->get_path());
+        $this->assertSame('file', $processor->get_earlier_path_type());
+        $this->assertNull($processor->get_later_path_type());
 
         $processor->close();
     }
 
     public function testCurrentPathAndCursorRemainStableUntilConsumption(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
             $this->entry('same.txt', 10),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
+        $later_index_file = $this->write_index('later.jsonl', [
             $this->entry('same.txt', 20),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $initial_cursor = $processor->get_cursor();
 
         $this->assertTrue($processor->next_path());
@@ -125,67 +125,67 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testConsumptionAdvancesOnlyTheIndexesRepresentedByTheCurrentPath(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
-            $this->entry('a-before'),
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
+            $this->entry('a-earlier'),
             $this->entry('c-shared'),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('b-after'),
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('b-later'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('file', $processor->get_before_path_type());
-        $this->assertNull($processor->get_after_path_type());
+        $this->assertSame('file', $processor->get_earlier_path_type());
+        $this->assertNull($processor->get_later_path_type());
         $processor->consume_current_path();
-        $after_before_only = $processor->get_cursor();
-        $this->assertGreaterThan(0, $after_before_only['before_index_byte_offset']);
-        $this->assertSame(0, $after_before_only['after_index_byte_offset']);
-        $this->assertNull($after_before_only['previous_after_index_entry_path_b64']);
+        $cursor_after_earlier_only_path = $processor->get_cursor();
+        $this->assertGreaterThan(0, $cursor_after_earlier_only_path['earlier_index_byte_offset']);
+        $this->assertSame(0, $cursor_after_earlier_only_path['later_index_byte_offset']);
+        $this->assertNull($cursor_after_earlier_only_path['previous_later_index_entry_path_b64']);
 
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_before_path_type());
-        $this->assertSame('file', $processor->get_after_path_type());
+        $this->assertNull($processor->get_earlier_path_type());
+        $this->assertSame('file', $processor->get_later_path_type());
         $processor->consume_current_path();
-        $after_after_only = $processor->get_cursor();
+        $cursor_after_later_only_path = $processor->get_cursor();
         $this->assertSame(
-            $after_before_only['before_index_byte_offset'],
-            $after_after_only['before_index_byte_offset']
+            $cursor_after_earlier_only_path['earlier_index_byte_offset'],
+            $cursor_after_later_only_path['earlier_index_byte_offset']
         );
-        $this->assertGreaterThan(0, $after_after_only['after_index_byte_offset']);
+        $this->assertGreaterThan(0, $cursor_after_later_only_path['later_index_byte_offset']);
         $this->assertSame(
-            base64_encode('b-after'),
-            $after_after_only['previous_after_index_entry_path_b64']
+            base64_encode('b-later'),
+            $cursor_after_later_only_path['previous_later_index_entry_path_b64']
         );
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('file', $processor->get_before_path_type());
-        $this->assertSame('file', $processor->get_after_path_type());
+        $this->assertSame('file', $processor->get_earlier_path_type());
+        $this->assertSame('file', $processor->get_later_path_type());
         $processor->consume_current_path();
-        $after_shared = $processor->get_cursor();
+        $cursor_after_shared_path = $processor->get_cursor();
         $this->assertGreaterThan(
-            $after_after_only['before_index_byte_offset'],
-            $after_shared['before_index_byte_offset']
+            $cursor_after_later_only_path['earlier_index_byte_offset'],
+            $cursor_after_shared_path['earlier_index_byte_offset']
         );
         $this->assertGreaterThan(
-            $after_after_only['after_index_byte_offset'],
-            $after_shared['after_index_byte_offset']
+            $cursor_after_later_only_path['later_index_byte_offset'],
+            $cursor_after_shared_path['later_index_byte_offset']
         );
         $processor->close();
     }
 
     public function testResumeRepeatsTheCurrentPathWhoseConsumptionWasNotStored(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
             $this->entry('a.txt'),
             $this->entry('c.txt'),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
+        $later_index_file = $this->write_index('later.jsonl', [
             $this->entry('b.txt'),
             $this->entry('c.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
         $stored_cursor = $processor->get_cursor();
@@ -194,8 +194,8 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
 
         $resumed_processor = FileIndexDiffProcessor::resume(
-            $before_index_file,
-            $after_index_file,
+            $earlier_index_file,
+            $later_index_file,
             $stored_cursor
         );
         $this->assertTrue($resumed_processor->next_path());
@@ -204,59 +204,59 @@ final class FileIndexDiffProcessorTest extends TestCase
         $resumed_processor->close();
     }
 
-    public function testPreviousAfterPathSurvivesBeforeOnlyPathsAndResume(): void
+    public function testPreviousLaterPathSurvivesEarlierOnlyPathsAndResume(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', [
-            $this->entry('b-before'),
+        $earlier_index_file = $this->write_index('earlier.jsonl', [
+            $this->entry('b-earlier'),
             $this->entry('c-shared'),
         ]);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('a-after'),
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('a-later'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('a-after', $processor->get_previous_after_path());
+        $this->assertSame('a-later', $processor->get_previous_later_path());
         $processor->consume_current_path();
         $cursor = $processor->get_cursor();
         $processor->close();
 
         $resumed_processor = FileIndexDiffProcessor::resume(
-            $before_index_file,
-            $after_index_file,
+            $earlier_index_file,
+            $later_index_file,
             $cursor
         );
         $this->assertTrue($resumed_processor->next_path());
-        $this->assertSame('file', $resumed_processor->get_before_path_type());
-        $this->assertSame('file', $resumed_processor->get_after_path_type());
+        $this->assertSame('file', $resumed_processor->get_earlier_path_type());
+        $this->assertSame('file', $resumed_processor->get_later_path_type());
         $this->assertSame(
-            'a-after',
-            $resumed_processor->get_previous_after_path()
+            'a-later',
+            $resumed_processor->get_previous_later_path()
         );
         $resumed_processor->close();
     }
 
-    public function testMissingBeforeIndexRepresentsAnEmptyEarlierSnapshot(): void
+    public function testMissingEarlierIndexRepresentsAnEmptyEarlierSnapshot(): void
     {
-        $after_index_file = $this->write_index('after.jsonl', [
+        $later_index_file = $this->write_index('later.jsonl', [
             $this->entry('first.txt'),
             $this->entry('second.txt'),
         ]);
         $processor = FileIndexDiffProcessor::start(
-            $this->temp_dir . '/missing-before.jsonl',
-            $after_index_file
+            $this->temp_dir . '/missing-earlier.jsonl',
+            $later_index_file
         );
 
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_before_path_type());
-        $this->assertSame('file', $processor->get_after_path_type());
+        $this->assertNull($processor->get_earlier_path_type());
+        $this->assertSame('file', $processor->get_later_path_type());
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_before_path_type());
-        $this->assertSame('file', $processor->get_after_path_type());
+        $this->assertNull($processor->get_earlier_path_type());
+        $this->assertSame('file', $processor->get_later_path_type());
         $processor->consume_current_path();
         $this->assertFalse($processor->next_path());
         $processor->close();
@@ -264,40 +264,40 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testDirectoryEntryKeepsItsEmptyMarker(): void
     {
-        $after_index_file = $this->write_index('after.jsonl', [
+        $later_index_file = $this->write_index('later.jsonl', [
             $this->entry('empty-directory', 10, 0, 'dir', true),
         ]);
         $processor = FileIndexDiffProcessor::start(
-            $this->temp_dir . '/missing-before.jsonl',
-            $after_index_file
+            $this->temp_dir . '/missing-earlier.jsonl',
+            $later_index_file
         );
 
         $this->assertTrue($processor->next_path());
         $this->assertSame('empty-directory', $processor->get_path());
-        $this->assertSame('dir', $processor->get_after_path_type());
-        $this->assertSame(0, $processor->get_after_size());
-        $this->assertSame(10, $processor->get_after_ctime());
-        $this->assertTrue($processor->get_after_directory_is_empty());
+        $this->assertSame('dir', $processor->get_later_path_type());
+        $this->assertSame(0, $processor->get_later_size());
+        $this->assertSame(10, $processor->get_later_ctime());
+        $this->assertTrue($processor->get_later_directory_is_empty());
         $processor->close();
     }
 
-    public function testMissingAfterIndexIsRejected(): void
+    public function testMissingLaterIndexIsRejected(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', []);
+        $earlier_index_file = $this->write_index('earlier.jsonl', []);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Failed to open the after file index');
+        $this->expectExceptionMessage('Failed to open the later file index');
         FileIndexDiffProcessor::start(
-            $before_index_file,
-            $this->temp_dir . '/missing-after.jsonl'
+            $earlier_index_file,
+            $this->temp_dir . '/missing-later.jsonl'
         );
     }
 
-    public function testConsumingAfterBothIndexesReachEofIsRejected(): void
+    public function testConsumingWhenBothIndexesReachedEofIsRejected(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', []);
-        $after_index_file = $this->write_index('after.jsonl', []);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $earlier_index_file = $this->write_index('earlier.jsonl', []);
+        $later_index_file = $this->write_index('later.jsonl', []);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $this->assertFalse($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -311,11 +311,11 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testCloseIsIdempotentAndMakesTheProcessorTerminal(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', []);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('after.txt'),
+        $earlier_index_file = $this->write_index('earlier.jsonl', []);
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('later.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $this->assertTrue($processor->next_path());
         $processor->close();
         $processor->close();
@@ -327,11 +327,11 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testGettersDoNotSelectAPath(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', []);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('after.txt'),
+        $earlier_index_file = $this->write_index('earlier.jsonl', []);
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('later.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Call next_path() first');
@@ -344,11 +344,11 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testNextPathRejectsAnUnconsumedCurrentPath(): void
     {
-        $before_index_file = $this->write_index('before.jsonl', []);
-        $after_index_file = $this->write_index('after.jsonl', [
-            $this->entry('after.txt'),
+        $earlier_index_file = $this->write_index('earlier.jsonl', []);
+        $later_index_file = $this->write_index('later.jsonl', [
+            $this->entry('later.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
         $this->assertTrue($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -406,11 +406,11 @@ final class FileIndexDiffProcessorTest extends TestCase
     {
         return [
             $processor->get_path(),
-            $processor->get_before_path_type(),
-            $processor->get_after_path_type(),
-            $processor->get_before_lookahead_path(),
-            $processor->get_after_lookahead_path(),
-            $processor->get_previous_after_path(),
+            $processor->get_earlier_path_type(),
+            $processor->get_later_path_type(),
+            $processor->get_earlier_lookahead_path(),
+            $processor->get_later_lookahead_path(),
+            $processor->get_previous_later_path(),
         ];
     }
 }

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -51,24 +51,27 @@ final class FileIndexDiffProcessorTest extends TestCase
         ]);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
 
+        $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['after', null, 'after-only.txt', 'before-only.txt', 'after-only.txt', null],
+            ['after-only.txt', null, 'file', 'before-only.txt', 'after-only.txt', null],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['before', 'before-only.txt', null, 'before-only.txt', 'shared.txt', 'after-only.txt'],
+            ['before-only.txt', 'file', null, 'before-only.txt', 'shared.txt', 'after-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['both', 'shared.txt', 'shared.txt', 'shared.txt', 'shared.txt', 'after-only.txt'],
+            ['shared.txt', 'file', 'file', 'shared.txt', 'shared.txt', 'after-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
 
-        $this->assertNull($processor->get_current_path());
-        $this->assertNull($processor->get_current_path());
+        $this->assertFalse($processor->next_path());
+        $this->assertFalse($processor->next_path());
         $processor->close();
     }
 
@@ -86,10 +89,15 @@ final class FileIndexDiffProcessorTest extends TestCase
         );
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
 
-        $this->assertSame('A-after', $processor->get_current_path()['after']['path']);
-        $this->assertSame('after', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('A-after', $processor->get_path());
+        $this->assertNull($processor->get_before_path_type());
+        $this->assertSame('file', $processor->get_after_path_type());
         $processor->consume_current_path();
-        $this->assertSame("\xD0-before", $processor->get_current_path()['before']['path']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame("\xD0-before", $processor->get_path());
+        $this->assertSame('file', $processor->get_before_path_type());
+        $this->assertNull($processor->get_after_path_type());
 
         $processor->close();
     }
@@ -105,8 +113,9 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
         $initial_cursor = $processor->get_cursor();
 
-        $first_read = $processor->get_current_path();
-        $this->assertSame($first_read, $processor->get_current_path());
+        $this->assertTrue($processor->next_path());
+        $first_read = $this->current_path_summary($processor);
+        $this->assertSame($first_read, $this->current_path_summary($processor));
         $this->assertSame($initial_cursor, $processor->get_cursor());
 
         $processor->consume_current_path();
@@ -126,14 +135,18 @@ final class FileIndexDiffProcessorTest extends TestCase
         ]);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
 
-        $this->assertSame('before', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('file', $processor->get_before_path_type());
+        $this->assertNull($processor->get_after_path_type());
         $processor->consume_current_path();
         $after_before_only = $processor->get_cursor();
         $this->assertGreaterThan(0, $after_before_only['before_index_byte_offset']);
         $this->assertSame(0, $after_before_only['after_index_byte_offset']);
         $this->assertNull($after_before_only['previous_after_index_entry_path_b64']);
 
-        $this->assertSame('after', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertNull($processor->get_before_path_type());
+        $this->assertSame('file', $processor->get_after_path_type());
         $processor->consume_current_path();
         $after_after_only = $processor->get_cursor();
         $this->assertSame(
@@ -146,7 +159,9 @@ final class FileIndexDiffProcessorTest extends TestCase
             $after_after_only['previous_after_index_entry_path_b64']
         );
 
-        $this->assertSame('both', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('file', $processor->get_before_path_type());
+        $this->assertSame('file', $processor->get_after_path_type());
         $processor->consume_current_path();
         $after_shared = $processor->get_cursor();
         $this->assertGreaterThan(
@@ -171,9 +186,11 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('c.txt'),
         ]);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
         $stored_cursor = $processor->get_cursor();
-        $unconsumed_path = $processor->get_current_path();
+        $this->assertTrue($processor->next_path());
+        $unconsumed_path = $this->current_path_summary($processor);
         $processor->close();
 
         $resumed_processor = FileIndexDiffProcessor::resume(
@@ -181,7 +198,8 @@ final class FileIndexDiffProcessorTest extends TestCase
             $after_index_file,
             $stored_cursor
         );
-        $this->assertSame($unconsumed_path, $resumed_processor->get_current_path());
+        $this->assertTrue($resumed_processor->next_path());
+        $this->assertSame($unconsumed_path, $this->current_path_summary($resumed_processor));
         $this->assertSame($stored_cursor, $resumed_processor->get_cursor());
         $resumed_processor->close();
     }
@@ -197,9 +215,11 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('c-shared'),
         ]);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
 
-        $this->assertSame('a-after', $processor->get_current_path()['previous_after_path']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('a-after', $processor->get_previous_after_path());
         $processor->consume_current_path();
         $cursor = $processor->get_cursor();
         $processor->close();
@@ -209,10 +229,12 @@ final class FileIndexDiffProcessorTest extends TestCase
             $after_index_file,
             $cursor
         );
-        $this->assertSame('both', $resumed_processor->get_current_path()['order']);
+        $this->assertTrue($resumed_processor->next_path());
+        $this->assertSame('file', $resumed_processor->get_before_path_type());
+        $this->assertSame('file', $resumed_processor->get_after_path_type());
         $this->assertSame(
             'a-after',
-            $resumed_processor->get_current_path()['previous_after_path']
+            $resumed_processor->get_previous_after_path()
         );
         $resumed_processor->close();
     }
@@ -228,11 +250,15 @@ final class FileIndexDiffProcessorTest extends TestCase
             $after_index_file
         );
 
-        $this->assertSame('after', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertNull($processor->get_before_path_type());
+        $this->assertSame('file', $processor->get_after_path_type());
         $processor->consume_current_path();
-        $this->assertSame('after', $processor->get_current_path()['order']);
+        $this->assertTrue($processor->next_path());
+        $this->assertNull($processor->get_before_path_type());
+        $this->assertSame('file', $processor->get_after_path_type());
         $processor->consume_current_path();
-        $this->assertNull($processor->get_current_path());
+        $this->assertFalse($processor->next_path());
         $processor->close();
     }
 
@@ -246,7 +272,12 @@ final class FileIndexDiffProcessorTest extends TestCase
             $after_index_file
         );
 
-        $this->assertTrue($processor->get_current_path()['after']['empty']);
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('empty-directory', $processor->get_path());
+        $this->assertSame('dir', $processor->get_after_path_type());
+        $this->assertSame(0, $processor->get_after_size());
+        $this->assertSame(10, $processor->get_after_ctime());
+        $this->assertTrue($processor->get_after_directory_is_empty());
         $processor->close();
     }
 
@@ -267,10 +298,10 @@ final class FileIndexDiffProcessorTest extends TestCase
         $before_index_file = $this->write_index('before.jsonl', []);
         $after_index_file = $this->write_index('after.jsonl', []);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
-        $this->assertNull($processor->get_current_path());
+        $this->assertFalse($processor->next_path());
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cannot consume a completed file-index diff');
+        $this->expectExceptionMessage('No current file-index path');
         try {
             $processor->consume_current_path();
         } finally {
@@ -285,13 +316,48 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('after.txt'),
         ]);
         $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
-        $processor->get_current_path();
+        $this->assertTrue($processor->next_path());
         $processor->close();
         $processor->close();
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot use a closed file-index diff processor');
-        $processor->get_current_path();
+        $processor->next_path();
+    }
+
+    public function testGettersDoNotSelectAPath(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', []);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('after.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Call next_path() first');
+        try {
+            $processor->get_path();
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testNextPathRejectsAnUnconsumedCurrentPath(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', []);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('after.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $this->assertTrue($processor->next_path());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('before consuming the current path');
+        try {
+            $processor->next_path();
+        } finally {
+            $processor->close();
+        }
     }
 
     /**
@@ -338,15 +404,13 @@ final class FileIndexDiffProcessorTest extends TestCase
     /** @return array{string,string|null,string|null,string|null,string|null,string|null} */
     private function current_path_summary(FileIndexDiffProcessor $processor): array
     {
-        $current_path = $processor->get_current_path();
-        $this->assertIsArray($current_path);
         return [
-            $current_path['order'],
-            $current_path['before']['path'] ?? null,
-            $current_path['after']['path'] ?? null,
-            $current_path['before_lookahead']['path'] ?? null,
-            $current_path['after_lookahead']['path'] ?? null,
-            $current_path['previous_after_path'],
+            $processor->get_path(),
+            $processor->get_before_path_type(),
+            $processor->get_after_path_type(),
+            $processor->get_before_lookahead_path(),
+            $processor->get_after_lookahead_path(),
+            $processor->get_previous_after_path(),
         ];
     }
 }

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -39,33 +39,33 @@ final class FileIndexDiffProcessorTest extends TestCase
         parent::tearDown();
     }
 
-    public function testAlignsEarlierLaterAndSharedPaths(): void
+    public function testAlignsOldNewAndSharedPaths(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
-            $this->entry('b-earlier-only.txt', 10),
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('b-old-only.txt', 10),
             $this->entry('shared.txt', 20),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('a-later-only.txt', 30),
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('a-new-only.txt', 30),
             $this->entry('shared.txt', 40),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['a-later-only.txt', null, 'file', 'b-earlier-only.txt', 'a-later-only.txt', null],
+            ['a-new-only.txt', null, 'file', 'b-old-only.txt', null, null],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['b-earlier-only.txt', 'file', null, 'b-earlier-only.txt', 'shared.txt', 'a-later-only.txt'],
+            ['b-old-only.txt', 'file', null, null, 'shared.txt', 'a-new-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
-            ['shared.txt', 'file', 'file', 'shared.txt', 'shared.txt', 'a-later-only.txt'],
+            ['shared.txt', 'file', 'file', null, null, 'a-new-only.txt'],
             $this->current_path_summary($processor)
         );
         $processor->consume_current_path();
@@ -77,40 +77,40 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testComparesDecodedPathBytesInsteadOfBase64Text(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
-            $this->entry("\xD0-earlier"),
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry("\xD0-old"),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('A-later'),
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('A-new'),
         ]);
         $this->assertLessThan(
             0,
-            strcmp(base64_encode("\xD0-earlier"), base64_encode('A-later'))
+            strcmp(base64_encode("\xD0-old"), base64_encode('A-new'))
         );
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('A-later', $processor->get_path());
-        $this->assertNull($processor->get_earlier_path_type());
-        $this->assertSame('file', $processor->get_later_path_type());
+        $this->assertSame('A-new', $processor->get_path());
+        $this->assertNull($processor->get_path_type_in_old_index());
+        $this->assertSame('file', $processor->get_path_type_in_new_index());
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
-        $this->assertSame("\xD0-earlier", $processor->get_path());
-        $this->assertSame('file', $processor->get_earlier_path_type());
-        $this->assertNull($processor->get_later_path_type());
+        $this->assertSame("\xD0-old", $processor->get_path());
+        $this->assertSame('file', $processor->get_path_type_in_old_index());
+        $this->assertNull($processor->get_path_type_in_new_index());
 
         $processor->close();
     }
 
     public function testCurrentPathAndCursorRemainStableUntilConsumption(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
+        $old_index_file = $this->write_index('old.jsonl', [
             $this->entry('same.txt', 10),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
+        $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('same.txt', 20),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $initial_cursor = $processor->get_cursor();
 
         $this->assertTrue($processor->next_path());
@@ -125,67 +125,67 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testConsumptionAdvancesOnlyTheIndexesRepresentedByTheCurrentPath(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
-            $this->entry('a-earlier'),
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('a-old'),
             $this->entry('c-shared'),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('b-later'),
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('b-new'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('file', $processor->get_earlier_path_type());
-        $this->assertNull($processor->get_later_path_type());
+        $this->assertSame('file', $processor->get_path_type_in_old_index());
+        $this->assertNull($processor->get_path_type_in_new_index());
         $processor->consume_current_path();
-        $cursor_after_earlier_only_path = $processor->get_cursor();
-        $this->assertGreaterThan(0, $cursor_after_earlier_only_path['earlier_index_byte_offset']);
-        $this->assertSame(0, $cursor_after_earlier_only_path['later_index_byte_offset']);
-        $this->assertNull($cursor_after_earlier_only_path['previous_later_index_entry_path_b64']);
+        $cursor_after_old_only_path = $processor->get_cursor();
+        $this->assertGreaterThan(0, $cursor_after_old_only_path['old_index_byte_offset']);
+        $this->assertSame(0, $cursor_after_old_only_path['new_index_byte_offset']);
+        $this->assertNull($cursor_after_old_only_path['preceding_new_index_entry_path_b64']);
 
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_earlier_path_type());
-        $this->assertSame('file', $processor->get_later_path_type());
+        $this->assertNull($processor->get_path_type_in_old_index());
+        $this->assertSame('file', $processor->get_path_type_in_new_index());
         $processor->consume_current_path();
-        $cursor_after_later_only_path = $processor->get_cursor();
+        $cursor_after_new_only_path = $processor->get_cursor();
         $this->assertSame(
-            $cursor_after_earlier_only_path['earlier_index_byte_offset'],
-            $cursor_after_later_only_path['earlier_index_byte_offset']
+            $cursor_after_old_only_path['old_index_byte_offset'],
+            $cursor_after_new_only_path['old_index_byte_offset']
         );
-        $this->assertGreaterThan(0, $cursor_after_later_only_path['later_index_byte_offset']);
+        $this->assertGreaterThan(0, $cursor_after_new_only_path['new_index_byte_offset']);
         $this->assertSame(
-            base64_encode('b-later'),
-            $cursor_after_later_only_path['previous_later_index_entry_path_b64']
+            base64_encode('b-new'),
+            $cursor_after_new_only_path['preceding_new_index_entry_path_b64']
         );
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('file', $processor->get_earlier_path_type());
-        $this->assertSame('file', $processor->get_later_path_type());
+        $this->assertSame('file', $processor->get_path_type_in_old_index());
+        $this->assertSame('file', $processor->get_path_type_in_new_index());
         $processor->consume_current_path();
         $cursor_after_shared_path = $processor->get_cursor();
         $this->assertGreaterThan(
-            $cursor_after_later_only_path['earlier_index_byte_offset'],
-            $cursor_after_shared_path['earlier_index_byte_offset']
+            $cursor_after_new_only_path['old_index_byte_offset'],
+            $cursor_after_shared_path['old_index_byte_offset']
         );
         $this->assertGreaterThan(
-            $cursor_after_later_only_path['later_index_byte_offset'],
-            $cursor_after_shared_path['later_index_byte_offset']
+            $cursor_after_new_only_path['new_index_byte_offset'],
+            $cursor_after_shared_path['new_index_byte_offset']
         );
         $processor->close();
     }
 
     public function testResumeRepeatsTheCurrentPathWhoseConsumptionWasNotStored(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
+        $old_index_file = $this->write_index('old.jsonl', [
             $this->entry('a.txt'),
             $this->entry('c.txt'),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
+        $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('b.txt'),
             $this->entry('c.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
         $stored_cursor = $processor->get_cursor();
@@ -194,8 +194,8 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
 
         $resumed_processor = FileIndexDiffProcessor::resume(
-            $earlier_index_file,
-            $later_index_file,
+            $old_index_file,
+            $new_index_file,
             $stored_cursor
         );
         $this->assertTrue($resumed_processor->next_path());
@@ -204,59 +204,59 @@ final class FileIndexDiffProcessorTest extends TestCase
         $resumed_processor->close();
     }
 
-    public function testPreviousLaterPathSurvivesEarlierOnlyPathsAndResume(): void
+    public function testPrecedingNewPathSurvivesOldOnlyPathsAndResume(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', [
-            $this->entry('b-earlier'),
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('b-old'),
             $this->entry('c-shared'),
         ]);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('a-later'),
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('a-new'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
         $processor->consume_current_path();
 
         $this->assertTrue($processor->next_path());
-        $this->assertSame('a-later', $processor->get_previous_later_path());
+        $this->assertSame('a-new', $processor->get_preceding_path_in_new_index());
         $processor->consume_current_path();
         $cursor = $processor->get_cursor();
         $processor->close();
 
         $resumed_processor = FileIndexDiffProcessor::resume(
-            $earlier_index_file,
-            $later_index_file,
+            $old_index_file,
+            $new_index_file,
             $cursor
         );
         $this->assertTrue($resumed_processor->next_path());
-        $this->assertSame('file', $resumed_processor->get_earlier_path_type());
-        $this->assertSame('file', $resumed_processor->get_later_path_type());
+        $this->assertSame('file', $resumed_processor->get_path_type_in_old_index());
+        $this->assertSame('file', $resumed_processor->get_path_type_in_new_index());
         $this->assertSame(
-            'a-later',
-            $resumed_processor->get_previous_later_path()
+            'a-new',
+            $resumed_processor->get_preceding_path_in_new_index()
         );
         $resumed_processor->close();
     }
 
-    public function testMissingEarlierIndexRepresentsAnEmptyEarlierSnapshot(): void
+    public function testMissingOldIndexRepresentsAnEmptyOldSnapshot(): void
     {
-        $later_index_file = $this->write_index('later.jsonl', [
+        $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('first.txt'),
             $this->entry('second.txt'),
         ]);
         $processor = FileIndexDiffProcessor::start(
-            $this->temp_dir . '/missing-earlier.jsonl',
-            $later_index_file
+            $this->temp_dir . '/missing-old.jsonl',
+            $new_index_file
         );
 
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_earlier_path_type());
-        $this->assertSame('file', $processor->get_later_path_type());
+        $this->assertNull($processor->get_path_type_in_old_index());
+        $this->assertSame('file', $processor->get_path_type_in_new_index());
         $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
-        $this->assertNull($processor->get_earlier_path_type());
-        $this->assertSame('file', $processor->get_later_path_type());
+        $this->assertNull($processor->get_path_type_in_old_index());
+        $this->assertSame('file', $processor->get_path_type_in_new_index());
         $processor->consume_current_path();
         $this->assertFalse($processor->next_path());
         $processor->close();
@@ -264,40 +264,40 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testDirectoryEntryKeepsItsEmptyMarker(): void
     {
-        $later_index_file = $this->write_index('later.jsonl', [
+        $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('empty-directory', 10, 0, 'dir', true),
         ]);
         $processor = FileIndexDiffProcessor::start(
-            $this->temp_dir . '/missing-earlier.jsonl',
-            $later_index_file
+            $this->temp_dir . '/missing-old.jsonl',
+            $new_index_file
         );
 
         $this->assertTrue($processor->next_path());
         $this->assertSame('empty-directory', $processor->get_path());
-        $this->assertSame('dir', $processor->get_later_path_type());
-        $this->assertSame(0, $processor->get_later_size());
-        $this->assertSame(10, $processor->get_later_ctime());
-        $this->assertTrue($processor->get_later_directory_is_empty());
+        $this->assertSame('dir', $processor->get_path_type_in_new_index());
+        $this->assertSame(0, $processor->get_size_in_new_index());
+        $this->assertSame(10, $processor->get_ctime_in_new_index());
+        $this->assertTrue($processor->get_directory_is_empty_in_new_index());
         $processor->close();
     }
 
-    public function testMissingLaterIndexIsRejected(): void
+    public function testMissingNewIndexIsRejected(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', []);
+        $old_index_file = $this->write_index('old.jsonl', []);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Failed to open the later file index');
+        $this->expectExceptionMessage('Failed to open the new file index');
         FileIndexDiffProcessor::start(
-            $earlier_index_file,
-            $this->temp_dir . '/missing-later.jsonl'
+            $old_index_file,
+            $this->temp_dir . '/missing-new.jsonl'
         );
     }
 
     public function testConsumingWhenBothIndexesReachedEofIsRejected(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', []);
-        $later_index_file = $this->write_index('later.jsonl', []);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $old_index_file = $this->write_index('old.jsonl', []);
+        $new_index_file = $this->write_index('new.jsonl', []);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $this->assertFalse($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -311,11 +311,11 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testCloseIsIdempotentAndMakesTheProcessorTerminal(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', []);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('later.txt'),
+        $old_index_file = $this->write_index('old.jsonl', []);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('new.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
         $processor->close();
         $processor->close();
@@ -327,11 +327,11 @@ final class FileIndexDiffProcessorTest extends TestCase
 
     public function testGettersDoNotSelectAPath(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', []);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('later.txt'),
+        $old_index_file = $this->write_index('old.jsonl', []);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('new.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Call next_path() first');
@@ -342,13 +342,53 @@ final class FileIndexDiffProcessorTest extends TestCase
         }
     }
 
+    public function testFollowingOldPathRequiresTheCurrentPathToBeAbsentFromTheOldIndex(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('shared.txt'),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('shared.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $this->assertTrue($processor->next_path());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('current path occurs in the old index');
+        try {
+            $processor->get_following_path_in_old_index();
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testFollowingNewPathRequiresTheCurrentPathToBeAbsentFromTheNewIndex(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('shared.txt'),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('shared.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $this->assertTrue($processor->next_path());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('current path occurs in the new index');
+        try {
+            $processor->get_following_path_in_new_index();
+        } finally {
+            $processor->close();
+        }
+    }
+
     public function testNextPathRejectsAnUnconsumedCurrentPath(): void
     {
-        $earlier_index_file = $this->write_index('earlier.jsonl', []);
-        $later_index_file = $this->write_index('later.jsonl', [
-            $this->entry('later.txt'),
+        $old_index_file = $this->write_index('old.jsonl', []);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('new.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($earlier_index_file, $later_index_file);
+        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -404,13 +444,19 @@ final class FileIndexDiffProcessorTest extends TestCase
     /** @return array{string,string|null,string|null,string|null,string|null,string|null} */
     private function current_path_summary(FileIndexDiffProcessor $processor): array
     {
+        $old_path_type = $processor->get_path_type_in_old_index();
+        $new_path_type = $processor->get_path_type_in_new_index();
         return [
             $processor->get_path(),
-            $processor->get_earlier_path_type(),
-            $processor->get_later_path_type(),
-            $processor->get_earlier_lookahead_path(),
-            $processor->get_later_lookahead_path(),
-            $processor->get_previous_later_path(),
+            $old_path_type,
+            $new_path_type,
+            $old_path_type === null
+                ? $processor->get_following_path_in_old_index()
+                : null,
+            $new_path_type === null
+                ? $processor->get_following_path_in_new_index()
+                : null,
+            $processor->get_preceding_path_in_new_index(),
         ];
     }
 }

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -49,27 +49,23 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('a-new-only.txt', 30),
             $this->entry('shared.txt', 40),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
         $this->assertSame(
             ['a-new-only.txt', null, 'file', 'b-old-only.txt', null, null],
             $this->current_path_summary($processor)
         );
-        $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
             ['b-old-only.txt', 'file', null, null, 'shared.txt', 'a-new-only.txt'],
             $this->current_path_summary($processor)
         );
-        $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame(
             ['shared.txt', 'file', 'file', null, null, 'a-new-only.txt'],
             $this->current_path_summary($processor)
         );
-        $processor->consume_current_path();
-
         $this->assertFalse($processor->next_path());
         $this->assertFalse($processor->next_path());
         $processor->close();
@@ -87,13 +83,12 @@ final class FileIndexDiffProcessorTest extends TestCase
             0,
             strcmp(base64_encode("\xD0-old"), base64_encode('A-new'))
         );
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
         $this->assertSame('A-new', $processor->get_path());
         $this->assertNull($processor->get_path_type_in_old_index());
         $this->assertSame('file', $processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertSame("\xD0-old", $processor->get_path());
         $this->assertSame('file', $processor->get_path_type_in_old_index());
@@ -102,7 +97,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
     }
 
-    public function testCurrentPathAndCursorRemainStableUntilConsumption(): void
+    public function testCurrentPathAndCursorRemainStableUntilNextPath(): void
     {
         $old_index_file = $this->write_index('old.jsonl', [
             $this->entry('same.txt', 10),
@@ -110,7 +105,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('same.txt', 20),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $initial_cursor = $processor->get_cursor();
 
         $this->assertTrue($processor->next_path());
@@ -118,12 +113,12 @@ final class FileIndexDiffProcessorTest extends TestCase
         $this->assertSame($first_read, $this->current_path_summary($processor));
         $this->assertSame($initial_cursor, $processor->get_cursor());
 
-        $processor->consume_current_path();
+        $this->assertFalse($processor->next_path());
         $this->assertNotSame($initial_cursor, $processor->get_cursor());
         $processor->close();
     }
 
-    public function testConsumptionAdvancesOnlyTheIndexesRepresentedByTheCurrentPath(): void
+    public function testNextPathAdvancesOnlyTheIndexesContainingTheCurrentPath(): void
     {
         $old_index_file = $this->write_index('old.jsonl', [
             $this->entry('a-old'),
@@ -133,21 +128,20 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('b-new'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
 
         $this->assertTrue($processor->next_path());
         $this->assertSame('file', $processor->get_path_type_in_old_index());
         $this->assertNull($processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $cursor_after_old_only_path = $processor->get_cursor();
         $this->assertGreaterThan(0, $cursor_after_old_only_path['old_index_byte_offset']);
         $this->assertSame(0, $cursor_after_old_only_path['new_index_byte_offset']);
         $this->assertNull($cursor_after_old_only_path['preceding_new_index_entry_path_b64']);
 
-        $this->assertTrue($processor->next_path());
         $this->assertNull($processor->get_path_type_in_old_index());
         $this->assertSame('file', $processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $cursor_after_new_only_path = $processor->get_cursor();
         $this->assertSame(
             $cursor_after_old_only_path['old_index_byte_offset'],
@@ -159,10 +153,9 @@ final class FileIndexDiffProcessorTest extends TestCase
             $cursor_after_new_only_path['preceding_new_index_entry_path_b64']
         );
 
-        $this->assertTrue($processor->next_path());
         $this->assertSame('file', $processor->get_path_type_in_old_index());
         $this->assertSame('file', $processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
+        $this->assertFalse($processor->next_path());
         $cursor_after_shared_path = $processor->get_cursor();
         $this->assertGreaterThan(
             $cursor_after_new_only_path['old_index_byte_offset'],
@@ -185,11 +178,10 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('b.txt'),
             $this->entry('c.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
-        $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $stored_cursor = $processor->get_cursor();
-        $this->assertTrue($processor->next_path());
         $unconsumed_path = $this->current_path_summary($processor);
         $processor->close();
 
@@ -214,13 +206,11 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('a-new'),
             $this->entry('c-shared'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
-        $processor->consume_current_path();
-
         $this->assertTrue($processor->next_path());
         $this->assertSame('a-new', $processor->get_preceding_path_in_new_index());
-        $processor->consume_current_path();
+        $this->assertTrue($processor->next_path());
         $cursor = $processor->get_cursor();
         $processor->close();
 
@@ -245,7 +235,7 @@ final class FileIndexDiffProcessorTest extends TestCase
             $this->entry('first.txt'),
             $this->entry('second.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start(
+        $processor = FileIndexDiffProcessor::create(
             $this->temp_dir . '/missing-old.jsonl',
             $new_index_file
         );
@@ -253,11 +243,9 @@ final class FileIndexDiffProcessorTest extends TestCase
         $this->assertTrue($processor->next_path());
         $this->assertNull($processor->get_path_type_in_old_index());
         $this->assertSame('file', $processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
         $this->assertTrue($processor->next_path());
         $this->assertNull($processor->get_path_type_in_old_index());
         $this->assertSame('file', $processor->get_path_type_in_new_index());
-        $processor->consume_current_path();
         $this->assertFalse($processor->next_path());
         $processor->close();
     }
@@ -267,7 +255,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('empty-directory', 10, 0, 'dir', true),
         ]);
-        $processor = FileIndexDiffProcessor::start(
+        $processor = FileIndexDiffProcessor::create(
             $this->temp_dir . '/missing-old.jsonl',
             $new_index_file
         );
@@ -287,26 +275,20 @@ final class FileIndexDiffProcessorTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to open the new file index');
-        FileIndexDiffProcessor::start(
+        FileIndexDiffProcessor::create(
             $old_index_file,
             $this->temp_dir . '/missing-new.jsonl'
         );
     }
 
-    public function testConsumingWhenBothIndexesReachedEofIsRejected(): void
+    public function testEmptyIndexesReachEofImmediately(): void
     {
         $old_index_file = $this->write_index('old.jsonl', []);
         $new_index_file = $this->write_index('new.jsonl', []);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertFalse($processor->next_path());
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('No current file-index path');
-        try {
-            $processor->consume_current_path();
-        } finally {
-            $processor->close();
-        }
+        $this->assertFalse($processor->next_path());
+        $processor->close();
     }
 
     public function testCloseIsIdempotentAndMakesTheProcessorTerminal(): void
@@ -315,7 +297,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('new.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
         $processor->close();
         $processor->close();
@@ -331,7 +313,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('new.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Call next_path() first');
@@ -350,7 +332,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('shared.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -370,7 +352,7 @@ final class FileIndexDiffProcessorTest extends TestCase
         $new_index_file = $this->write_index('new.jsonl', [
             $this->entry('shared.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
         $this->assertTrue($processor->next_path());
 
         $this->expectException(LogicException::class);
@@ -382,22 +364,23 @@ final class FileIndexDiffProcessorTest extends TestCase
         }
     }
 
-    public function testNextPathRejectsAnUnconsumedCurrentPath(): void
+    public function testNextPathConsumesTheCurrentPathBeforeSelectingAnother(): void
     {
-        $old_index_file = $this->write_index('old.jsonl', []);
-        $new_index_file = $this->write_index('new.jsonl', [
-            $this->entry('new.txt'),
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('first.txt'),
+            $this->entry('second.txt'),
         ]);
-        $processor = FileIndexDiffProcessor::start($old_index_file, $new_index_file);
+        $new_index_file = $this->write_index('new.jsonl', []);
+        $processor = FileIndexDiffProcessor::create($old_index_file, $new_index_file);
+        $initial_cursor = $processor->get_cursor();
         $this->assertTrue($processor->next_path());
+        $this->assertSame('first.txt', $processor->get_path());
+        $this->assertSame($initial_cursor, $processor->get_cursor());
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('before consuming the current path');
-        try {
-            $processor->next_path();
-        } finally {
-            $processor->close();
-        }
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('second.txt', $processor->get_path());
+        $this->assertNotSame($initial_cursor, $processor->get_cursor());
+        $processor->close();
     }
 
     /**

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-index-diff-processor.php';
+
+/**
+ * Covers FileIndexDiffProcessor alignment and interruption boundaries.
+ *
+ * These tests use small real JSONL indexes so byte offsets, retained entries,
+ * decoded-path ordering, EOF, close(), and resume() exercise the same stream
+ * operations used by pull and push.
+ */
+final class FileIndexDiffProcessorTest extends TestCase
+{
+    private string $temp_dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temp_dir = sys_get_temp_dir()
+            . '/file-index-diff-processor-'
+            . bin2hex(random_bytes(6));
+        mkdir($this->temp_dir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (scandir($this->temp_dir) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                unlink($this->temp_dir . '/' . $entry);
+            }
+        }
+        rmdir($this->temp_dir);
+        parent::tearDown();
+    }
+
+    public function testAlignsBeforeAfterAndSharedPaths(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry('before-only.txt', 10),
+            $this->entry('shared.txt', 20),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('after-only.txt', 30),
+            $this->entry('shared.txt', 40),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+
+        $this->assertSame(
+            ['after', null, 'after-only.txt', 'before-only.txt', 'after-only.txt', null],
+            $this->current_path_summary($processor)
+        );
+        $processor->consume_current_path();
+        $this->assertSame(
+            ['before', 'before-only.txt', null, 'before-only.txt', 'shared.txt', 'after-only.txt'],
+            $this->current_path_summary($processor)
+        );
+        $processor->consume_current_path();
+        $this->assertSame(
+            ['both', 'shared.txt', 'shared.txt', 'shared.txt', 'shared.txt', 'after-only.txt'],
+            $this->current_path_summary($processor)
+        );
+        $processor->consume_current_path();
+
+        $this->assertNull($processor->get_current_path());
+        $this->assertNull($processor->get_current_path());
+        $processor->close();
+    }
+
+    public function testComparesDecodedPathBytesInsteadOfBase64Text(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry("\xD0-before"),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('A-after'),
+        ]);
+        $this->assertLessThan(
+            0,
+            strcmp(base64_encode("\xD0-before"), base64_encode('A-after'))
+        );
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+
+        $this->assertSame('A-after', $processor->get_current_path()['after']['path']);
+        $this->assertSame('after', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $this->assertSame("\xD0-before", $processor->get_current_path()['before']['path']);
+
+        $processor->close();
+    }
+
+    public function testCurrentPathAndCursorRemainStableUntilConsumption(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry('same.txt', 10),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('same.txt', 20),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $initial_cursor = $processor->get_cursor();
+
+        $first_read = $processor->get_current_path();
+        $this->assertSame($first_read, $processor->get_current_path());
+        $this->assertSame($initial_cursor, $processor->get_cursor());
+
+        $processor->consume_current_path();
+        $this->assertNotSame($initial_cursor, $processor->get_cursor());
+        $processor->close();
+    }
+
+    public function testConsumptionAdvancesOnlyTheIndexesRepresentedByTheCurrentPath(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry('a-before'),
+            $this->entry('c-shared'),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('b-after'),
+            $this->entry('c-shared'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+
+        $this->assertSame('before', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $after_before_only = $processor->get_cursor();
+        $this->assertGreaterThan(0, $after_before_only['before_index_byte_offset']);
+        $this->assertSame(0, $after_before_only['after_index_byte_offset']);
+        $this->assertNull($after_before_only['previous_after_index_entry_path_b64']);
+
+        $this->assertSame('after', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $after_after_only = $processor->get_cursor();
+        $this->assertSame(
+            $after_before_only['before_index_byte_offset'],
+            $after_after_only['before_index_byte_offset']
+        );
+        $this->assertGreaterThan(0, $after_after_only['after_index_byte_offset']);
+        $this->assertSame(
+            base64_encode('b-after'),
+            $after_after_only['previous_after_index_entry_path_b64']
+        );
+
+        $this->assertSame('both', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $after_shared = $processor->get_cursor();
+        $this->assertGreaterThan(
+            $after_after_only['before_index_byte_offset'],
+            $after_shared['before_index_byte_offset']
+        );
+        $this->assertGreaterThan(
+            $after_after_only['after_index_byte_offset'],
+            $after_shared['after_index_byte_offset']
+        );
+        $processor->close();
+    }
+
+    public function testResumeRepeatsTheCurrentPathWhoseConsumptionWasNotStored(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry('a.txt'),
+            $this->entry('c.txt'),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('b.txt'),
+            $this->entry('c.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor->consume_current_path();
+        $stored_cursor = $processor->get_cursor();
+        $unconsumed_path = $processor->get_current_path();
+        $processor->close();
+
+        $resumed_processor = FileIndexDiffProcessor::resume(
+            $before_index_file,
+            $after_index_file,
+            $stored_cursor
+        );
+        $this->assertSame($unconsumed_path, $resumed_processor->get_current_path());
+        $this->assertSame($stored_cursor, $resumed_processor->get_cursor());
+        $resumed_processor->close();
+    }
+
+    public function testPreviousAfterPathSurvivesBeforeOnlyPathsAndResume(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', [
+            $this->entry('b-before'),
+            $this->entry('c-shared'),
+        ]);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('a-after'),
+            $this->entry('c-shared'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor->consume_current_path();
+
+        $this->assertSame('a-after', $processor->get_current_path()['previous_after_path']);
+        $processor->consume_current_path();
+        $cursor = $processor->get_cursor();
+        $processor->close();
+
+        $resumed_processor = FileIndexDiffProcessor::resume(
+            $before_index_file,
+            $after_index_file,
+            $cursor
+        );
+        $this->assertSame('both', $resumed_processor->get_current_path()['order']);
+        $this->assertSame(
+            'a-after',
+            $resumed_processor->get_current_path()['previous_after_path']
+        );
+        $resumed_processor->close();
+    }
+
+    public function testMissingBeforeIndexRepresentsAnEmptyEarlierSnapshot(): void
+    {
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('first.txt'),
+            $this->entry('second.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start(
+            $this->temp_dir . '/missing-before.jsonl',
+            $after_index_file
+        );
+
+        $this->assertSame('after', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $this->assertSame('after', $processor->get_current_path()['order']);
+        $processor->consume_current_path();
+        $this->assertNull($processor->get_current_path());
+        $processor->close();
+    }
+
+    public function testDirectoryEntryKeepsItsEmptyMarker(): void
+    {
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('empty-directory', 10, 0, 'dir', true),
+        ]);
+        $processor = FileIndexDiffProcessor::start(
+            $this->temp_dir . '/missing-before.jsonl',
+            $after_index_file
+        );
+
+        $this->assertTrue($processor->get_current_path()['after']['empty']);
+        $processor->close();
+    }
+
+    public function testMissingAfterIndexIsRejected(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', []);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to open the after file index');
+        FileIndexDiffProcessor::start(
+            $before_index_file,
+            $this->temp_dir . '/missing-after.jsonl'
+        );
+    }
+
+    public function testConsumingAfterBothIndexesReachEofIsRejected(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', []);
+        $after_index_file = $this->write_index('after.jsonl', []);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $this->assertNull($processor->get_current_path());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot consume a completed file-index diff');
+        try {
+            $processor->consume_current_path();
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testCloseIsIdempotentAndMakesTheProcessorTerminal(): void
+    {
+        $before_index_file = $this->write_index('before.jsonl', []);
+        $after_index_file = $this->write_index('after.jsonl', [
+            $this->entry('after.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::start($before_index_file, $after_index_file);
+        $processor->get_current_path();
+        $processor->close();
+        $processor->close();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot use a closed file-index diff processor');
+        $processor->get_current_path();
+    }
+
+    /**
+     * @param list<array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}> $entries
+     */
+    private function write_index(string $filename, array $entries): string
+    {
+        $index_file = $this->temp_dir . '/' . $filename;
+        $lines = '';
+        foreach ($entries as $entry) {
+            $encoded_entry = $entry;
+            $encoded_entry['path'] = base64_encode($entry['path']);
+            $lines .= json_encode(
+                $encoded_entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
+        }
+        file_put_contents($index_file, $lines);
+        return $index_file;
+    }
+
+    /**
+     * @return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}
+     */
+    private function entry(
+        string $path,
+        int $ctime = 1,
+        int $size = 1,
+        string $type = 'file',
+        ?bool $directory_is_empty = null
+    ): array {
+        $entry = [
+            'path' => $path,
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => $type,
+        ];
+        if ($directory_is_empty !== null) {
+            $entry['empty'] = $directory_is_empty;
+        }
+        return $entry;
+    }
+
+    /** @return array{string,string|null,string|null,string|null,string|null,string|null} */
+    private function current_path_summary(FileIndexDiffProcessor $processor): array
+    {
+        $current_path = $processor->get_current_path();
+        $this->assertIsArray($current_path);
+        return [
+            $current_path['order'],
+            $current_path['before']['path'] ?? null,
+            $current_path['after']['path'] ?? null,
+            $current_path['before_lookahead']['path'] ?? null,
+            $current_path['after_lookahead']['path'] ?? null,
+            $current_path['previous_after_path'],
+        ];
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -539,18 +539,33 @@ final class PushPlanTest extends TestCase
     public function testStepRetainsTheNextFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
-        $fresh_local_index_handle_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_handle');
-        $fresh_local_index_entry_property = new ReflectionProperty(PushPlan::class, 'fresh_local_index_entry');
+        $index_diff_processor_property = new ReflectionProperty(
+            PushPlan::class,
+            'index_diff_processor'
+        );
+        $after_index_handle_property = new ReflectionProperty(
+            FileIndexDiffProcessor::class,
+            'after_index_handle'
+        );
+        $after_index_entry_property = new ReflectionProperty(
+            FileIndexDiffProcessor::class,
+            'after_index_entry'
+        );
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
-        $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
+        $index_diff_processor = $index_diff_processor_property->getValue($plan);
+        $fresh_local_index_handle = $after_index_handle_property->getValue(
+            $index_diff_processor
+        );
         $this->assertIsResource($fresh_local_index_handle);
         $this->assertGreaterThan(
             $first_plan_cursor['byte_offset_in_fresh_local_index'],
             ftell($fresh_local_index_handle)
         );
-        $retained_fresh_local_index_entry = $fresh_local_index_entry_property->getValue($plan);
+        $retained_fresh_local_index_entry = $after_index_entry_property->getValue(
+            $index_diff_processor
+        );
         $this->assertIsArray($retained_fresh_local_index_entry);
         $this->assertSame('file-0001.txt', $retained_fresh_local_index_entry['path']);
 

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -539,9 +539,9 @@ final class PushPlanTest extends TestCase
     public function testStepRetainsTheFollowingFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
-        $index_diff_processor_property = new ReflectionProperty(
+        $index_diff_property = new ReflectionProperty(
             PushPlan::class,
-            'index_diff_processor'
+            'index_diff'
         );
         $new_index_handle_property = new ReflectionProperty(
             FileIndexDiffProcessor::class,
@@ -554,9 +554,9 @@ final class PushPlanTest extends TestCase
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
-        $index_diff_processor = $index_diff_processor_property->getValue($plan);
+        $index_diff = $index_diff_property->getValue($plan);
         $fresh_local_index_handle = $new_index_handle_property->getValue(
-            $index_diff_processor
+            $index_diff
         );
         $this->assertIsResource($fresh_local_index_handle);
         $this->assertGreaterThan(
@@ -564,7 +564,7 @@ final class PushPlanTest extends TestCase
             ftell($fresh_local_index_handle)
         );
         $retained_fresh_local_index_entry = $new_index_entry_property->getValue(
-            $index_diff_processor
+            $index_diff
         );
         $this->assertIsArray($retained_fresh_local_index_entry);
         $this->assertSame('file-0001.txt', $retained_fresh_local_index_entry['path']);

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -543,19 +543,19 @@ final class PushPlanTest extends TestCase
             PushPlan::class,
             'index_diff_processor'
         );
-        $after_index_handle_property = new ReflectionProperty(
+        $later_index_handle_property = new ReflectionProperty(
             FileIndexDiffProcessor::class,
-            'after_index_handle'
+            'later_index_handle'
         );
-        $after_index_entry_property = new ReflectionProperty(
+        $later_index_entry_property = new ReflectionProperty(
             FileIndexDiffProcessor::class,
-            'after_index_entry'
+            'later_index_entry'
         );
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
         $index_diff_processor = $index_diff_processor_property->getValue($plan);
-        $fresh_local_index_handle = $after_index_handle_property->getValue(
+        $fresh_local_index_handle = $later_index_handle_property->getValue(
             $index_diff_processor
         );
         $this->assertIsResource($fresh_local_index_handle);
@@ -563,7 +563,7 @@ final class PushPlanTest extends TestCase
             $first_plan_cursor['byte_offset_in_fresh_local_index'],
             ftell($fresh_local_index_handle)
         );
-        $retained_fresh_local_index_entry = $after_index_entry_property->getValue(
+        $retained_fresh_local_index_entry = $later_index_entry_property->getValue(
             $index_diff_processor
         );
         $this->assertIsArray($retained_fresh_local_index_entry);

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -536,26 +536,26 @@ final class PushPlanTest extends TestCase
         );
     }
 
-    public function testStepRetainsTheNextFreshLocalIndexEntryUntilClose(): void
+    public function testStepRetainsTheFollowingFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
         $index_diff_processor_property = new ReflectionProperty(
             PushPlan::class,
             'index_diff_processor'
         );
-        $later_index_handle_property = new ReflectionProperty(
+        $new_index_handle_property = new ReflectionProperty(
             FileIndexDiffProcessor::class,
-            'later_index_handle'
+            'new_index_handle'
         );
-        $later_index_entry_property = new ReflectionProperty(
+        $new_index_entry_property = new ReflectionProperty(
             FileIndexDiffProcessor::class,
-            'later_index_entry'
+            'new_index_entry'
         );
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
         $index_diff_processor = $index_diff_processor_property->getValue($plan);
-        $fresh_local_index_handle = $later_index_handle_property->getValue(
+        $fresh_local_index_handle = $new_index_handle_property->getValue(
             $index_diff_processor
         );
         $this->assertIsResource($fresh_local_index_handle);
@@ -563,7 +563,7 @@ final class PushPlanTest extends TestCase
             $first_plan_cursor['byte_offset_in_fresh_local_index'],
             ftell($fresh_local_index_handle)
         );
-        $retained_fresh_local_index_entry = $later_index_entry_property->getValue(
+        $retained_fresh_local_index_entry = $new_index_entry_property->getValue(
             $index_diff_processor
         );
         $this->assertIsArray($retained_fresh_local_index_entry);
@@ -613,7 +613,7 @@ final class PushPlanTest extends TestCase
             'local_paths_to_push_count',
             'local_file_bytes_to_push',
             'deleted_directory_stack_top_byte_offset',
-            'previous_fresh_local_index_entry_path',
+            'preceding_fresh_local_index_entry_path',
         ], array_keys($cursor['position']));
         $this->assertSame(1, $cursor['position']['local_paths_to_push_count']);
         $this->assertSame(1, $cursor['position']['local_file_bytes_to_push']);


### PR DESCRIPTION
Adds `FileIndexDiffProcessor`, a single-pass, resumable traversal over an old and new path-sorted filesystem index. It labels each current path as `added`, `modified`, `deleted`, or `unchanged`, so callers choose an operation without rebuilding the index comparison. `PushPlan` now uses the same processor.

## Usage

Create the comparison and select its first path:

```php
$index_diff = FileIndexDiffProcessor::create(
    $old_index_file,
    $new_index_file
);
$has_path = $index_diff->next_path();
```

`get_path_transition()` describes the difference between the old and new index records. A path present in both indexes is `modified` when its type, size, or ctime differs:

```php
while ($has_path) {
    $path = $index_diff->get_path();

    switch ($index_diff->get_path_transition()) {
        case "added":
            handle_added_path($path);
            break;
        case "modified":
            handle_modified_path($path);
            break;
        case "deleted":
            handle_deleted_path($path);
            break;
        case "unchanged":
            break;
    }

    $has_path = $index_diff->next_path();
    save_cursor($index_diff->get_cursor());
}

$index_diff->close();
```

The per-index getters expose record details when an operation needs them:

```php
if ($index_diff->get_path_transition() === "modified") {
    compare_sizes(
        $index_diff->get_size_in_old_index(),
        $index_diff->get_size_in_new_index()
    );
}
```

When a path is absent from an index, the neighboring-path getters describe the position where it would occur. For a path deleted from the new index:

```php
if ($index_diff->get_path_transition() === "deleted") {
    $preceding_path = $index_diff->get_preceding_path_in_new_index();
    $following_path = $index_diff->get_following_path_in_new_index();
}
```

For a path added to the new index, inspect the following path in the old index:

```php
if ($index_diff->get_path_transition() === "added") {
    $following_path = $index_diff->get_following_path_in_old_index();
}
```

A following-path getter requires the current path to be absent from that index. Otherwise the processor has not read the entry after the current path and rejects the call.

Resume from the cursor stored after `next_path()` advances past a processed path:

```php
$index_diff = FileIndexDiffProcessor::resume(
    $old_index_file,
    $new_index_file,
    $stored_cursor
);
```

A selected path is not part of the cursor until the following `next_path()` call advances past it. Closing before that call leaves the path available for replay after resume. Both index files must remain unchanged while a cursor may be resumed.

The processor holds at most one unread entry from each index. Its dedicated tests cover all four transition labels, decoded-path ordering, preceding and following paths, cursor movement, resume, missing indexes, EOF, and close.

#468 follows this PR in the stack.

## Testing

```
cd tests
../vendor/bin/phpunit Import/FileIndexDiffProcessorTest.php Import/PushPlanTest.php
../vendor/bin/phpcs ../packages/reprint-client/src/lib/index/class-file-index-diff-processor.php Import/FileIndexDiffProcessorTest.php
cd ..
vendor/bin/phpstan analyze --memory-limit=1G
git diff --check
```
