### PR TITLE
[PHP] Use shared helpers for plugin, maintenance, and runtime paths

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -6042,13 +6042,7 @@ class ImportClient
         $retained_plugins = [];
         while ($processor->next_value()) {
             $basename = $processor->get_value();
-            $is_match = false;
-            foreach ($plugin_dirs as $dir) {
-                if (strpos($basename, $dir . '/') === 0) {
-                    $is_match = true;
-                    break;
-                }
-            }
+            $is_match = path_is_descendant_of($basename, $plugin_dirs);
             if ($is_match) {
                 $deactivated_plugins[] = $basename;
             } else {
@@ -9581,35 +9575,21 @@ class ImportClient
         // Security: Ensure path is under the filesystem root
         $real_filesystem_root = $this->filesystem_root;
 
-        // Resolve the target path (or what it would be)
-        // For non-existent paths, resolve the parent and append the final component
-        $check_path = $dir;
-        while (
-            !file_exists($check_path) &&
-            $check_path !== dirname($check_path)
-        ) {
-            $check_path = dirname($check_path);
-        }
-
-        if (file_exists($check_path)) {
-            $real_check = realpath($check_path);
-            if (
-                $real_check === false ||
-                !path_is_same_as_or_descendant_of($real_check, $real_filesystem_root)
-            ) {
-                // In preserve-local mode, a path that resolves outside the
-                // filesystem root is expected when a directory like wp-content/plugins
-                // is symlinked to a shared hosting location.  Skip gracefully
-                // instead of treating it as a security violation.
-                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-                    throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: path resolves outside filesystem root via symlink: {$dir}",
-                    );
-                }
-                throw new RuntimeException(
-                    "Security: Refusing to create directory outside filesystem root: {$dir}",
+        // Resolve the nearest existing ancestor while retaining any missing tail.
+        $resolved_directory = realpath_with_missing_tail($dir);
+        if (!path_is_same_as_or_descendant_of($resolved_directory, $real_filesystem_root)) {
+            // In preserve-local mode, a path that resolves outside the
+            // filesystem root is expected when a directory like wp-content/plugins
+            // is symlinked to a shared hosting location.  Skip gracefully
+            // instead of treating it as a security violation.
+            if ($this->fs_root_nonempty_behavior === 'preserve-local') {
+                throw new PreserveLocalSkipException(
+                    "PRESERVE-LOCAL: path resolves outside filesystem root via symlink: {$dir}",
                 );
             }
+            throw new RuntimeException(
+                "Security: Refusing to create directory outside filesystem root: {$dir}",
+            );
         }
 
         if (is_dir($dir) && !is_link($dir)) {

--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -141,7 +141,9 @@ function generate_runtime_php(RuntimeManifest $manifest, string $filesystem_root
  */
 function generate_sqlite_loader_code(array $sqlite): string
 {
-    $plugin_dir = addslashes($sqlite['plugin_dir']);
+    $integration_path = addslashes(
+        wp_join_unix_paths($sqlite['plugin_dir'], '/wp-includes/sqlite/db.php')
+    );
     $db_dir = addslashes($sqlite['db_dir']);
     $db_file = addslashes($sqlite['db_file']);
 
@@ -196,7 +198,7 @@ class Streaming_SQLite_Loader {
 PROXY_BODY
     . "\n"
     // Inject the resolved plugin path into the loader method.
-    . "        \$integration = '{$plugin_dir}/wp-includes/sqlite/db.php';\n"
+    . "        \$integration = '{$integration_path}';\n"
     . <<<'PROXY_TAIL'
         require_once $integration;
         if ($GLOBALS['wpdb'] === $this) {

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -5,6 +5,7 @@
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\assert_valid_relative_path;
 use function WordPress\Reprint\Exporter\normalize_excluded_paths;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
@@ -2454,7 +2455,7 @@ final class Site_Export_Push_Session {
             );
         }
         assert_valid_relative_path($path, 'Document-root-relative path');
-        if ($path === '.maintenance' || strpos($path, '.maintenance/') === 0) {
+        if (path_is_same_as_or_descendant_of($path, '.maintenance')) {
             throw new InvalidArgumentException('The WordPress maintenance marker path is reserved: ' . base64_encode($path) . '.');
         }
     }

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -66,6 +66,7 @@ class DeactivateHostPluginsTest extends TestCase
         $this->insertOption($pdo, 'active_plugins', serialize([
             'sg-cachepress/sg-cachepress.php',
             'sg-security/sg-security.php',
+            'sg-cachepress-extra/sg-cachepress-extra.php',
             'woocommerce/woocommerce.php',
             'akismet/akismet.php',
         ]));
@@ -96,6 +97,7 @@ class DeactivateHostPluginsTest extends TestCase
         $remaining = unserialize($this->fetchOption($pdo, 'active_plugins'));
         $this->assertSame(
             [
+                'sg-cachepress-extra/sg-cachepress-extra.php',
                 'woocommerce/woocommerce.php',
                 'akismet/akismet.php',
             ],

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -144,6 +144,20 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->assertStringContainsString("Constant already defined", $runtime);
     }
 
+    public function testSqliteLoaderJoinsThePluginDirectoryAndIntegrationPath(): void
+    {
+        $runtime = \generate_sqlite_loader_code([
+            'plugin_dir' => '/runtime/sqlite-database-integration/',
+            'db_dir' => '/runtime/database/',
+            'db_file' => '.ht.sqlite',
+        ]);
+
+        $this->assertStringContainsString(
+            "\$integration = '/runtime/sqlite-database-integration/wp-includes/sqlite/db.php';",
+            $runtime,
+        );
+    }
+
     public function testDefaultSqlitePathKeepsTheRootContentDirectory(): void
     {
         if (!extension_loaded('pdo_sqlite')) {

--- a/tests/Import/TypeSwapTest.php
+++ b/tests/Import/TypeSwapTest.php
@@ -87,6 +87,31 @@ class TypeSwapTest extends TestCase
     }
 
     /**
+     * create_directory_if_missing should not follow a symlink beyond the filesystem root.
+     */
+    public function testEnsureDirectoryPathRejectsExternalSymlink(): void
+    {
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
+        $fsRoot = realpath($this->tempDir . '/fs-root');
+        $this->assertIsString($fsRoot);
+
+        $externalDirectory = $this->tempDir . '/external-directory';
+        mkdir($externalDirectory, 0755);
+        symlink($externalDirectory, $fsRoot . '/shared-directory');
+
+        $reflection = new \ReflectionClass($client);
+        $method = $reflection->getMethod('create_directory_if_missing');
+        try {
+            $method->invoke($client, $fsRoot . '/shared-directory/child');
+            $this->fail('A symlink outside the filesystem root was followed.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString('outside filesystem root', $exception->getMessage());
+        }
+
+        $this->assertDirectoryDoesNotExist($externalDirectory . '/child');
+    }
+
+    /**
      * A file chunk should replace a symlink-to-directory with a regular file.
      */
     public function testFileChunkReplacesSymlinkToDirectory()

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -311,6 +311,17 @@ final class PushSessionTest extends TestCase {
         }
     }
 
+    public function testMaintenancePrefixSiblingCanReachWork(): void {
+        $push_session = $this->push_session('24242424242424242424242424242424');
+
+        $this->push_file($push_session, '.maintenance-backup/allowed.php', 'safe');
+
+        $this->assertSame(
+            'complete',
+            $push_session->get_status('.maintenance-backup/allowed.php')['path']['state'],
+        );
+    }
+
     public function testCommitTraversesAncestorsOfAnExcludedPathToInstallItsSibling(): void {
         $excluded_directory = $this->docroot . '/wp-content/plugins/reprint';
         mkdir($excluded_directory, 0700, true);


### PR DESCRIPTION
Pull and push path handling now uses the shared component-boundary, canonical-ancestor, and Unix-join rules, so similarly named paths and symlinked ancestors are classified consistently.

This replaces the SiteGround plugin loop, maintenance marker check, directory-creation preflight, and generated SQLite integration path. Tests cover similarly named plugin and maintenance paths, an external symlink, and a trailing plugin-directory separator.

## Testing

- `cd tests && ../vendor/bin/phpunit Import/DeactivateHostPluginsTest.php PushSessionTest.php Import/TypeSwapTest.php Import/SqliteRuntimeConfigTest.php Import/RemapSeamTest.php`
- `vendor/bin/phpstan analyze --memory-limit=1G`
- `git diff --check`
- PHPCS violation counts unchanged from the trunk baseline for every changed file.