### PR TITLE
[PHP] Classify Base64 shortcode bodies in post content

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
@@ -39,6 +39,26 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 class CautiousTextBlockMarkupUrlProcessor extends BlockMarkupUrlProcessor {
     /**
+     * Replace the current text token without passing it through the HTML
+     * encoder. The caller has already rewritten a nested data value and must
+     * preserve the surrounding shortcode or builder bytes verbatim.
+     */
+    public function replace_raw_current_text(string $updated_text): bool
+    {
+        if ('#text' !== $this->get_token_type()) {
+            return false;
+        }
+
+        $this->get_updated_html();
+        if (!$this->set_modifiable_text('')) {
+            return false;
+        }
+
+        $this->lexical_updates['modifiable text']->text = $updated_text;
+        return true;
+    }
+
+    /**
      * Replace configured URL bases in the current raw text token.
      *
      * WP_HTML_Tag_Processor exposes decoded text through get_modifiable_text()

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -58,10 +58,10 @@
  * no partial replacement:
  *
  * - A target path may contain non-empty slash-separated components composed
- *   only of ASCII letters, digits, hyphens, and underscores. Each target slash
- *   copies the spelling of a slash from the configured source path, candidate
+ *   only of ASCII letters, digits, hyphens, and underscores. Its slashes use
+ *   the first spelling available from the configured source path, candidate
  *   suffix, or protocol separator. A scheme-less authority without such a
- *   slash is left unchanged.
+ *   spelling is left unchanged when the target has a path.
  * - Target ports, user information, queries, fragments, IPv4/IPv6 addresses,
  *   and Unicode domains are not supported. Punycode domains are supported.
  * - Unicode source domains and paths are not supported.
@@ -308,8 +308,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      * Build a candidate pattern adapted from URLInTextProcessor's URL finder.
      *
      * The pattern recognizes only this mapping's authority and initial path.
-     * Capturing those slices, rather than a complete parsed URL, lets callers
-     * replace the authority without rendering any surrounding syntax.
+     * Capturing their raw ranges and a nearby slash spelling lets callers add a
+     * restricted target path without rendering the surrounding syntax.
      */
     private function create_url_candidate_pattern(
         string $source_scheme,

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -31,8 +31,9 @@
  * of those formats and could corrupt the value.
  *
  * Instead, the processor performs one narrow operation: find the configured
- * source base as bytes and replace that entire slice with a target domain. It
- * does not decode, normalize, or re-encode the input.
+ * source base as bytes and replace that entire slice with a target domain and,
+ * when safely available, a restricted target path. It does not decode,
+ * normalize, or re-encode the input.
  *
  * Supported sources:
  *
@@ -53,11 +54,14 @@
  *   Only source.example is replaced. The username, password, path, query, and
  *   fragment remain byte-for-byte unchanged.
  *
- * Unsupported mappings are discarded as a whole. There is no partial
- * replacement:
+ * Mappings that cannot be safely rendered are discarded as a whole. There is
+ * no partial replacement:
  *
- * - A target path is not supported. Writing it would require choosing whether
- *   each slash should be /, \/, or something else.
+ * - A target path may contain non-empty slash-separated components composed
+ *   only of ASCII letters, digits, hyphens, and underscores. Each target slash
+ *   copies the spelling of a slash from the configured source path, candidate
+ *   suffix, or protocol separator. A scheme-less authority without such a
+ *   slash is left unchanged.
  * - Target ports, user information, queries, fragments, IPv4/IPv6 addresses,
  *   and Unicode domains are not supported. Punycode domains are supported.
  * - Unicode source domains and paths are not supported.
@@ -101,6 +105,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
+     *     target_path: string,
      *     pattern: string
      * }>
      */
@@ -116,9 +121,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
+     *     target_path: string,
      *     pattern: string,
      *     start: int,
-     *     base_length: int
+     *     base_length: int,
+     *     replacement: string
      * }|null
      */
     private ?array $matched_url = null;
@@ -131,7 +138,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *
      * A source may include an initial path containing only bytes from `!`
      * (0x21) through `~` (0x7E). A target must be an HTTP(S) URL with a
