### PR TITLE
[PHP] Plan file-sync patches from index diffs

### DIFF
--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -179,12 +179,14 @@ The cursor contains the plan directory, filesystem root, local index file,
 document root's local relative path, and current planning position. During
 indexing, that position contains the `FileIndexProcessor` cursor and committed
 fresh-index byte offset. During diffing, each step flushes only the path list or
-append-only deleted-directory stack changed by that step before updating the two index
-offsets, two output byte offsets, and active stack byte offset. Each stack entry
-links to the preceding active directory, so continuation reads only the top
-entry. A later process passes the stored cursor to `PushPlan::resume()`. The
-plan uses its private exclusions copy, discards bytes beyond the stored output
-offsets, and continues from the retained internal phase.
+append-only active deletion roots file changed by that step before updating
+the two output byte offsets and the nested FileSyncPatchPlanner cursor. Each
+active deletion root links to the preceding one, so continuation reads only
+the current root. PushPlan stores and restores the planner cursor without
+rebuilding it. A later process passes the stored cursor to
+`PushPlan::resume()`. The plan uses its private exclusions copy, discards bytes
+beyond the stored output offsets, and continues from the retained internal
+phase.
 
 The first push to a site has no local index or previously pushed rows. Every
 current file, symlink, and empty directory is selected, and no local deletion
@@ -326,7 +328,7 @@ state:
       fresh_local_index.jsonl           plan-owned fresh local index
       local_paths_to_push.jsonl         local paths to push
       local_paths_to_delete             raw NUL-delimited document-root-relative paths
