### PR TITLE
Add `--on-flatten-to-conflict=error|replace|adopt` flag to supersede `--force`

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -173,6 +173,13 @@ class ImportClient
      */
     public const FLATTEN_TO_CONFLICT_MODES = ['error', 'replace', 'adopt'];
 
+    /**
+     * Suffix for the path a cross-filesystem adopt copies into before renaming
+     * it to its real name. Derived from the destination rather than random, so
+     * a later run clears what an interrupted one left behind.
+     */
+    private const FLATTEN_ADOPT_STAGING_SUFFIX = '.reprint-adopt-incomplete';
+
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
@@ -5299,7 +5306,28 @@ class ImportClient
                 );
             }
         } elseif (!@rename($target_entry, $source_entry)) {
-            $this->flatten_copy_local_path($target_entry, $source_entry);
+            // Copy beside the destination and rename it into place, never into
+            // the destination itself. A copy that dies partway — a full disk, an
+            // unreadable file, a signal during a large one — would otherwise
+            // leave a partial entry that the next run reads as the pulled copy,
+            // skips, and then deletes the intact original along with the
+            // flattened wp-content. The staging path is derived, not random, so
+            // a later run clears whatever the last one abandoned. Both paths sit
+            // in the filesystem root, so the rename is atomic.
+            $staging_path = $source_entry . self::FLATTEN_ADOPT_STAGING_SUFFIX;
+            $this->remove_local_absolute_path_without_following_symlinks($staging_path);
+            try {
+                $this->flatten_copy_local_path($target_entry, $staging_path);
+                if (!@rename($staging_path, $source_entry)) {
+                    throw new RuntimeException(
+                        "Copied {$target_entry} to {$staging_path} but could not move it " .
+                            "to {$source_entry}.",
+                    );
+                }
+            } catch (Throwable $copy_failure) {
+                $this->remove_local_absolute_path_without_following_symlinks($staging_path);
+                throw $copy_failure;
+            }
             if (
                 !$this->remove_local_absolute_path_without_following_symlinks(
                     $target_entry
@@ -12595,7 +12623,8 @@ if (
                 "directories on the source server (e.g. WP Cloud with ABSPATH at\n" .
                 "/srv/htdocs and WP_CONTENT_DIR at /tmp/__wp__/wp-content).\n" .
                 "\n" .
-                "No files are copied — only symlinks are created. Idempotent.\n" .
+                "Only symlinks are created; the pulled files stay where they are.\n" .
+                "Idempotent.\n" .
                 "\n" .
                 "--on-flatten-to-conflict decides what happens when a real file or\n" .
                 "directory already sits where a symlink must go:\n" .
@@ -12611,7 +12640,12 @@ if (
                 "files-push, which read only --fs-root, can still see them. The\n" .
                 "pulled copy wins wherever both sides hold the same path, and only\n" .
                 "wp-content is adopted — the rest of the layout is core, which the\n" .
-                "pull owns entirely.\n",
+                "pull owns entirely.\n" .
+                "\n" .
+                "adopt is the one mode that writes outside --flatten-to. It renames\n" .
+                "each entry into --fs-root, and copies then removes it instead when\n" .
+                "the two directories are on different filesystems, where a rename\n" .
+                "cannot work. Either way the entry ends up in --fs-root only.\n",
             "extra" => null,
         ],
         "apply-runtime" => [

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -166,6 +166,13 @@ class ImportClient
     /** Progress output modes accepted by every command. */
     public const PROGRESS_OUTPUT_MODES = ['auto', 'tty', 'jsonl'];
 
+    /**
+     * What flat-docroot does when a real file or directory sits where a
+     * symlink must go: stop, replace it, or move whatever only --flatten-to
+     * holds into --fs-root and then replace it.
+     */
+    public const FLATTEN_TO_CONFLICT_MODES = ['error', 'replace', 'adopt'];
+
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
@@ -4469,8 +4476,9 @@ class ImportClient
      * wp-content/, wp-load.php structure.
      *
      * The command is idempotent: re-running refreshes all symlinks.
-     * If a path that should be a symlink is a regular file/directory,
-     * the command stops with an error unless --force is specified.
+     * When a path that should be a symlink is a regular file or directory,
+     * --on-flatten-to-conflict decides what happens: stop, replace it, or
+     * replace it after moving whatever only --flatten-to has into --fs-root.
      */
     public function run_flat_document_root(array $options): void
     {
@@ -4482,7 +4490,36 @@ class ImportClient
         }
 
         $flatten_to = trim_right_slash($flatten_to);
+
+        // --force predates the three-way option and says the same thing as
+        // 'replace', so it stays as its alias.
+        $conflict_mode = $options["on_flatten_to_conflict"] ?? null;
         $force = $options["force"] ?? false;
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions quote CLI option values, never HTML output.
+        if (
+            $conflict_mode !== null &&
+            !in_array($conflict_mode, self::FLATTEN_TO_CONFLICT_MODES, true)
+        ) {
+            throw new InvalidArgumentException(
+                "Invalid --on-flatten-to-conflict value: {$conflict_mode}. Valid values: " .
+                    implode(", ", self::FLATTEN_TO_CONFLICT_MODES),
+            );
+        }
+        if ($force && $conflict_mode !== null && $conflict_mode !== "replace") {
+            throw new InvalidArgumentException(
+                "--force means --on-flatten-to-conflict=replace, which contradicts " .
+                    "--on-flatten-to-conflict={$conflict_mode}. Pass one of them.",
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        if ($conflict_mode === null) {
+            $conflict_mode = $force ? "replace" : "error";
+        }
+
+        // 'adopt' salvages wp-content and replaces everything else, because
+        // the rest of the layout is core, which the pull owns entirely.
+        $replace_conflicts = $conflict_mode !== "error";
+        $adopt_flatten_to_content = $conflict_mode === "adopt";
 
         // Ensure the filesystem root exists
         if (!is_dir($this->filesystem_root)) {
@@ -4590,7 +4627,8 @@ class ImportClient
             sprintf(
                 "FLAT-DOCUMENT-ROOT | abspath=%s wp_admin=%s wp_includes=%s " .
                     "content_dir=%s content_detached=%s " .
-                    "plugins_detached=%s mu_plugins_detached=%s uploads_detached=%s",
+                    "plugins_detached=%s mu_plugins_detached=%s uploads_detached=%s " .
+                    "on_flatten_to_conflict=%s",
                 $abspath,
                 $wp_admin_path ?? "(from abspath)",
                 $wp_includes_path ?? "(from abspath)",
@@ -4599,12 +4637,31 @@ class ImportClient
                 $plugins_detached ? "yes" : "no",
                 $mu_plugins_detached ? "yes" : "no",
                 $uploads_detached ? "yes" : "no",
+                $conflict_mode,
             ),
         );
 
         $created = 0;
         $refreshed = 0;
         $forced = 0;
+        $adopted = 0;
+
+        // Which wp-content entries hold independent things, so that adoption
+        // may walk into them. The conventional names cover every site; the
+        // preflight ones cover a site that renamed a component directory.
+        // A name neither tree has simply never matches.
+        $unit_container_names = ["plugins", "mu-plugins", "themes"];
+        $file_container_names = ["uploads"];
+        foreach ([$plugins_dir, $mu_plugins_dir] as $unit_component_dir) {
+            if ($unit_component_dir !== null) {
+                $unit_container_names[] = basename($unit_component_dir);
+            }
+        }
+        if ($uploads_basedir !== null) {
+            $file_container_names[] = basename($uploads_basedir);
+        }
+        $unit_container_names = array_values(array_unique($unit_container_names));
+        $file_container_names = array_values(array_unique($file_container_names));
 
         // Determine what to skip from ABSPATH enumeration.
         // Components with known detached locations are handled separately.
@@ -4643,10 +4700,21 @@ class ImportClient
 
             $source = wp_join_unix_paths($local_abspath, $entry);
             $target = wp_join_unix_paths($flatten_to, $entry);
+            // wp-content is the only ABSPATH entry the target can own files
+            // in; the rest is core, which the pull owns entirely.
+            if ($adopt_flatten_to_content && $entry === "wp-content") {
+                $this->flatten_adopt_content_directory(
+                    $source,
+                    $target,
+                    $adopted,
+                    $unit_container_names,
+                    $file_container_names,
+                );
+            }
             $this->flatten_place_symlink(
                 $source,
                 $target,
-                $force,
+                $replace_conflicts,
                 $created,
                 $refreshed,
                 $forced,
@@ -4659,7 +4727,7 @@ class ImportClient
             $this->flatten_place_symlink(
                 $local_wp_admin,
                 wp_join_unix_paths($flatten_to, "wp-admin"),
-                $force,
+                $replace_conflicts,
                 $created,
                 $refreshed,
                 $forced,
@@ -4669,7 +4737,7 @@ class ImportClient
             $this->flatten_place_symlink(
                 $local_wp_includes,
                 wp_join_unix_paths($flatten_to, "wp-includes"),
-                $force,
+                $replace_conflicts,
                 $created,
                 $refreshed,
                 $forced,
@@ -4693,7 +4761,7 @@ class ImportClient
                 $this->flatten_place_symlink(
                     $local_parent_wp_config,
                     $wp_config_in_flatten,
-                    $force,
+                    $replace_conflicts,
                     $created,
                     $refreshed,
                     $forced,
@@ -4713,24 +4781,41 @@ class ImportClient
             $wp_content_target = wp_join_unix_paths($flatten_to, "wp-content");
             $this->flatten_ensure_real_directory(
                 $wp_content_target,
-                $force,
+                $replace_conflicts,
                 $forced,
             );
+
+            // Determine which sub-entries to skip (will be overridden)
+            $skip_from_content = [];
+            if ($plugins_detached) {
+                $skip_from_content["plugins"] = true;
+            }
+            if ($mu_plugins_detached) {
+                $skip_from_content["mu-plugins"] = true;
+            }
+            if ($uploads_detached) {
+                $skip_from_content["uploads"] = true;
+            }
+
+            // wp-content itself stays a real directory here, so its target-only
+            // entries are never deleted — but they would stay outside the
+            // filesystem root, where files-push cannot reach them. The detached
+            // sub-components are skipped because they are adopted below,
+            // against the source each one actually comes from.
+            if ($adopt_flatten_to_content) {
+                $this->flatten_adopt_content_directory(
+                    $local_content_dir,
+                    $wp_content_target,
+                    $adopted,
+                    $unit_container_names,
+                    $file_container_names,
+                    array_keys($skip_from_content),
+                );
+            }
 
             // Symlink all entries from content_dir into the real wp-content dir
             if (is_dir($local_content_dir)) {
                 $content_entries = @scandir($local_content_dir) ?: [];
-                // Determine which sub-entries to skip (will be overridden)
-                $skip_from_content = [];
-                if ($plugins_detached) {
-                    $skip_from_content["plugins"] = true;
-                }
-                if ($mu_plugins_detached) {
-                    $skip_from_content["mu-plugins"] = true;
-                }
-                if ($uploads_detached) {
-                    $skip_from_content["uploads"] = true;
-                }
 
                 foreach ($content_entries as $entry) {
                     if ($entry === "." || $entry === "..") {
@@ -4744,7 +4829,7 @@ class ImportClient
                     $this->flatten_place_symlink(
                         $source,
                         $target,
-                        $force,
+                        $replace_conflicts,
                         $created,
                         $refreshed,
                         $forced,
@@ -4755,10 +4840,13 @@ class ImportClient
             // Symlink detached sub-components into wp-content
             if ($plugins_detached && is_dir($local_plugins_dir)) {
                 $target = wp_join_unix_paths($wp_content_target, "plugins");
+                if ($adopt_flatten_to_content) {
+                    $this->flatten_adopt_unit_container($local_plugins_dir, $target, $adopted);
+                }
                 $this->flatten_place_symlink(
                     $local_plugins_dir,
                     $target,
-                    $force,
+                    $replace_conflicts,
                     $created,
                     $refreshed,
                     $forced,
@@ -4766,10 +4854,13 @@ class ImportClient
             }
             if ($mu_plugins_detached && is_dir($local_mu_plugins_dir)) {
                 $target = wp_join_unix_paths($wp_content_target, "mu-plugins");
+                if ($adopt_flatten_to_content) {
+                    $this->flatten_adopt_unit_container($local_mu_plugins_dir, $target, $adopted);
+                }
                 $this->flatten_place_symlink(
                     $local_mu_plugins_dir,
                     $target,
-                    $force,
+                    $replace_conflicts,
                     $created,
                     $refreshed,
                     $forced,
@@ -4777,10 +4868,13 @@ class ImportClient
             }
             if ($uploads_detached && is_dir($local_uploads_basedir)) {
                 $target = wp_join_unix_paths($wp_content_target, "uploads");
+                if ($adopt_flatten_to_content) {
+                    $this->flatten_adopt_file_tree($local_uploads_basedir, $target, $adopted);
+                }
                 $this->flatten_place_symlink(
                     $local_uploads_basedir,
                     $target,
-                    $force,
+                    $replace_conflicts,
                     $created,
                     $refreshed,
                     $forced,
@@ -4791,10 +4885,19 @@ class ImportClient
             // Simple case: just symlink the whole content_dir as wp-content.
             if (is_dir($local_content_dir)) {
                 $target = wp_join_unix_paths($flatten_to, "wp-content");
+                if ($adopt_flatten_to_content) {
+                    $this->flatten_adopt_content_directory(
+                        $local_content_dir,
+                        $target,
+                        $adopted,
+                        $unit_container_names,
+                        $file_container_names,
+                    );
+                }
                 $this->flatten_place_symlink(
                     $local_content_dir,
                     $target,
-                    $force,
+                    $replace_conflicts,
                     $created,
                     $refreshed,
                     $forced,
@@ -4810,10 +4913,13 @@ class ImportClient
 
         $this->audit_log(
             sprintf(
-                "FLAT-DOCUMENT-ROOT | Complete: %d created, %d refreshed, %d force-replaced",
+                "FLAT-DOCUMENT-ROOT | Complete: %d created, %d refreshed, %d force-replaced, " .
+                    "%d adopted (mode: %s)",
                 $created,
                 $refreshed,
                 $forced,
+                $adopted,
+                $conflict_mode,
             ),
             true,
         );
@@ -4827,9 +4933,11 @@ class ImportClient
             "wp_includes_path" => $wp_includes_path,
             "content_dir" => $content_dir,
             "content_detached" => $content_detached,
+            "on_flatten_to_conflict" => $conflict_mode,
             "created" => $created,
             "refreshed" => $refreshed,
             "force_replaced" => $forced,
+            "adopted" => $adopted,
         ];
         if (!$this->progress->is_mode('pipeline')) {
             fwrite($this->progress_fd, json_encode($result) . "\n");
@@ -4985,6 +5093,273 @@ class ImportClient
         );
         $created++;
     }
+
+    /**
+     * Move the wp-content entries that only $target holds into $source, so
+     * that replacing $target with a symlink no longer deletes them.
+     *
+     * Called only by run_flat_document_root(), in its 'adopt' conflict mode.
+     *
+     * Merging stops at whole units. A plugin or a theme belongs to one side
+     * or the other: descending into one the pull also has would keep the
+     * files its version dropped, leaving a directory that matches no release
+     * and pushing those files back to the source later. So the walk passes
+     * through the directories that hold independent things and stops at the
+     * things themselves:
+     *
+     *   plugins, mu-plugins, themes -> one level, each child whole
+     *   uploads                     -> all the way down, each file its own
+     *   anything else               -> whole, because its insides are unknown
+     *
+     * Per entry at this level:
+     *
+     *   - absent from the source -> move it into the source
+     *   - a container above      -> walk it under that container's rule
+     *   - anything else          -> leave it, the pulled copy wins
+     *
+     * Nothing is deleted here. The caller places the symlinks afterwards, so
+     * a failed move stops the command with the flattened layout still intact.
+     *
+     * @param string   $source                 Filesystem-root directory the entries belong in.
+     * @param string   $target                 Flattened directory being merged away.
+     * @param int      $adopted                Running count of moved entries, by reference.
+     * @param string[] $unit_container_names   Entry names whose own children are whole
+     *                                         plugins or themes.
+     * @param string[] $file_container_names   Entry names whose contents merge file by file.
+     * @param string[] $target_entries_to_skip Top-level entry names this call must not move,
+     *                                         because another (source, target) pair owns them.
+     */
+    private function flatten_adopt_content_directory(
+        string $source,
+        string $target,
+        int &$adopted,
+        array $unit_container_names,
+        array $file_container_names,
+        array $target_entries_to_skip = []
+    ): void {
+        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+            return;
+        }
+
+        foreach (@scandir($target) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            if (in_array($entry, $target_entries_to_skip, true)) {
+                continue;
+            }
+            $source_entry = wp_join_unix_paths($source, $entry);
+            $target_entry = wp_join_unix_paths($target, $entry);
+
+            if (!file_exists($source_entry) && !is_link($source_entry)) {
+                $this->flatten_move_into_filesystem_root($target_entry, $source_entry);
+                ++$adopted;
+                continue;
+            }
+            if (in_array($entry, $unit_container_names, true)) {
+                $this->flatten_adopt_unit_container($source_entry, $target_entry, $adopted);
+                continue;
+            }
+            if (in_array($entry, $file_container_names, true)) {
+                $this->flatten_adopt_file_tree($source_entry, $target_entry, $adopted);
+            }
+        }
+    }
+
+    /**
+     * Move whole plugins or themes that only $target holds into $source.
+     *
+     * Each child is one unit. A name the pull also has stays the pull's, down
+     * to the last file, so two versions of the same plugin never merge.
+     */
+    private function flatten_adopt_unit_container(
+        string $source,
+        string $target,
+        int &$adopted
+    ): void {
+        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+            return;
+        }
+
+        foreach (@scandir($target) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $source_entry = wp_join_unix_paths($source, $entry);
+            if (file_exists($source_entry) || is_link($source_entry)) {
+                continue;
+            }
+            $this->flatten_move_into_filesystem_root(
+                wp_join_unix_paths($target, $entry),
+                $source_entry
+            );
+            ++$adopted;
+        }
+    }
+
+    /**
+     * Move the files that only $target holds into $source, to the leaf.
+     *
+     * For uploads, where each file stands alone: a photo the pull does not
+     * have is its own thing, not part of some larger version.
+     */
+    private function flatten_adopt_file_tree(
+        string $source,
+        string $target,
+        int &$adopted
+    ): void {
+        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+            return;
+        }
+
+        foreach (@scandir($target) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $source_entry = wp_join_unix_paths($source, $entry);
+            $target_entry = wp_join_unix_paths($target, $entry);
+
+            if (!file_exists($source_entry) && !is_link($source_entry)) {
+                $this->flatten_move_into_filesystem_root($target_entry, $source_entry);
+                ++$adopted;
+                continue;
+            }
+            $this->flatten_adopt_file_tree($source_entry, $target_entry, $adopted);
+        }
+    }
+
+    /**
+     * Whether both paths are real directories, so their entries can be
+     * compared. A symlinked target is a previous flatten and holds nothing
+     * of its own.
+     */
+    private function flatten_both_sides_are_real_directories(
+        string $source,
+        string $target
+    ): bool {
+        return !is_link($source) &&
+            is_dir($source) &&
+            !is_link($target) &&
+            is_dir($target);
+    }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions carry CLI filesystem paths, never HTML output.
+
+    /**
+     * Move one flattened entry to its place under the filesystem root.
+     *
+     * A symlink is recreated rather than moved: a relative link value is read
+     * against its own parent directory, and the two parents sit at different
+     * depths. An absolute value already resolves the same from either.
+     *
+     * rename() reports EXDEV when --flatten-to and --fs-root are on different
+     * filesystems, which nothing stops the caller from choosing, so a copy is
+     * the fallback rather than the error.
+     *
+     * Only the moved entry's own value is rewritten. A relative symlink deeper
+     * in a moved directory keeps its value, which still resolves when it points
+     * within that directory and breaks when it points out of it. No move can
+     * preserve the second kind.
+     */
+    private function flatten_move_into_filesystem_root(
+        string $target_entry,
+        string $source_entry
+    ): void {
+        if (is_link($target_entry)) {
+            $link_value = readlink($target_entry);
+            if ($link_value === false) {
+                throw new RuntimeException(
+                    "Could not read the symlink value at {$target_entry}.",
+                );
+            }
+            if (strpos($link_value, "/") !== 0) {
+                $link_value = self::compute_relative_path(
+                    realpath_with_missing_tail(dirname($source_entry)),
+                    normalize_path(
+                        wp_join_unix_paths(dirname($target_entry), $link_value)
+                    )
+                );
+            }
+            if (!symlink($link_value, $source_entry)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$source_entry} -> {$link_value}",
+                );
+            }
+            if (!unlink($target_entry)) {
+                throw new RuntimeException(
+                    "Created {$source_entry} but could not remove the original " .
+                        "symlink at {$target_entry}.",
+                );
+            }
+        } elseif (!@rename($target_entry, $source_entry)) {
+            $this->flatten_copy_local_path($target_entry, $source_entry);
+            if (
+                !$this->remove_local_absolute_path_without_following_symlinks(
+                    $target_entry
+                )
+            ) {
+                throw new RuntimeException(
+                    "Copied {$target_entry} to {$source_entry} but could not remove " .
+                        "the original at {$target_entry}.",
+                );
+            }
+        }
+
+        $this->audit_log(
+            "FLAT-DOCUMENT-ROOT ADOPT | Moved into the filesystem root: " .
+                "{$target_entry} -> {$source_entry}",
+        );
+    }
+
+    /**
+     * Copy a file, symlink, or directory tree to a path that does not exist yet.
+     *
+     * This is the cross-filesystem half of a move, so it reproduces a symlink
+     * as a symlink instead of following it into its target. Values are kept
+     * verbatim: an entry and everything below it move together, so a relative
+     * value that resolves within the tree still resolves after the copy.
+     */
+    private function flatten_copy_local_path(string $from, string $to): void
+    {
+        if (is_link($from)) {
+            $link_value = readlink($from);
+            if ($link_value === false) {
+                throw new RuntimeException(
+                    "Could not read the symlink value at {$from}.",
+                );
+            }
+            if (!symlink($link_value, $to)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$to} -> {$link_value}",
+                );
+            }
+            return;
+        }
+
+        // A failed copy or mkdir here is reported as an exception naming both
+        // paths, so the raw PHP warning would only duplicate it.
+        if (!is_dir($from)) {
+            if (!@copy($from, $to)) {
+                throw new RuntimeException("Failed to copy {$from} to {$to}.");
+            }
+            return;
+        }
+
+        if (!@mkdir($to, 0755, true)) {
+            throw new RuntimeException("Failed to create directory: {$to}");
+        }
+        foreach (@scandir($from) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $this->flatten_copy_local_path(
+                wp_join_unix_paths($from, $entry),
+                wp_join_unix_paths($to, $entry)
+            );
+        }
+    }
+
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
     /**
      * Ensure a path is a real directory (not a symlink).
@@ -11405,10 +11780,21 @@ if (
             'commands' => ['pull', 'flat-docroot'],
         ],
         [
+            'name' => 'on-flatten-to-conflict',
+            'type' => 'value',
+            'target' => 'on_flatten_to_conflict',
+            'placeholder' => 'MODE',
+            'valid_values' => ImportClient::FLATTEN_TO_CONFLICT_MODES,
+            'help' => 'What to do when a real file or directory sits where a symlink must go: ' .
+                'error (default), replace it, or adopt — move wp-content entries that only ' .
+                '--flatten-to has into --fs-root, then replace (the pulled copy wins on conflicts)',
+            'commands' => ['pull', 'flat-docroot'],
+        ],
+        [
             'name' => 'force',
             'type' => 'flag',
             'target' => 'force',
-            'help' => 'Remove conflicting non-symlink files and replace with symlinks',
+            'help' => 'Alias for --on-flatten-to-conflict=replace',
             'commands' => ['pull', 'flat-docroot'],
         ],
 
@@ -12203,8 +12589,22 @@ if (
                 "/srv/htdocs and WP_CONTENT_DIR at /tmp/__wp__/wp-content).\n" .
                 "\n" .
                 "No files are copied — only symlinks are created. Idempotent.\n" .
-                "If a path that should be a symlink is a regular file or directory,\n" .
-                "the command stops with an error unless --force is specified.\n",
+                "\n" .
+                "--on-flatten-to-conflict decides what happens when a real file or\n" .
+                "directory already sits where a symlink must go:\n" .
+                "\n" .
+                "  error    Stop and say what blocked the link. The default.\n" .
+                "  replace  Delete it. --force is an alias for this mode.\n" .
+                "  adopt    Move the wp-content entries that only --flatten-to has\n" .
+                "           into --fs-root, then replace as above.\n" .
+                "\n" .
+                "Use adopt when flattening onto a site that already exists. replace\n" .
+                "deletes the plugins, themes and uploads that only --flatten-to has;\n" .
+                "adopt keeps them, and keeps them where later commands such as\n" .
+                "files-push, which read only --fs-root, can still see them. The\n" .
+                "pulled copy wins wherever both sides hold the same path, and only\n" .
+                "wp-content is adopted — the rest of the layout is core, which the\n" .
+                "pull owns entirely.\n",
             "extra" => null,
         ],
         "apply-runtime" => [

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4703,7 +4703,7 @@ class ImportClient
             // wp-content is the only ABSPATH entry the target can own files
             // in; the rest is core, which the pull owns entirely.
             if ($adopt_flatten_to_content && $entry === "wp-content") {
-                $this->flatten_adopt_content_directory(
+                $this->flatten_adopt_wp_content(
                     $source,
                     $target,
                     $adopted,
@@ -4803,7 +4803,7 @@ class ImportClient
             // sub-components are skipped because they are adopted below,
             // against the source each one actually comes from.
             if ($adopt_flatten_to_content) {
-                $this->flatten_adopt_content_directory(
+                $this->flatten_adopt_wp_content(
                     $local_content_dir,
                     $wp_content_target,
                     $adopted,
@@ -4886,7 +4886,7 @@ class ImportClient
             if (is_dir($local_content_dir)) {
                 $target = wp_join_unix_paths($flatten_to, "wp-content");
                 if ($adopt_flatten_to_content) {
-                    $this->flatten_adopt_content_directory(
+                    $this->flatten_adopt_wp_content(
                         $local_content_dir,
                         $target,
                         $adopted,
@@ -5095,10 +5095,15 @@ class ImportClient
     }
 
     /**
-     * Move the wp-content entries that only $target holds into $source, so
-     * that replacing $target with a symlink no longer deletes them.
+     * Adopt into the pulled wp-content: move the entries that only the
+     * flattened wp-content holds into the pulled one, so that replacing it
+     * with a symlink no longer deletes them.
      *
-     * Called only by run_flat_document_root(), in its 'adopt' conflict mode.
+     * This is the wp-content level and nothing else. The only caller is
+     * run_flat_document_root(), in its 'adopt' conflict mode, and every call
+     * passes <flatten-to>/wp-content as the flattened side. The two
+     * directories below it, flatten_adopt_unit_container() and
+     * flatten_adopt_file_tree(), are the generic ones.
      *
      * Merging stops at whole units. A plugin or a theme belongs to one side
      * or the other: descending into one the pull also has would keep the
@@ -5113,55 +5118,62 @@ class ImportClient
      *
      * Per entry at this level:
      *
-     *   - absent from the source -> move it into the source
-     *   - a container above      -> walk it under that container's rule
-     *   - anything else          -> leave it, the pulled copy wins
+     *   - absent from the pulled side -> move it there
+     *   - a container above           -> walk it under that container's rule
+     *   - anything else               -> leave it, the pulled copy wins
      *
      * Nothing is deleted here. The caller places the symlinks afterwards, so
      * a failed move stops the command with the flattened layout still intact.
      *
-     * @param string   $source                 Filesystem-root directory the entries belong in.
-     * @param string   $target                 Flattened directory being merged away.
-     * @param int      $adopted                Running count of moved entries, by reference.
-     * @param string[] $unit_container_names   Entry names whose own children are whole
-     *                                         plugins or themes.
-     * @param string[] $file_container_names   Entry names whose contents merge file by file.
-     * @param string[] $target_entries_to_skip Top-level entry names this call must not move,
-     *                                         because another (source, target) pair owns them.
+     * @param string   $pulled_content_directory Filesystem-root wp-content the entries belong in.
+     * @param string   $flattened_wp_content     Flattened wp-content being merged away.
+     * @param int      $adopted                  Running count of moved entries, by reference.
+     * @param string[] $unit_container_names     Entry names whose own children are whole
+     *                                           plugins or themes.
+     * @param string[] $file_container_names     Entry names whose contents merge file by file.
+     * @param string[] $entries_to_skip          Entry names this call must not move, because
+     *                                           another (source, target) pair owns them.
      */
-    private function flatten_adopt_content_directory(
-        string $source,
-        string $target,
+    private function flatten_adopt_wp_content(
+        string $pulled_content_directory,
+        string $flattened_wp_content,
         int &$adopted,
         array $unit_container_names,
         array $file_container_names,
-        array $target_entries_to_skip = []
+        array $entries_to_skip = []
     ): void {
-        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+        // Only a real directory on both sides has entries to compare. A
+        // symlinked target is a previous flatten, and holds nothing of its own.
+        if (
+            is_link($pulled_content_directory) ||
+            !is_dir($pulled_content_directory) ||
+            is_link($flattened_wp_content) ||
+            !is_dir($flattened_wp_content)
+        ) {
             return;
         }
 
-        foreach (@scandir($target) ?: [] as $entry) {
+        foreach (@scandir($flattened_wp_content) ?: [] as $entry) {
             if ($entry === "." || $entry === "..") {
                 continue;
             }
-            if (in_array($entry, $target_entries_to_skip, true)) {
+            if (in_array($entry, $entries_to_skip, true)) {
                 continue;
             }
-            $source_entry = wp_join_unix_paths($source, $entry);
-            $target_entry = wp_join_unix_paths($target, $entry);
+            $pulled_entry = wp_join_unix_paths($pulled_content_directory, $entry);
+            $flattened_entry = wp_join_unix_paths($flattened_wp_content, $entry);
 
-            if (!file_exists($source_entry) && !is_link($source_entry)) {
-                $this->flatten_move_into_filesystem_root($target_entry, $source_entry);
+            if (!file_exists($pulled_entry) && !is_link($pulled_entry)) {
+                $this->flatten_move_into_filesystem_root($flattened_entry, $pulled_entry);
                 ++$adopted;
                 continue;
             }
             if (in_array($entry, $unit_container_names, true)) {
-                $this->flatten_adopt_unit_container($source_entry, $target_entry, $adopted);
+                $this->flatten_adopt_unit_container($pulled_entry, $flattened_entry, $adopted);
                 continue;
             }
             if (in_array($entry, $file_container_names, true)) {
-                $this->flatten_adopt_file_tree($source_entry, $target_entry, $adopted);
+                $this->flatten_adopt_file_tree($pulled_entry, $flattened_entry, $adopted);
             }
         }
     }
@@ -5177,7 +5189,12 @@ class ImportClient
         string $target,
         int &$adopted
     ): void {
-        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+        if (
+            is_link($source) ||
+            !is_dir($source) ||
+            is_link($target) ||
+            !is_dir($target)
+        ) {
             return;
         }
 
@@ -5208,7 +5225,12 @@ class ImportClient
         string $target,
         int &$adopted
     ): void {
-        if (!$this->flatten_both_sides_are_real_directories($source, $target)) {
+        if (
+            is_link($source) ||
+            !is_dir($source) ||
+            is_link($target) ||
+            !is_dir($target)
+        ) {
             return;
         }
 
@@ -5226,21 +5248,6 @@ class ImportClient
             }
             $this->flatten_adopt_file_tree($source_entry, $target_entry, $adopted);
         }
-    }
-
-    /**
-     * Whether both paths are real directories, so their entries can be
-     * compared. A symlinked target is a previous flatten and holds nothing
-     * of its own.
-     */
-    private function flatten_both_sides_are_real_directories(
-        string $source,
-        string $target
-    ): bool {
-        return !is_link($source) &&
-            is_dir($source) &&
-            !is_link($target) &&
-            is_dir($target);
     }
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions carry CLI filesystem paths, never HTML output.

--- a/tests/Import/FlatDocrootConflictModeTest.php
+++ b/tests/Import/FlatDocrootConflictModeTest.php
@@ -1,0 +1,510 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/**
+ * Verify the three --on-flatten-to-conflict modes.
+ *
+ * 'adopt' is the one that carries weight: it moves wp-content entries that
+ * only the flattened directory holds into the filesystem root, so replacing
+ * that directory with a symlink keeps them and files-push — which reads the
+ * filesystem root and nothing else — can still see them.
+ */
+class FlatDocrootConflictModeTest extends TestCase
+{
+    private const ABSPATH = '/srv/htdocs/wordpress/';
+
+    private string $tempDir;
+    private string $stateDir;
+    private string $filesystemRoot;
+    private string $flattenTo;
+    private string $localAbspath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/flat-docroot-conflict-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->filesystemRoot = $this->tempDir . '/fs-root';
+        $this->flattenTo = $this->tempDir . '/flat';
+        $this->localAbspath = $this->filesystemRoot . self::ABSPATH;
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->localAbspath, 0755, true);
+        file_put_contents($this->localAbspath . 'wp-load.php', '<?php // wp-load');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testMovesTargetOnlyEntriesIntoTheFilesystemRoot(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php // pulled');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+        $this->writeFlattened('wp-content/themes/local-theme/style.css', '/* local */');
+        $this->writeFlattened('wp-content/custom-folder/note.txt', 'keep me');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertFileExists(
+            $this->localAbspath . 'wp-content/plugins/local-only/plugin.php',
+            'a local-only plugin now lives under the filesystem root, where files-push reads',
+        );
+        $this->assertFileExists($this->localAbspath . 'wp-content/themes/local-theme/style.css');
+        $this->assertFileExists($this->localAbspath . 'wp-content/custom-folder/note.txt');
+        $this->assertFileExists(
+            $this->flattenTo . '/wp-content/plugins/local-only/plugin.php',
+            'and is still reachable through the flattened layout',
+        );
+        $this->assertFileExists($this->flattenTo . '/wp-content/plugins/from-the-pull/plugin.php');
+    }
+
+    public function testWpContentStaysASingleSymlink(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php // pulled');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertTrue(
+            is_link($this->flattenTo . '/wp-content'),
+            'the flattened layout stays a view: one symlink for the whole subtree',
+        );
+        $this->assertFalse(
+            is_link($this->flattenTo . '/wp-content/plugins/local-only'),
+            'the adopted plugin is a real directory behind that symlink, not a link of its own',
+        );
+    }
+
+    public function testPulledCopyWinsACollision(): void
+    {
+        $this->writePulled('wp-content/plugins/shared/plugin.php', '<?php // from the pull');
+        $this->writeFlattened('wp-content/plugins/shared/plugin.php', '<?php // from the target');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertStringContainsString(
+            'from the pull',
+            file_get_contents($this->flattenTo . '/wp-content/plugins/shared/plugin.php'),
+            'a collision resolves to the pulled copy rather than raising',
+        );
+    }
+
+    public function testMovesASymlinkAndKeepsItResolving(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('shared-store/local-plugin/plugin.php', '<?php // shared store');
+        mkdir($this->flattenTo . '/wp-content/plugins', 0755, true);
+        // A relative value read against a parent two levels below --flatten-to.
+        symlink(
+            '../../shared-store/local-plugin',
+            $this->flattenTo . '/wp-content/plugins/linked-plugin',
+        );
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $moved = $this->localAbspath . 'wp-content/plugins/linked-plugin';
+        $this->assertTrue(is_link($moved), 'the entry is still a symlink, not a copy of its target');
+        $this->assertFileExists(
+            $moved . '/plugin.php',
+            'and its rewritten value still resolves from the deeper parent',
+        );
+        $this->assertStringContainsString(
+            'shared store',
+            file_get_contents($moved . '/plugin.php'),
+        );
+    }
+
+    public function testExplodedLayoutAdoptsAgainstEachComponentSource(): void
+    {
+        // uploads detached from content_dir forces the exploded layout, where
+        // wp-content is a real directory rather than one symlink.
+        $this->writeFileUnderFilesystemRoot(
+            '/srv/htdocs/wp-content/plugins/from-the-pull/plugin.php',
+            '<?php',
+        );
+        $this->writeFileUnderFilesystemRoot('/srv/uploads/2026/01/pulled.jpg', 'pulled');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+        $this->writeFlattened('wp-content/uploads/2026/02/local.jpg', 'local');
+        $this->writeFlattened('wp-content/local-folder/note.txt', 'keep me');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt'], [
+            'content_dir' => '/srv/htdocs/wp-content',
+            'uploads' => ['basedir' => '/srv/uploads'],
+        ]);
+
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/htdocs/wp-content/plugins/local-only/plugin.php',
+            'a local-only plugin lands under the plugins source',
+        );
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/uploads/2026/02/local.jpg',
+            'a local-only upload lands under the detached uploads source, not under content_dir',
+        );
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/htdocs/wp-content/local-folder/note.txt',
+            'an entry belonging to no component lands under content_dir',
+        );
+        $this->assertFileExists($this->flattenTo . '/wp-content/uploads/2026/01/pulled.jpg');
+        $this->assertFileExists($this->flattenTo . '/wp-content/uploads/2026/02/local.jpg');
+    }
+
+    public function testSecondFlattenChangesNothing(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+        $firstPass = $this->describeTree($this->filesystemRoot);
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertSame(
+            $firstPass,
+            $this->describeTree($this->filesystemRoot),
+            're-running moves nothing further: wp-content is already a symlink',
+        );
+        $this->assertFileExists($this->flattenTo . '/wp-content/plugins/local-only/plugin.php');
+    }
+
+    public function testAPluginBothSidesHaveIsNeverMerged(): void
+    {
+        // The pull carries WooCommerce 9.2; the local site has 8.5. Merging
+        // them would leave files 9.0 dropped inside a directory claiming to
+        // be 9.2, and push those files back to the source later.
+        $this->writePulled('wp-content/plugins/woocommerce/woocommerce.php', 'Version: 9.2');
+        $this->writePulled('wp-content/plugins/woocommerce/includes/class-wc-new.php', 'new');
+        $this->writeFlattened('wp-content/plugins/woocommerce/woocommerce.php', 'Version: 8.5');
+        $this->writeFlattened('wp-content/plugins/woocommerce/includes/class-wc-legacy.php', 'old');
+        $this->writeFlattened('wp-content/plugins/woocommerce/legacy-assets/old.js', 'old');
+        $this->writeFlattened('wp-content/plugins/my-dev-plugin/plugin.php', 'mine');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $plugins = $this->localAbspath . 'wp-content/plugins';
+        $this->assertFileDoesNotExist(
+            $plugins . '/woocommerce/includes/class-wc-legacy.php',
+            'a file the pulled version dropped is not carried into it',
+        );
+        $this->assertFileDoesNotExist(
+            $plugins . '/woocommerce/legacy-assets/old.js',
+            'nor is a whole directory the pulled version dropped',
+        );
+        $this->assertFileExists($plugins . '/woocommerce/includes/class-wc-new.php');
+        $this->assertSame('Version: 9.2', file_get_contents($plugins . '/woocommerce/woocommerce.php'));
+        $this->assertFileExists(
+            $plugins . '/my-dev-plugin/plugin.php',
+            'a plugin only the local site has is still adopted whole',
+        );
+    }
+
+    public function testAThemeBothSidesHaveIsNeverMerged(): void
+    {
+        $this->writePulled('wp-content/themes/twentytwentyfive/style.css', 'Version: 1.3');
+        $this->writeFlattened('wp-content/themes/twentytwentyfive/style.css', 'Version: 1.0');
+        $this->writeFlattened('wp-content/themes/twentytwentyfive/patterns/dropped.php', 'old');
+        $this->writeFlattened('wp-content/themes/my-child-theme/style.css', 'mine');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $themes = $this->localAbspath . 'wp-content/themes';
+        $this->assertFileDoesNotExist($themes . '/twentytwentyfive/patterns/dropped.php');
+        $this->assertSame('Version: 1.3', file_get_contents($themes . '/twentytwentyfive/style.css'));
+        $this->assertFileExists($themes . '/my-child-theme/style.css');
+    }
+
+    public function testUploadsMergeFileByFile(): void
+    {
+        // Media is not a versioned payload: a photo the pull lacks is its own
+        // thing, so uploads merges to the leaf where plugins does not.
+        $this->writePulled('wp-content/uploads/2026/01/pulled.jpg', 'pulled');
+        $this->writeFlattened('wp-content/uploads/2026/01/local.jpg', 'local');
+        $this->writeFlattened('wp-content/uploads/2025/12/older.jpg', 'local');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $uploads = $this->localAbspath . 'wp-content/uploads';
+        $this->assertFileExists(
+            $uploads . '/2026/01/local.jpg',
+            'a local-only file inside a month both sides have is kept',
+        );
+        $this->assertFileExists($uploads . '/2025/12/older.jpg');
+        $this->assertFileExists($uploads . '/2026/01/pulled.jpg');
+    }
+
+    public function testAnUnknownDirectoryBothSidesHaveIsLeftToThePull(): void
+    {
+        // Nothing here says what the directory holds, so it is treated as one
+        // unit. The local-only file inside it goes with the replaced
+        // directory; a directory only the local site has is still adopted.
+        $this->writePulled('wp-content/languages/admin-en_GB.mo', 'pulled');
+        $this->writeFlattened('wp-content/languages/plugins/local-only.mo', 'local');
+        $this->writeFlattened('wp-content/my-own-folder/keep.txt', 'local');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertFileDoesNotExist(
+            $this->localAbspath . 'wp-content/languages/plugins/local-only.mo',
+        );
+        $this->assertFileExists($this->localAbspath . 'wp-content/my-own-folder/keep.txt');
+    }
+
+    public function testAdoptReplacesCoreWithoutNeedingForceAsWell(): void
+    {
+        // What `studio create` leaves behind: a real core directory and a real
+        // wp-content, both standing where symlinks must go. One mode has to
+        // settle both, or every caller would pass two flags that disagree.
+        $this->writePulled('wp-admin/admin.php', '<?php // pulled core');
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-admin/admin.php', '<?php // blank install core');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+
+        $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+
+        $this->assertTrue(
+            is_link($this->flattenTo . '/wp-admin'),
+            'core is replaced, exactly as replace would have done',
+        );
+        $this->assertStringContainsString(
+            'pulled core',
+            file_get_contents($this->flattenTo . '/wp-admin/admin.php'),
+        );
+        $this->assertFileExists(
+            $this->localAbspath . 'wp-content/plugins/local-only/plugin.php',
+            'and wp-content is salvaged rather than deleted',
+        );
+    }
+
+    public function testForceContradictingTheModeIsRefused(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--force means --on-flatten-to-conflict=replace');
+        $this->flatten(['force' => true, 'on_flatten_to_conflict' => 'adopt']);
+    }
+
+    public function testForceAgreeingWithTheModeIsAccepted(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php');
+
+        $this->flatten(['force' => true, 'on_flatten_to_conflict' => 'replace']);
+
+        $this->assertTrue(is_link($this->flattenTo . '/wp-content'));
+    }
+
+    public function testAnUnknownModeIsRefused(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid --on-flatten-to-conflict value: adapt');
+        $this->flatten(['on_flatten_to_conflict' => 'adapt']);
+    }
+
+    public function testErrorModeIsTheDefaultAndRefusesAnExistingDirectory(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php');
+
+        $this->expectException(\RuntimeException::class);
+        $this->flatten();
+    }
+
+    public function testForceIsAnAliasForReplaceAndStillDeletesWpContent(): void
+    {
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php');
+
+        $this->flatten(['force' => true]);
+
+        $this->assertTrue(is_link($this->flattenTo . '/wp-content'));
+        $this->assertFileDoesNotExist(
+            $this->flattenTo . '/wp-content/plugins/local-only/plugin.php',
+            'the documented replace behaviour is unchanged',
+        );
+    }
+
+    public function testAFailedMoveLeavesTheFlattenedDirectoryIntact(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            $this->markTestSkipped('Directory permissions do not stop root from writing.');
+        }
+
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/plugin.php', '<?php // local');
+        $this->writeFlattened('wp-content/themes/local-theme/style.css', '/* local */');
+        // rename() into a read-only plugins directory fails, and so does the
+        // copy fallback, so the command stops before any symlink is placed.
+        chmod($this->localAbspath . 'wp-content/plugins', 0555);
+
+        try {
+            $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+            $this->fail('the failed move should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            // Expected.
+        } finally {
+            chmod($this->localAbspath . 'wp-content/plugins', 0755);
+        }
+
+        $this->assertFileExists(
+            $this->flattenTo . '/wp-content/plugins/local-only/plugin.php',
+            'the entry that could not move is still where it was',
+        );
+        $this->assertFalse(
+            is_link($this->flattenTo . '/wp-content'),
+            'nothing was replaced with a symlink, so nothing was deleted',
+        );
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Run flat-docroot against the layout built by the write* helpers.
+     *
+     * @param array $options   Options for run_flat_document_root, merged over
+     *                         --flatten-to. Pass on_flatten_to_conflict, force,
+     *                         or neither.
+     * @param array $pathsUrls Extra preflight paths_urls keys, for layouts
+     *                         where wp-content or its sub-components sit
+     *                         outside ABSPATH.
+     */
+    private function flatten(array $options = [], array $pathsUrls = []): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'table_prefix' => 'wp_',
+                            'paths_urls' => array_merge(
+                                ['abspath' => self::ABSPATH],
+                                $pathsUrls,
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'run_flat_document_root', [
+            array_merge(['flatten_to' => $this->flattenTo], $options),
+        ]);
+    }
+
+    private function writePulled(string $relative, string $contents): void
+    {
+        $this->writeFile($this->localAbspath . $relative, $contents);
+    }
+
+    private function writeFlattened(string $relative, string $contents): void
+    {
+        $this->writeFile($this->flattenTo . '/' . $relative, $contents);
+    }
+
+    private function writeFileUnderFilesystemRoot(string $absolute, string $contents): void
+    {
+        $this->writeFile($this->filesystemRoot . $absolute, $contents);
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * List every path under $dir with its type, for comparing two runs.
+     *
+     * @return string[] Sorted "type relative/path" lines.
+     */
+    private function describeTree(string $dir): array
+    {
+        $described = [];
+        $stack = [$dir];
+        while ($stack !== []) {
+            $current = array_pop($stack);
+            foreach (scandir($current) ?: [] as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $path = $current . '/' . $entry;
+                $relative = substr($path, strlen($dir));
+                if (is_link($path)) {
+                    $described[] = 'link ' . $relative . ' -> ' . readlink($path);
+                    continue;
+                }
+                if (is_dir($path)) {
+                    $described[] = 'dir  ' . $relative;
+                    $stack[] = $path;
+                    continue;
+                }
+                $described[] = 'file ' . $relative . ' ' . md5_file($path);
+            }
+        }
+        sort($described);
+        return $described;
+    }
+
+    private function writeState(array $state): void
+    {
+        \write_current_pull_state($this->makeClient(), $state);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient(
+            'https://source.example/export.php',
+            $this->stateDir,
+            $this->filesystemRoot,
+        );
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('state');
+        $property->setValue($client, $state);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $m = $reflection->getMethod($method);
+        return $m->invoke($client, ...$args);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                @chmod($path, 0755);
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/FlatDocrootConflictModeTest.php
+++ b/tests/Import/FlatDocrootConflictModeTest.php
@@ -364,6 +364,52 @@ class FlatDocrootConflictModeTest extends TestCase
         );
     }
 
+    public function testACopyThatFailsPartwayLeavesNothingAtTheDestination(): void
+    {
+        if ( function_exists('posix_getuid') && posix_getuid() === 0 ) {
+            $this->markTestSkipped('File permissions do not stop root from reading.');
+        }
+
+        $this->writePulled('wp-content/plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFlattened('wp-content/plugins/local-only/first.php', '<?php // copied');
+        $this->writeFlattened('wp-content/plugins/local-only/second.php', '<?php // unreadable');
+        $this->writeFlattened('wp-content/plugins/local-only/third.php', '<?php // never reached');
+        // rename() needs to write to the entry's parent, so a read-only parent
+        // sends the move down the cross-filesystem copy path, and an unreadable
+        // file part-way through that copy fails it after it has written some.
+        chmod($this->flattenTo . '/wp-content/plugins/local-only/second.php', 0000);
+        chmod($this->flattenTo . '/wp-content/plugins', 0555);
+
+        try {
+            $this->flatten(['on_flatten_to_conflict' => 'adopt']);
+            $this->fail('the failed copy should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            // Expected.
+        } finally {
+            chmod($this->flattenTo . '/wp-content/plugins', 0755);
+            chmod($this->flattenTo . '/wp-content/plugins/local-only/second.php', 0644);
+        }
+
+        $plugins = $this->localAbspath . 'wp-content/plugins';
+        $this->assertFileDoesNotExist(
+            $plugins . '/local-only',
+            'a half-copied entry must not sit at the name the next run reads as the pulled copy',
+        );
+        $this->assertSame(
+            [],
+            glob($plugins . '/*.reprint-adopt-incomplete') ?: [],
+            'and the staging path it copied into is cleared',
+        );
+        $this->assertFileExists(
+            $this->flattenTo . '/wp-content/plugins/local-only/first.php',
+            'the original is untouched, so a later run can try again',
+        );
+        $this->assertFalse(
+            is_link($this->flattenTo . '/wp-content'),
+            'nothing was replaced with a symlink, so nothing was deleted',
+        );
+    }
+
     // ---- helpers ----
 
     /**


### PR DESCRIPTION
This PR addresses the same fundamental issue as https://github.com/WordPress/reprint/pull/383, but takes a new approach: instead of keeping the pre-existing files and directories in the `flatten_to` dir, they are now moved into the fs-root.

---

This PR adds an `--on-flatten-to-conflict=error|replace|adopt` flag to the `flat-docroot` and `pull` commands. `error` is still the default. The old `--force` flag is now an alias for `replace`, and both behave exactly as before.

`flat-docroot --on-flatten-to-conflict=adopt` keeps the plugins, themes, and uploads that only the `flatten_to` dir had, instead of deleting them.

## Background

In Studio, there's always a local WordPress site that we use Reprint to pull into. That local site can be freshly minted and contain nothing but the default WordPress placeholder content, or it can contain a bunch of existing plugins/themes/uploads. When it does have pre-existing content, we want that content to be preserved on the first Reprint pull.

`flat-docroot --force` would wipe it, which is exactly what we don't want. 

https://github.com/WordPress/reprint/pull/383 is not a good solution to this problem, as anything that lives only in the `flatten_to` dir is invisible to Reprint when pushing back to the site (we will soon also implement Reprint-based pushes in Studio). 

## Exact behavior

- Any immediate descendant of `wp-content` in flatten-to that **is not** present in fs-root **is moved** wholesale. Example: a `debug.log` file, a `plugins` dir that exists only in flatten-to, or any custom directory.
- Any immediate descendant of `wp-content` in flatten-to that **is** present in fs-root is **not moved**. 
- In the `plugins`, `themes`, and `mu-plugins` directories, immediate descendants **are moved** from flatten-to into fs-root only if the same name does not exist in fs-root. Example: flatten-to has a `woocommerce` plugin, and so does fs-root. In this case, fs-root wins, which prevents problems if the plugin/theme versions do not match.
- In the `uploads` directory, all descendants (not only immediate ones) that exist in flatten-to but not in fs-root **are moved** into fs-root.
- Symlinks that are moved from flatten-to into fs-root are recreated if the target path is relative, so that they keep pointing to the right path.

## Testing instructions

TBD. I'm looking to spin up a Studio PR that lets us test this through the `pull-reprint` command.