### PR TITLE
[PHP] Extract uploads paths from generated runtime requests

### DIFF
--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -96,6 +96,8 @@ function generate_runtime_php(RuntimeManifest $manifest, string $filesystem_root
 
     $lines[] = generate_runtime_request_path_code();
     $lines[] = '';
+    $lines[] = generate_runtime_uploads_request_relative_path_code();
+    $lines[] = '';
 
     // SQLite lazy-loading proxy — replaces $wpdb before WordPress boots.
     // WordPress's require_wp_db() sees $wpdb is already set and skips
@@ -408,6 +410,53 @@ if (!function_exists('reprint_runtime_request_path')) {
         }
 
         return $request_path;
+    }
+}
+PHP;
+}
+
+/**
+ * Generate the runtime helper that extracts a path below WordPress uploads.
+ *
+ * The returned suffix has no leading slash and retains percent encoding. The
+ * generic request-path helper rejects decoded parent components before this
+ * helper looks for the uploads marker.
+ */
+function generate_runtime_uploads_request_relative_path_code(): string
+{
+    return <<<'PHP'
+if (!function_exists('reprint_runtime_uploads_request_relative_path')) {
+    /**
+     * Returns the raw path below /wp-content/uploads/ for this request.
+     *
+     * The marker may follow an installation subdirectory. The return value
+     * has no leading slash and retains percent encoding. Missing or unsafe
+     * request paths, and the uploads directory itself, return null.
+     *
+     * Examples:
+     *
+     *     /wp-content/uploads/2026/photo.jpg -> 2026/photo.jpg
+     *     /site/wp-content/uploads/photo.jpg -> photo.jpg
+     *     /wp-content/uploads/               -> null
+     */
+    function reprint_runtime_uploads_request_relative_path(): ?string
+    {
+        $request_path = reprint_runtime_request_path();
+        if ($request_path === null) {
+            return null;
+        }
+
+        $uploads_marker = '/wp-content/uploads/';
+        $uploads_marker_offset = strpos($request_path, $uploads_marker);
+        if ($uploads_marker_offset === false) {
+            return null;
+        }
+
+        $uploads_relative_path = ltrim(
+            substr($request_path, $uploads_marker_offset + strlen($uploads_marker)),
+            '/'
+        );
+        return $uploads_relative_path === '' ? null : $uploads_relative_path;
     }
 }
 PHP;

--- a/packages/reprint-client/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-client/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -48,18 +48,16 @@ function remote_upload_proxy_code(): string
 	if ($method !== 'GET' && $method !== 'HEAD') return;
 
 	$uri = $_SERVER['REQUEST_URI'] ?? '';
-	$path = parse_url($uri, PHP_URL_PATH);
-	if (!is_string($path) || $path === '') return;
-
-	if (!preg_match('#/wp-content/uploads/(.+)$#', $path, $matches)) return;
+	$uploads_relative_path = reprint_runtime_uploads_request_relative_path();
+	if ($uploads_relative_path === null) return;
 
 	$content_dir = defined('WP_CONTENT_DIR')
 		? rtrim(WP_CONTENT_DIR, '/')
 		: rtrim($_SERVER['DOCUMENT_ROOT'] ?? '', '/') . '/wp-content';
-	$local_path = $content_dir . '/uploads/' . ltrim($matches[1], '/');
+	$local_path = $content_dir . '/uploads/' . $uploads_relative_path;
 	if (file_exists($local_path)) return;
 
-	$target_url = rtrim(REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL, '/') . '/' . ltrim($matches[1], '/');
+	$target_url = rtrim(REPRINT_REMOTE_UPLOAD_PROXY_BASE_URL, '/') . '/' . $uploads_relative_path;
 	$query = parse_url($uri, PHP_URL_QUERY);
 	if (is_string($query) && $query !== '') {
 		$target_url .= '?' . $query;

--- a/tests/Import/RuntimeRequestPathTest.php
+++ b/tests/Import/RuntimeRequestPathTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/host/class-runtime-manifest.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/target-runtime/load.php';
+
+class RuntimeRequestPathTest extends TestCase
+{
+    private string $temporary_directory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->temporary_directory = sys_get_temp_dir()
+            . '/runtime-request-path-'
+            . bin2hex(random_bytes(6));
+        mkdir($this->temporary_directory, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (scandir($this->temporary_directory) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                @unlink($this->temporary_directory . '/' . $entry);
+            }
+        }
+        @rmdir($this->temporary_directory);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider provideRequestPaths
+     */
+    public function testRuntimeRequestPathPreservesSafeRawPaths(
+        string $request_uri,
+        ?string $expected_path
+    ): void {
+        $this->assertSame(
+            $expected_path,
+            $this->run_generated_runtime_helper('reprint_runtime_request_path', $request_uri)
+        );
+    }
+
+    public static function provideRequestPaths(): array
+    {
+        return [
+            'path and query' => [
+                '/wp-content/uploads/2026/photo.jpg?size=large',
+                '/wp-content/uploads/2026/photo.jpg',
+            ],
+            'empty request target' => ['', '/'],
+            'encoded parent component' => ['/wp-content/%2e%2e/wp-config.php', null],
+            'encoded NUL byte' => ['/wp-content/uploads/%00photo.jpg', null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUploadsRequestPaths
+     */
+    public function testRuntimeUploadsRequestPathReturnsTheUploadsSuffix(
+        string $request_uri,
+        ?string $expected_path
+    ): void {
+        $this->assertSame(
+            $expected_path,
+            $this->run_generated_runtime_helper(
+                'reprint_runtime_uploads_request_relative_path',
+                $request_uri
+            )
+        );
+    }
+
+    public static function provideUploadsRequestPaths(): array
+    {
+        return [
+            'site root upload' => [
+                '/wp-content/uploads/2026/photo.jpg?size=large',
+                '2026/photo.jpg',
+            ],
+            'subdirectory upload' => [
+                '/site/wp-content/uploads/photo.jpg',
+                'photo.jpg',
+            ],
+            'uploads directory' => ['/wp-content/uploads/', null],
+            'outside uploads' => ['/wp-content/themes/style.css', null],
+            'encoded parent component' => ['/wp-content/uploads/%2e%2e/wp-config.php', null],
+        ];
+    }
+
+    private function run_generated_runtime_helper(string $function_name, string $request_uri): ?string
+    {
+        $runtime_path = $this->temporary_directory . '/runtime.php';
+        $manifest = new \RuntimeManifest('other');
+        $runtime = \generate_runtime_php($manifest, $this->temporary_directory);
+        file_put_contents(
+            $runtime_path,
+            $runtime
+            . "\n\$_SERVER['REQUEST_URI'] = " . var_export($request_uri, true) . ";\n"
+            . "echo json_encode({$function_name}(), JSON_THROW_ON_ERROR);\n"
+        );
+
+        $process = proc_open(
+            [PHP_BINARY, $runtime_path],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->assertSame(0, proc_close($process), $stderr);
+        $this->assertIsString($stdout);
+
+        $result = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertTrue(is_string($result) || $result === null);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
The generated remote-upload proxy now receives one validated uploads-relative request suffix, so unsafe request paths cannot be turned into local filesystem or source URL paths.

The emitted helper preserves percent encoding, supports WordPress under an installation subdirectory, and returns no value for an empty uploads suffix, a path outside uploads, or a request rejected by the shared request-path parser.

Tests run the emitted runtime in a separate PHP process and cover raw paths, queries, encoded parent components, encoded NUL bytes, and uploads suffix extraction.