### PR TITLE
Allow retries for more transient-like cURL errors

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -177,6 +177,23 @@ class ImportClient
      */
     private const MAX_CONSECUTIVE_INTERRUPTED_RESPONSES = 3;
 
+    /**
+     * cURL error numbers that can be temporary, often meaning the peer cut the transfer short.
+     * We can attempt some retries from these errors before giving up.
+     */
+    private const TRANSIENT_CURL_ERROR_NUMBERS = [
+        // Transfer- and socket-level; reachable over any HTTP version.
+        18, // CURLE_PARTIAL_FILE — transfer shorter or longer than announced
+        52, // CURLE_GOT_NOTHING  — empty response
+        55, // CURLE_SEND_ERROR   — peer reset while the request body was uploading
+        56, // CURLE_RECV_ERROR   — connection reset / receive failure
+        // HTTP/2 framing layer; reachable only when h2 is negotiated.
+        16, // CURLE_HTTP2        — HTTP/2 connection framing error (GOAWAY)
+        92, // CURLE_HTTP2_STREAM — HTTP/2 stream reset by the server (RST_STREAM)
+        // HTTP/3 framing layer. Inert until something opts into h3
+        95, // CURLE_HTTP3        — HTTP/3 layer error
+    ];
+
     /** @var string Remote Reprint API URL. */
     public $remote_reprint_api_url;
 
