### PR TITLE
[PHP] Preserve root slashes in cautious URL rewrites

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -39,7 +39,8 @@
  * - ASCII domains and IPv4 or IPv6 addresses, with an optional port.
  * - An optional initial path containing only bytes from `!` (0x21) through
  *   `~` (0x7E). Spaces and multibyte characters are rejected. That path is
- *   part of the source base and is removed with it. Mapping
+ *   part of the source base and is removed with it. A root slash is the URL
+ *   separator rather than a removable path, so it remains after replacement. Mapping
  *   https://source.example/media to
  *   https://destination.example changes
  *   https://source.example/media/logo.png to
@@ -332,15 +333,19 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             return null;
         }
 
+        // A source URL ending at its authority uses / as the URL separator,
+        // not as an initial path to remove. Leave its original spelling alone.
+        $source_path = $source['path'] === '/' ? '' : $source['path'];
+
         return [
             'source_authority' => $source['authority'],
-            'source_path'      => $source['path'],
-            'source_base'      => $source['authority'] . $source['path'],
+            'source_path'      => $source_path,
+            'source_base'      => $source['authority'] . $source_path,
             'target_domain'    => $target['host'],
             'pattern'          => $this->create_url_candidate_pattern(
                 $source['scheme'],
                 $source['authority'],
-                $source['path']
+                $source_path
             ),
         ];
     }

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -131,6 +131,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https:\\/\\/destination.example\\/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
             ],
+            'source root slash remains after a longer target domain' => [
+                'http://source.example/',
+                'http://much-longer-destination.example/',
+                ['http://source.example/' => 'http://much-longer-destination.example'],
+            ],
             'escaped JSON in a shortcode attribute' => [
                 '[builder config="{\\"image\\":\\"https:\\/\\/source.example\\/media\\/hero.jpg\\"}"]',
                 '[builder config="{\\"image\\":\\"https:\\/\\/destination.example\\/media\\/hero.jpg\\"}"]',

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -164,6 +164,25 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame('https://new-site.com/page', unserialize($result));
     }
 
+    public function testPreservesRootSlashInSerializedPhp(): void
+    {
+        $rewriter = $this->createRewriter([
+            'http://old-site.com/' => 'http://much-longer-destination.example',
+        ]);
+        $input = serialize(['siteurl' => 'http://old-site.com/']);
+
+        $result = $rewriter->rewrite($input);
+
+        $this->assertSame(
+            'http://much-longer-destination.example/',
+            unserialize($result)['siteurl']
+        );
+        $this->assertStringContainsString(
+            's:' . strlen('http://much-longer-destination.example/') . ':',
+            $result
+        );
+    }
+
     public function testRewritesUrlsInDoubleSerializedPhp(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
Mappings such as `http://old-site.com/` no longer lose the root slash when a cautious rewrite replaces their authority.

For this mapping:

```text
http://old-site.com/ → http://much-longer-destination.example
```

the old cautious replacement produced a valid serialization of the wrong URL:

```text
a:1:{s:7:"siteurl";s:20:"http://old-site.com/";}
→ a:1:{s:7:"siteurl";s:38:"http://much-longer-destination.example";}
```

The source `/` was treated as a removable path. This change replaces only the authority, retaining the original separator:

```text
a:1:{s:7:"siteurl";s:39:"http://much-longer-destination.example/";}
```

Mapped non-root paths continue to be removed. Tests cover the cautious processor and the serialized PHP byte-length prefix.
