### PR TITLE
[PHP] Use cautious URL-base replacement for block text tokens

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
@@ -32,6 +32,7 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
  * base processor should update those spans without decoding and re-encoding
  * their enclosing format. Once that exists, this subclass should disappear.
  *
+ * @method string get_modifiable_text()
  * @method bool set_modifiable_text(string $plaintext_content)
  * @property array<string, WP_HTML_Text_Replacement> $lexical_updates
  */

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
@@ -1,0 +1,84 @@
+<?php
+
+use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
+
+/**
+ * Uses cautious byte replacement for text tokens in block markup.
+ *
+ * This is a temporary bridge. BlockMarkupUrlProcessor already understands
+ * HTML URL attributes, block attributes, and CSS. Its text-token path uses a
+ * general URL parser, however, and that parser must write the complete URL
+ * back after changing it. A shortcode such as:
+ *
+ * ```
+ * [vc_video link="https:\/\/source.example\/media\/video.mp4"]
+ * ```
+ *
+ * has no declared escaping rules. Decoding and serializing that URL can change
+ * its slashes, quotes, entities, query, or fragment. This subclass replaces
+ * only the configured source base in the raw text-token bytes. The surrounding
+ * bytes never pass through the HTML text encoder.
+ *
+ * Tags, block attributes, and CSS continue through BlockMarkupUrlProcessor.
+ * This class deliberately does not inspect arbitrary HTML attributes. A
+ * SiteOrigin value such as this remains unchanged:
+ *
+ * ```
+ * <input value="{&quot;url&quot;:&quot;https:\/\/source.example\/image.jpg&quot;}">
+ * ```
+ *
+ * The intended design belongs in the PHP toolkit: structured processors
+ * should expose the raw spans of opaque string leaves, and the cautious URL
+ * base processor should update those spans without decoding and re-encoding
+ * their enclosing format. Once that exists, this subclass should disappear.
+ *
+ * @method bool set_modifiable_text(string $plaintext_content)
+ * @property array<string, WP_HTML_Text_Replacement> $lexical_updates
+ */
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+class CautiousTextBlockMarkupUrlProcessor extends BlockMarkupUrlProcessor {
+    /**
+     * Replace configured URL bases in the current raw text token.
+     *
+     * WP_HTML_Tag_Processor exposes decoded text through get_modifiable_text()
+     * and HTML-encodes the complete replacement in set_modifiable_text(). The
+     * protected lexical update contains the raw span selected by the parser.
+     * Replacing its text directly preserves every byte outside the URL base.
+     *
+     * @param array<string, string> $url_mapping Source URL base => target URL.
+     */
+    public function replace_url_bases_in_current_text(array $url_mapping): bool
+    {
+        if ('#text' !== $this->get_token_type()) {
+            return false;
+        }
+
+        // Apply earlier tag, block-attribute, or CSS changes before reading the
+        // current span. Their replacement lengths may have shifted its offset.
+        $html = $this->get_updated_html();
+
+        if (!$this->set_modifiable_text('')) {
+            return false;
+        }
+
+        $text_update = $this->lexical_updates['modifiable text'];
+        $raw_text = substr($html, $text_update->start, $text_update->length);
+        $processor = new CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules(
+            $raw_text,
+            $url_mapping
+        );
+
+        while ($processor->next_url()) {
+            $processor->replace_url_base();
+        }
+
+        $updated_text = $processor->get_updated_text();
+        if ($updated_text === $raw_text) {
+            unset($this->lexical_updates['modifiable text']);
+            return false;
+        }
+
+        $text_update->text = $updated_text;
+        return true;
+    }
+}

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -1,6 +1,5 @@
 <?php
 
-use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
 use WordPress\DataLiberation\URL\URLInTextProcessor;
 use WordPress\DataLiberation\URL\WPURL;
 
@@ -19,8 +18,8 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → BlockMarkupUrlProcessor (block_markup hint) or
- *    URLInTextProcessor (default)
+ * 4. Leaf text → CautiousTextBlockMarkupUrlProcessor (block_markup hint)
+ *    or URLInTextProcessor (default)
  *
  * HTML is never auto-detected — the caller must explicitly pass
  * content_type='block_markup' for values known to contain HTML/block markup.
