### PR TITLE
[PHP] Leave partial opaque URL authorities unchanged

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -72,7 +72,9 @@
  * name different resources when their case differs. A scheme may begin at the
  * start of the value or after a byte other than an ASCII letter, plus sign, or
  * hyphen. Scheme-less authorities use a stricter boundary so the scanner does
- * not mistake part of another URL or identifier for a match.
+ * not mistake part of another URL or identifier for a match. A dot or colon
+ * immediately after the configured base is rejected: it may continue the host
+ * name or introduce a port which the mapping did not include.
  *
  * Example usage:
  *
@@ -308,7 +310,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             (?=
                 $
                 | ' . $escaped_separator . '/
-                | [/?# \t\r\n.,!;:)\]}>"\']
+                | [/?# \t\r\n,!;)\]}>"\']
             )
         ~x';
     }

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -191,6 +191,16 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'not-the-right-source.com destination.com/media/logo.png',
                 ['https://source.com' => 'https://destination.com'],
             ],
+            'only standalone scheme-less host outside another URL path' => [
+                'site.com/source.com/media/logo.png source.com/media/logo.png',
+                'site.com/source.com/media/logo.png destination.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'outer URL path stays unchanged while full query URL is rewritten' => [
+                'https://site.com/source.com/media?next=https://source.com/media/logo.png',
+                'https://site.com/source.com/media?next=https://destination.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
         ];
     }
 
@@ -399,6 +409,56 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https&colon;&sol;&sol;source.example&sol;media&sol;logo.png',
                 'https&colon;&sol;&sol;source.example&sol;media&sol;logo.png',
                 ['https://source.example' => 'https://destination.example'],