-      deleted_directories_stack.jsonl   append-only planning stack
+      deleted_directories_stack.jsonl   active directory-deletion roots
 ```
 
 The sender has an explicit start/step/cancel/close lifecycle.

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -60,6 +60,12 @@ local relative path to a document-root-relative path.
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
+- A **file sync patch planner** compares a patch base index with a patch result
+  index and selects `copy`, `delete`, or `replace` operations. To make two
+  trees identical, the destination is the patch base and the source is the
+  patch result. To copy only source changes, the source snapshots from the
+  last sync and now are the patch base and result. The planner owns the index
+  diff and the active deletion roots file.
 - The **pull index WAL** records completed pull mutations awaiting application
   to the remote and local indexes.
 - A **pull plan** lists remote absolute paths still scheduled for download or
@@ -270,13 +276,12 @@ Use these names verbatim:
 | Active plan directory | `plan`, `$plan_directory` |
 | Plan-owned fresh local index file | `fresh_local_index.jsonl`, `$fresh_local_index_file` |
 | Local index file | `local_index.jsonl`, `local_index_file`, `$local_index_file` |
-| Byte offset in the local index | `byte_offset_in_local_index`, `$byte_offset_in_local_index` |
 | Local paths to push | `local_paths_to_push.jsonl`, `$local_paths_to_push` |
 | Local paths to delete | `local_paths_to_delete`, `$local_paths_to_delete` |
 | Local push state directory | `push_state_directory`, `$push_state_directory` |
 | PushPlan cursor | `push_plan_cursor`, `$push_plan_cursor`, `get_cursor()` |
 | Sender-owned excluded paths | `excluded_paths.json`, `$excluded_paths_path` |
-| Deleted-directory stack | `deleted_directories_stack.jsonl`, `$deleted_directories_stack` |
+| Active deletion roots | `deleted_directories_stack.jsonl`, `$active_deletion_roots_file` |
 | Active state | `sender.json`, `$state_path` |
 | Selected path-list cursor | `$local_paths_to_push_byte_offset` |
 | Selected local-path count | `local_paths_to_push_count`, `$local_paths_to_push_count` |
@@ -302,18 +307,20 @@ a target-confirmed files-push commit, advanced path by path by later completed
 files-pull mutations.
 Files-pull does not scan unrelated paths or accept their pending local changes.
 PushPlan diffs its fresh local index against the local index its caller
-supplies. `byte_offset_in_local_index` is the position from which its current
-lookahead entry is read again after resume.
+supplies. Its FileSyncPatchPlanner owns the FileIndexDiffProcessor and the
+active deletion roots file. That file remembers directory deletions which
+cover index paths the planner has not processed yet.
 
 The PushPlan cursor is stored in `sender.json`. It contains `plan_directory`,
 `filesystem_root`, `local_index_file`, and the current
 planning position. During `indexing`, that position contains the
 FileIndexProcessor cursor and the committed byte offset in
-`fresh_local_index.jsonl`. During `diffing`, it contains the index offsets,
-output offsets, and the active byte offset in
-`deleted_directories_stack.jsonl`. The stack file is append-only; each entry
-links to the preceding active directory. The exclusions have a maximum of 100
-paths. The `sender.json` phases are `creating`, `finishing_previous_commit`,
+`fresh_local_index.jsonl`. During `diffing`, it contains the output offsets
+and the complete FileSyncPatchPlanner cursor. PushPlan
+stores that nested cursor without unpacking or rebuilding it. The active
+deletion roots file is append-only; each entry links to the preceding active
+directory. The exclusions have a maximum of 100 paths. The `sender.json`
+phases are `creating`, `finishing_previous_commit`,
 `starting_plan`, `planning`, `pushing_paths`, `pushing_deletes`, `committing`,
 `saving_local_index`, `completing`, `removing`, and `discarding_plan`. It stores
 both the current and blocking push session IDs, selected path-list cursor,
@@ -513,7 +520,6 @@ Use these names verbatim inside `PushPlan`:
 | Local index file | `$local_index_file` |
 | Open local index file | `$local_index_file_handle` |
 | Local index lookahead entry | `$local_index_lookahead_entry`, `$local_index_lookahead_entry_loaded` |
-| Byte offset in the local index | `$byte_offset_in_local_index` |
 | Read the next index entry | `read_next_index_entry()`, `$index_file_handle` |
 | Index entry and shape | `$index_entry`, `$local_index_entry`, `$local_index_entry_shape`, `index_entry_shape()` |
 | Cursor | `$cursor`, `get_cursor()` |
@@ -521,10 +527,9 @@ Use these names verbatim inside `PushPlan`:
 | Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
 | Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |
-| Byte offset in the fresh local index during diff | `$byte_offset_in_fresh_local_index` |
 | Open fresh local index | `$fresh_local_index_handle` |
 | Combined index bytes | `$index_bytes_total` |
-| Index diff cursor | `IndexDiffCursor` |
+| File-sync planner cursor | `file_sync_planner_cursor`, `$file_sync_planner_cursor` |
 | Plan progress | `get_progress()` |
 | Start index diff | `start_index_diff()` |
 | Seek an index file | `seek_index_file_to_byte_offset()`, `$index_file_handle` |

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -1,0 +1,680 @@
+<?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Filesystem\wp_unix_path_segments;
+use function WordPress\Reprint\Exporter\path_is_descendant_of;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+
+require_once __DIR__ . '/class-file-index-diff-processor.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing streaming classes.
+
+/**
+ * Plans a file-sync patch from two indexed file trees.
+ *
+ * The patch base index describes the state before the patch. The patch result
+ * index describes the state after it. Both indexes use the same path
+ * coordinates and are sorted by decoded path bytes. The caller chooses these
+ * indexes based on the sync intent:
+ *
+ * - To make two file trees identical, compare the current destination index
+ *   with the current source index.
+ * - To copy only source changes, compare the source index saved at the last
+ *   sync with the current source index. Apply that patch to the destination.
+ *
+ * The planner does not know the sync intent. It receives the two indexes
+ * already chosen by its caller.
+ *
+ * FileIndexDiffProcessor aligns their entries and labels each path. This
+ * planner turns those labels into one operation for the current path:
+ *
+ * - `copy` copies the patch-result entry.
+ * - `delete` deletes a path from the patch base.
+ * - `replace` deletes a path, then copies the patch-result entry there.
+ *
+ * One path may need both actions. Replacing a directory tree with a file, for
+ * example, deletes the tree and copies the file. The planner combines
+ * a removed subtree into one deletion when the indexes allow it. It does not
+ * detect renames or compare file contents. Here, minimizing means removing
+ * redundant path operations, not finding the smallest possible patch.
+ *
+ * ## Sparse directory entries
+ *
+ * Non-empty directories have no index entry. Their descendants imply that the
+ * directory exists. The planner uses the paths preceding and following the
+ * current position to decide whether a missing directory still has a result
+ * descendant. When a whole directory disappeared, it emits the highest
+ * missing directory instead of deleting every indexed descendant.
+ *
+ * An append-only file keeps that deletion active while later base entries are
+ * descendants of it. A sibling such as `tree-other` may sort between `tree`
+ * and `tree/child`, so each active root links to the preceding one instead of
+ * assuming all descendants are adjacent.
+ *
+ * ## Selection
+ *
+ * Included and excluded roots use the same coordinates as the index paths. An
+ * empty included root selects every relative path. A planned operation is
+ * omitted when its path falls outside every included root or intersects an
+ * excluded root. The index diff still consumes that path.
+ *
+ * ## Traversal and resume
+ *
+ * Each call to next_path() processes at most one path. The getters describe
+ * that path until the following call. is_complete() becomes true after the
+ * last path. A false next_path() result means no path remains and stays false.
+ *
+ *     $planner = FileSyncPatchPlanner::create(
+ *         $patch_base_index_file,
+ *         $patch_result_index_file,
+ *         $active_deletion_roots_file
+ *     );
+ *     while ($planner->next_path()) {
+ *         $operation = $planner->get_operation();
+ *         if ($operation !== null) {
+ *             append_sync_operation($operation);
+ *         }
+ *         save_cursor($planner->get_cursor());
+ *     }
+ *     $planner->close();
+ *
+ * The cursor contains everything resume() needs: both index paths, the active
+ * deletion roots file, path selection, and the current byte offsets. The
+ * active deletion roots file may contain bytes beyond the cursor after an
+ * interruption. resume() ignores those bytes.
+ *
+ * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
+ * @phpstan-type Cursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type ActiveDeletionRoot array{path:string,previous_byte_offset:int|null}
+ * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
+ * @phpstan-type DeleteOperation array{action:'delete',path:string}
+ * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource}
+ * @phpstan-type SyncOperation DeleteOperation|CopyOperation
+ */
+final class FileSyncPatchPlanner
+{
+    /** Sorted comparison of the patch base and result indexes. */
+    private FileIndexDiffProcessor $index_diff;
+
+    /** @var resource Open append-only file of active deletion roots. */
+    private $active_deletion_roots_handle;
+
+    /** @var list<string> Index path roots within which changes may be planned. */
+    private array $included_index_path_roots;
+
+    /** @var list<string> Index path roots which no planned operation may affect. */
+    private array $excluded_index_path_roots;
+
+    /** @var ActiveDeletionRoot|null Top active deleted-directory root. */
+    private ?array $active_deletion_root = null;
+
+    /** @var Cursor Cursor after the last path processed by next_path(). */
+    private array $cursor;
+
+    /** Whether the diff processor has already selected the next path. */
+    private bool $index_diff_path_selected = false;
+
+    /** @var SyncOperation|null Operation selected for the current path. */
+    private ?array $operation = null;
+
+    /** Whether both indexes reached EOF. */
+    private bool $complete = false;
+
+    /** Whether close() made this planner terminal. */
+    private bool $closed = false;
+
+    /**
+     * Creates a planner before the first path in either index.
+     *
+     * The active deletion roots file is replaced with an empty file. Use
+     * resume() to continue from a cursor returned by get_cursor().
+     *
+     * @param string       $patch_base_index_file          Tree state before the patch, or a missing path for an empty tree.
+     * @param string       $patch_result_index_file        Tree state described by the patch.
+     * @param string       $active_deletion_roots_file     State for directory deletions which cover paths not processed yet.
+     * @param list<string> $included_index_path_roots      Roots within which changes may be planned.
+     * @param list<string> $excluded_index_path_roots      Roots which changes must not affect.
+     * @return self Open planner positioned before the first path.
+     */
+    public static function create(
+        string $patch_base_index_file,
+        string $patch_result_index_file,
+        string $active_deletion_roots_file,
+        array $included_index_path_roots = [""],
+        array $excluded_index_path_roots = []
+    ): self {
+        if (file_put_contents($active_deletion_roots_file, "") !== 0) {
+            throw new RuntimeException(
+                "Failed to initialize the active deletion roots file: {$active_deletion_roots_file}"
+            );
+        }
+        return self::resume(
+            [
+                "patch_base_index_file" => $patch_base_index_file,
+                "patch_result_index_file" => $patch_result_index_file,
+                "active_deletion_roots_file" => $active_deletion_roots_file,
+                "included_index_path_roots" => $included_index_path_roots,
+                "excluded_index_path_roots" => $excluded_index_path_roots,
+                "index_diff_cursor" => [
+                    "old_index_byte_offset" => 0,
+                    "new_index_byte_offset" => 0,
+                    "preceding_new_index_entry_path_b64" => null,
+                ],
+                "active_deletion_root_byte_offset" => null,
+            ]
+        );
+    }
+
+    /**
+     * Reopens a planner at its last stored cursor.
+     *
+     * Both index files must still contain the same snapshots used by create().
+     * The active deletion roots file must still belong to this plan.
+     *
+     * @param array $cursor {
+     *     Cursor returned by get_cursor().
+     *
+     *     @type string       $patch_base_index_file                    Tree state before the patch.
+     *     @type string       $patch_result_index_file                  Tree state described by the patch.
+     *     @type string       $active_deletion_roots_file               State for active directory deletions.
+     *     @type list<string> $included_index_path_roots                Roots within which changes may be planned.
+     *     @type list<string> $excluded_index_path_roots                Roots which changes must not affect.
+     *     @type array        $index_diff_cursor                        File-index diff cursor.
+     *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
+     * }
+     * @phpstan-param Cursor $cursor
+     * @return self Open planner restored at the supplied cursor.
+     */
+    public static function resume(array $cursor): self
+    {
+        $planner = new self();
+        $planner->cursor = $cursor;
+        $planner->included_index_path_roots =
+            $cursor["included_index_path_roots"];
+        $planner->excluded_index_path_roots =
+            $cursor["excluded_index_path_roots"];
+        $planner->index_diff = FileIndexDiffProcessor::resume(
+            $cursor["patch_base_index_file"],
+            $cursor["patch_result_index_file"],
+            $cursor["index_diff_cursor"]
+        );
+        $planner->active_deletion_roots_handle = fopen(
+            $cursor["active_deletion_roots_file"],
+            "a+b"
+        );
+        if (!is_resource($planner->active_deletion_roots_handle)) {
+            $planner->index_diff->close();
+            throw new RuntimeException(
+                "Failed to open the active deletion roots file: "
+                . $cursor["active_deletion_roots_file"]
+            );
+        }
+        $planner->active_deletion_root =
+            $planner->read_active_deletion_root(
+                $cursor["active_deletion_root_byte_offset"]
+            );
+        return $planner;
+    }
+
+    /**
+     * Processes the next path found in the patch base or result index.
+     *
+     * True means the getters describe one processed path. False means there
+     * was no path left to process. A true result may also make is_complete()
+     * true when that path was the last one.
+     */
+    public function next_path(): bool
+    {
+        $this->assert_open();
+        $this->operation = null;
+        if ($this->complete) {
+            return false;
+        }
+        if (
+            !$this->index_diff_path_selected
+            && !$this->index_diff->next_path()
+        ) {
+            $this->complete = true;
+            return false;
+        }
+        $this->index_diff_path_selected = true;
+
+        $index_path = $this->index_diff->get_path();
+        $patch_base_path_type = $this->index_diff->get_path_type_in_old_index();
+        $patch_result_path_type = $this->index_diff->get_path_type_in_new_index();
+        $path_transition = $this->index_diff->get_path_transition();
+        $patch_result_entry_shape = $patch_result_path_type === null
+            ? null
+            : $this->index_entry_shape($patch_result_path_type);
+        $patch_base_entry_shape = $patch_base_path_type === null
+            ? null
+            : $this->index_entry_shape($patch_base_path_type);
+        $path_to_delete = null;
+        $path_to_copy = null;
+        $active_deletion_root_byte_offset =
+            $this->cursor["active_deletion_root_byte_offset"];
+
+        if (
+            $patch_base_path_type !== null
+            && $this->active_deletion_root !== null
+        ) {
+            // Byte sorting can place `a-other` before `a/child`. Keep the
+            // active root until the patch base has moved beyond its subtree.
+            $descendant_prefix =
+                $this->active_deletion_root["path"] . "/";
+            if (
+                !path_is_same_as_or_descendant_of(
+                    $index_path,
+                    $this->active_deletion_root["path"]
+                )
+                && strcmp($index_path, $descendant_prefix) > 0
+            ) {
+                $active_deletion_root_byte_offset =
+                    $this->active_deletion_root["previous_byte_offset"];
+                $this->active_deletion_root =
+                    $this->read_active_deletion_root(
+                        $active_deletion_root_byte_offset
+                    );
+            }
+        }
+
+        if ($path_transition === "added") {
+            // A NUL byte cannot occur in an index path. Use it when there is
+            // no following patch-base path so the descendant test cannot match.
+            $patch_result_entry_replaces_patch_base_subtree =
+                path_is_same_as_or_descendant_of(
+                    $this->index_diff->get_following_path_in_old_index()
+                        ?? "\0",
+                    $index_path
+                );
+            if (
+                $patch_result_entry_replaces_patch_base_subtree
+                && $this->path_may_change($index_path)
+                && !$this->active_deletion_root_covers_path($index_path)
+            ) {
+                $path_to_delete = $index_path;
+                $active_deletion_root_byte_offset =
+                    $this->append_active_deletion_root(
+                        $index_path,
+                        $active_deletion_root_byte_offset
+                    );
+            }
+            if ($this->path_may_change($index_path)) {
+                $path_to_copy = $index_path;
+            }
+        } elseif ($path_transition === "deleted") {
+            $patch_base_empty_directory_is_implied_by_patch_result_descendant =
+                $patch_base_entry_shape === "empty_directory"
+                && $this->patch_result_index_contains_path_or_descendant(
+                    $index_path,
+                    $this->index_diff->get_preceding_path_in_new_index(),
+                    $this->index_diff->get_following_path_in_new_index()
+                );
+
+            // Find the highest patch-base directory without a patch-result
+            // entry below it. Only the adjacent result entries can neighbor
+            // each parent in byte order, so no index rescan is needed.
+            $candidate_path_to_delete = $index_path;
+            $index_path_components = wp_unix_path_segments($index_path);
+            $candidate_path_components = [];
+            for (
+                $index = 0,
+                $component_count = count($index_path_components) - 1;
+                $index < $component_count;
+                ++$index
+            ) {
+                $candidate_path_components[] = $index_path_components[$index];
+                $candidate_path = wp_join_unix_paths(
+                    ...$candidate_path_components
+                );
+                if (
+                    !$this->patch_result_index_contains_path_or_descendant(
+                        $candidate_path,
+                        $this->index_diff->get_preceding_path_in_new_index(),
+                        $this->index_diff->get_following_path_in_new_index()
+                    )
+                ) {
+                    $candidate_path_to_delete = $candidate_path;
+                    break;
+                }
+            }
+            if (
+                !$patch_base_empty_directory_is_implied_by_patch_result_descendant
+                && $this->path_may_change($candidate_path_to_delete)
+                && !$this->active_deletion_root_covers_path($index_path)
+            ) {
+                $path_to_delete = $candidate_path_to_delete;
+                if ($candidate_path_to_delete !== $index_path) {
+                    $active_deletion_root_byte_offset =
+                        $this->append_active_deletion_root(
+                            $candidate_path_to_delete,
+                            $active_deletion_root_byte_offset
+                        );
+                }
+            }
+        } else {
+            $patch_result_entry_is_file_or_symlink =
+                $patch_result_entry_shape === "file"
+                || $patch_result_entry_shape === "symlink";
+            $patch_base_entry_is_file_or_symlink =
+                $patch_base_entry_shape === "file"
+                || $patch_base_entry_shape === "symlink";
+            $empty_directory_needs_copy =
+                $patch_result_entry_shape === "empty_directory"
+                && $patch_base_entry_shape !== "empty_directory";
+            $changed_file_or_symlink_needs_copy =
+                $patch_result_entry_is_file_or_symlink
+                && $path_transition === "modified";
+            // The diff defines modification by type, size, and ctime. Only a
+            // modified file or symlink needs its result value copied.
+            $needs_delete =
+                $patch_result_entry_is_file_or_symlink
+                !== $patch_base_entry_is_file_or_symlink;
+            $path_may_change = $this->path_may_change($index_path);
+
+            if (
+                $needs_delete
+                && $path_may_change
+                && !$this->active_deletion_root_covers_path($index_path)
+            ) {
+                $path_to_delete = $index_path;
+            }
+            if (
+                ( $empty_directory_needs_copy
+                    || $changed_file_or_symlink_needs_copy )
+                && $path_may_change
+            ) {
+                $path_to_copy = $index_path;
+            }
+        }
+
+        if ($path_to_copy !== null) {
+            $this->operation = [
+                "action" => $path_to_delete === null ? "copy" : "replace",
+                "path" => $path_to_copy,
+                "expected_source" => [
+                    "type" => $patch_result_path_type,
+                    "size" => $this->index_diff->get_size_in_new_index(),
+                    "ctime" => $this->index_diff->get_ctime_in_new_index(),
+                ],
+            ];
+        } elseif ($path_to_delete !== null) {
+            $this->operation = [
+                "action" => "delete",
+                "path" => $path_to_delete,
+            ];
+        }
+
+        $this->complete = !$this->index_diff->next_path();
+        $this->index_diff_path_selected = !$this->complete;
+        if ($this->complete) {
+            $active_deletion_root_byte_offset = null;
+            $this->active_deletion_root = null;
+        }
+        $this->cursor["index_diff_cursor"] = $this->index_diff->get_cursor();
+        $this->cursor["active_deletion_root_byte_offset"] =
+            $active_deletion_root_byte_offset;
+        return true;
+    }
+
+    /** Returns whether the last processed path exhausted both indexes. */
+    public function is_complete(): bool
+    {
+        return $this->complete;
+    }
+
+    /**
+     * Returns the operation selected for the current path.
+     *
+     * Null means the current path needs no operation. A `delete` operation has
+     * only an action and path. A `copy` or `replace` operation also records the
+     * source state expected when the operation is performed. `replace` means
+     * delete the path before copying the patch-result entry there.
+     *
+     * @return array|null {
+     *     Current sync operation, or null.
+     *
+     *     @type string $action          `copy`, `delete`, or `replace`.
+     *     @type string $path            Path on which to operate.
+     *     @type array  $expected_source {
+     *         Source state required by `copy` and `replace`. Absent for `delete`.
+     *
+     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type int    $size  Expected size.
+     *         @type int    $ctime Expected inode change time.
+     *     }
+     * }
+     * @phpstan-return SyncOperation|null
+     */
+    public function get_operation(): ?array
+    {
+        $this->assert_open();
+        return $this->operation;
+    }
+
+    /**
+     * Returns everything needed to resume after the current path.
+     *
+     * @return array {
+     *     Cursor for resume().
+     *
+     *     @type string       $patch_base_index_file                    Tree state before the patch.
+     *     @type string       $patch_result_index_file                  Tree state described by the patch.
+     *     @type string       $active_deletion_roots_file               State for active directory deletions.
+     *     @type list<string> $included_index_path_roots                Roots within which changes may be planned.
+     *     @type list<string> $excluded_index_path_roots                Roots which changes must not affect.
+     *     @type array        $index_diff_cursor                        File-index diff cursor.
+     *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
+     * }
+     * @phpstan-return Cursor
+     */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Flushes active deletion roots before the cursor is stored. */
+    public function flush_pending_outputs(): void
+    {
+        if (!fflush($this->active_deletion_roots_handle)) {
+            throw new RuntimeException(
+                "Failed to flush the active deletion roots file."
+            );
+        }
+    }
+
+    /** Closes the index diff and work-file handle. Repeated calls do nothing. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->index_diff->close();
+        if (is_resource($this->active_deletion_roots_handle)) {
+            fclose($this->active_deletion_roots_handle);
+        }
+        $this->closed = true;
+    }
+
+    /** Checks adjacent patch-result entries for a path or its descendant. */
+    private function patch_result_index_contains_path_or_descendant(
+        string $index_path,
+        ?string $preceding_patch_result_index_path,
+        ?string $following_patch_result_index_path
+    ): bool {
+        // NUL cannot occur in an index path and cannot match either test.
+        $preceding_patch_result_index_path =
+            $preceding_patch_result_index_path ?? "\0";
+        $following_patch_result_index_path =
+            $following_patch_result_index_path ?? "\0";
+
+        return path_is_same_as_or_descendant_of(
+            $preceding_patch_result_index_path,
+            $index_path
+        ) || path_is_same_as_or_descendant_of(
+            $following_patch_result_index_path,
+            $index_path
+        );
+    }
+
+    /** Returns the logical entry kind used by the plan transition table. */
+    private function index_entry_shape(string $path_type): string
+    {
+        if ($path_type === "file") {
+            return "file";
+        }
+        if ($path_type === "link") {
+            return "symlink";
+        }
+        return "empty_directory";
+    }
+
+    /** Adds one active deletion root and returns its byte offset. */
+    private function append_active_deletion_root(
+        string $index_path,
+        ?int $previous_byte_offset
+    ): int {
+        if (fseek($this->active_deletion_roots_handle, 0, SEEK_END) !== 0) {
+            throw new RuntimeException(
+                "Failed to seek to the end of the active deletion roots file."
+            );
+        }
+        $byte_offset = ftell($this->active_deletion_roots_handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the active deletion roots byte offset."
+            );
+        }
+        $line = json_encode(
+            [
+                "path_b64" => base64_encode($index_path),
+                "previous_byte_offset" => $previous_byte_offset,
+            ],
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (
+            fwrite($this->active_deletion_roots_handle, $line)
+            !== strlen($line)
+        ) {
+            throw new RuntimeException(
+                "Failed to append to the active deletion roots file."
+            );
+        }
+        $this->active_deletion_root = [
+            "path" => $index_path,
+            "previous_byte_offset" => $previous_byte_offset,
+        ];
+        return $byte_offset;
+    }
+
+    /** Returns one active deletion root addressed by its byte offset. */
+    private function read_active_deletion_root(
+        ?int $byte_offset
+    ): ?array {
+        if ($byte_offset === null) {
+            return null;
+        }
+        if (
+            fseek(
+                $this->active_deletion_roots_handle,
+                $byte_offset
+            ) !== 0
+        ) {
+            throw new RuntimeException(
+                "Failed to seek in the active deletion roots file."
+            );
+        }
+        $line = fgets($this->active_deletion_roots_handle);
+        if (!is_string($line)) {
+            throw new RuntimeException(
+                "Failed to read the active deletion root at byte {$byte_offset}."
+            );
+        }
+        try {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException(
+                "Failed to decode the active deletion root at byte {$byte_offset}.",
+                0,
+                $exception
+            );
+        }
+        /** @var array{path_b64:string,previous_byte_offset:int|null} $entry */
+        $index_path = base64_decode($entry["path_b64"], true);
+        if ($index_path === false) {
+            throw new RuntimeException(
+                "Failed to decode the deleted-directory path at byte {$byte_offset}."
+            );
+        }
+        return [
+            "path" => $index_path,
+            "previous_byte_offset" => $entry["previous_byte_offset"],
+        ];
+    }
+
+    /** Reports whether the active deletion root contains the index path. */
+    private function active_deletion_root_covers_path(
+        string $index_path
+    ): bool {
+        return $this->active_deletion_root !== null
+            && path_is_descendant_of(
+                $index_path,
+                $this->active_deletion_root["path"]
+            );
+    }
+
+    /**
+     * Reports whether a planned operation may change the index path.
+     *
+     * The path must be inside an included root. It must not be an excluded
+     * root, sit below one, or contain one. The last case prevents a parent
+     * deletion or replacement from changing an excluded descendant.
+     */
+    private function path_may_change(string $index_path): bool
+    {
+        $is_included = false;
+        foreach ($this->included_index_path_roots as $included_index_path_root) {
+            if (
+                $included_index_path_root === ""
+                || path_is_same_as_or_descendant_of(
+                    $index_path,
+                    $included_index_path_root
+                )
+            ) {
+                $is_included = true;
+                break;
+            }
+        }
+        if (!$is_included) {
+            return false;
+        }
+        foreach ($this->excluded_index_path_roots as $excluded_index_path_root) {
+            if (
+                $excluded_index_path_root === ""
+                || path_is_same_as_or_descendant_of(
+                    $index_path,
+                    $excluded_index_path_root
+                )
+                || path_is_same_as_or_descendant_of(
+                    $excluded_index_path_root,
+                    $index_path
+                )
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Rejects calls after close(). */
+    private function assert_open(): void
+    {
+        if ($this->closed) {
+            throw new LogicException(
+                "Cannot use a closed file sync patch planner."
+            );
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -2,13 +2,10 @@
 
 use function Reprint\Importer\sort_index_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
-use function WordPress\Filesystem\wp_unix_path_segments;
-use function WordPress\Reprint\Exporter\path_is_descendant_of;
-use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
-require_once __DIR__ . '/../index/class-file-index-diff-processor.php';
+require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -22,7 +19,7 @@ require_once __DIR__ . '/../index/class-file-index-diff-processor.php';
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
- * FileIndexProcessor, FileIndexDiffProcessor, the fresh local index, the
+ * FileIndexProcessor, FileSyncPatchPlanner, the fresh local index, the
  * meaning of its cursor, and the two completed path lists. A caller which
  * resumes across processes stores the cursor returned by get_cursor().
  *
@@ -59,18 +56,20 @@ require_once __DIR__ . '/../index/class-file-index-diff-processor.php';
  * bytes beyond saved offsets, so an interrupted step cannot leave duplicate
  * durable entries.
  *
- * PushPlan retains the next entry from each index and the top of an append-only
- * deleted-directory stack needed to suppress redundant descendant deletions. It
- * never loads an index, path list, or the stack in full.
+ * FileSyncPatchPlanner retains the next entry from each index and writes the
+ * active directory-deletion roots needed to suppress redundant descendant
+ * deletions. PushPlan stores its cursor without unpacking it. Neither class
+ * loads an index, path list, or the active deletion roots file in full.
  *
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',byte_offset_in_fresh_local_index:int,byte_offset_in_local_index:int,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null,deleted_directory_stack_top_byte_offset:int|null,preceding_fresh_local_index_entry_path:string|null}
+ * @phpstan-type FileSyncPlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
+ * @phpstan-type FileSyncPlannerCursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:FileSyncPlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',file_sync_planner_cursor:FileSyncPlannerCursor,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
- * @phpstan-type DeletedDirectoryStackEntry array{path:string,previous_byte_offset:int|null}
  */
 class PushPlan
 {
@@ -98,8 +97,8 @@ class PushPlan
     /** @var string Plan path containing receiver-owned exclusions for the active push. */
     private string $excluded_paths_file;
 
-    /** @var string Append-only deleted-directory stack for the active plan. */
-    private string $deleted_directories_stack;
+    /** @var string State for directory deletions which cover paths not processed yet. */
+    private string $active_deletion_roots_file;
 
     /** @var list<string> Receiver-owned paths that the plan must not push or delete. */
     private array $excluded_paths = [];
@@ -113,14 +112,8 @@ class PushPlan
     /** @var FileIndexProcessor Fresh local index traversal retained during indexing. */
     private FileIndexProcessor $file_index_processor;
 
-    /** Sorted local-index comparison retained during the diff phase. */
-    private FileIndexDiffProcessor $index_diff;
-
-    /** Whether the diff processor already selected the path for the next step. */
-    private bool $index_diff_path_selected = false;
-
-    /** @var DeletedDirectoryStackEntry|null Top active deleted-directory stack entry. */
-    private ?array $deleted_directory_stack_entry = null;
+    /** File-sync patch planner retained during the diff phase. */
+    private FileSyncPatchPlanner $patch_planner;
 
     /** @var resource|null Open fresh local index retained during indexing. */
     private $fresh_local_index_handle = null;
@@ -128,9 +121,6 @@ class PushPlan
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
     private $local_paths_to_delete_handle = null;
-    /** @var resource|null */
-    private $deleted_directories_stack_handle = null;
-
     /** @var int|null Combined size of the two retained indexes during the index diff. */
     private ?int $index_bytes_total = null;
 
@@ -237,7 +227,16 @@ class PushPlan
         if ($position["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
         } elseif ($position["phase"] === "diffing") {
-            $plan->open_plan_files();
+            $plan->open_plan_output_files(
+                $position["byte_offset_in_local_paths_to_push"],
+                $position["byte_offset_in_local_paths_to_delete"]
+            );
+            $file_sync_planner_cursor =
+                $position["file_sync_planner_cursor"];
+            $plan->patch_planner = FileSyncPatchPlanner::resume(
+                $file_sync_planner_cursor
+            );
+            $plan->set_index_bytes_total();
         }
         return $plan;
     }
@@ -283,8 +282,10 @@ class PushPlan
             return $progress;
         }
 
-        $index_bytes_done = $position["byte_offset_in_fresh_local_index"]
-            + $position["byte_offset_in_local_index"];
+        $index_diff_cursor =
+            $position["file_sync_planner_cursor"]["index_diff_cursor"];
+        $index_bytes_done = $index_diff_cursor["new_index_byte_offset"]
+            + $index_diff_cursor["old_index_byte_offset"];
         $progress["index_bytes_done"] = min($index_bytes_done, $this->index_bytes_total);
         $progress["index_bytes_total"] = $this->index_bytes_total;
         return $progress;
@@ -322,9 +323,11 @@ class PushPlan
         if (
             ( is_resource($this->local_paths_to_push_handle) && !fflush($this->local_paths_to_push_handle) )
             || ( is_resource($this->local_paths_to_delete_handle) && !fflush($this->local_paths_to_delete_handle) )
-            || ( is_resource($this->deleted_directories_stack_handle) && !fflush($this->deleted_directories_stack_handle) )
         ) {
             throw new RuntimeException("Failed to flush a push-plan output.");
+        }
+        if (isset($this->patch_planner)) {
+            $this->patch_planner->flush_pending_outputs();
         }
     }
 
@@ -355,7 +358,7 @@ class PushPlan
         $this->local_paths_to_delete = wp_join_unix_paths($plan_directory, "local_paths_to_delete");
         $this->fresh_local_index_file = wp_join_unix_paths($plan_directory, "fresh_local_index.jsonl");
         $this->excluded_paths_file = wp_join_unix_paths($plan_directory, "excluded_paths.json");
-        $this->deleted_directories_stack = wp_join_unix_paths($plan_directory, "deleted_directories_stack.jsonl");
+        $this->active_deletion_roots_file = wp_join_unix_paths($plan_directory, "deleted_directories_stack.jsonl");
     }
 
     /**
@@ -399,53 +402,6 @@ class PushPlan
             false,
             false,
             $this->plan_directory
-        );
-    }
-
-    /**
-     * Opens and positions the files used by start() and resume().
-     *
-     * Indexes are positioned at their durable cursor offsets. Output bytes
-     * beyond their durable offsets are discarded before writing continues.
-     */
-    private function open_plan_files(): void
-    {
-        /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor["position"];
-        $this->deleted_directory_stack_entry = null;
-        $this->local_paths_to_push_handle = $this->open_push_plan_output_file_at_byte_offset(
-            $this->local_paths_to_push,
-            $cursor["byte_offset_in_local_paths_to_push"]
-        );
-        $this->local_paths_to_delete_handle = $this->open_push_plan_output_file_at_byte_offset(
-            $this->local_paths_to_delete,
-            $cursor["byte_offset_in_local_paths_to_delete"]
-        );
-        $this->index_diff = FileIndexDiffProcessor::resume(
-            $this->local_index_file,
-            $this->fresh_local_index_file,
-            [
-                "old_index_byte_offset" => $cursor["byte_offset_in_local_index"],
-                "new_index_byte_offset" => $cursor["byte_offset_in_fresh_local_index"],
-                "preceding_new_index_entry_path_b64" =>
-                    $cursor["preceding_fresh_local_index_entry_path"] === null
-                        ? null
-                        : base64_encode($cursor["preceding_fresh_local_index_entry_path"]),
-            ]
-        );
-        $fresh_local_index_bytes = filesize($this->fresh_local_index_file);
-        $local_index_bytes = is_file($this->local_index_file)
-            ? filesize($this->local_index_file)
-            : 0;
-        if (is_int($fresh_local_index_bytes) && is_int($local_index_bytes)) {
-            $this->index_bytes_total = $fresh_local_index_bytes + $local_index_bytes;
-        }
-        $this->deleted_directories_stack_handle = fopen($this->deleted_directories_stack, "a+b");
-        if (!is_resource($this->deleted_directories_stack_handle)) {
-            throw new RuntimeException("Failed to open the deleted-directory stack: {$this->deleted_directories_stack}");
-        }
-        $this->deleted_directory_stack_entry = $this->read_deleted_directory_stack_entry(
-            $cursor["deleted_directory_stack_top_byte_offset"]
         );
     }
 
@@ -539,21 +495,69 @@ class PushPlan
                 "Failed to sort the fresh local index: {$this->fresh_local_index_file}"
             );
         }
-        if (file_put_contents($this->deleted_directories_stack, "") !== 0) {
-            throw new RuntimeException("Failed to initialize the deleted-directory stack: {$this->deleted_directories_stack}");
-        }
+        $this->open_plan_output_files(0, 0);
+        $this->patch_planner = FileSyncPatchPlanner::create(
+            $this->local_index_file,
+            $this->fresh_local_index_file,
+            $this->active_deletion_roots_file,
+            [$this->document_root_local_relative_path],
+            $this->get_excluded_index_path_roots()
+        );
         $this->cursor["position"] = [
             "phase" => "diffing",
-            "byte_offset_in_fresh_local_index" => 0,
-            "byte_offset_in_local_index" => 0,
+            "file_sync_planner_cursor" => $this->patch_planner->get_cursor(),
             "byte_offset_in_local_paths_to_push" => 0,
             "byte_offset_in_local_paths_to_delete" => 0,
             "local_paths_to_push_count" => 0,
             "local_file_bytes_to_push" => 0,
-            "deleted_directory_stack_top_byte_offset" => null,
-            "preceding_fresh_local_index_entry_path" => null,
         ];
-        $this->open_plan_files();
+        $this->set_index_bytes_total();
+    }
+
+    /** Opens both patch-plan outputs at their durable byte offsets. */
+    private function open_plan_output_files(
+        int $byte_offset_in_local_paths_to_push,
+        int $byte_offset_in_local_paths_to_delete
+    ): void {
+        $this->local_paths_to_push_handle =
+            $this->open_push_plan_output_file_at_byte_offset(
+                $this->local_paths_to_push,
+                $byte_offset_in_local_paths_to_push
+            );
+        $this->local_paths_to_delete_handle =
+            $this->open_push_plan_output_file_at_byte_offset(
+                $this->local_paths_to_delete,
+                $byte_offset_in_local_paths_to_delete
+            );
+    }
+
+    /** Returns target exclusions in local-index coordinates. */
+    private function get_excluded_index_path_roots(): array
+    {
+        $excluded_index_path_roots = [];
+        foreach ($this->excluded_paths as $excluded_path) {
+            $excluded_index_path_roots[] =
+                $this->document_root_local_relative_path === ""
+                    ? $excluded_path
+                    : wp_join_unix_paths(
+                        $this->document_root_local_relative_path,
+                        $excluded_path
+                    );
+        }
+        return $excluded_index_path_roots;
+    }
+
+    /** Stores the byte total used to report index-diff progress. */
+    private function set_index_bytes_total(): void
+    {
+        $fresh_local_index_bytes = filesize($this->fresh_local_index_file);
+        $local_index_bytes = is_file($this->local_index_file)
+            ? filesize($this->local_index_file)
+            : 0;
+        if (is_int($fresh_local_index_bytes) && is_int($local_index_bytes)) {
+            $this->index_bytes_total = $fresh_local_index_bytes
+                + $local_index_bytes;
+        }
     }
 
     /**
@@ -624,21 +628,15 @@ class PushPlan
         $cursor = $this->cursor["position"];
         $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
         $local_file_bytes_to_push = $cursor["local_file_bytes_to_push"];
-        $deleted_directory_stack_top_byte_offset =
-            $cursor["deleted_directory_stack_top_byte_offset"];
-        if (
-            !$this->index_diff_path_selected
-            && !$this->index_diff->next_path()
-        ) {
+
+        if (!$this->patch_planner->next_path()) {
             if (
                 !fflush($this->local_paths_to_push_handle)
                 || !fflush($this->local_paths_to_delete_handle)
-                || !fflush($this->deleted_directories_stack_handle)
             ) {
                 throw new RuntimeException("Failed to flush a push-plan output.");
             }
-            $deleted_directory_stack_top_byte_offset = null;
-            $this->deleted_directory_stack_entry = null;
+            $this->patch_planner->flush_pending_outputs();
             $this->cursor["position"] = [
                 "phase" => "complete",
                 "local_paths_to_push_count" => $local_paths_to_push_count,
@@ -646,193 +644,36 @@ class PushPlan
             ];
             return false;
         }
-        $this->index_diff_path_selected = true;
 
-        $local_relative_path = $this->index_diff->get_path();
-        $local_index_path_type = $this->index_diff->get_path_type_in_old_index();
-        $fresh_local_index_path_type = $this->index_diff->get_path_type_in_new_index();
-        $local_path_transition = $this->index_diff->get_path_transition();
-        $fresh_local_index_entry_shape = $fresh_local_index_path_type === null
-            ? null
-            : $this->index_entry_shape($fresh_local_index_path_type);
-        $local_index_entry_shape = $local_index_path_type === null
-            ? null
-            : $this->index_entry_shape($local_index_path_type);
-
-        if ($local_index_path_type !== null) {
-            // Byte sorting can put a sibling such as `a-other` before
-            // `a/child`. Keep a deleted root while local index entries
-            // remain within that root's descendants.
-            if ($this->deleted_directory_stack_entry !== null) {
-                $descendant_prefix = $this->deleted_directory_stack_entry["path"] . "/";
-                if (
-                    !path_is_same_as_or_descendant_of(
-                        $local_relative_path,
-                        $this->deleted_directory_stack_entry["path"]
-                    )
-                    && strcmp($local_relative_path, $descendant_prefix) > 0
-                ) {
-                    $deleted_directory_stack_top_byte_offset =
-                        $this->deleted_directory_stack_entry["previous_byte_offset"];
-                    $this->deleted_directory_stack_entry =
-                        $this->read_deleted_directory_stack_entry(
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                }
+        $operation = $this->patch_planner->get_operation();
+        if ($operation !== null) {
+            if ($operation["action"] !== "copy") {
+                $this->append_local_path_to_delete($operation["path"]);
             }
-        }
-
-        if ($local_path_transition === "added") {
-            // New files, symlinks, and empty directories need to be pushed.
-            // A NUL byte cannot occur in an indexed path, so it cannot match
-            // when the old index has no following path.
-            $fresh_local_index_entry_replaces_local_subtree =
-                path_is_same_as_or_descendant_of(
-                    $this->index_diff->get_following_path_in_old_index() ?? "\0",
-                    $local_relative_path
-                );
-            if (
-                $fresh_local_index_entry_replaces_local_subtree
-                && !$this->path_conflicts_with_excluded_paths($local_relative_path)
-                && !$this->deleted_directory_stack_covers_path(
-                    $local_relative_path,
-                    $this->deleted_directory_stack_entry
-                )
-            ) {
-                $this->append_local_path_to_delete($local_relative_path);
-                $deleted_directory_stack_top_byte_offset =
-                    $this->append_deleted_directory_stack_entry(
-                        $local_relative_path,
-                        $deleted_directory_stack_top_byte_offset
-                    );
-            }
-            if (!$this->path_conflicts_with_excluded_paths($local_relative_path)) {
-                $fresh_local_index_size = $this->index_diff->get_size_in_new_index();
-                $this->append_local_path_to_push(
-                    $local_relative_path,
-                    $fresh_local_index_path_type,
-                    $fresh_local_index_size,
-                    $this->index_diff->get_ctime_in_new_index()
-                );
+            if ($operation["action"] !== "delete") {
+                $this->append_local_path_to_push($operation);
                 if ($local_paths_to_push_count !== null) {
                     ++$local_paths_to_push_count;
                 }
                 if (
                     $local_file_bytes_to_push !== null
-                    && $fresh_local_index_path_type === "file"
+                    && $operation["expected_source"]["type"] === "file"
                 ) {
-                    $local_file_bytes_to_push += $fresh_local_index_size;
-                }
-            }
-        } elseif ($local_path_transition === "deleted") {
-            $local_empty_directory_is_implied_by_fresh_descendant =
-                $local_index_entry_shape === "empty_directory"
-                && $this->fresh_index_contains_path_or_descendant(
-                    $local_relative_path,
-                    $this->index_diff->get_preceding_path_in_new_index(),
-                    $this->index_diff->get_following_path_in_new_index()
-                );
-            $local_path_to_delete = $this->local_path_to_delete(
-                $local_relative_path,
-                $this->index_diff->get_preceding_path_in_new_index(),
-                $this->index_diff->get_following_path_in_new_index()
-            );
-            // A sparse index entry derives one deleted root, covering its
-            // following descendant entries.
-            if (
-                !$local_empty_directory_is_implied_by_fresh_descendant
-                && !$this->path_conflicts_with_excluded_paths($local_path_to_delete)
-                && !$this->deleted_directory_stack_covers_path(
-                    $local_relative_path,
-                    $this->deleted_directory_stack_entry
-                )
-            ) {
-                $this->append_local_path_to_delete($local_path_to_delete);
-                if ($local_path_to_delete !== $local_relative_path) {
-                    $deleted_directory_stack_top_byte_offset =
-                        $this->append_deleted_directory_stack_entry(
-                            $local_path_to_delete,
-                            $deleted_directory_stack_top_byte_offset
-                        );
-                }
-            }
-        } else {
-            $fresh_local_index_entry_is_file_or_symlink =
-                $fresh_local_index_entry_shape === "file"
-                || $fresh_local_index_entry_shape === "symlink";
-            $local_index_entry_is_file_or_symlink =
-                $local_index_entry_shape === "file"
-                || $local_index_entry_shape === "symlink";
-            $empty_directory_needs_push =
-                $fresh_local_index_entry_shape === "empty_directory"
-                && $local_index_entry_shape !== "empty_directory";
-            // The diff processor defines modification by type, ctime, and
-            // size. Only modified files and symlinks need to be uploaded.
-            $changed_file_or_symlink_needs_push =
-                $fresh_local_index_entry_is_file_or_symlink
-                && $local_path_transition === "modified";
-            $needs_delete =
-                $fresh_local_index_entry_is_file_or_symlink
-                !== $local_index_entry_is_file_or_symlink;
-            $needs_push = $empty_directory_needs_push
-                || $changed_file_or_symlink_needs_push;
-            $path_is_excluded = $this->path_conflicts_with_excluded_paths(
-                $local_relative_path
-            );
-
-            if (
-                $needs_delete
-                && !$path_is_excluded
-                && !$this->deleted_directory_stack_covers_path(
-                    $local_relative_path,
-                    $this->deleted_directory_stack_entry
-                )
-            ) {
-                $this->append_local_path_to_delete($local_relative_path);
-            }
-            if ($needs_push && !$path_is_excluded) {
-                $fresh_local_index_size = $this->index_diff->get_size_in_new_index();
-                $this->append_local_path_to_push(
-                    $local_relative_path,
-                    $fresh_local_index_path_type,
-                    $fresh_local_index_size,
-                    $this->index_diff->get_ctime_in_new_index()
-                );
-                if ($local_paths_to_push_count !== null) {
-                    ++$local_paths_to_push_count;
-                }
-                if (
-                    $local_file_bytes_to_push !== null
-                    && $fresh_local_index_path_type === "file"
-                ) {
-                    $local_file_bytes_to_push += $fresh_local_index_size;
+                    $local_file_bytes_to_push +=
+                        $operation["expected_source"]["size"];
                 }
             }
         }
 
-        $complete = !$this->index_diff->next_path();
-        $this->index_diff_path_selected = !$complete;
+        $complete = $this->patch_planner->is_complete();
         if ($complete) {
             if (
                 !fflush($this->local_paths_to_push_handle)
                 || !fflush($this->local_paths_to_delete_handle)
-                || !fflush($this->deleted_directories_stack_handle)
             ) {
                 throw new RuntimeException("Failed to flush a push-plan output.");
             }
-            $deleted_directory_stack_top_byte_offset = null;
-            $this->deleted_directory_stack_entry = null;
-        }
-        $index_diff_cursor = $this->index_diff->get_cursor();
-        $preceding_fresh_local_index_entry_path = null;
-        if ($index_diff_cursor["preceding_new_index_entry_path_b64"] !== null) {
-            $preceding_fresh_local_index_entry_path = base64_decode(
-                $index_diff_cursor["preceding_new_index_entry_path_b64"],
-                true
-            );
-            if ($preceding_fresh_local_index_entry_path === false) {
-                throw new RuntimeException("The local-index diff cursor has an invalid preceding path.");
-            }
+            $this->patch_planner->flush_pending_outputs();
         }
         $this->cursor["position"] = $complete
             ? [
@@ -842,20 +683,14 @@ class PushPlan
             ]
             : [
                 "phase" => "diffing",
-                "byte_offset_in_fresh_local_index" =>
-                    $index_diff_cursor["new_index_byte_offset"],
-                "byte_offset_in_local_index" =>
-                    $index_diff_cursor["old_index_byte_offset"],
+                "file_sync_planner_cursor" =>
+                    $this->patch_planner->get_cursor(),
                 "byte_offset_in_local_paths_to_push" =>
                     ftell($this->local_paths_to_push_handle),
                 "byte_offset_in_local_paths_to_delete" =>
                     ftell($this->local_paths_to_delete_handle),
                 "local_paths_to_push_count" => $local_paths_to_push_count,
                 "local_file_bytes_to_push" => $local_file_bytes_to_push,
-                "deleted_directory_stack_top_byte_offset" =>
-                    $deleted_directory_stack_top_byte_offset,
-                "preceding_fresh_local_index_entry_path" =>
-                    $preceding_fresh_local_index_entry_path,
             ];
         return !$complete;
     }
@@ -872,8 +707,8 @@ class PushPlan
         if (isset($this->file_index_processor)) {
             $this->file_index_processor->close();
         }
-        if (isset($this->index_diff)) {
-            $this->index_diff->close();
+        if (isset($this->patch_planner)) {
+            $this->patch_planner->close();
         }
         $this->close_fresh_local_index_handle();
         if (is_resource($this->local_paths_to_push_handle)) {
@@ -882,14 +717,8 @@ class PushPlan
         if (is_resource($this->local_paths_to_delete_handle)) {
             fclose($this->local_paths_to_delete_handle);
         }
-        if (is_resource($this->deleted_directories_stack_handle)) {
-            fclose($this->deleted_directories_stack_handle);
-        }
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
-        $this->deleted_directories_stack_handle = null;
-        $this->deleted_directory_stack_entry = null;
-        $this->index_diff_path_selected = false;
         $this->closed = true;
     }
 
@@ -939,109 +768,36 @@ class PushPlan
     }
 
     /**
-     * Returns the highest deleted directory without a fresh entry below it.
-     *
-     * Only the preceding and following fresh entries can neighbor a path in
-     * byte order, so this derives one subtree root without retaining the tree.
-     *
-     * @param string|null $preceding_fresh_local_index_entry_path Path immediately before this position.
-     * @param string|null $following_fresh_local_index_entry_path Path immediately after this position.
-     */
-    private function local_path_to_delete(
-        string $local_relative_path,
-        ?string $preceding_fresh_local_index_entry_path,
-        ?string $following_fresh_local_index_entry_path
-    ): string
-    {
-        $local_relative_path_components = wp_unix_path_segments($local_relative_path);
-        $candidate_local_relative_path_components = [];
-        for ($index = 0, $component_count = count($local_relative_path_components) - 1; $index < $component_count; ++$index) {
-            $candidate_local_relative_path_components[] = $local_relative_path_components[$index];
-            $candidate_local_relative_path = wp_join_unix_paths(
-                ...$candidate_local_relative_path_components
-            );
-            if (
-                !$this->fresh_index_contains_path_or_descendant(
-                    $candidate_local_relative_path,
-                    $preceding_fresh_local_index_entry_path,
-                    $following_fresh_local_index_entry_path
-                )
-            ) {
-                return $candidate_local_relative_path;
-            }
-        }
-        return $local_relative_path;
-    }
-
-    /**
-     * Checks the adjacent fresh entries for a path or one of its descendants.
-     *
-     * @param string|null $preceding_fresh_local_index_entry_path Path immediately before this position.
-     * @param string|null $following_fresh_local_index_entry_path Path immediately after this position.
-     */
-    private function fresh_index_contains_path_or_descendant(
-        string $local_relative_path,
-        ?string $preceding_fresh_local_index_entry_path,
-        ?string $following_fresh_local_index_entry_path
-    ): bool
-    {
-        // Use an invalid path that cannot match an indexed local relative path
-        // so both comparisons below always receive strings.
-        $preceding_fresh_local_index_entry_path =
-            $preceding_fresh_local_index_entry_path ?? "\0";
-        $following_fresh_local_index_entry_path =
-            $following_fresh_local_index_entry_path ?? "\0";
-
-        return path_is_same_as_or_descendant_of(
-            $preceding_fresh_local_index_entry_path,
-            $local_relative_path
-        ) || path_is_same_as_or_descendant_of(
-            $following_fresh_local_index_entry_path,
-            $local_relative_path
-        );
-    }
-
-    /**
-     * Returns the logical entry kind used by the transition table.
-     *
-     * @param string $path_type Entry type: `file`, `link`, or `dir`.
-     * @return 'file'|'symlink'|'empty_directory'
-     */
-    private function index_entry_shape(string $path_type): string
-    {
-        if ($path_type === "file") {
-            return "file";
-        }
-        if ($path_type === "link") {
-            return "symlink";
-        }
-        return "empty_directory";
-    }
-
-    /**
-     * Appends one path and its planned type, size, and ctime to the JSONL list.
+     * Appends one copy or replace operation to the JSONL push list.
      *
      * Base64 keeps arbitrary filesystem path bytes representable in JSON.
      *
-     * @param string $local_relative_path Local relative path selected for push.
-     * @param string $path_type           Entry type: `file`, `link`, or `dir`.
-     * @param int    $size                Indexed size used for change detection.
-     * @param int    $ctime               Indexed change timestamp.
+     * @param array $operation {
+     *     Copy or replace operation selected by FileSyncPatchPlanner.
+     *
+     *     @type string $action          `copy` or `replace`.
+     *     @type string $path            Local relative path selected for push.
+     *     @type array  $expected_source {
+     *         Source state required when the path is pushed.
+     *
+     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type int    $size  Expected size.
+     *         @type int    $ctime Expected inode change time.
+     *     }
+     * }
+     * @phpstan-param array{action:'copy'|'replace',path:string,expected_source:array{type:string,size:int,ctime:int}} $operation
      */
-    private function append_local_path_to_push(
-        string $local_relative_path,
-        string $path_type,
-        int $size,
-        int $ctime
-    ): void {
+    private function append_local_path_to_push(array $operation): void {
         $local_path_to_push_json_line = json_encode(
             [
-                "path" => base64_encode($local_relative_path),
-                "type" => $path_type === "link"
+                "path" => base64_encode($operation["path"]),
+                "type" => $operation["expected_source"]["type"] === "link"
                     ? "symlink"
-                    : ($path_type === "dir" ? "directory" : "file"),
-                "size" => $size,
-                "ctime" => $ctime,
+                    : ( $operation["expected_source"]["type"] === "dir"
+                        ? "directory"
+                        : "file" ),
+                "size" => $operation["expected_source"]["size"],
+                "ctime" => $operation["expected_source"]["ctime"],
             ],
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         ) . "\n";
@@ -1071,116 +827,6 @@ class PushPlan
         if (fwrite($this->local_paths_to_delete_handle, $document_root_relative_path_with_nul) !== strlen($document_root_relative_path_with_nul)) {
             throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
         }
-    }
-
-    /**
-     * Appends one active directory and links it to the preceding stack entry.
-     *
-     * @param string   $path                 Raw directory path selected for deletion.
-     * @param int|null $previous_byte_offset Byte offset of the preceding active entry.
-     * @return int Byte offset of the appended entry.
-     */
-    private function append_deleted_directory_stack_entry(string $path, ?int $previous_byte_offset): int
-    {
-        if (fseek($this->deleted_directories_stack_handle, 0, SEEK_END) !== 0) {
-            throw new RuntimeException("Failed to seek to the end of the deleted-directory stack.");
-        }
-        $byte_offset = ftell($this->deleted_directories_stack_handle);
-        if (!is_int($byte_offset)) {
-            throw new RuntimeException("Failed to determine the deleted-directory stack byte offset.");
-        }
-        $line = json_encode(
-            [
-                "path_b64" => base64_encode($path),
-                "previous_byte_offset" => $previous_byte_offset,
-            ],
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (fwrite($this->deleted_directories_stack_handle, $line) !== strlen($line)) {
-            throw new RuntimeException("Failed to append to the deleted-directory stack.");
-        }
-        $this->deleted_directory_stack_entry = [
-            "path" => $path,
-            "previous_byte_offset" => $previous_byte_offset,
-        ];
-        return $byte_offset;
-    }
-
-    /**
-     * Reads one stack entry addressed by the planning cursor.
-     *
-     * @param int|null $byte_offset Entry byte offset, or null for an empty stack.
-     * @return DeletedDirectoryStackEntry|null Decoded stack entry, or null.
-     */
-    private function read_deleted_directory_stack_entry(?int $byte_offset): ?array
-    {
-        if ($byte_offset === null) {
-            return null;
-        }
-        if (fseek($this->deleted_directories_stack_handle, $byte_offset) !== 0) {
-            throw new RuntimeException("Failed to seek in the deleted-directory stack.");
-        }
-        $line = fgets($this->deleted_directories_stack_handle);
-        if (!is_string($line)) {
-            throw new RuntimeException("Failed to read the deleted-directory stack entry at byte {$byte_offset}.");
-        }
-        try {
-            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException("Failed to decode the deleted-directory stack entry at byte {$byte_offset}.", 0, $exception);
-        }
-        /** @var array{path_b64:string,previous_byte_offset:int|null} $entry */
-        $path = base64_decode($entry["path_b64"], true);
-        if ($path === false) {
-            throw new RuntimeException("Failed to decode the deleted-directory path at byte {$byte_offset}.");
-        }
-        return [
-            "path" => $path,
-            "previous_byte_offset" => $entry["previous_byte_offset"],
-        ];
-    }
-
-    /**
-     * Reports whether the active deleted directory contains the path.
-     *
-     * @param string                          $path  Raw filesystem path to classify.
-     * @param DeletedDirectoryStackEntry|null $entry Top active stack entry.
-     */
-    private function deleted_directory_stack_covers_path(string $path, ?array $entry): bool
-    {
-        return $entry !== null
-            && path_is_descendant_of($path, $entry["path"]);
-    }
-
-    /**
-     * Indicates whether pushing or deleting the path could change an excluded
-     * path.
-     *
-     * The path conflicts when it is excluded, is inside an excluded directory,
-     * or contains an excluded descendant. The last case prevents deleting or
-     * replacing a directory from removing an excluded descendant with it.
-     *
-     * @param string $path Raw filesystem path considered for push or deletion.
-     * @return bool Whether operating on the path could change an excluded path.
-     */
-    private function path_conflicts_with_excluded_paths(string $path): bool
-    {
-        $document_root_relative_path = relative_path_under(
-            $path,
-            $this->document_root_local_relative_path
-        );
-        if ($document_root_relative_path === null) {
-            return true;
-        }
-        foreach ($this->excluded_paths as $excluded_path) {
-            if (
-                path_is_same_as_or_descendant_of($document_root_relative_path, $excluded_path)
-                || path_is_same_as_or_descendant_of($excluded_path, $document_root_relative_path)
-            ) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/tests/Import/FileSyncPatchPlannerTest.php
+++ b/tests/Import/FileSyncPatchPlannerTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php';
+
+/**
+ * Covers file-sync patch operations, tree boundaries, and resume cursors.
+ *
+ * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
+ * @phpstan-type SyncOperation array{action:'delete',path:string}|array{action:'copy'|'replace',path:string,expected_source:ExpectedSource}
+ */
+final class FileSyncPatchPlannerTest extends TestCase
+{
+    private string $temp_dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temp_dir = sys_get_temp_dir()
+            . '/file-sync-patch-planner-'
+            . bin2hex(random_bytes(6));
+        mkdir($this->temp_dir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (scandir($this->temp_dir) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                unlink($this->temp_dir . '/' . $entry);
+            }
+        }
+        rmdir($this->temp_dir);
+        parent::tearDown();
+    }
+
+    public function testPlansAddedModifiedDeletedAndReplacedPaths(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'b-deleted.txt' => $this->entry('b-deleted.txt'),
+            'c-empty-to-file' => $this->entry('c-empty-to-file', 1, 0, 'dir'),
+            'd-file-to-empty' => $this->entry('d-file-to-empty'),
+            'e-modified.txt' => $this->entry('e-modified.txt', 1),
+            'f-unchanged.txt' => $this->entry('f-unchanged.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'a-added.txt' => $this->entry('a-added.txt', 2, 3),
+            'c-empty-to-file' => $this->entry('c-empty-to-file', 2, 4),
+            'd-file-to-empty' => $this->entry('d-file-to-empty', 2, 0, 'dir'),
+            'e-modified.txt' => $this->entry('e-modified.txt', 2),
+            'f-unchanged.txt' => $this->entry('f-unchanged.txt'),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertSame(
+            [
+                $this->copy_operation('copy', 'a-added.txt', 'file', 3, 2),
+                $this->delete_operation('b-deleted.txt'),
+                $this->copy_operation('replace', 'c-empty-to-file', 'file', 4, 2),
+                $this->copy_operation('replace', 'd-file-to-empty', 'dir', 0, 2),
+                $this->copy_operation('copy', 'e-modified.txt', 'file', 1, 2),
+                null,
+            ],
+            $this->collect_operations($planner)
+        );
+        $this->assertTrue($planner->is_complete());
+        $this->assertFalse($planner->next_path());
+        $planner->close();
+    }
+
+    public function testReplacesASubtreeWithOnePatchResultPath(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'tree/child.txt' => $this->entry('tree/child.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'tree' => $this->entry('tree', 2),
+            // `-` sorts before `/`, so this sibling appears before tree/child.
+            'tree-other.txt' => $this->entry('tree-other.txt', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertSame(
+            [
+                $this->copy_operation('replace', 'tree', 'file', 1, 2),
+                $this->copy_operation('copy', 'tree-other.txt', 'file', 1, 2),
+                null,
+            ],
+            $this->collect_operations($planner)
+        );
+        $planner->close();
+    }
+
+    public function testCollapsesADeletedSubtreeToItsRoot(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'gone/child.txt' => $this->entry('gone/child.txt'),
+            'gone/nested/leaf.txt' => $this->entry('gone/nested/leaf.txt'),
+            'stays.txt' => $this->entry('stays.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'stays.txt' => $this->entry('stays.txt'),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertSame(
+            [
+                $this->delete_operation('gone'),
+                null,
+                null,
+            ],
+            $this->collect_operations($planner)
+        );
+        $planner->close();
+    }
+
+    public function testIncludedAndExcludedRootsLimitBothOperations(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'outside/deleted.txt' => $this->entry('outside/deleted.txt'),
+            'selected/delete.txt' => $this->entry('selected/delete.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'outside/added.txt' => $this->entry('outside/added.txt', 2),
+            'selected/excluded/added.txt' =>
+                $this->entry('selected/excluded/added.txt', 2),
+            'selected/copied.txt' =>
+                $this->entry('selected/copied.txt', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file(),
+            ['selected'],
+            ['selected/excluded']
+        );
+
+        $operations = $this->collect_operations($planner);
+        $this->assertSame(
+            [
+                null,
+                null,
+                $this->copy_operation('copy', 'selected/copied.txt', 'file', 1, 2),
+                $this->delete_operation('selected/delete.txt'),
+                null,
+            ],
+            $operations
+        );
+        $planner->close();
+    }
+
+    public function testResumeKeepsAnActiveDeletionRootAcrossASibling(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a/child.txt' => $this->entry('a/child.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'a' => $this->entry('a', 2),
+            'a-other.txt' => $this->entry('a-other.txt', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('replace', 'a', 'file', 1, 2),
+            $planner->get_operation()
+        );
+        $planner->flush_pending_outputs();
+        $cursor = $planner->get_cursor();
+        $planner->close();
+
+        $resumed_planner = FileSyncPatchPlanner::resume($cursor);
+        $this->assertSame(
+            [
+                $this->copy_operation('copy', 'a-other.txt', 'file', 1, 2),
+                null,
+            ],
+            $this->collect_operations($resumed_planner)
+        );
+        $resumed_planner->close();
+        $resumed_planner->close();
+    }
+
+    /** @return list<SyncOperation|null> */
+    private function collect_operations(FileSyncPatchPlanner $planner): array
+    {
+        $operations = [];
+        while ($planner->next_path()) {
+            $operations[] = $planner->get_operation();
+        }
+        return $operations;
+    }
+
+    /**
+     * @param 'copy'|'replace' $action Whether the source entry replaces a conflicting path.
+     * @return SyncOperation
+     */
+    private function copy_operation(
+        string $action,
+        string $path,
+        string $type,
+        int $size,
+        int $ctime
+    ): array {
+        return [
+            'action' => $action,
+            'path' => $path,
+            'expected_source' => [
+                'type' => $type,
+                'size' => $size,
+                'ctime' => $ctime,
+            ],
+        ];
+    }
+
+    /** @return SyncOperation */
+    private function delete_operation(string $path): array
+    {
+        return [
+            'action' => 'delete',
+            'path' => $path,
+        ];
+    }
+
+    /**
+     * @param array<string,array{path:string,ctime:int,size:int,type:string,empty?:bool}> $entries
+     */
+    private function write_index(string $filename, array $entries): string
+    {
+        ksort($entries, SORT_STRING);
+        $lines = [];
+        foreach ($entries as $entry) {
+            $entry['path'] = base64_encode($entry['path']);
+            $lines[] = json_encode(
+                $entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+        $path = $this->temp_dir . '/' . $filename;
+        file_put_contents($path, $lines === [] ? '' : implode("\n", $lines) . "\n");
+        return $path;
+    }
+
+    /** @return array{path:string,ctime:int,size:int,type:string,empty?:bool} */
+    private function entry(
+        string $path,
+        int $ctime = 1,
+        int $size = 1,
+        string $type = 'file'
+    ): array {
+        $entry = [
+            'path' => $path,
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => $type,
+        ];
+        if ($type === 'dir') {
+            $entry['empty'] = true;
+        }
+        return $entry;
+    }
+
+    private function active_deletion_roots_file(): string
+    {
+        return $this->temp_dir . '/deleted-directories.jsonl';
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -287,7 +287,7 @@ final class PushPlanTest extends TestCase
         $this->assertSame("gone\0", file_get_contents($this->planPath('local_paths_to_delete')));
     }
 
-    public function testDeletedDirectoryStackAppendsWithoutGrowingTheCursor(): void
+    public function testActiveDeletionRootsAppendWithoutGrowingTheCursor(): void
     {
         $this->saveLocalIndex($this->writeIndex([
             'a/child.txt' => [1, 1, 'file'],
@@ -296,11 +296,16 @@ final class PushPlanTest extends TestCase
         $plan = $this->startPlan();
 
         $this->assertTrue($this->nextPlanStep($plan));
-        $stack_bytes = filesize($this->planPath('deleted_directories_stack.jsonl'));
-        $this->assertIsInt($stack_bytes);
-        $this->assertGreaterThan(0, $stack_bytes);
+        $active_deletion_roots_bytes = filesize($this->planPath('deleted_directories_stack.jsonl'));
+        $this->assertIsInt($active_deletion_roots_bytes);
+        $this->assertGreaterThan(0, $active_deletion_roots_bytes);
         $first_cursor = $this->planCursor();
-        $this->assertSame(0, $first_cursor['deleted_directory_stack_top_byte_offset']);
+        $this->assertSame(
+            0,
+            $first_cursor['file_sync_planner_cursor'][
+                'active_deletion_root_byte_offset'
+            ]
+        );
 
         $this->assertFalse($this->nextPlanStep($plan));
         $complete_cursor = $this->planCursor();
@@ -312,7 +317,7 @@ final class PushPlanTest extends TestCase
             ],
             $complete_cursor
         );
-        $this->assertSame($stack_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
+        $this->assertSame($active_deletion_roots_bytes, filesize($this->planPath('deleted_directories_stack.jsonl')));
         $plan->close();
 
         $this->assertSame("a\0b.txt\0", file_get_contents($this->planPath('local_paths_to_delete')));
@@ -539,8 +544,12 @@ final class PushPlanTest extends TestCase
     public function testStepRetainsTheFollowingFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
-        $index_diff_property = new ReflectionProperty(
+        $patch_planner_property = new ReflectionProperty(
             PushPlan::class,
+            'patch_planner'
+        );
+        $index_diff_property = new ReflectionProperty(
+            FileSyncPatchPlanner::class,
             'index_diff'
         );
         $new_index_handle_property = new ReflectionProperty(
@@ -554,13 +563,16 @@ final class PushPlanTest extends TestCase
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
-        $index_diff = $index_diff_property->getValue($plan);
+        $patch_planner = $patch_planner_property->getValue($plan);
+        $index_diff = $index_diff_property->getValue($patch_planner);
         $fresh_local_index_handle = $new_index_handle_property->getValue(
             $index_diff
         );
         $this->assertIsResource($fresh_local_index_handle);
         $this->assertGreaterThan(
-            $first_plan_cursor['byte_offset_in_fresh_local_index'],
+            $first_plan_cursor['file_sync_planner_cursor'][
+                'index_diff_cursor'
+            ]['new_index_byte_offset'],
             ftell($fresh_local_index_handle)
         );
         $retained_fresh_local_index_entry = $new_index_entry_property->getValue(
@@ -572,7 +584,9 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($this->nextPlanStep($plan));
         $second_plan_cursor = $this->planCursor();
         $this->assertGreaterThan(
-            $second_plan_cursor['byte_offset_in_fresh_local_index'],
+            $second_plan_cursor['file_sync_planner_cursor'][
+                'index_diff_cursor'
+            ]['new_index_byte_offset'],
             ftell($fresh_local_index_handle)
         );
         $this->assertPathCounts(2, 0);
@@ -606,15 +620,21 @@ final class PushPlanTest extends TestCase
         $this->assertSame('', $cursor['document_root_local_relative_path']);
         $this->assertSame([
             'phase',
-            'byte_offset_in_fresh_local_index',
-            'byte_offset_in_local_index',
+            'file_sync_planner_cursor',
             'byte_offset_in_local_paths_to_push',
             'byte_offset_in_local_paths_to_delete',
             'local_paths_to_push_count',
             'local_file_bytes_to_push',
-            'deleted_directory_stack_top_byte_offset',
-            'preceding_fresh_local_index_entry_path',
         ], array_keys($cursor['position']));
+        $this->assertSame([
+            'patch_base_index_file',
+            'patch_result_index_file',
+            'active_deletion_roots_file',
+            'included_index_path_roots',
+            'excluded_index_path_roots',
+            'index_diff_cursor',
+            'active_deletion_root_byte_offset',
+        ], array_keys($cursor['position']['file_sync_planner_cursor']));
         $this->assertSame(1, $cursor['position']['local_paths_to_push_count']);
         $this->assertSame(1, $cursor['position']['local_file_bytes_to_push']);
         $this->assertSame(


### PR DESCRIPTION
PushPlan now reads one `copy`, `delete`, or `replace` operation from `FileSyncPatchPlanner` for each indexed path. Its output files and resume behavior do not change.

The caller chooses the two indexes:

| Sync goal | Patch base | Patch result |
| --- | --- | --- |
| Make the trees identical | Destination now | Source now |
| Copy only source changes | Source at the last sync | Source now |

The planner does not need to know the sync goal. It builds the patch described by the two indexes. Push uses it now. Pull can use the same planner later with a different index pair.

`FileIndexDiffProcessor` lines up entries with the same path and says whether each path was added, deleted, modified, or unchanged. `FileSyncPatchPlanner` turns that into an operation. It also handles sparse directories, subtree replacement, and included and excluded roots. It does not detect renames or compare file contents.

The planner writes active directory-deletion roots to an append-only work file. If it plans deletion of `gone`, that state stops it from also planning deletion of `gone/one.txt` and `gone/two.txt`. The file lets that state survive interruption without loading all deletion roots into memory.

A `copy` or `replace` operation includes the source type, size, and ctime expected by the plan. Push checks these values before it copies the path. If the source changed, the old plan is stale and push restarts with a fresh local index.

## Usage

```php
$planner = FileSyncPatchPlanner::create(
    $patch_base_index_file,
    $patch_result_index_file,
    $active_deletion_roots_file
);

while ($planner->next_path()) {
    $operation = $planner->get_operation();
    if ($operation !== null) {
        append_sync_operation($operation);
    }

    save_cursor($planner->get_cursor());
}

$planner->close();
```

The returned cursor contains the index paths, path selection, work-file path, and byte offsets. Resuming does not rebuild any of it:

```php
$file_sync_planner_cursor = load_cursor();
$planner = FileSyncPatchPlanner::resume($file_sync_planner_cursor);
```

PushPlan stores that cursor as `file_sync_planner_cursor` and passes it back unchanged.

`get_operation()` returns one of these shapes:

```php
[
    'action' => 'delete',
    'path' => 'old/file.txt',
]

[
    'action' => 'copy', // Or 'replace'.
    'path' => 'new/file.txt',
    'expected_source' => [
        'type' => 'file',
        'size' => 1234,
        'ctime' => 1786543210,
    ],
]
```

## Testing

The unit suite covers added, modified, deleted, and replaced paths; sparse subtree deletion; included and excluded roots; resume with an active deletion root; and the nested planner cursor. The PushPlan suite checks that using the planner does not change its output.