@@ -37,6 +36,15 @@ class StructuredDataUrlRewriter
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
+
+    /**
+     * Exact configured URL spellings used for byte-level replacement in block
+     * markup text tokens. The parsed mapping below serves the structured URL
+     * processors; it cannot preserve the caller's lexical source base.
+     *
+     * @var array<string, string>
+     */
+    private array $url_mapping;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -84,6 +92,8 @@ class StructuredDataUrlRewriter
      */
     public function __construct(array $url_mapping)
     {
+        $this->url_mapping = $url_mapping;
+
         // Extract unique source domains for the quick-reject check.
         $domains = [];
         foreach (array_keys($url_mapping) as $from_url) {
@@ -331,12 +341,11 @@ class StructuredDataUrlRewriter
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * Block markup owns HTML attributes, block-comment JSON, CSS url() values,
-     * text URLs, entity decoding, URL casing, and IDN canonicalization. This
-     * intentionally routes through the structured parser instead of doing a
-     * literal source-base replacement, because one database value may contain
-     * multiple spellings of the same URL that only the parser can recognize as
-     * equivalent.
+     * Block markup owns HTML attributes, block-comment JSON, and CSS url()
+     * values. Raw text tokens use cautious source-base replacement because they
+     * may contain shortcodes or another syntax with unknown escaping rules.
+     * Arbitrary HTML attributes remain outside that fallback until their raw
+     * string spans can be exposed without re-encoding the containing markup.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -437,48 +446,54 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
-                $p = new BlockMarkupUrlProcessor( $content, $base_url );
-                while ( $p->next_url() ) {
-                    $raw_url = $p->get_raw_url();
+                $p = new CautiousTextBlockMarkupUrlProcessor( $content, $base_url );
+                while ( $p->next_token() ) {
                     $token_type = $p->get_token_type() ?? '';
-                    $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
-                    $cached = $this->get_cached_rewrite_result($cache_key);
-                    if ($cached !== null) {
-                        if ($cached !== false) {
-                            $p->set_url($cached['raw_url'], $cached['parsed_url']);
+                    if ( '#text' === $token_type ) {
+                        if ($this->maybe_contains_rewritable_urls($p->get_modifiable_text())) {
+                            $p->replace_url_bases_in_current_text($this->url_mapping);
                         }
                         continue;
                     }
 
-                    $parsed_url = $p->get_parsed_url();
-                    $converted = false;
-                    foreach ( $parsed_mapping as $mapping ) {
-                        if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $converted = WPURL::replace_base_url(
-                                $parsed_url,
-                                array(
-                                    'old_base_url' => $base_url,
-                                    'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $raw_url,
-                                    'is_relative'  => (
-                                        '#text' !== $token_type &&
-                                        ! WPURL::can_parse($raw_url)
-                                    ),
-                                )
-                            );
-                            break;
+                    while ( $p->next_url_in_current_token() ) {
+                        $raw_url = $p->get_raw_url();
+                        $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+                        $cached = $this->get_cached_rewrite_result($cache_key);
+                        if ($cached !== null) {
+                            if ($cached !== false) {
+                                $p->set_url($cached['raw_url'], $cached['parsed_url']);
+                            }
+                            continue;
                         }
-                    }
 
-                    $cache_value = false;
-                    if ($converted !== false) {
-                        $cache_value = [
-                            'raw_url'    => (string) $converted,
-                            'parsed_url' => $converted->new_url,
-                        ];
-                        $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+                        $parsed_url = $p->get_parsed_url();
+                        $converted = false;
+                        foreach ( $parsed_mapping as $mapping ) {
+                            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                                $converted = WPURL::replace_base_url(
+                                    $parsed_url,
+                                    array(
+                                        'old_base_url' => $base_url,
+                                        'new_base_url' => $mapping['to_url'],
+                                        'raw_url'      => $raw_url,
+                                        'is_relative'  => ! WPURL::can_parse($raw_url),
+                                    )
+                                );
+                                break;
+                            }
+                        }
+
+                        $cache_value = false;
+                        if ($converted !== false) {
+                            $cache_value = [
+                                'raw_url'    => (string) $converted,
+                                'parsed_url' => $converted->new_url,
+                            ];
+                            $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+                        }
+                        $this->set_cached_rewrite_result($cache_key, $cache_value);
                     }
-                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_html();

--- a/packages/reprint-client/src/lib/url-rewrite/load.php
+++ b/packages/reprint-client/src/lib/url-rewrite/load.php
@@ -17,6 +17,9 @@ require_once __DIR__ . '/class-fast-insert-scanner.php';
 require_once __DIR__ . '/class-sqlite-prepared-insert-builder.php';
 require_once __DIR__ . '/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php';
 
+// Extends the toolkit block processor and uses the cautious text processor.
+require_once __DIR__ . '/class-cautious-text-block-markup-url-processor.php';
+
 // Depend on the iterators above
 require_once __DIR__ . '/class-structured-data-url-rewriter.php';
 require_once __DIR__ . '/class-domain-collector.php';

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -351,6 +352,85 @@ class StructuredDataUrlRewriterTest extends TestCase
         $input = '<a href="https://old-site.com/page">Link</a>';
         $result = $rewriter->rewrite($input, 'block_markup');
         $this->assertStringContainsString('https://new-site.com/page', $result);
+    }
+
+    #[DataProvider('block_markup_text_node_cases')]
+    public function testBlockMarkupTextNodesUseCautiousUrlBaseReplacement(
+        string $input,
+        string $expected
+    ): void {
+        $rewriter = $this->createRewriter();
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string}>
+     */
+    public static function block_markup_text_node_cases(): array
+    {
+        return [
+            'core shortcode block body' => [
+                '<!-- wp:shortcode -->[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]<!-- /wp:shortcode -->',
+                '<!-- wp:shortcode -->[vc_video link="https:\/\/new-site.com\/media\/video.mp4"]<!-- /wp:shortcode -->',
+            ],
+            'shortcode text inside a core HTML block' => [
+                '<!-- wp:html --><p>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]</p><!-- /wp:html -->',
+                '<!-- wp:html --><p>[vc_video link="https:\/\/new-site.com\/media\/video.mp4"]</p><!-- /wp:html -->',
+            ],
+            'Elementor-style HTML containing shortcode text' => [
+                '<section data-builder="elementor"><p>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]</p></section>',
+                '<section data-builder="elementor"><p>[vc_video link="https:\/\/new-site.com\/media\/video.mp4"]</p></section>',
+            ],
+            'pure WPBakery shortcode record' => [
+                '[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '[vc_video link="https:\/\/new-site.com\/media\/video.mp4"]',
+            ],
+            'pure Divi 4 shortcode record' => [
+                '[et_pb_section background_image=”https:\/\/old-site.com\/media\/hero.jpg”][/et_pb_section]',
+                '[et_pb_section background_image=”https:\/\/new-site.com\/media\/hero.jpg”][/et_pb_section]',
+            ],
+            'entity-quoted CSS in a WPBakery shortcode attribute' => [
+                '[vc_column css=&#187;.vc_custom{background-image:url(https:\/\/old-site.com\/media\/hero.jpg?id=8086) !important;}&#187;]',
+                '[vc_column css=&#187;.vc_custom{background-image:url(https:\/\/new-site.com\/media\/hero.jpg?id=8086) !important;}&#187;]',
+            ],
+            'ordinary prose in a block-markup column' => [
+                'Download https:\/\/old-site.com\/media\/guide.pdf for the full guide.',
+                'Download https:\/\/new-site.com\/media\/guide.pdf for the full guide.',
+            ],
+        ];
+    }
+
+    public function testBlockMarkupLeavesEncodedSiteOriginInputValueUnchanged(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<input type="hidden" value="{&quot;instance&quot;:{&quot;url&quot;:&quot;https:\/\/old-site.com\/media\/hero.jpg&quot;}}">';
+
+        $this->assertSame($input, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testBlockMarkupTextOffsetFollowsAnEarlierStructuredReplacement(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://very-long-source.example' => 'https://new.example',
+        ]);
+        $input = '<a href="https://very-long-source.example/page">'
+            . '[vc_video link="https:\/\/very-long-source.example\/media\/video.mp4"]'
+            . '</a>';
+        $expected = '<a href="https://new.example/page">'
+            . '[vc_video link="https:\/\/new.example\/media\/video.mp4"]'
+            . '</a>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testBlockMarkupStillUsesTheCssUrlProcessorForStyleAttributes(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<div style="background-image:url(https://old-site.com/media/hero.jpg)"></div>';
+        $expected = '<div style="background-image:url(&quot;https://new-site.com/media/hero.jpg&quot;)"></div>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }
 
     public function testKnownBlockMarkupRewritesEscapedBlockJsonAndHtml(): void


### PR DESCRIPTION
Block-markup text tokens now replace only the mapped URL-base bytes.

Given this mapping:

```
https://old-site.com => https://new-site.com
```

and this shortcode:

```
[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]
```

`URLInTextProcessor` parsed and serialized the complete URL. The result changed bytes which did not belong to the mapping:

```diff
-[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]
+[vc_video link=&quot;https:\/\new-site.com\/media\/video.mp4&quot;]
```

This PR produces:

```diff
-[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]
+[vc_video link="https:\/\/new-site.com\/media\/video.mp4"]
```

The protocol separators, path, quotes, and shortcode syntax remain exactly as stored.

`BlockMarkupUrlProcessor` still owns the syntax it understands:

```
#tag           -> HTML URL attributes and CSS
#block-comment -> block attributes
#text          -> cautious raw URL-base replacement
```

This covers `core/shortcode` bodies, shortcode text inside `core/html`, Elementor HTML, pure WPBakery and Divi 4 records, and ordinary prose stored in block-markup columns.

This is a temporary bridge. The HTML processor exposes decoded text and normally HTML-encodes the complete replacement. The bridge takes the raw lexical span already selected by that parser and changes only the mapped base. The intended PHP toolkit API should expose raw spans for opaque string leaves directly; this subclass can then be removed.

## Limits

The fallback stops at the `#text` boundary. It does not inspect arbitrary HTML attributes or rebuild a shortcode which crosses several HTML tokens.

These remain outside the cautious path:

```html
<!-- HTML attributes -->
<input value="{&quot;url&quot;:&quot;https:\/\/old-site.com\/image.jpg&quot;}">

<!-- Block attributes -->
<!-- wp:builder {"shortcode":"[vc_video link=\"https://old-site.com/video.mp4\"]"} /-->
```

### Target URLs

The target must be an HTTP(S) URL whose only URL component after the scheme is a supported domain name. Punycode is accepted:

```
https://old.example => https://new.example
https://old.example => https://xn--bcher-kva.example
```

These mappings are rejected as a whole:

```
https://old.example => https://new.example/
https://old.example => https://new.example/base
https://old.example => https://new.example:8443
https://old.example => https://127.0.0.1
https://old.example => https://[::1]
https://old.example => https://bücher.example
https://old.example => https://user@new.example
https://old.example => https://new.example?mode=import
https://old.example => https://new.example#content
```

There is no partial domain replacement when a mapping is rejected. Even a trailing `/` is a target path. Writing it would require choosing whether the surrounding format expects `/`, `\/`, `\\/`, or another spelling. This processor refuses to choose.

The target scheme validates the mapping but is not written into the candidate. Only the domain is replaced:

```diff
 mapping: http://old.example => https://new.example

-http://old.example/image.jpg
+http://new.example/image.jpg
```

A source may contain a path prefix because that prefix already has a spelling in the input. The complete source base is removed:

```diff
 mapping: https://old.example/media => https://new.example

-https:\/\/old.example\/media\/image.jpg
+https:\/\/new.example\/image.jpg
```

### Text matching

These spellings are recognized without normalizing them:

```
https://old.example/image.jpg
https:\/\/old.example\/image.jpg
https\:\/\/old.example\/image.jpg
https:\\\/\\\/old.example\\\/image.jpg
old.example/image.jpg
```

These are left alone:

```
https\3a \2f \2f old.example/image.jpg
https%3A%2F%2Fold.example/image.jpg
https&#58;//old.example/image.jpg
site.example/old.example/image.jpg
not-the-right-old.example/image.jpg
https://old.example:8443/image.jpg
```

The first three require CSS, percent, or HTML-entity decoding. The next two are not standalone authorities. The last has a port which the source mapping did not include.

The authority is matched case-insensitively. A configured source path is matched byte-for-byte because path case may select a different resource. A source path may contain bytes from `!` (`0x21`) through `~` (`0x7E`); spaces and multibyte characters in the configured base are rejected. Those bytes are allowed after the matched base and remain untouched.

User information and the URL suffix are outside the replacement:

```diff
 mapping: https://old.example => https://new.example

-https://user:password@old.example/image.jpg?download=1#preview
+https://user:password@new.example/image.jpg?download=1#preview
```

The source base must remain contiguous inside one raw `#text` token. This change does not join a shortcode across HTML tags or look inside an arbitrary HTML attribute or block-attribute string.

## Follow-up

The structured processors should expose raw replacement spans for every string leaf they own:

```
PHP serialization -> string value plus its length field
JSON              -> raw string-content span
block attributes  -> nested raw string-content span
HTML attributes   -> raw attribute-value span
HTML text         -> raw text span
```

Known syntax keeps its existing URL parser. An opaque leaf gets cautious base replacement against its raw span. Only that span is changed; the enclosing shortcode, JSON document, HTML attribute, or serialized value remains under the processor which knows how to write it back.

That removes this subclass and covers SiteOrigin-style encoded attributes and shortcode-valued block attributes without adding a blind second pass over the complete value.

## Testing

The tests spell out exact input and output strings for the supported builder forms, preserve entity-quoted shortcode CSS, verify a text-token offset after an earlier length-changing HTML attribute rewrite, and lock the SiteOrigin attribute limitation.




