### PR TITLE
[PHP] Classify CSS and JSON script text

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-text-block-markup-url-processor.php
@@ -59,7 +59,7 @@ class CautiousTextBlockMarkupUrlProcessor extends BlockMarkupUrlProcessor {
     }
 
     /**
-     * Replace configured URL bases in the current raw text token.
+     * Replace configured URL bases in the current raw modifiable text.
      *
      * WP_HTML_Tag_Processor exposes decoded text through get_modifiable_text()
      * and HTML-encodes the complete replacement in set_modifiable_text(). The
@@ -70,7 +70,7 @@ class CautiousTextBlockMarkupUrlProcessor extends BlockMarkupUrlProcessor {
      */
     public function replace_url_bases_in_current_text(array $url_mapping): bool
     {
-        if ('#text' !== $this->get_token_type()) {
+        if ($this->get_token_type() !== '#text' && $this->get_token_type() !== '#tag') {
             return false;
         }
 

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -481,6 +481,13 @@ class StructuredDataUrlRewriter
                         continue;
                     }
 
+                    if ($this->token_has_css_or_json_text($p)) {
+                        $text = $p->get_modifiable_text();
+                        if ($this->maybe_contains_rewritable_urls($text)) {
+                            $p->replace_url_bases_in_current_text($this->url_mapping);
+                        }
+                    }
+
                     while ( $p->next_url_in_current_token() ) {
                         $raw_url = $p->get_raw_url();
                         $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
@@ -570,6 +577,32 @@ class StructuredDataUrlRewriter
                 _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );
                 return '';
         }
+    }
+
+    /**
+     * Return whether the current tag owns CSS or JSON text. Those values are
+     * raw text in the HTML tokenizer, not ordinary HTML text nodes. Keep their
+     * original escaping while the cautious processor replaces only a mapped
+     * URL base.
+     */
+    private function token_has_css_or_json_text(CautiousTextBlockMarkupUrlProcessor $processor): bool
+    {
+        $tag = strtolower($processor->get_tag() ?? '');
+        if ($tag === 'style') {
+            return true;
+        }
+
+        if ($tag !== 'script') {
+            return false;
+        }
+
+        $type = $processor->get_attribute('type');
+        if (!is_string($type)) {
+            return false;
+        }
+
+        $mime_type = strtolower(trim(explode(';', $type, 2)[0]));
+        return $mime_type === 'application/ld+json' || $mime_type === 'application/json';
     }
 
     /**

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -377,6 +377,24 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }
 
+    public function testBlockMarkupUsesCautiousReplacementInStyleTagText(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<style>.hero{background:url(https:\\/\\/old-site.com\\/uploads\\/hero.jpg)}</style>';
+        $expected = '<style>.hero{background:url(https:\\/\\/new-site.com\\/uploads\\/hero.jpg)}</style>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testBlockMarkupUsesCautiousReplacementInJsonScriptText(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<script type="application/ld+json; charset=UTF-8">{"image":"https:\\/\\/old-site.com\\/uploads\\/logo.png"}</script>';
+        $expected = '<script type="application/ld+json; charset=UTF-8">{"image":"https:\\/\\/new-site.com\\/uploads\\/logo.png"}</script>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
     /**
      * @return array<string, array{0:string, 1:string}>
      */


### PR DESCRIPTION
This stacked draft recognizes CSS in style tags and JSON in script tags declared as application/ld+json or application/json. Their raw modifiable text now uses the cautious base replacement, preserving its existing quote and escape spelling.\n\nStyle attributes keep their existing structured CSS path; this change does not broaden CSS escape decoding or arbitrary attribute processing.