-     * supported domain and no path or other URL components:
+     * supported domain and an optional path of slash-separated ASCII letters,
+     * digits, hyphens, and underscores. Other URL components are rejected:
      *
      * ```
      * [
@@ -186,8 +194,9 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *
      * Mapping source.example/media to destination.example changes
      * https://source.example/media/logo.png to
-     * https://destination.example/logo.png. The protocol and logo.png suffix
-     * are outside the matched base and remain unchanged.
+     * https://destination.example/assets/logo.png when the target has the
+     * restricted /assets path. The protocol and logo.png suffix are outside
+     * the matched base and remain unchanged.
      */
     public function replace_url_base(): bool
     {
@@ -198,7 +207,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
         $this->lexical_updates[$this->matched_url['start']] = [
             'start'       => $this->matched_url['start'],
             'length'      => $this->matched_url['base_length'],
-            'replacement' => $this->matched_url['target_domain'],
+            'replacement' => $this->matched_url['replacement'],
         ];
 
         return true;
@@ -237,9 +246,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
+     *     target_path: string,
      *     pattern: string,
      *     start: int,
-     *     base_length: int
+     *     base_length: int,
+     *     replacement: string
      * }|null
      */
     private function find_next_url_base(): ?array
@@ -262,11 +273,31 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                 continue;
             }
 
+            $target_path_separator = '';
+            if ($mapping['target_path'] !== '') {
+                $target_path_separator = null;
+                foreach (['source_path_separator', 'suffix_separator', 'scheme_path_separator'] as $separator_name) {
+                    if (isset($matches[$separator_name]) && $matches[$separator_name][1] !== -1) {
+                        $target_path_separator = $matches[$separator_name][0];
+                        break;
+                    }
+                }
+
+                if ($target_path_separator === null) {
+                    continue;
+                }
+            }
+
             $next_match = array_merge(
                 $mapping,
                 [
                     'start'       => $authority_start,
                     'base_length' => strlen($matches['base'][0]),
+                    'replacement' => $mapping['target_domain'] . str_replace(
+                        '/',
+                        $target_path_separator . '/',
+                        $mapping['target_path']
+                    ),
                 ]
             );
         }
@@ -288,11 +319,16 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     ): string
     {
         $escaped_separator = '(?:\\\\{1}|\\\\{3})?';
-        $source_path_pattern = str_replace(
-            '/',
-            $escaped_separator . '/',
-            preg_quote($source_path, '~')
-        );
+        $source_path_pattern = '';
+        if ($source_path !== '') {
+            $source_path_pattern =
+                '(?<source_path_separator>' . $escaped_separator . ')/' .
+                str_replace(
+                    '/',
+                    $escaped_separator . '/',
+                    preg_quote(substr($source_path, 1), '~')
+                );
+        }
 
         return '~
             (?<![A-Za-z0-9._%+\\/@-])
@@ -300,7 +336,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                 (?i:' . preg_quote($source_scheme, '~') . ')
                 ' . $escaped_separator . ':
                 ' . $escaped_separator . '/
-                ' . $escaped_separator . '/
+                (?<scheme_path_separator>' . $escaped_separator . ')/
                 (?:[^\s<>@/\\\\]+@)?
             )?
             (?<base>
@@ -309,7 +345,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             )
             (?=
                 $
-                | ' . $escaped_separator . '/
+                | (?<suffix_separator>' . $escaped_separator . ')/
                 | [/?# \t\r\n,!;)\]}>"\']
             )
         ~x';
@@ -321,6 +357,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
+     *     target_path: string,
      *     pattern: string
      * }|null
      */
@@ -337,6 +374,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             'source_path'      => $source['path'],
             'source_base'      => $source['authority'] . $source['path'],
             'target_domain'    => $target['host'],
+            'target_path'      => $target['path'],
             'pattern'          => $this->create_url_candidate_pattern(
                 $source['scheme'],
                 $source['authority'],
@@ -364,8 +402,12 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
         $scheme = strtolower( (string) $parts['scheme'] );
         $host = (string) $parts['host'];
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
+        $has_unsupported_target_path =
+            !$is_source_url &&
+            $path !== '' &&
+            preg_match('#^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$#', $path) !== 1;
         if (( $scheme !== 'http' && $scheme !== 'https' )
-            || ( !$is_source_url && ( array_key_exists('port', $parts) || $path !== '' ) )
+            || ( !$is_source_url && ( array_key_exists('port', $parts) || $has_unsupported_target_path ) )
             || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
             || !$this->contains_only_exclamation_mark_through_tilde_bytes($path)) {
             return null;

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -192,11 +192,10 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * Queues replacement of the complete current source base.
      *
-     * Mapping source.example/media to destination.example changes
+     * Mapping source.example/media to destination.example/assets changes
      * https://source.example/media/logo.png to
-     * https://destination.example/assets/logo.png when the target has the
-     * restricted /assets path. The protocol and logo.png suffix are outside
-     * the matched base and remain unchanged.
+     * https://destination.example/assets/logo.png. The protocol and original
+     * /logo.png suffix are outside the matched base and remain unchanged.
      */
     public function replace_url_base(): bool
     {

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -128,6 +128,7 @@ class SqlStatementRewriter
             && strpos($sql, 'dHA6') === false
             && strpos($sql, 'dHBz') === false
             && strpos($sql, 'dHRw') === false
+            && !$this->might_contain_nested_builder_data($sql)
         ) {
             return $sql;
         }
@@ -154,6 +155,23 @@ class SqlStatementRewriter
         $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
         $scanner = new Base64ValueScanner($sql, $tokens);
         return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+    }
+
+    /**
+     * Return whether an INSERT names a WordPress content column which may hold
+     * a nested builder value. An outer Base64 payload cannot expose the HTTP
+     * prefix when a shortcode body contains a second Base64 payload, so those
+     * columns must reach the decoded-value classifier.
+     */
+    private function might_contain_nested_builder_data(string $sql): bool
+    {
+        foreach (['post_content', 'post_content_filtered', 'post_excerpt', 'comment_content', 'description'] as $column) {
+            if (stripos($sql, $column) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -185,17 +203,19 @@ class SqlStatementRewriter
 
     private function rewrite_value_for_column(string $value, string $table, ?string $column): string
     {
-        if (strpos($value, 'http') === false) {
-            return $value;
-        }
-
-        if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
-            return $value;
-        }
-
         $content_type = $column !== null
             ? $this->get_content_type($table, $column)
             : null;
+
+        if (
+            $content_type !== StructuredDataUrlRewriter::BLOCK_MARKUP &&
+            (
+                strpos($value, 'http') === false ||
+                !$this->url_rewriter->value_might_contain_source_domain($value)
+            )
+        ) {
+            return $value;
+        }
 
         // Rewrite URLs in the value. Known block-markup columns go through
         // the structured block parser so alternate URL spellings (for example
@@ -222,32 +242,40 @@ class SqlStatementRewriter
     private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
     {
         while ($scanner->next_value()) {
-            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
-                continue;
-            }
-
-            $value = $scanner->get_value();
-
-            if (strpos($value, 'http') === false) {
-                continue;
-            }
-
-            if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
-                continue;
-            }
-
             // Determine content type hint for this column.
             $column_name = null;
+            $table_name = '';
             if ($value_to_column_map !== null) {
+                $table_name = $value_to_column_map['table'];
                 $column_name = $this->find_column_at_offset(
                     $value_to_column_map['column_map'],
                     $scanner->get_match_offset()
                 );
             }
 
+            $content_type = $column_name !== null
+                ? $this->get_content_type($table_name, $column_name)
+                : null;
+            $nested_builder_data = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP;
+            if (!$nested_builder_data && !$scanner->encoded_payload_could_contain_http_scheme()) {
+                continue;
+            }
+
+            $value = $scanner->get_value();
+
+            if (
+                !$nested_builder_data &&
+                (
+                    strpos($value, 'http') === false ||
+                    !$this->url_rewriter->value_might_contain_source_domain($value)
+                )
+            ) {
+                continue;
+            }
+
             $rewritten = $this->rewrite_value_for_column(
                 $value,
-                $value_to_column_map['table'] ?? '',
+                $table_name,
                 $column_name
             );
 

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -154,7 +154,13 @@ class StructuredDataUrlRewriter
         // source domain, there's nothing to rewrite. This avoids expensive
         // parsing (serialized PHP, JSON, block markup) for the vast majority
         // of values that don't contain any rewritable URLs.
-        if (!$this->maybe_contains_rewritable_urls($value)) {
+        if (
+            !$this->maybe_contains_rewritable_urls($value) &&
+            (
+                $content_type !== self::BLOCK_MARKUP ||
+                !$this->might_contain_base64_shortcode_body($value)
+            )
+        ) {
             return $value;
         }
 
@@ -227,6 +233,19 @@ class StructuredDataUrlRewriter
             }
         }
         return false;
+    }
+
+    /**
+     * Return whether a block-markup value may contain a Base64 shortcode body.
+     * The later decoder remains the authority on Base64 validity and whether
+     * the decoded value actually contains a mapped URL.
+     */
+    private function might_contain_base64_shortcode_body(string $value): bool
+    {
+        return preg_match(
+            '/\[[A-Za-z][A-Za-z0-9_-]*(?:\s+[^\]]*)?\][A-Za-z0-9+\/=]+\[\/[A-Za-z][A-Za-z0-9_-]*\]/',
+            $value
+        ) === 1;
     }
 
     /**
@@ -450,7 +469,13 @@ class StructuredDataUrlRewriter
                 while ( $p->next_token() ) {
                     $token_type = $p->get_token_type() ?? '';
                     if ( '#text' === $token_type ) {
-                        if ($this->maybe_contains_rewritable_urls($p->get_modifiable_text())) {
+                        $text = $p->get_modifiable_text();
+                        $rewritten_text = $this->rewrite_base64_shortcode_bodies($text);
+                        if ($rewritten_text !== $text) {
+                            $p->replace_raw_current_text($rewritten_text);
+                            continue;
+                        }
+                        if ($this->maybe_contains_rewritable_urls($text)) {
                             $p->replace_url_bases_in_current_text($this->url_mapping);
                         }
                         continue;
@@ -545,5 +570,38 @@ class StructuredDataUrlRewriter
                 _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );
                 return '';
         }
+    }
+
+    /**
+     * Rewrite a Base64 payload which is the complete body of a shortcode.
+     *
+     * Builder records often make an opaque Base64 value the content between a
+     * shortcode opener and its matching closer. The block-markup processor
+     * sees that whole record as one text token, so the decoded value would
+     * otherwise never reach the JSON, block-markup, or cautious text routes.
+     * This only accepts a contiguous canonical Base64 payload and changes the
+     * enclosing shortcode when its decoded value contains a mapped URL.
+     */
+    private function rewrite_base64_shortcode_bodies(string $text): string
+    {
+        $rewritten = preg_replace_callback(
+            '/(\[([A-Za-z][A-Za-z0-9_-]*)(?:\s+[^\]]*)?\])([A-Za-z0-9+\/=]+)(\[\/\2\])/',
+            function (array $matches): string {
+                $decoded = base64_decode($matches[3], true);
+                if ($decoded === false || !$this->maybe_contains_rewritable_urls($decoded)) {
+                    return $matches[0];
+                }
+
+                $updated = $this->rewrite($decoded, self::BLOCK_MARKUP);
+                if ($updated === $decoded) {
+                    return $matches[0];
+                }
+
+                return $matches[1] . base64_encode($updated) . $matches[4];
+            },
+            $text
+        );
+
+        return $rewritten ?? $text;
     }
 }

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -226,11 +226,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https:\\\\\/\\\\\\/destination.example\\\\\\/assets',
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
-            'target path uses the literal separator from the configured source path' => [
-                'https:\\/\\/source.example/media/logo.png',
-                'https:\\/\\/destination.example/assets/logo.png',
-                ['https://source.example/media' => 'https://destination.example/assets'],
-            ],
             'target path comes before a query after an unmapped authority' => [
                 'https:\\/\\/source.example?download=1',
                 'https:\\/\\/destination.example\\/assets?download=1',

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -201,20 +201,15 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://site.com/source.com/media?next=https://destination.com/media/logo.png',
                 ['https://source.com' => 'https://destination.com'],
             ],
-            'literal target path replaces a configured source path' => [
-                'https://source.example/media/logo.png',
-                'https://destination.example/assets/logo.png',
-                ['https://source.example/media' => 'https://destination.example/assets'],
-            ],
-            'target path accepts hyphen underscore and nested components' => [
-                'https://source.example/media/logo.png',
-                'https://destination.example/assets-2026/_private/logo.png',
-                ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
-            ],
-            'escaped target path uses the source path slash spelling' => [
+            'target path replaces an escaped configured source path' => [
                 'https:\\/\\/source.example\\/media\\/logo.png',
                 'https:\\/\\/destination.example\\/assets\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path accepts hyphen underscore and nested components' => [
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/assets-2026\\/_private\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
             ],
             'target path uses the slash immediately after an unmapped authority' => [
                 'source.example\\/logo.png',
@@ -222,8 +217,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target path uses the protocol separator when the URL has no suffix' => [
-                'https:\\\\\/\\\\\\/source.example',
-                'https:\\\\\/\\\\\\/destination.example\\\\\\/assets',
+                'https:\\/\\/source.example',
+                'https:\\/\\/destination.example\\/assets',
                 ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target path comes before a query after an unmapped authority' => [
@@ -246,23 +241,23 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 ['https://source.example/media' => 'https://destination.example'],
             ],
             'target path has a dot segment' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets/../private'],
             ],
             'target path has an empty segment' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets//private'],
             ],
             'target path has a percent escape' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets%2Fprivate'],
             ],
             'target path ends with a slash' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/source.example\\/media\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets/'],
             ],
             'scheme-less authority without a separator stays unchanged' => [

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -201,6 +201,41 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://site.com/source.com/media?next=https://destination.com/media/logo.png',
                 ['https://source.com' => 'https://destination.com'],
             ],
+            'literal target path replaces a configured source path' => [
+                'https://source.example/media/logo.png',
+                'https://destination.example/assets/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path accepts hyphen underscore and nested components' => [
+                'https://source.example/media/logo.png',
+                'https://destination.example/assets-2026/_private/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
+            ],
+            'escaped target path uses the source path slash spelling' => [
+                'https:\\/\\/source.example\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/assets\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path uses the slash immediately after an unmapped authority' => [
+                'source.example\\/logo.png',
+                'destination.example\\/assets\\/logo.png',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'target path uses the protocol separator when the URL has no suffix' => [
+                'https:\\\\\/\\\\\\/source.example',
+                'https:\\\\\/\\\\\\/destination.example\\\\\\/assets',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
+            'target path uses the literal separator from the configured source path' => [
+                'https:\\/\\/source.example/media/logo.png',
+                'https:\\/\\/destination.example/assets/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'target path comes before a query after an unmapped authority' => [
+                'https:\\/\\/source.example?download=1',
+                'https:\\/\\/destination.example\\/assets?download=1',
+                ['https://source.example' => 'https://destination.example/assets'],
+            ],
         ];
     }
 
@@ -215,10 +250,30 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://SOURCE.EXAMPLE/Media/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
             ],
-            'target has a path' => [
+            'target path has a dot segment' => [
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
-                ['https://source.example/media' => 'https://destination.example/assets'],
+                ['https://source.example/media' => 'https://destination.example/assets/../private'],
+            ],
+            'target path has an empty segment' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets//private'],
+            ],
+            'target path has a percent escape' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets%2Fprivate'],
+            ],
+            'target path ends with a slash' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets/'],
+            ],
+            'scheme-less authority without a separator stays unchanged' => [
+                'source.example',
+                'source.example',
+                ['https://source.example' => 'https://destination.example/assets'],
             ],
             'target has a percent-encoded path' => [
                 'https://source.example/media/logo.png',

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -193,6 +193,22 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
+    public function testPostContentRewritesBase64ShortcodeBodyWithoutAnOuterHttpPrefix(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = '[vc_raw_html]' . base64_encode(
+            '<img src="https://old-site.com/uploads/logo.png">'
+        ) . '[/vc_raw_html]';
+        $expected = '[vc_raw_html]' . base64_encode(
+            '<img src="https://new-site.com/uploads/logo.png">'
+        ) . '[/vc_raw_html]';
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('" . base64_encode($value) . "'));";
+
+        $values = $this->collectValues($rewriter->rewrite($sql));
+
+        $this->assertSame([$expected], $values);
+    }
+
     public function testUnknownColumnUsesPlainTextUrlScanning(): void
     {
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -364,6 +364,19 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }
 
+    public function testBlockMarkupRewritesBase64ShortcodeBody(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[vc_raw_html]' . base64_encode(
+            '<img src="https://old-site.com/uploads/logo.png">'
+        ) . '[/vc_raw_html]';
+        $expected = '[vc_raw_html]' . base64_encode(
+            '<img src="https://new-site.com/uploads/logo.png">'
+        ) . '[/vc_raw_html]';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
     /**
      * @return array<string, array{0:string, 1:string}>
      */


### PR DESCRIPTION
This stacked draft lets known WordPress content columns reach the nested-data classifier even when an outer Base64 SQL value does not contain an HTTP prefix. It then detects canonical Base64 shortcode bodies, decodes their value, routes it through the existing block-markup classifier, and restores the original shortcode bytes around the rewritten payload.\n\nIt deliberately does not add builder-specific URL rules or broaden URL spelling support.