### PR TITLE
[PHP] Guard rich URL targets and site-builder text rewrites

### DIFF
--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -401,6 +401,59 @@ class StructuredDataUrlRewriterTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<string, string> $mapping
+     */
+    #[DataProvider('structured_target_base_cases')]
+    public function testKnownStructuredUrlsAcceptTargetsWhichOpaqueTextCannotSafelyWrite(
+        string $input,
+        string $expected,
+        array $mapping
+    ): void {
+        $rewriter = $this->createRewriter($mapping);
+
+        $this->assertSame($expected, $rewriter->rewrite_known_block_markup_value($input));
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string, 2:array<string, string>}>
+     */
+    public static function structured_target_base_cases(): array
+    {
+        return [
+            'trailing slash' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://new.example/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://new.example/'],
+            ],
+            'initial path' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://new.example/base/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://new.example/base'],
+            ],
+            'port' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://new.example:8443/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://new.example:8443'],
+            ],
+            'IPv4 address' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://192.0.2.1/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://192.0.2.1'],
+            ],
+            'IPv6 address' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://[2001:db8::1]/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://[2001:db8::1]'],
+            ],
+            'Unicode domain' => [
+                '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://xn--bcher-kva.example/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                ['https://old-site.com' => 'https://bücher.example'],
+            ],
+        ];
+    }
+
     public function testBlockMarkupLeavesEncodedSiteOriginInputValueUnchanged(): void
     {
         $rewriter = $this->createRewriter();

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -25,6 +25,28 @@ describe('Import: URL Rewriting', () => {
     // Derive source domain from site registry so the port stays in sync
     const SOURCE_DOMAIN = new URL(getSiteUrl(site)).origin;
     const TARGET_DOMAIN = 'https://target.example.com';
+    const ESCAPED_SOURCE_DOMAIN = SOURCE_DOMAIN.replaceAll('/', '\\/');
+    const ESCAPED_TARGET_DOMAIN = 'http:\\/\\/target.example.com';
+    const SITE_BUILDER_CASES = [
+        {
+            name: 'WPBakery escaped video shortcode',
+            slug: 'url-rewrite-wpbakery-video',
+            input: `[vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"]`,
+            expected: `[vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"]`,
+        },
+        {
+            name: 'WPBakery entity-quoted CSS shortcode attribute',
+            slug: 'url-rewrite-wpbakery-css',
+            input: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+            expected: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+        },
+        {
+            name: 'Divi shortcode inside a core HTML block',
+            slug: 'url-rewrite-divi-in-core-html',
+            input: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+            expected: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+        },
+    ];
 
     beforeAll(async () => {
         await ensureSite(site, {
@@ -68,6 +90,13 @@ describe('Import: URL Rewriting', () => {
                     `INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (?, ?, ?)`,
                     [postId, '_no_urls', 'Just a regular string with no URLs']
                 );
+
+                for (const testCase of SITE_BUILDER_CASES) {
+                    await conn.query(
+                        `INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_password, post_name, to_ping, pinged, post_modified, post_modified_gmt, post_content_filtered, post_parent, guid, menu_order, post_type, post_mime_type, comment_count) VALUES (1, NOW(), NOW(), ?, ?, '', 'publish', 'open', 'open', '', ?, '', '', NOW(), NOW(), '', 0, ?, 0, 'post', '', 0)`,
+                        [testCase.input, testCase.name, testCase.slug, `${SOURCE_DOMAIN}/${testCase.slug}`]
+                    );
+                }
             },
         });
         tempDir = createTempDir('e2e-url-rewriting');
@@ -230,6 +259,18 @@ describe('Import: URL Rewriting', () => {
             !row.post_content.includes(SOURCE_DOMAIN),
             `Expected block markup to NOT contain source domain, got: ${row.post_content}`
         );
+    });
+
+    it.each(SITE_BUILDER_CASES)('$name is rewritten without changing its escaping', async (testCase) => {
+        const conn = await createMysqlConnection(importDb);
+        const [[row]] = await conn.query(
+            'SELECT post_content FROM wp_posts WHERE post_name = ?',
+            [testCase.slug]
+        );
+        await conn.end();
+
+        assert.ok(row, `Expected ${testCase.slug} post`);
+        assert.equal(row.post_content, testCase.expected);
     });
 
     it('plain text URLs in post_excerpt are rewritten', async () => {

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -23,7 +23,9 @@ describe('Import: URL Rewriting', () => {
     const site = 'url-rewriting';
     const importDb = 'e2e_url_rewriting_import_36';
     let tempDir;
-    // Derive source domain from site registry so the port stays in sync
+    // db-apply still needs the source domain from the site registry. The test
+    // cases spell out that domain so their input and expected output remain
+    // readable string literals.
     const SOURCE_DOMAIN = new URL(getSiteUrl(site)).origin;
     const TARGET_DOMAIN = 'https://target.example.com';
     // These shapes come from the WPBakery and Divi records in the site-builder
@@ -36,36 +38,36 @@ describe('Import: URL Rewriting', () => {
         {
             name: 'nested WPBakery escaped video shortcode',
             slug: 'url-rewrite-wpbakery-video',
-            input: `[vc_row][vc_column width="1/2"][vc_video link="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
-            expected: `[vc_row][vc_column width="1/2"][vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
+            input: '[vc_row][vc_column width="1/2"][vc_video link="http:\\/\\/127.0.0.1:8108\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]',
+            expected: '[vc_row][vc_column width="1/2"][vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]',
             rendered: '<div data-e2e-shortcode="vc_row"><div data-e2e-shortcode="vc_column"><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/video.mp4"></span></div></div>',
         },
         {
             name: 'WPBakery entity-quoted CSS shortcode attribute',
             slug: 'url-rewrite-wpbakery-css',
-            input: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
-            expected: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+            input: '[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(http:\\/\\/127.0.0.1:8108\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]',
+            expected: '[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]',
             rendered: '<div data-e2e-shortcode="vc_column"></div>',
         },
         {
             name: 'WPBakery shortcode nested across broken-looking paragraph markup',
             slug: 'url-rewrite-wpbakery-mixed-html',
-            input: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
-            expected: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
+            input: '[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="http:\\/\\/127.0.0.1:8108\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]',
+            expected: '[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]',
             rendered: '<div data-e2e-shortcode="vc_column_text"></p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/tour.mp4"></span></p>\r\n<p></div>',
         },
         {
             name: 'Divi shortcode inside a core HTML block',
             slug: 'url-rewrite-divi-in-core-html',
-            input: `<!-- wp:html --><p>[et_pb_section background_image=”${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
-            expected: `<!-- wp:html --><p>[et_pb_section background_image=”http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+            input: '<!-- wp:html --><p>[et_pb_section background_image=”http:\\/\\/127.0.0.1:8108\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->',
+            expected: '<!-- wp:html --><p>[et_pb_section background_image=”http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->',
             rendered: '<p><div data-e2e-shortcode="et_pb_section"></div></p>',
         },
         {
             name: 'Divi image card with entities and pipe-delimited state',
             slug: 'url-rewrite-divi-image-card',
-            input: `[dipl_image_card title="Social Media Strategy" image="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
-            expected: `[dipl_image_card title="Social Media Strategy" image="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
+            input: '[dipl_image_card title="Social Media Strategy" image="http:\\/\\/127.0.0.1:8108\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]',
+            expected: '[dipl_image_card title="Social Media Strategy" image="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]',
             rendered: '<span data-e2e-shortcode="dipl_image_card" data-url="http://target.example.com/wp-content/uploads/investment-plan.jpg"></span>',
         },
     ];
@@ -78,36 +80,36 @@ describe('Import: URL Rewriting', () => {
         {
             name: 'WPBakery table with percent-encoded HTML and URL',
             slug: 'url-rewrite-wpbakery-percent-encoded-table',
-            input: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${encodeURIComponent(SOURCE_DOMAIN + '/wp-content/uploads/manual.pdf')}%22%3ELink%3C%2Fa%3E[/vc_table]`,
-            expected: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${encodeURIComponent('http://target.example.com/wp-content/uploads/manual.pdf')}%22%3ELink%3C%2Fa%3E[/vc_table]`,
+            input: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22http%3A%2F%2F127.0.0.1%3A8108%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
+            expected: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22http%3A%2F%2Ftarget.example.com%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
             rendered: '<div data-e2e-shortcode="vc_table">Download,<a href="http://target.example.com/wp-content/uploads/manual.pdf">Link</a></div>',
         },
         {
             name: 'WPBakery raw HTML with a Base64-encoded link',
             slug: 'url-rewrite-wpbakery-base64-html',
-            input: `[vc_raw_html]${Buffer.from(`<a href="${SOURCE_DOMAIN}/manual.pdf">Manual</a>`).toString('base64')}[/vc_raw_html]`,
-            expected: `[vc_raw_html]${Buffer.from('<a href="http://target.example.com/manual.pdf">Manual</a>').toString('base64')}[/vc_raw_html]`,
+            input: '[vc_raw_html]PGEgaHJlZj0iaHR0cDovLzEyNy4wLjAuMTo4MTA4L21hbnVhbC5wZGYiPk1hbnVhbDwvYT4=[/vc_raw_html]',
+            expected: '[vc_raw_html]PGEgaHJlZj0iaHR0cDovL3RhcmdldC5leGFtcGxlLmNvbS9tYW51YWwucGRmIj5NYW51YWw8L2E+[/vc_raw_html]',
             rendered: '<a href="http://target.example.com/manual.pdf">Manual</a>',
         },
         {
             name: 'SiteOrigin JSON encoded inside an HTML attribute',
             slug: 'url-rewrite-siteorigin-input-value',
-            input: `[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/hero.jpg&quot;}">[/vc_column_text]`,
+            input: '[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;http:\\/\\/127.0.0.1:8108\\/hero.jpg&quot;}">[/vc_column_text]',
             expected: '[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;http:\\/\\/target.example.com\\/hero.jpg&quot;}">[/vc_column_text]',
             rendered: '<div data-e2e-shortcode="vc_column_text"><input type="hidden" value="{&quot;url&quot;:&quot;http:\\/\\/target.example.com\\/hero.jpg&quot;}"></div>',
         },
         {
             name: 'shortcode stored inside block JSON attributes',
             slug: 'url-rewrite-shortcode-block-attribute',
-            input: `<!-- wp:reprint/e2e-shortcode {"shortcode":"[vc_video link=\\"${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/video.mp4\\"]"} /-->`,
+            input: '<!-- wp:reprint/e2e-shortcode {"shortcode":"[vc_video link=\\"http:\\/\\/127.0.0.1:8108\\/video.mp4\\"]"} /-->',
             expected: '<!-- wp:reprint/e2e-shortcode {"shortcode":"[vc_video link=\\"http:\\/\\/target.example.com\\/video.mp4\\"]"} /-->',
             rendered: '<span data-e2e-shortcode="vc_video" data-url="http://target.example.com/video.mp4"></span>',
         },
         {
             name: 'percent-encoded redirect URL in a shortcode attribute',
             slug: 'url-rewrite-percent-encoded-query-url',
-            input: `[vc_video link="https://archive.example/watch?next=${encodeURIComponent(SOURCE_DOMAIN + '/video.mp4')}"]`,
-            expected: `[vc_video link="https://archive.example/watch?next=${encodeURIComponent('http://target.example.com/video.mp4')}"]`,
+            input: '[vc_video link="https://archive.example/watch?next=http%3A%2F%2F127.0.0.1%3A8108%2Fvideo.mp4"]',
+            expected: '[vc_video link="https://archive.example/watch?next=http%3A%2F%2Ftarget.example.com%2Fvideo.mp4"]',
             rendered: `<span data-e2e-shortcode="vc_video" data-url="https://archive.example/watch?next=${encodeURIComponent('http://target.example.com/video.mp4')}"></span>`,
         },
         {
@@ -120,6 +122,8 @@ describe('Import: URL Rewriting', () => {
     ];
 
     beforeAll(async () => {
+        assert.equal(SOURCE_DOMAIN, 'http://127.0.0.1:8108');
+
         await ensureSite(site, {
             afterCreate: async (siteDir) => {
                 const muPluginDir = join(siteDir, 'wp-content', 'mu-plugins');

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -26,9 +26,6 @@ describe('Import: URL Rewriting', () => {
     // Derive source domain from site registry so the port stays in sync
     const SOURCE_DOMAIN = new URL(getSiteUrl(site)).origin;
     const TARGET_DOMAIN = 'https://target.example.com';
-    const ESCAPED_SOURCE_DOMAIN = SOURCE_DOMAIN.replaceAll('/', '\\/');
-    const ESCAPED_TARGET_DOMAIN = 'http:\\/\\/target.example.com';
-    const PERCENT_ENCODED_SOURCE_MANUAL_URL = encodeURIComponent(`${SOURCE_DOMAIN}/wp-content/uploads/manual.pdf`);
     // These shapes come from the WPBakery and Divi records in the site-builder
     // markup report. The URLs use this test site's origin so db-apply can map
     // them, but the surrounding shortcode grammar is kept intact. In
@@ -39,44 +36,86 @@ describe('Import: URL Rewriting', () => {
         {
             name: 'nested WPBakery escaped video shortcode',
             slug: 'url-rewrite-wpbakery-video',
-            input: `[vc_row][vc_column width="1/2"][vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
-            expected: `[vc_row][vc_column width="1/2"][vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
+            input: `[vc_row][vc_column width="1/2"][vc_video link="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
+            expected: `[vc_row][vc_column width="1/2"][vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
             rendered: '<div data-e2e-shortcode="vc_row"><div data-e2e-shortcode="vc_column"><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/video.mp4"></span></div></div>',
         },
         {
             name: 'WPBakery entity-quoted CSS shortcode attribute',
             slug: 'url-rewrite-wpbakery-css',
-            input: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
-            expected: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+            input: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+            expected: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
             rendered: '<div data-e2e-shortcode="vc_column"></div>',
         },
         {
             name: 'WPBakery shortcode nested across broken-looking paragraph markup',
             slug: 'url-rewrite-wpbakery-mixed-html',
-            input: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
-            expected: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
+            input: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
+            expected: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
             rendered: '<div data-e2e-shortcode="vc_column_text"></p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/tour.mp4"></span></p>\r\n<p></div>',
-        },
-        {
-            name: 'WPBakery table with percent-encoded HTML and URL',
-            slug: 'url-rewrite-wpbakery-percent-encoded-table',
-            input: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${PERCENT_ENCODED_SOURCE_MANUAL_URL}%22%3ELink%3C%2Fa%3E[/vc_table]`,
-            expected: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${PERCENT_ENCODED_SOURCE_MANUAL_URL}%22%3ELink%3C%2Fa%3E[/vc_table]`,
-            rendered: `<div data-e2e-shortcode="vc_table">Download,<a href="${SOURCE_DOMAIN}/wp-content/uploads/manual.pdf">Link</a></div>`,
         },
         {
             name: 'Divi shortcode inside a core HTML block',
             slug: 'url-rewrite-divi-in-core-html',
-            input: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
-            expected: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+            input: `<!-- wp:html --><p>[et_pb_section background_image=”${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+            expected: `<!-- wp:html --><p>[et_pb_section background_image=”http:\\/\\/target.example.com\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
             rendered: '<p><div data-e2e-shortcode="et_pb_section"></div></p>',
         },
         {
             name: 'Divi image card with entities and pipe-delimited state',
             slug: 'url-rewrite-divi-image-card',
-            input: `[dipl_image_card title="Social Media Strategy" image="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
-            expected: `[dipl_image_card title="Social Media Strategy" image="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
+            input: `[dipl_image_card title="Social Media Strategy" image="${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
+            expected: `[dipl_image_card title="Social Media Strategy" image="http:\\/\\/target.example.com\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
             rendered: '<span data-e2e-shortcode="dipl_image_card" data-url="http://target.example.com/wp-content/uploads/investment-plan.jpg"></span>',
+        },
+    ];
+
+    // These are useful failures, not descriptions of current behavior. A
+    // migration user would reasonably expect each URL to move, but the URL is
+    // hidden behind a second encoding layer or a structured attribute whose
+    // raw string span is not available to the cautious processor yet.
+    const SITE_BUILDER_EXPECTED_FAILURES = [
+        {
+            name: 'WPBakery table with percent-encoded HTML and URL',
+            slug: 'url-rewrite-wpbakery-percent-encoded-table',
+            input: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${encodeURIComponent(SOURCE_DOMAIN + '/wp-content/uploads/manual.pdf')}%22%3ELink%3C%2Fa%3E[/vc_table]`,
+            expected: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${encodeURIComponent('http://target.example.com/wp-content/uploads/manual.pdf')}%22%3ELink%3C%2Fa%3E[/vc_table]`,
+            rendered: '<div data-e2e-shortcode="vc_table">Download,<a href="http://target.example.com/wp-content/uploads/manual.pdf">Link</a></div>',
+        },
+        {
+            name: 'WPBakery raw HTML with a Base64-encoded link',
+            slug: 'url-rewrite-wpbakery-base64-html',
+            input: `[vc_raw_html]${Buffer.from(`<a href="${SOURCE_DOMAIN}/manual.pdf">Manual</a>`).toString('base64')}[/vc_raw_html]`,
+            expected: `[vc_raw_html]${Buffer.from('<a href="http://target.example.com/manual.pdf">Manual</a>').toString('base64')}[/vc_raw_html]`,
+            rendered: '<a href="http://target.example.com/manual.pdf">Manual</a>',
+        },
+        {
+            name: 'SiteOrigin JSON encoded inside an HTML attribute',
+            slug: 'url-rewrite-siteorigin-input-value',
+            input: `[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/hero.jpg&quot;}">[/vc_column_text]`,
+            expected: '[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;http:\\/\\/target.example.com\\/hero.jpg&quot;}">[/vc_column_text]',
+            rendered: '<div data-e2e-shortcode="vc_column_text"><input type="hidden" value="{&quot;url&quot;:&quot;http:\\/\\/target.example.com\\/hero.jpg&quot;}"></div>',
+        },
+        {
+            name: 'shortcode stored inside block JSON attributes',
+            slug: 'url-rewrite-shortcode-block-attribute',
+            input: `<!-- wp:reprint/e2e-shortcode {"shortcode":"[vc_video link=\\"${SOURCE_DOMAIN.replaceAll('/', '\\/')}\\/video.mp4\\"]"} /-->`,
+            expected: '<!-- wp:reprint/e2e-shortcode {"shortcode":"[vc_video link=\\"http:\\/\\/target.example.com\\/video.mp4\\"]"} /-->',
+            rendered: '<span data-e2e-shortcode="vc_video" data-url="http://target.example.com/video.mp4"></span>',
+        },
+        {
+            name: 'percent-encoded redirect URL in a shortcode attribute',
+            slug: 'url-rewrite-percent-encoded-query-url',
+            input: `[vc_video link="https://archive.example/watch?next=${encodeURIComponent(SOURCE_DOMAIN + '/video.mp4')}"]`,
+            expected: `[vc_video link="https://archive.example/watch?next=${encodeURIComponent('http://target.example.com/video.mp4')}"]`,
+            rendered: `<span data-e2e-shortcode="vc_video" data-url="https://archive.example/watch?next=${encodeURIComponent('http://target.example.com/video.mp4')}"></span>`,
+        },
+        {
+            name: 'JSON Unicode escapes for every source authority byte',
+            slug: 'url-rewrite-json-unicode-escaped-authority',
+            input: '[vc_video link="http:\\u002f\\u002f127\\u002e0\\u002e0\\u002e1\\u003a8108\\u002fvideo.mp4"]',
+            expected: '[vc_video link="http:\\u002f\\u002ftarget\\u002eexample\\u002ecom\\u002fvideo.mp4"]',
+            rendered: '<span data-e2e-shortcode="vc_video" data-url="http://target.example.com/video.mp4"></span>',
         },
     ];
 
@@ -93,13 +132,21 @@ function reprint_e2e_container_shortcode($attributes, $content = null, $tag = ''
 function reprint_e2e_media_shortcode($attributes, $content = null, $tag = '') {
     $url_attribute = 'vc_video' === $tag ? 'link' : 'image';
     $url = isset($attributes[$url_attribute]) ? (string) $attributes[$url_attribute] : '';
-    $url = html_entity_decode(str_replace(chr(92) . '/', '/', $url), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $json_decoded_url = json_decode('"' . str_replace('"', '\\"', $url) . '"');
+    if (is_string($json_decoded_url)) {
+        $url = $json_decoded_url;
+    }
+    $url = html_entity_decode($url, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
     return '<span data-e2e-shortcode="' . esc_attr($tag) . '" data-url="' . esc_url($url) . '"></span>';
 }
 
 function reprint_e2e_table_shortcode($attributes, $content = null) {
     return '<div data-e2e-shortcode="vc_table">' . rawurldecode((string) $content) . '</div>';
+}
+
+function reprint_e2e_raw_html_shortcode($attributes, $content = null) {
+    return (string) base64_decode((string) $content, true);
 }
 
 foreach (['vc_row', 'vc_column', 'vc_column_text', 'et_pb_section'] as $shortcode) {
@@ -109,6 +156,12 @@ foreach (['vc_video', 'dipl_image_card'] as $shortcode) {
     add_shortcode($shortcode, 'reprint_e2e_media_shortcode');
 }
 add_shortcode('vc_table', 'reprint_e2e_table_shortcode');
+add_shortcode('vc_raw_html', 'reprint_e2e_raw_html_shortcode');
+register_block_type('reprint/e2e-shortcode', [
+    'render_callback' => static function ($attributes) {
+        return do_shortcode((string) ($attributes['shortcode'] ?? ''));
+    },
+]);
 `);
             },
             customDb: async (dbName, conn) => {
@@ -152,7 +205,7 @@ add_shortcode('vc_table', 'reprint_e2e_table_shortcode');
                     [postId, '_no_urls', 'Just a regular string with no URLs']
                 );
 
-                for (const testCase of SITE_BUILDER_CASES) {
+                for (const testCase of [...SITE_BUILDER_CASES, ...SITE_BUILDER_EXPECTED_FAILURES]) {
                     await conn.query(
                         `INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_password, post_name, to_ping, pinged, post_modified, post_modified_gmt, post_content_filtered, post_parent, guid, menu_order, post_type, post_mime_type, comment_count) VALUES (1, NOW(), NOW(), ?, ?, '', 'publish', 'open', 'open', '', ?, '', '', NOW(), NOW(), '', 0, ?, 0, 'post', '', 0)`,
                         [testCase.input, testCase.name, testCase.slug, `${SOURCE_DOMAIN}/${testCase.slug}`]
@@ -343,6 +396,29 @@ add_shortcode('vc_table', 'reprint_e2e_table_shortcode');
         assert.equal(row.post_content, testCase.expected);
         assert.equal(renderPostContent(row.post_content), testCase.rendered);
     });
+
+    for (const testCase of SITE_BUILDER_EXPECTED_FAILURES) {
+        it.fails(`${testCase.name} should move with the site and still render`, async () => {
+            const conn = await createMysqlConnection(importDb);
+            const [[row]] = await conn.query(
+                'SELECT post_content FROM wp_posts WHERE post_name = ?',
+                [testCase.slug]
+            );
+            await conn.end();
+
+            assert.ok(row, `Expected ${testCase.slug} post`);
+            assert.deepEqual(
+                {
+                    stored: row.post_content,
+                    rendered: renderPostContent(row.post_content),
+                },
+                {
+                    stored: testCase.expected,
+                    rendered: testCase.rendered,
+                }
+            );
+        });
+    }
 
     it('plain text URLs in post_excerpt are rewritten', async () => {
         const conn = await createMysqlConnection(importDb);

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -9,7 +9,8 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -27,29 +28,89 @@ describe('Import: URL Rewriting', () => {
     const TARGET_DOMAIN = 'https://target.example.com';
     const ESCAPED_SOURCE_DOMAIN = SOURCE_DOMAIN.replaceAll('/', '\\/');
     const ESCAPED_TARGET_DOMAIN = 'http:\\/\\/target.example.com';
+    const PERCENT_ENCODED_SOURCE_MANUAL_URL = encodeURIComponent(`${SOURCE_DOMAIN}/wp-content/uploads/manual.pdf`);
+    // These shapes come from the WPBakery and Divi records in the site-builder
+    // markup report. The URLs use this test site's origin so db-apply can map
+    // them, but the surrounding shortcode grammar is kept intact. In
+    // particular, artifact 575 supplies the broken-looking paragraph body,
+    // artifact 562 the percent-encoded table, and artifact 804 the image card.
+    // https://adamziel.github.io/llm-research/reports/site-builder-markup.html
     const SITE_BUILDER_CASES = [
         {
-            name: 'WPBakery escaped video shortcode',
+            name: 'nested WPBakery escaped video shortcode',
             slug: 'url-rewrite-wpbakery-video',
-            input: `[vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"]`,
-            expected: `[vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"]`,
+            input: `[vc_row][vc_column width="1/2"][vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
+            expected: `[vc_row][vc_column width="1/2"][vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/video.mp4"][/vc_column][/vc_row]`,
+            rendered: '<div data-e2e-shortcode="vc_row"><div data-e2e-shortcode="vc_column"><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/video.mp4"></span></div></div>',
         },
         {
             name: 'WPBakery entity-quoted CSS shortcode attribute',
             slug: 'url-rewrite-wpbakery-css',
             input: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
             expected: `[vc_column width=&#187;1\\/2&#8243; css=&#187;.vc_custom{background-image:url(${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg?id=8086) !important;}&#187;]`,
+            rendered: '<div data-e2e-shortcode="vc_column"></div>',
+        },
+        {
+            name: 'WPBakery shortcode nested across broken-looking paragraph markup',
+            slug: 'url-rewrite-wpbakery-mixed-html',
+            input: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
+            expected: `[vc_column_text]</p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p>[vc_video link="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/tour.mp4"]</p>\r\n<p>[/vc_column_text]`,
+            rendered: '<div data-e2e-shortcode="vc_column_text"></p>\r\n<h4><strong>Monohull</strong></h4>\r\n<p><span data-e2e-shortcode="vc_video" data-url="http://target.example.com/wp-content/uploads/tour.mp4"></span></p>\r\n<p></div>',
+        },
+        {
+            name: 'WPBakery table with percent-encoded HTML and URL',
+            slug: 'url-rewrite-wpbakery-percent-encoded-table',
+            input: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${PERCENT_ENCODED_SOURCE_MANUAL_URL}%22%3ELink%3C%2Fa%3E[/vc_table]`,
+            expected: `[vc_table allow_html="1"]Download,%3Ca%20href%3D%22${PERCENT_ENCODED_SOURCE_MANUAL_URL}%22%3ELink%3C%2Fa%3E[/vc_table]`,
+            rendered: `<div data-e2e-shortcode="vc_table">Download,<a href="${SOURCE_DOMAIN}/wp-content/uploads/manual.pdf">Link</a></div>`,
         },
         {
             name: 'Divi shortcode inside a core HTML block',
             slug: 'url-rewrite-divi-in-core-html',
             input: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
             expected: `<!-- wp:html --><p>[et_pb_section background_image=”${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/hero.jpg”][/et_pb_section]</p><!-- /wp:html -->`,
+            rendered: '<p><div data-e2e-shortcode="et_pb_section"></div></p>',
+        },
+        {
+            name: 'Divi image card with entities and pipe-delimited state',
+            slug: 'url-rewrite-divi-image-card',
+            input: `[dipl_image_card title="Social Media Strategy" image="${ESCAPED_SOURCE_DOMAIN}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
+            expected: `[dipl_image_card title="Social Media Strategy" image="${ESCAPED_TARGET_DOMAIN}\\/wp-content\\/uploads\\/investment-plan.jpg" icon="&#xe0e3;||divi||400" content_bg_color_gradient_stops="#141252 0%|#303b90 100%"][/dipl_image_card]`,
+            rendered: '<span data-e2e-shortcode="dipl_image_card" data-url="http://target.example.com/wp-content/uploads/investment-plan.jpg"></span>',
         },
     ];
 
     beforeAll(async () => {
         await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                const muPluginDir = join(siteDir, 'wp-content', 'mu-plugins');
+                mkdirSync(muPluginDir, { recursive: true });
+                writeFileSync(join(muPluginDir, 'e2e-site-builder-shortcodes.php'), `<?php
+function reprint_e2e_container_shortcode($attributes, $content = null, $tag = '') {
+    return '<div data-e2e-shortcode="' . esc_attr($tag) . '">' . do_shortcode((string) $content) . '</div>';
+}
+
+function reprint_e2e_media_shortcode($attributes, $content = null, $tag = '') {
+    $url_attribute = 'vc_video' === $tag ? 'link' : 'image';
+    $url = isset($attributes[$url_attribute]) ? (string) $attributes[$url_attribute] : '';
+    $url = html_entity_decode(str_replace(chr(92) . '/', '/', $url), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    return '<span data-e2e-shortcode="' . esc_attr($tag) . '" data-url="' . esc_url($url) . '"></span>';
+}
+
+function reprint_e2e_table_shortcode($attributes, $content = null) {
+    return '<div data-e2e-shortcode="vc_table">' . rawurldecode((string) $content) . '</div>';
+}
+
+foreach (['vc_row', 'vc_column', 'vc_column_text', 'et_pb_section'] as $shortcode) {
+    add_shortcode($shortcode, 'reprint_e2e_container_shortcode');
+}
+foreach (['vc_video', 'dipl_image_card'] as $shortcode) {
+    add_shortcode($shortcode, 'reprint_e2e_media_shortcode');
+}
+add_shortcode('vc_table', 'reprint_e2e_table_shortcode');
+`);
+            },
             customDb: async (dbName, conn) => {
                 // WordPress tables already exist from wp core install.
                 // Just INSERT additional test data into existing tables.
@@ -114,6 +175,15 @@ describe('Import: URL Rewriting', () => {
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function renderPostContent(postContent) {
+        const php = "require $argv[1] . '/wp-load.php'; echo do_shortcode(do_blocks(base64_decode($argv[2], true)));";
+        return execFileSync(
+            process.env.PHP_BINARY || 'php',
+            ['-r', php, getSiteDir(site), Buffer.from(postContent).toString('base64')],
+            { encoding: 'utf8' }
+        ).trim();
     }
 
     it('db-pull completes and produces db.sql', () => {
@@ -261,7 +331,7 @@ describe('Import: URL Rewriting', () => {
         );
     });
 
-    it.each(SITE_BUILDER_CASES)('$name is rewritten without changing its escaping', async (testCase) => {
+    it.each(SITE_BUILDER_CASES)('$name survives URL rewriting and still renders', async (testCase) => {
         const conn = await createMysqlConnection(importDb);
         const [[row]] = await conn.query(
             'SELECT post_content FROM wp_posts WHERE post_name = ?',
@@ -271,6 +341,7 @@ describe('Import: URL Rewriting', () => {
 
         assert.ok(row, `Expected ${testCase.slug} post`);
         assert.equal(row.post_content, testCase.expected);
+        assert.equal(renderPostContent(row.post_content), testCase.rendered);
     });
 
     it('plain text URLs in post_excerpt are rewritten', async () => {


### PR DESCRIPTION
URL rewriting now has regression coverage for rich target bases and site-builder `post_content` executed by WordPress after import.

Known HTML structure can write target paths, ports, IPv4 addresses, IPv6 addresses, and Unicode domains. Opaque text cannot choose how those bytes should be escaped. The unit matrix puts both forms in the same value and spells out the complete result:

```html
<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]
```

With a target path, the HTML attribute becomes:

```html
<a href="https://new.example/base/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]
```

The parsed attribute receives the path. The escaped shortcode remains byte-for-byte unchanged. Separate cases cover a trailing slash, port, IPv4 address, IPv6 address, and a Unicode domain serialized as Punycode.

The `db-apply` E2E scenario stores nested WPBakery containers, entity-quoted shortcode CSS, a shortcode spanning broken-looking paragraph markup, a Divi shortcode inside `core/html`, and a Divi image card with entities and pipe-delimited state. The latter two complex shortcode shapes follow artifacts 575 and 804 in the site-builder markup report.

A test-only must-use plugin registers deterministic handlers for those shortcode names. After checking the complete imported `post_content`, the test runs it through WordPress `do_blocks()` and `do_shortcode()` and compares the rendered result. A hostname-only assertion would miss both byte corruption and a shortcode which no longer executes.

Six expected-failure cases state behavior users will reasonably ask for but the cautious text processor cannot provide yet:

```text
percent-encoded HTML and URL in vc_table
Base64 HTML in vc_raw_html
SiteOrigin JSON inside an HTML attribute
shortcode text inside block JSON attributes
percent-encoded nested redirect URL
JSON Unicode escapes for the source authority
```

Each case states the complete destination bytes and rendered output. Vitest's `fails` marker keeps these misses visible without making the branch permanently red. When one starts working completely, its unexpected pass fails CI until the case moves into the ordinary regression table.

## Testing

Run the URL-rewriting PHPUnit suite. CI provisions WordPress and MySQL, runs the real `db-pull` and `db-apply` commands, then checks the imported strings and rendered shortcode output.
