### PR TITLE
[PHP] Validate generated runtime request paths before filesystem routing

### DIFF
--- a/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
@@ -71,12 +71,8 @@ class PhpBuiltinApplier implements RuntimeApplier
         $lines = [];
         $lines[] = '// CLI-server routing (php -S only).';
         $lines[] = '// Handles static files, PHP execution, and WordPress pretty permalinks.';
-        $lines[] = '$path = parse_url($_SERVER[\'REQUEST_URI\'] ?? \'/\', PHP_URL_PATH);';
-        $lines[] = 'if (!is_string($path) || $path === \'\') {';
-        $lines[] = '    $path = \'/\';';
-        $lines[] = '}';
-        $lines[] = '$decoded_path = rawurldecode($path);';
-        $lines[] = 'if (strpos($decoded_path, "\0") !== false || preg_match(\'#(?:^|/)\\.\\.(?:/|$)#\', $decoded_path)) {';
+        $lines[] = '$path = reprint_runtime_request_path();';
+        $lines[] = 'if ($path === null) {';
         $lines[] = '    return false;';
         $lines[] = '}';
         $lines[] = '$document_root = rtrim($_SERVER[\'DOCUMENT_ROOT\'] ?? \'\', \'/\');';

--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -94,6 +94,9 @@ function generate_runtime_php(RuntimeManifest $manifest, string $filesystem_root
         $lines[] = '';
     }
 
+    $lines[] = generate_runtime_request_path_code();
+    $lines[] = '';
+
     // SQLite lazy-loading proxy — replaces $wpdb before WordPress boots.
     // WordPress's require_wp_db() sees $wpdb is already set and skips
     // the MySQL connection. The first real database call triggers the
@@ -354,6 +357,60 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
         }
     }
     return $code;
+}
+
+/**
+ * Generate the runtime helper that reads a request URI path before a handler
+ * maps it to the local filesystem.
+ *
+ * The helper preserves percent encoding in its return value so existing
+ * callers keep their raw request-path behavior. It rejects a NUL byte or a
+ * parent component after decoding, which prevents an encoded path from
+ * escaping a filesystem root.
+ */
+function generate_runtime_request_path_code(): string
+{
+    return <<<'PHP'
+if (!function_exists('reprint_runtime_request_path')) {
+    /**
+     * Returns the raw request URI path when it is safe for filesystem mapping.
+     *
+     * Query strings are omitted. Percent encoding remains intact so a caller
+     * can preserve the request path spelling. A decoded NUL byte or `..`
+     * component returns null.
+     *
+     * Examples:
+     *
+     *     /wp-content/uploads/photo.jpg?size=large -> /wp-content/uploads/photo.jpg
+     *     /wp-content/%2e%2e/wp-config.php         -> null
+     */
+    function reprint_runtime_request_path(): ?string
+    {
+        $request_uri = $_SERVER['REQUEST_URI'] ?? '/';
+        if (!is_string($request_uri)) {
+            return null;
+        }
+
+        $request_path = parse_url($request_uri, PHP_URL_PATH);
+        if (!is_string($request_path)) {
+            return null;
+        }
+        if ($request_path === '') {
+            return '/';
+        }
+
+        $decoded_request_path = rawurldecode($request_path);
+        if (
+            strpos($decoded_request_path, "\0") !== false
+            || preg_match('#(?:^|/)\.\.(?:/|$)#', $decoded_request_path)
+        ) {
+            return null;
+        }
+
+        return $request_path;
+    }
+}
+PHP;
 }
 
 /**

--- a/tests/Import/PhpBuiltinRuntimeRoutingTest.php
+++ b/tests/Import/PhpBuiltinRuntimeRoutingTest.php
@@ -132,4 +132,30 @@ class PhpBuiltinRuntimeRoutingTest extends TestCase
 
         $this->assertSame("body{color:#111}\n", $output);
     }
+
+    public function testRoutesPhpFilesWithoutTheirQueryString(): void
+    {
+        $output = $this->runRuntime('/wp-admin/install.php?from=runtime-test');
+
+        $this->assertStringContainsString('core-install', $output);
+    }
+
+    public function testRoutesMoreThanOneRequestInTheSameProcess(): void
+    {
+        $this->assertStringContainsString(
+            'core-install',
+            $this->runRuntime('/wp-admin/install.php'),
+        );
+        $this->assertStringContainsString(
+            'docroot-plugin',
+            $this->runRuntime('/wp-content/plugins/example/site.php'),
+        );
+    }
+
+    public function testRejectsEncodedParentComponentsBeforeRouting(): void
+    {
+        $output = $this->runRuntime('/wp-content/%2e%2e/wp-admin/install.php');
+
+        $this->assertSame('', $output);
+    }
 }


### PR DESCRIPTION
Generated runtimes now parse one raw request path before mapping it to the filesystem, so an encoded parent component cannot reach the PHP built-in router.

The emitted helper removes the query string, preserves percent encoding for existing filename handling, and rejects decoded NUL bytes and parent components. It is safe when `runtime.php` runs more than once in one PHP process.

Tests cover normal routing, query strings, encoded parent components, and repeated runtime inclusion.