@@ -9952,32 +9969,69 @@ class ImportClient
      */
     private function check_curl_error($ch): void
     {
-        if (!curl_errno($ch)) {
+        $error_number = curl_errno($ch);
+        if (!$error_number) {
             return;
         }
-        $errno = curl_errno($ch);
-        $error = curl_error($ch);
-        $timeout_errno = defined("CURLE_OPERATION_TIMEDOUT")
+
+        $error_message = curl_error($ch);
+        $protocol = self::describe_curl_http_version(
+            (int) curl_getinfo($ch, CURLINFO_HTTP_VERSION),
+        );
+        $timeout_error_number = defined("CURLE_OPERATION_TIMEDOUT")
             ? CURLE_OPERATION_TIMEDOUT
             : 28;
-        $this->last_curl_errno = $errno;
-        $this->last_curl_timeout = $errno === $timeout_errno;
+
+        $this->last_curl_errno = $error_number;
+        $this->last_curl_timeout = $error_number === $timeout_error_number;
+
         if ($this->last_curl_timeout) {
-            throw new CurlTimeoutException("cURL error: {$error}");
-        }
-        // These errors mean the response ended before cURL could finish
-        // receiving it. Content-decoding failures such as
-        // CURLE_BAD_CONTENT_ENCODING (61) remain fatal because the same bytes
-        // will fail again after resumption.
-        //   18 = CURLE_PARTIAL_FILE (transfer closed mid-stream)
-        //   52 = CURLE_GOT_NOTHING (empty response)
-        //   56 = CURLE_RECV_ERROR (connection reset / receive failure)
-        if (in_array($errno, [18, 52, 56], true)) {
-            throw new TransientInterruptionException(
-                "cURL error ({$errno}): {$error}",
+            throw new CurlTimeoutException(
+                "cURL error over {$protocol}: {$error_message}",
             );
         }
-        throw new RuntimeException("cURL error ($errno): {$error}");
+
+        if (in_array($error_number, self::TRANSIENT_CURL_ERROR_NUMBERS, true)) {
+            throw new TransientInterruptionException(
+                "cURL error ({$error_number}) over {$protocol}: {$error_message}",
+            );
+        }
+
+        throw new RuntimeException(
+            "cURL error ({$error_number}) over {$protocol}: {$error_message}",
+        );
+    }
+
+    /**
+     * Render a CURLINFO_HTTP_VERSION value as the wire protocol name.
+     *
+     * An error number alone does not say which protocol a request negotiated,
+     * which is what makes a transport failure hard to diagnose after the fact.
+     * Naming the protocol in the error puts it in the operator's log.
+     *
+     * These are libcurl's runtime values, not PHP's constant names, so they are
+     * matched as literals: CURL_HTTP_VERSION_3 does not exist on the PHP 7.4
+     * this package supports, and naming it would fatal on any PHP that predates
+     * it while libcurl still reports 30 for an h3 transfer.
+     *
+     * @param int $http_version Value from curl_getinfo(CURLINFO_HTTP_VERSION).
+     */
+    private static function describe_curl_http_version(int $http_version): string
+    {
+        switch ($http_version) {
+            case 1: // CURL_HTTP_VERSION_1_0
+                return "HTTP/1.0";
+            case 2: // CURL_HTTP_VERSION_1_1
+                return "HTTP/1.1";
+            case 3: // CURL_HTTP_VERSION_2_0
+                return "HTTP/2";
+            case 30: // CURL_HTTP_VERSION_3
+                return "HTTP/3";
+            default:
+                // CURL_HTTP_VERSION_NONE — the connection failed before a
+                // protocol was negotiated, or the value is from a newer curl.
+                return "unnegotiated HTTP version";
+        }
     }
 
     /**
@@ -10588,7 +10642,11 @@ class ImportClient
         $result = curl_exec($ch);
         $this->audit_log(
             "curl_exec completed, result=" .
-                ($result === false ? "false" : "true"),
+                ($result === false ? "false" : "true") .
+                " | protocol=" .
+                self::describe_curl_http_version(
+                    (int) curl_getinfo($ch, CURLINFO_HTTP_VERSION),
+                ),
             false,
         );
 

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -391,6 +391,124 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // cURL error number classification
+    // ---------------------------------------------------------------
+
+    /**
+     * A real transfer cut short by the peer must raise
+     * TransientInterruptionException so the caller can checkpoint and resume.
+     *
+     * Driven over a real socket rather than by injecting an error number: a
+     * server that accepts and closes without replying makes cURL report either
+     * CURLE_GOT_NOTHING (52) or CURLE_RECV_ERROR (56) depending on how far the
+     * exchange got. Both are in TRANSIENT_CURL_ERROR_NUMBERS, so this proves
+     * the classification on the wire instead of restating the constant.
+     */
+    public function testTransferCutShortByPeerIsTransient()
+    {
+        [$server, $url] = $this->startConnectionClosingServer();
+
+        try {
+            $curl = curl_init($url);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+            curl_exec($curl);
+
+            $errorNumber = curl_errno($curl);
+            $this->assertContains(
+                $errorNumber,
+                [52, 56],
+                'The stub server should make cURL report a cut-short transfer',
+            );
+
+            [$client, $reflection] = $this->prepareClient();
+            $checkCurlError = $reflection->getMethod('check_curl_error');
+
+            try {
+                $checkCurlError->invoke($client, $curl);
+                $this->fail('A transfer cut short by the peer should have thrown');
+            } catch (TransientInterruptionException $e) {
+                $this->assertStringContainsString("({$errorNumber})", $e->getMessage());
+            }
+
+            curl_close($curl);
+        } finally {
+            proc_close($server);
+        }
+    }
+
+    /**
+     * A failure that will reproduce on the next request must stay fatal.
+     * Connecting to a closed port yields CURLE_COULDNT_CONNECT (7), which is
+     * deliberately absent from TRANSIENT_CURL_ERROR_NUMBERS.
+     */
+    public function testUnreachableHostStaysFatal()
+    {
+        $curl = curl_init('http://127.0.0.1:1/');
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_exec($curl);
+
+        $this->assertSame(
+            7,
+            curl_errno($curl),
+            'Connecting to a closed port should report CURLE_COULDNT_CONNECT',
+        );
+
+        [$client, $reflection] = $this->prepareClient();
+        $checkCurlError = $reflection->getMethod('check_curl_error');
+
+        try {
+            $checkCurlError->invoke($client, $curl);
+            $this->fail('An unreachable host should have thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertNotInstanceOf(
+                InterruptedResponseException::class,
+                $e,
+                'An unreachable host must not be treated as a resumable interruption',
+            );
+        }
+
+        curl_close($curl);
+    }
+
+    /**
+     * Start a server that accepts a connection then closes it without a
+     * response. Returns the process handle and the URL to request.
+     */
+    private function startConnectionClosingServer(): array
+    {
+        $port = 8000 + (getmypid() % 20000);
+        $script = $this->tempDir . '/close-immediately.php';
+        file_put_contents($script, <<<'PHP'
+<?php
+$server = stream_socket_server("tcp://127.0.0.1:" . $argv[1], $errno, $errstr);
+if (!$server) {
+    exit(1);
+}
+echo "ready\n";
+$connection = stream_socket_accept($server, 10);
+if ($connection) {
+    fclose($connection);
+}
+fclose($server);
+PHP);
+
+        $process = proc_open(
+            sprintf('%s %s %d', escapeshellarg(PHP_BINARY), escapeshellarg($script), $port),
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+        $this->assertIsResource($process, 'The stub server should start');
+
+        // Block until the listener is bound so the request cannot race it.
+        $this->assertSame('ready', trim((string) fgets($pipes[1])));
+
+        return [$process, "http://127.0.0.1:{$port}/"];
+    }
+
+
+    // ---------------------------------------------------------------
     // Consecutive interrupted-response counter
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
These are the cURL error codes that can indicate just a temporary hiccup, so we should retry again up to the max retry limit (3) rather than hard aborting right away.