### PR TITLE
[PHP] Render cautious target paths with protocol slash spelling

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -104,6 +104,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_base: string,
      *     target_domain: string,
      *     target_scheme: string,
+     *     target_path: string,
      *     pattern: string
      * }>
      */
@@ -120,9 +121,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_base: string,
      *     target_domain: string,
      *     target_scheme: string,
+     *     target_path: string,
      *     pattern: string,
      *     start: int,
      *     base_length: int,
+     *     replacement: string,
      *     scheme_start: int|null,
      *     scheme_length: int,
      *     candidate_scheme: string
@@ -206,7 +209,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
         $this->lexical_updates[$this->matched_url['start']] = [
             'start'       => $this->matched_url['start'],
             'length'      => $this->matched_url['base_length'],
-            'replacement' => $this->matched_url['target_domain'],
+            'replacement' => $this->matched_url['replacement'],
         ];
 
         if (
@@ -259,9 +262,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_base: string,
      *     target_domain: string,
      *     target_scheme: string,
+     *     target_path: string,
      *     pattern: string,
      *     start: int,
      *     base_length: int,
+     *     replacement: string,
      *     scheme_start: int|null,
      *     scheme_length: int,
      *     candidate_scheme: string
@@ -292,6 +297,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                 [
                     'start'         => $authority_start,
                     'base_length'   => strlen($matches['base'][0]),
+                    'replacement'   => $mapping['target_domain'] . str_replace(
+                        '/',
+                        $matches['protocol_path_separator'][0],
+                        $mapping['target_path']
+                    ),
                     'scheme_start'  => $matches['scheme'][1] === -1
                         ? null
                         : $matches['scheme'][1],
@@ -315,7 +325,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     private function create_url_candidate_pattern(
         string $source_scheme,
         string $source_authority,
-        string $source_path
+        string $source_path,
+        bool $requires_protocol
     ): string
     {
         $escaped_separator = '(?:\\\\{1}|\\\\{3})?';
@@ -325,15 +336,20 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             preg_quote($source_path, '~')
         );
 
+        $protocol_pattern = '
+            (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
+            ' . $escaped_separator . ':
+            (?<protocol_path_separator>' . $escaped_separator . '/)
+            ' . $escaped_separator . '/
+            (?:[^\s<>@/\\\\]+@)?
+        ';
+        if (!$requires_protocol) {
+            $protocol_pattern = '(?:' . $protocol_pattern . ')?';
+        }
+
         return '~
             (?<![A-Za-z0-9._%+\\/@-])
-            (?:
-                (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
-                ' . $escaped_separator . ':
-                ' . $escaped_separator . '/
-                ' . $escaped_separator . '/
-                (?:[^\s<>@/\\\\]+@)?
-            )?
+            ' . $protocol_pattern . '
             (?<base>
                 (?<authority>(?i:' . preg_quote($source_authority, '~') . '))
                 ' . $source_path_pattern . '
@@ -353,6 +369,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_base: string,
      *     target_domain: string,
      *     target_scheme: string,
+     *     target_path: string,
      *     pattern: string
      * }|null
      */
@@ -374,10 +391,12 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             'source_base'      => $source['authority'] . $source_path,
             'target_domain'    => $target['host'],
             'target_scheme'    => $target['scheme'],
+            'target_path'      => $target['path'],
             'pattern'          => $this->create_url_candidate_pattern(
                 $source['scheme'],
                 $source['authority'],
-                $source_path
+                $source_path,
+                $target['path'] !== ''
             ),
         ];
     }
@@ -401,8 +420,12 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
         $scheme = strtolower( (string) $parts['scheme'] );
         $host = (string) $parts['host'];
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
+        $has_unsupported_target_path =
+            !$is_source_url
+            && $path !== ''
+            && preg_match('#^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$#', $path) !== 1;
         if (( $scheme !== 'http' && $scheme !== 'https' )
-            || ( !$is_source_url && ( array_key_exists('port', $parts) || $path !== '' ) )
+            || ( !$is_source_url && ( array_key_exists('port', $parts) || $has_unsupported_target_path ) )
             || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
             || !$this->contains_only_exclamation_mark_through_tilde_bytes($path)) {
             return null;

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -58,8 +58,10 @@
  * Unsupported mappings are discarded as a whole. There is no partial
  * replacement:
  *
- * - A target path is not supported. Writing it would require choosing whether
- *   each slash should be /, \/, or something else.
+ * - A target path may contain non-empty slash-separated components composed
+ *   only of ASCII letters, digits, hyphens, and underscores. Each slash copies
+ *   the spelling of the first slash in the matched protocol. A scheme-less
+ *   authority stays unchanged when the target has a path.
  * - Target ports, user information, queries, fragments, IPv4/IPv6 addresses,
  *   and Unicode domains are not supported. Punycode domains are supported.
  * - Unicode source domains and paths are not supported.
@@ -318,9 +320,9 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      * Build a candidate pattern adapted from URLInTextProcessor's URL finder.
      *
      * The pattern recognizes only this mapping's scheme, authority, and initial
-     * path. Capturing those slices, rather than a complete parsed URL, lets
-     * callers replace the scheme and authority without rendering separators or
-     * surrounding syntax.
+     * path. It captures the scheme and the first slash in the protocol. Those
+     * bytes supply the target protocol and target-path slash spelling without
+     * parsing or rewriting the surrounding text.
      */
     private function create_url_candidate_pattern(
         string $source_scheme,

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -31,9 +31,9 @@
  * of those formats and could corrupt the value.
  *
  * Instead, the processor performs one narrow operation: find the configured
- * source base as bytes and replace that entire slice with a target domain. It
- * replaces the literal protocol separately when the mapping changes it. It does
- * not decode, normalize, or re-encode the input.
+ * source base as bytes and replace that entire slice with a target domain and
+ * optional path. It replaces the literal protocol separately when the mapping
+ * changes it. It does not decode, normalize, or re-encode the input.
  *
  * Supported sources:
  *
@@ -143,11 +143,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *
      * A source may include an initial path containing only bytes from `!`
      * (0x21) through `~` (0x7E). A target must be an HTTP(S) URL with a
-     * supported domain and no path or other URL components:
+     * supported domain and an optional restricted path:
      *
      * ```
      * [
-     *     'https://source.example/media' => 'https://destination.example',
+     *     'https://source.example/media' => 'https://destination.example/assets',
      * ]
      * ```
      *
@@ -301,7 +301,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                     'base_length'   => strlen($matches['base'][0]),
                     'replacement'   => $mapping['target_domain'] . str_replace(
                         '/',
-                        $matches['protocol_path_separator'][0],
+                        $matches['protocol_slash'][0],
                         $mapping['target_path']
                     ),
                     'scheme_start'  => $matches['scheme'][1] === -1
@@ -337,21 +337,17 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             $escaped_separator . '/',
             preg_quote($source_path, '~')
         );
-
-        $protocol_pattern = '
-            (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
-            ' . $escaped_separator . ':
-            (?<protocol_path_separator>' . $escaped_separator . '/)
-            ' . $escaped_separator . '/
-            (?:[^\s<>@/\\\\]+@)?
-        ';
-        if (!$requires_protocol) {
-            $protocol_pattern = '(?:' . $protocol_pattern . ')?';
-        }
+        $protocol_optional_quantifier = $requires_protocol ? '' : '?';
 
         return '~
             (?<![A-Za-z0-9._%+\\/@-])
-            ' . $protocol_pattern . '
+            (?:
+                (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
+                ' . $escaped_separator . ':
+                (?<protocol_slash>' . $escaped_separator . '/)
+                ' . $escaped_separator . '/
+                (?:[^\s<>@/\\\\]+@)?
+            )' . $protocol_optional_quantifier . '
             (?<base>
                 (?<authority>(?i:' . preg_quote($source_authority, '~') . '))
                 ' . $source_path_pattern . '

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -194,11 +194,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * Queues replacement of the complete current source base.
      *
-     * Mapping source.example/media to destination.example changes
+     * Mapping source.example/media to destination.example/assets changes
      * https://source.example/media/logo.png to
-     * https://destination.example/logo.png. The logo.png suffix is outside the
-     * matched base and remains unchanged. A configured protocol change replaces
-     * only the literal scheme, preserving the separator's existing escaping.
+     * https://destination.example/assets/logo.png. The original /logo.png
+     * suffix is outside the matched base and remains unchanged. A configured
+     * protocol change replaces only the literal scheme.
      */
     public function replace_url_base(): bool
     {

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -216,6 +216,41 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://site.com/source.com/media?next=https://destination.com/media/logo.png',
                 ['https://source.com' => 'https://destination.com'],
             ],
+            'literal target path replaces a configured source path' => [
+                'https://source.example/media/logo.png',
+                'https://destination.example/assets/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path accepts hyphen underscore and nested components' => [
+                'https://source.example/media/logo.png',
+                'https://destination.example/assets-2026/_private/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
+            ],
+            'escaped target path uses the source path slash spelling' => [
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/assets\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path uses the slash immediately after an unmapped authority' => [
+                'source.example\\/logo.png',
+                'destination.example\\/assets\\/logo.png',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'target path uses the protocol separator when the URL has no suffix' => [
+                'https:\\\\\/\\\\\\/source.example',
+                'https:\\\\\/\\\\\\/destination.example\\\\\\/assets',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'target path uses the literal separator from the configured source path' => [
+                'https:\\/\\/source.example/media/logo.png',
+                'https:\\/\\/destination.example/assets/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path comes before a query after an unmapped authority' => [
+                'https:\\/\\/source.example?download=1',
+                'https:\\/\\/destination.example\\/assets?download=1',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
         ];
     }
 
@@ -230,10 +265,30 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://SOURCE.EXAMPLE/Media/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
             ],
-            'target has a path' => [
+            'target path has a dot segment' => [
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
-                ['https://source.example/media' => 'https://destination.example/assets'],
+                ['https://source.example/media' => 'https://destination.example/assets/../private'],
+            ],
+            'target path has an empty segment' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets//private'],
+            ],
+            'target path has a percent escape' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets%2Fprivate'],
+            ],
+            'target path ends with a slash' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets/'],
+            ],
+            'scheme-less authority without a separator stays unchanged' => [
+                'source.example',
+                'source.example',
+                ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target has a percent-encoded path' => [
                 'https://source.example/media/logo.png',

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -246,6 +246,16 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https:\\/\\/destination.example\\/assets?download=1',
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
+            'target path skips a preceding scheme-less occurrence' => [
+                'source.example https:\\/\\/source.example',
+                'source.example https:\\/\\/destination.example\\/assets',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'target path and protocol change use the same match' => [
+                'http:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/assets\\/logo.png',
+                ['http://source.example/media' => 'https://destination.example/assets'],
+            ],
         ];
     }
 

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -226,24 +226,19 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://destination.example/assets-2026/_private/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
             ],
-            'escaped target path uses the source path slash spelling' => [
+            'escaped target path copies the protocol slash spelling' => [
                 'https:\\/\\/source.example\\/media\\/logo.png',
                 'https:\\/\\/destination.example\\/assets\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets'],
-            ],
-            'target path uses the slash immediately after an unmapped authority' => [
-                'source.example\\/logo.png',
-                'destination.example\\/assets\\/logo.png',
-                ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target path uses the protocol separator when the URL has no suffix' => [
                 'https:\\\\\/\\\\\\/source.example',
                 'https:\\\\\/\\\\\\/destination.example\\\\\\/assets',
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
-            'target path uses the literal separator from the configured source path' => [
+            'target path copies the protocol slash when the source path slash differs' => [
                 'https:\\/\\/source.example/media/logo.png',
-                'https:\\/\\/destination.example/assets/logo.png',
+                'https:\\/\\/destination.example\\/assets/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets'],
             ],
             'target path comes before a query after an unmapped authority' => [
@@ -288,6 +283,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
             'scheme-less authority without a separator stays unchanged' => [
                 'source.example',
                 'source.example',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'scheme-less authority with a path stays unchanged' => [
+                'source.example\\/logo.png',
+                'source.example\\/logo.png',
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target has a percent-encoded path' => [

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -522,7 +522,7 @@ class StructuredDataUrlRewriterTest extends TestCase
      * @param array<string, string> $mapping
      */
     #[DataProvider('structured_target_base_cases')]
-    public function testKnownStructuredUrlsAcceptTargetsWhichOpaqueTextCannotSafelyWrite(
+    public function testKnownStructuredUrlsUseTargetBase(
         string $input,
         string $expected,
         array $mapping
@@ -545,7 +545,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ],
             'initial path' => [
                 '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
-                '<a href="https://new.example/base/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://new.example/base/media/image.jpg">Image</a>[vc_video link="https:\/\/new.example\/base\/media\/video.mp4"]',
                 ['https://old-site.com' => 'https://new.example/base'],
             ],
             'port' => [


### PR DESCRIPTION
Cautious opaque-text URL rewriting can now apply a restricted path from the destination URL while preserving the slash spelling already used by the text.

For this mapping:

```php
[
    'https://source.example/media' => 'https://destination.example/assets',
]
```

these inputs become:

```text
https://source.example/media/logo.png
https://destination.example/assets/logo.png

https:\/\/source.example\/media\/logo.png
https:\/\/destination.example\/assets\/logo.png
```

The candidate pattern captures the first slash in the matched `protocol://`. Each slash in `/assets` copies those exact bytes. The same capture works for literal, one-backslash, and three-backslash spellings. Protocol changes and target paths can be applied to the same match.

A target path requires an absolute URL match because a scheme-less authority has no protocol slash to copy. Scheme-less rewriting remains available for mappings without a target path. Target path components accept ASCII letters, digits, hyphens, and underscores; nested components are allowed. Other target URL parts keep their existing validation.

## Testing

```
cd tests
../vendor/bin/phpunit UrlRewriting
```

PHPStan and PHPCS also pass. `StructuredDataUrlRewriterTest.php` retains its one existing class-brace PHPCS error.