+            ],
+            'configured host appears in another absolute URL path' => [
+                'https://site.com/source.com/media/logo.png',
+                'https://site.com/source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host appears in another scheme-less URL path' => [
+                'site.com/source.com/media/logo.png',
+                'site.com/source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host follows an escaped outer path separator' => [
+                'https:\\/\\/site.com\\/source.com\\/media\\/logo.png',
+                'https:\\/\\/site.com\\/source.com\\/media\\/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host follows a percent-encoded outer path separator' => [
+                'https://site.com/path%2Fsource.com/media/logo.png',
+                'https://site.com/path%2Fsource.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host is the username of another URL' => [
+                'https://source.com@site.com/media/logo.png',
+                'https://source.com@site.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host is part of the password of another URL' => [
+                'https://user:source.com@site.com/media/logo.png',
+                'https://user:source.com@site.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host is the prefix of a filename' => [
+                'https://site.com/media/source.com.png',
+                'https://site.com/media/source.com.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'candidate authority has a trailing dot' => [
+                'https://source.com./media/logo.png',
+                'https://source.com./media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'longer unrelated host appears in an outer query value' => [
+                'https://site.com/?next=not-the-right-source.com/media/logo.png',
+                'https://site.com/?next=not-the-right-source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host follows another host inside an outer query value' => [
+                'https://site.com/?path=site.com/source.com/media/logo.png',
+                'https://site.com/?path=site.com/source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
             ],
         ];
     }

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -131,6 +131,66 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https:\\/\\/destination.example\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
             ],
+            'escaped JSON in a shortcode attribute' => [
+                '[builder config="{\\"image\\":\\"https:\\/\\/source.example\\/media\\/hero.jpg\\"}"]',
+                '[builder config="{\\"image\\":\\"https:\\/\\/destination.example\\/media\\/hero.jpg\\"}"]',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'multiply escaped JSON in an HTML attribute' => [
+                '<div data-builder="{\\\"image\\\":\\\"https:\\\\\\/\\\\\\/source.example\\\\\\/media\\\\\\/hero.jpg\\\"}"></div>',
+                '<div data-builder="{\\\"image\\\":\\\"https:\\\\\\/\\\\\\/destination.example\\\\\\/media\\\\\\/hero.jpg\\\"}"></div>',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'JSON-LD script text with escaped slashes' => [
+                '<script type="application/ld+json">{"@context":"https://schema.org","url":"https:\\/\\/source.example\\/products\\/boat"}</script>',
+                '<script type="application/ld+json">{"@context":"https://schema.org","url":"https:\\/\\/destination.example\\/products\\/boat"}</script>',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'entity-quoted JSON-LD in an HTML attribute' => [
+                '<div data-schema="{&quot;url&quot;:&quot;https:\\/\\/source.example\\/products\\/boat&quot;}"></div>',
+                '<div data-schema="{&quot;url&quot;:&quot;https:\\/\\/destination.example\\/products\\/boat&quot;}"></div>',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'escaped block markup in a shortcode text leaf' => [
+                '[vc_column_text]<!-- wp:image {\\"url\\":\\"https:\\/\\/source.example\\/media\\/hero.jpg\\"} --><figure><img src=\\"https:\\/\\/source.example\\/media\\/hero.jpg\\"></figure><!-- \\/wp:image -->[/vc_column_text]',
+                '[vc_column_text]<!-- wp:image {\\"url\\":\\"https:\\/\\/destination.example\\/media\\/hero.jpg\\"} --><figure><img src=\\"https:\\/\\/destination.example\\/media\\/hero.jpg\\"></figure><!-- \\/wp:image -->[/vc_column_text]',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'CSS image-set with literal and escaped URLs' => [
+                '[vc_column css=".hero{background-image:image-set(url(https://source.example/media/a.png) 1x,url(https:\\/\\/source.example\\/media\\/b.png) 2x);}"]',
+                '[vc_column css=".hero{background-image:image-set(url(https://destination.example/media/a.png) 1x,url(https:\\/\\/destination.example\\/media\\/b.png) 2x);}"]',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'HTML source set with literal and escaped URLs' => [
+                '<img srcset="https://source.example/media/a.png 1x, https:\\/\\/source.example\\/media\\/b.png 2x">',
+                '<img srcset="https://destination.example/media/a.png 1x, https:\\/\\/destination.example\\/media\\/b.png 2x">',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'emoji and multibyte bytes after the configured base' => [
+                'https://source.example/media/🚤.jpg?caption=🌊',
+                'https://destination.example/media/🚤.jpg?caption=🌊',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'control and high bytes after the configured base' => [
+                "https://source.example/media/logo.png?raw=\x1F\x7F\x80",
+                "https://destination.example/media/logo.png?raw=\x1F\x7F\x80",
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'source base path with accepted punctuation bytes' => [
+                'https://source.example/media[old]{v1}!/logo.png',
+                'https://destination.example/logo.png',
+                ['https://source.example/media[old]{v1}!' => 'https://destination.example'],
+            ],
+            'HTTP source mapping preserves the candidate protocol' => [
+                'http://source.example/media/logo.png',
+                'http://destination.example/media/logo.png',
+                ['http://source.example' => 'https://destination.example'],
+            ],
+            'exact scheme-less host beside a longer unrelated host' => [
+                'not-the-right-source.com source.com/media/logo.png',
+                'not-the-right-source.com destination.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
         ];
     }
 
@@ -244,6 +304,101 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example:8443/media/logo.png',
                 'https://source.example:8443/media/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
+            ],
+            'HTTPS mapping does not match an HTTP URL' => [
+                'http://source.com/media/logo.png',
+                'http://source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'HTTPS mapping does not match an FTP URL' => [
+                'ftp://source.com/media/logo.png',
+                'ftp://source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'HTTPS mapping does not match a protocol-relative URL' => [
+                '//source.com/media/logo.png',
+                '//source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'host is a hyphenated suffix of another host' => [
+                'https://not-the-right-source.com/media/logo.png',
+                'https://not-the-right-source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'host is a subdomain of the configured host' => [
+                'https://cdn.source.com/media/logo.png',
+                'https://cdn.source.com/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'configured host is a prefix of a longer host' => [
+                'https://source.com.evil.example/media/logo.png',
+                'https://source.com.evil.example/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'candidate domain has an unconfigured port' => [
+                'https://source.com:8443/media/logo.png',
+                'https://source.com:8443/media/logo.png',
+                ['https://source.com' => 'https://destination.com'],
+            ],
+            'candidate IPv4 address has an unconfigured port' => [
+                'https://192.0.2.1:8443/media/logo.png',
+                'https://192.0.2.1:8443/media/logo.png',
+                ['https://192.0.2.1' => 'https://destination.com'],
+            ],
+            'candidate IPv6 address has an unconfigured port' => [
+                'https://[2001:db8::1]:8443/media/logo.png',
+                'https://[2001:db8::1]:8443/media/logo.png',
+                ['https://[2001:db8::1]' => 'https://destination.com'],
+            ],
+            'target domain contains an emoji' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example' => 'https://🚤.example'],
+            ],
+            'source domain contains an emoji' => [
+                'https://🚤.example/media/logo.png',
+                'https://🚤.example/media/logo.png',
+                ['https://🚤.example' => 'https://destination.example'],
+            ],
+            'configured source path contains an emoji' => [
+                'https://source.example/🚤/logo.png',
+                'https://source.example/🚤/logo.png',
+                ['https://source.example/🚤' => 'https://destination.example'],
+            ],
+            'configured source path contains a space byte' => [
+                'https://source.example/media archive/logo.png',
+                'https://source.example/media archive/logo.png',
+                ['https://source.example/media archive' => 'https://destination.example'],
+            ],
+            'configured source path contains a control byte' => [
+                "https://source.example/media\x1Farchive/logo.png",
+                "https://source.example/media\x1Farchive/logo.png",
+                ["https://source.example/media\x1Farchive" => 'https://destination.example'],
+            ],
+            'configured source path contains a DEL byte' => [
+                "https://source.example/media\x7Farchive/logo.png",
+                "https://source.example/media\x7Farchive/logo.png",
+                ["https://source.example/media\x7Farchive" => 'https://destination.example'],
+            ],
+            'configured source path contains a high byte' => [
+                "https://source.example/media\x80archive/logo.png",
+                "https://source.example/media\x80archive/logo.png",
+                ["https://source.example/media\x80archive" => 'https://destination.example'],
+            ],
+            'protocol separators use two backslashes' => [
+                'https:\\\\/\\\\/source.example\\\\/media\\\\/logo.png',
+                'https:\\\\/\\\\/source.example\\\\/media\\\\/logo.png',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'protocol separators are percent encoded' => [
+                'https%3A%2F%2Fsource.example%2Fmedia%2Flogo.png',
+                'https%3A%2F%2Fsource.example%2Fmedia%2Flogo.png',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'protocol separators are HTML entities' => [
+                'https&colon;&sol;&sol;source.example&sol;media&sol;logo.png',
+                'https&colon;&sol;&sol;source.example&sol;media&sol;logo.png',
+                ['https://source.example' => 'https://destination.example'],
             ],
         ];
     }


### PR DESCRIPTION
A configured URL base is not a substring.

## Background

Before this PR, a mapping for:

```
https://source.com => https://destination.com
```

also rewrote these values:

```
https://source.com.evil.example/media/logo.png
https://source.com:8443/media/logo.png
```

That produced `destination.com.evil.example` and retained port `8443`. Neither authority was present in the mapping.

## This change

A dot or colon immediately after the configured base now rejects the candidate. A dot may continue the hostname. A colon may introduce a port. If either byte is outside the configured base, the processor leaves the text alone.

The test matrix also grows from 39 to 82 literal input/output cases. It covers shortcode attributes, escaped and multiply escaped JSON, JSON-LD, CSS, block markup, HTML attributes, emoji and non-printable bytes, IPv4 and IPv6 sources, ports, alternate schemes, protocol-relative URLs, and misleading occurrences such as `site.com/source.com` and `not-the-right-source.com`.

Complete JSON documents and other format-owned values remain outside this processor. The structured-looking cases are opaque text leaves containing nested or escaped markup.

## Testing

The URL-rewriting suite passes with 314 tests and 2,437 assertions. PHPStan, PHPCS, and `git diff --check` pass.
