### PR TITLE
[PHP] Preserve decoded URL suffixes in structured block markup

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -5,6 +5,8 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupProcessor;
 use WordPress\DataLiberation\URL\CSSURLProcessor;
 use WordPress\DataLiberation\URL\WPURL;
 
+use function WordPress\DataLiberation\URL\is_child_url_of;
+
 /**
  * Reports URLs in structured block markup and enables rewriting them.
  *
@@ -45,6 +47,16 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $base_url_object;
 	private $css_url_processor;
 	private $css_url_processor_updated;
+
+	/**
+	 * Whether a structured URL in this token failed source-boundary validation.
+	 *
+	 * The cautious pass cannot exclude that URL from its raw-token scan. Skipping
+	 * the pass for this token prevents it from bypassing the failed validation.
+	 *
+	 * @var bool
+	 */
+	private $structured_url_source_boundary_failed = false;
 
 	/**
 	 * The list of names of URL-related HTML attributes that may be available on
@@ -96,6 +108,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url                 = null;
 		$this->inspecting_html_attributes = null;
 		$this->css_url_processor          = null;
+		$this->structured_url_source_boundary_failed = false;
 		/*
 		 * Do not reset css_url_processor_updated – it is reset in
 		 * get_updated_html() which is called in parent::next_token().
@@ -138,6 +151,9 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	 */
 	public function replace_url_bases_in_current_token( CautiousURLBaseRewriteMapping $prepared_url_mapping ): bool {
 		$html = $this->get_updated_html();
+		if ( $this->structured_url_source_boundary_failed ) {
+			return false;
+		}
 		if ( ! $this->set_bookmark( 'cautious URL base replacement' ) ) {
 			return false;
 		}
@@ -378,6 +394,11 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		if ( null === $this->raw_url ) {
 			return false;
 		}
+		if ( $raw_url === $this->raw_url ) {
+			// A relative URL may resolve against a new base without changing its source spelling.
+			$this->parsed_url = $parsed_url;
+			return true;
+		}
 		$this->raw_url    = $raw_url;
 		$this->parsed_url = $parsed_url;
 		switch ( parent::get_token_type() ) {
@@ -407,11 +428,16 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	 * Rewrites the components of the currently matched URL from ones
 	 * provided in $from_url to ones specified in $to_url.
 	 *
-	 * It preserves the relative nature of the matched URL.
+	 * It keeps absolute URLs absolute, does not add a scheme to relative URLs,
+	 * and preserves every decoded URL byte outside the mapped scheme,
+	 * authority, and pathname prefix. Unsupported source spellings are left
+	 * unchanged.
 	 */
 	public function replace_base_url( $to_url, $base_url = null ) {
 		$base_url = $base_url ?? $this->base_url_object;
-		if ( ! $base_url ) {
+		$base_url = WPURL::parse( $base_url );
+		$to_url   = WPURL::parse( $to_url );
+		if ( false === $base_url || false === $to_url ) {
 			return false;
 		}
 
@@ -429,9 +455,186 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		$this->set_url( $result . '', $result->new_url );
+		$source_preserving_raw_url = self::create_source_preserving_raw_url(
+			$this->get_raw_url(),
+			$this->get_parsed_url(),
+			$result,
+			$base_url,
+			$to_url
+		);
+		if ( null === $source_preserving_raw_url ) {
+			/*
+			 * The cautious token pass cannot distinguish this structured URL from
+			 * opaque token content. Skip that pass rather than bypassing the failed
+			 * source-boundary check.
+			 */
+			$this->structured_url_source_boundary_failed = true;
+			return false;
+		}
 
-		return true;
+		return $this->set_url(
+			$source_preserving_raw_url,
+			WPURL::parse( $source_preserving_raw_url, $to_url->toString() )
+		);
+	}
+
+	/**
+	 * Creates a decoded URL with only its base components replaced.
+	 *
+	 * Only spellings whose base-component boundaries can be located from
+	 * literal delimiters are accepted. Ambiguous spellings return null. The
+	 * edited string is reparsed and returned only when it matches the normal
+	 * semantic conversion.
+	 *
+	 * @return string|null
+	 */
+	private static function create_source_preserving_raw_url( $raw_url, $url, $converted_url, $old_base_url, $new_base_url ) {
+		$updated_url = $converted_url->new_url;
+		$source_url = WPURL::parse( $raw_url, $old_base_url->toString() );
+		if (
+			false === $source_url ||
+			$source_url->toString() !== $url->toString() ||
+			! is_child_url_of( $source_url, $old_base_url )
+		) {
+			return null;
+		}
+
+		$is_absolute          = 1 === preg_match( '/\A([A-Za-z][A-Za-z0-9+.\-]*):\/\//', $raw_url, $absolute_match );
+		$is_protocol_relative = 0 === strpos( $raw_url, '//' );
+		$is_path_relative     = ! $is_absolute && ! $is_protocol_relative && 0 !== strpos( $raw_url, '/' );
+		if (
+			( $is_absolute && 'file' === strtolower( $absolute_match[1] ) ) ||
+			( ! $is_absolute && 1 === preg_match( '/\A[A-Za-z][A-Za-z0-9+.\-]*:/', $raw_url ) ) ||
+			( $is_path_relative && ( 0 === strpos( $raw_url, './' ) || 0 === strpos( $raw_url, '../' ) ) )
+		) {
+			return null;
+		}
+
+		$path_end     = strcspn( $raw_url, '?#' );
+		$path_start   = 0;
+		$replacements = array();
+		if ( $is_absolute || $is_protocol_relative ) {
+			$scheme_end      = $is_absolute ? strpos( $raw_url, ':' ) : null;
+			$authority_start = $is_absolute ? $scheme_end + 3 : 2;
+			$path_start      = $authority_start + strcspn( $raw_url, '/?#', $authority_start );
+			if ( $authority_start === $path_start ) {
+				return null;
+			}
+
+			$authority   = substr( $raw_url, $authority_start, $path_start - $authority_start );
+			$userinfo_at = strrpos( $authority, '@' );
+			$host_start  = $authority_start + ( false === $userinfo_at ? 0 : $userinfo_at + 1 );
+			$raw_host    = substr( $raw_url, $host_start, $path_start - $host_start );
+			if ( $is_absolute && $url->protocol !== $updated_url->protocol ) {
+				$replacements[] = array(
+					'start'       => 0,
+					'length'      => $scheme_end,
+					'replacement' => rtrim( $updated_url->protocol, ':' ),
+				);
+			}
+			if (
+				$url->host !== $updated_url->host ||
+				(
+					$url->protocol !== $updated_url->protocol &&
+					1 === preg_match( '/:\d+$/', $raw_host )
+				)
+			) {
+				$replacements[] = array(
+					'start'       => $host_start,
+					'length'      => $path_start - $host_start,
+					'replacement' => $updated_url->host,
+				);
+			}
+		}
+
+		if ( $old_base_url->pathname !== $new_base_url->pathname ) {
+			$raw_path = substr( $raw_url, $path_start, $path_end - $path_start );
+
+			/*
+			 * Rooted spellings use the parsed base's number of slash-delimited
+			 * segments. Relative spellings use the leading reference that resolves
+			 * to the base. Parsing that prefix validates its normalized path. Split
+			 * before decoding so "%2F" cannot become a delimiter.
+			 */
+			$source_segment_count = substr_count( rtrim( $old_base_url->pathname, '/' ), '/' );
+			if ( $is_path_relative ) {
+				$source_segment_count = (
+					'' === $raw_path ||
+					0 === $source_segment_count ||
+					'/' === substr( $old_base_url->pathname, -1 )
+				) ? 0 : 1;
+			}
+
+			$raw_path_segments = explode( '/', $raw_path );
+			$segments_to_use   = $source_segment_count + ( 0 === strpos( $raw_path, '/' ) ? 1 : 0 );
+			$source_length     = strlen( implode( '/', array_slice( $raw_path_segments, 0, $segments_to_use ) ) );
+
+			$source_prefix_url = WPURL::parse(
+				substr( $raw_url, 0, $path_start + $source_length ),
+				$old_base_url->toString()
+			);
+			if (
+				false === $source_prefix_url ||
+				$source_prefix_url->protocol !== $old_base_url->protocol ||
+				$source_prefix_url->hostname !== $old_base_url->hostname ||
+				array_map( 'rawurldecode', explode( '/', rtrim( $source_prefix_url->pathname, '/' ) ) ) !==
+					array_map( 'rawurldecode', explode( '/', rtrim( $old_base_url->pathname, '/' ) ) )
+			) {
+				return null;
+			}
+
+			$unmatched_path = substr( $raw_path, $source_length );
+			$target_path    = '/' === $new_base_url->pathname ? '' : rtrim( $new_base_url->pathname, '/' );
+			if (
+				'' !== $target_path &&
+				(
+					( '' !== $unmatched_path && '/' !== $unmatched_path[0] ) ||
+					( '' === $unmatched_path && $path_end < strlen( $raw_url ) ) ||
+					( $is_path_relative && '' === $raw_path && '/' === substr( $old_base_url->pathname, -1 ) )
+				)
+			) {
+				$target_path .= '/';
+			} elseif (
+				'' === $unmatched_path &&
+				'' === $target_path &&
+				( ! $is_path_relative || '' === $raw_path )
+			) {
+				$target_path = '/';
+			}
+			$replacements[] = array(
+				'start'       => $path_start,
+				'length'      => $source_length,
+				'replacement' => $target_path,
+			);
+		}
+
+		foreach ( $replacements as $replacement ) {
+			if ( false !== strpos( substr( $raw_url, $replacement['start'], $replacement['length'] ), '\\' ) ) {
+				return null;
+			}
+		}
+
+		$source_preserving_raw_url = $raw_url;
+		foreach ( array_reverse( $replacements ) as $replacement ) {
+			$source_preserving_raw_url = substr_replace(
+				$source_preserving_raw_url,
+				$replacement['replacement'],
+				$replacement['start'],
+				$replacement['length']
+			);
+		}
+
+		$source_preserving_url = WPURL::parse( $source_preserving_raw_url, $new_base_url->toString() );
+		$expected_url          = WPURL::parse( (string) $converted_url, $new_base_url->toString() );
+		if (
+			false === $source_preserving_url ||
+			false === $expected_url ||
+			$source_preserving_url->toString() !== $expected_url->toString()
+		) {
+			return null;
+		}
+
+		return $source_preserving_raw_url;
 	}
 
 	/**

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -31,7 +31,7 @@ class StructuredDataUrlRewriter
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
     private const STRUCTURED_REWRITE_CACHE_MAX = 4096;
-    private const REWRITE_RESULT_CACHE_MAX = 4096;
+    private const MAPPING_INDEX_CACHE_MAX = 4096;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
@@ -43,9 +43,9 @@ class StructuredDataUrlRewriter
      * Pre-parsed url_mapping: each entry is
      *   [ 'from_url' => <parsed URL>, 'to_url' => <parsed URL> ]
      * where <parsed URL> is whatever WPURL::parse() returns (declared as
-     * mixed here because is_child_url_of() and WPURL::replace_base_url()
-     * both accept either a string or the parsed object form — we pass the
-     * object form for performance).
+     * mixed here because is_child_url_of() and the structured block processor
+     * both accept either a string or the parsed object form — we pass the object
+     * form for performance).
      *
      * Parsing is pure, deterministic work that used to happen inside
      * rewrite_urls() on every leaf-value call. With N mappings and L leaves
@@ -61,9 +61,6 @@ class StructuredDataUrlRewriter
     /** @var string Default base_url used by the URL processors (first from-url). */
     private string $base_url;
 
-    /** @var string Cache namespace for this rewriter's URL mapping. */
-    private string $mapping_cache_key;
-
     /** @var array<string, array{content_type: string, input: string, output: string}> */
     private array $structured_rewrite_cache = [];
 
@@ -72,13 +69,20 @@ class StructuredDataUrlRewriter
 
     private int $structured_rewrite_cache_next = 0;
 
-    /** @var array<string, false|array{raw_url: string, parsed_url: mixed}> */
-    private array $rewrite_result_cache = [];
+    /**
+     * Mapping index by parsed URL, or false when no source base matches.
+     *
+     * Only selection is cached. Each occurrence still performs its own base
+     * replacement because equal parsed URLs may have different source spelling.
+     *
+     * @var array<string, false|int>
+     */
+    private array $mapping_index_cache = [];
 
     /** @var string[] */
-    private array $rewrite_result_cache_ring = [];
+    private array $mapping_index_cache_ring = [];
 
-    private int $rewrite_result_cache_next = 0;
+    private int $mapping_index_cache_next = 0;
 
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
@@ -107,8 +111,6 @@ class StructuredDataUrlRewriter
                 'to_url'   => WPURL::parse($to_url_string),
             ];
         }
-        $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
-
         // Default base_url: first from-url in the mapping. Preserves the
         // behaviour of the previous per-call default so outputs are unchanged.
         $from_urls = array_keys($url_mapping);
@@ -364,37 +366,31 @@ class StructuredDataUrlRewriter
         return false;
     }
 
-    private function get_cached_rewrite_result(string $cache_key)
+    private function get_cached_mapping_index(string $cache_key)
     {
-        return array_key_exists($cache_key, $this->rewrite_result_cache)
-            ? $this->rewrite_result_cache[$cache_key]
+        return array_key_exists($cache_key, $this->mapping_index_cache)
+            ? $this->mapping_index_cache[$cache_key]
             : null;
     }
 
     /**
-     * @param array|false $value {
-     *     Cached rewrite result, or false for an uncacheable value.
-     *
-     *     @type string $raw_url    Raw URL value.
-     *     @type mixed  $parsed_url Parsed URL value.
-     * }
-     * @phpstan-param false|array{raw_url: string, parsed_url: mixed} $value
+     * @param int|false $value Mapping index, or false when no source base matches.
      */
-    private function set_cached_rewrite_result(string $cache_key, $value): void
+    private function set_cached_mapping_index(string $cache_key, $value): void
     {
-        if (!array_key_exists($cache_key, $this->rewrite_result_cache)) {
-            if (count($this->rewrite_result_cache_ring) < self::REWRITE_RESULT_CACHE_MAX) {
-                $this->rewrite_result_cache_ring[] = $cache_key;
+        if (!array_key_exists($cache_key, $this->mapping_index_cache)) {
+            if (count($this->mapping_index_cache_ring) < self::MAPPING_INDEX_CACHE_MAX) {
+                $this->mapping_index_cache_ring[] = $cache_key;
             } else {
-                $evicted_key = $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next];
-                unset($this->rewrite_result_cache[$evicted_key]);
-                $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next] = $cache_key;
+                $evicted_key = $this->mapping_index_cache_ring[$this->mapping_index_cache_next];
+                unset($this->mapping_index_cache[$evicted_key]);
+                $this->mapping_index_cache_ring[$this->mapping_index_cache_next] = $cache_key;
             }
 
-            $this->rewrite_result_cache_next = ($this->rewrite_result_cache_next + 1) % self::REWRITE_RESULT_CACHE_MAX;
+            $this->mapping_index_cache_next = ($this->mapping_index_cache_next + 1) % self::MAPPING_INDEX_CACHE_MAX;
         }
 
-        $this->rewrite_result_cache[$cache_key] = $value;
+        $this->mapping_index_cache[$cache_key] = $value;
     }
 
     /**
@@ -440,44 +436,25 @@ class StructuredDataUrlRewriter
             case self::BLOCK_MARKUP:
                 $p = new StructuredBlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_token() ) {
-                    $token_type = $p->get_token_type() ?? '';
                     while ( $p->next_url_in_current_token() ) {
-                        $raw_url = $p->get_raw_url();
-                        $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
-                        $cached = $this->get_cached_rewrite_result($cache_key);
-                        if ($cached !== null) {
-                            if ($cached !== false) {
-                                $p->set_url($cached['raw_url'], $cached['parsed_url']);
-                            }
-                            continue;
-                        }
-
                         $parsed_url = $p->get_parsed_url();
-                        $converted = false;
-                        foreach ( $parsed_mapping as $mapping ) {
-                            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                                $converted = WPURL::replace_base_url(
-                                    $parsed_url,
-                                    array(
-                                        'old_base_url' => $base_url,
-                                        'new_base_url' => $mapping['to_url'],
-                                        'raw_url'      => $raw_url,
-                                        'is_relative'  => ! WPURL::can_parse($raw_url),
-                                    )
-                                );
-                                break;
+                        $cache_key = $parsed_url->toString();
+                        $cached = $this->get_cached_mapping_index($cache_key);
+                        if ($cached === null) {
+                            $cached = false;
+                            foreach ( $parsed_mapping as $mapping_index => $mapping ) {
+                                if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                                    $cached = $mapping_index;
+                                    break;
+                                }
                             }
+                            $this->set_cached_mapping_index($cache_key, $cached);
                         }
 
-                        $cache_value = false;
-                        if ($converted !== false) {
-                            $cache_value = [
-                                'raw_url'    => (string) $converted,
-                                'parsed_url' => $converted->new_url,
-                            ];
-                            $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+                        if ($cached !== false) {
+                            $mapping = $parsed_mapping[$cached];
+                            $p->replace_base_url($mapping['to_url'], $mapping['from_url']);
                         }
-                        $this->set_cached_rewrite_result($cache_key, $cache_value);
                     }
                     $p->replace_url_bases_in_current_token( $this->cautious_url_base_rewrite_mapping );
                 }

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -236,7 +236,7 @@ class SqlStatementRewriterTest extends TestCase
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('https://new-site.com/literal', $values[0]);
-        $this->assertStringContainsString('https://new-site.com/case-variant', $values[0]);
+        $this->assertStringContainsString('HTTPS://new-site.com/case-variant', $values[0]);
         $this->assertStringNotContainsString('old-site.com', strtolower($values[0]));
     }
 

--- a/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
+++ b/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
@@ -232,6 +232,264 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
         ];
     }
 
+    #[DataProvider('sourcePreservingStructuredBaseReplacementProvider')]
+    public function testBaseReplacementPreservesUnmatchedDecodedUrlBytes(
+        string $markup,
+        string $expected
+    ): void {
+        $processor = new StructuredBlockMarkupUrlProcessor(
+            $markup,
+            'http://old.example/media'
+        );
+
+        $this->assertTrue($processor->next_url());
+        $this->assertTrue($processor->replace_base_url('https://new.example/assets'));
+        $this->assertSame($expected, $processor->get_updated_html());
+    }
+
+    public static function sourcePreservingStructuredBaseReplacementProvider(): array
+    {
+        return [
+            'HTML attribute' => [
+                '<a href="http://old.example/media/a/./b/../%7e//file?raw=%2f+%20#F%72ag"></a>',
+                '<a href="https://new.example/assets/a/./b/../%7e//file?raw=%2f+%20#F%72ag"></a>',
+            ],
+            'CSS URL' => [
+                '<div style="background:url(http://old.example/media/file?raw=%2f+%20#F%72ag)"></div>',
+                '<div style="background:url(&quot;https://new.example/assets/file?raw=%2f+%20#F%72ag&quot;)"></div>',
+            ],
+            'block attribute' => [
+                '<!-- wp:image {"url":"http:\/\/old.example\/%6dedia\/file?raw=%2f+%20#F%72ag"} /-->',
+                '<!-- wp:image {"url":"https:\/\/new.example\/assets\/file?raw=%2f+%20#F%72ag"} /-->',
+            ],
+        ];
+    }
+
+    #[DataProvider('decodedUrlCasesProvider')]
+    public function testBaseReplacementHandlesDecodedUrlForms(
+        string $rawUrl,
+        string $oldBaseUrl,
+        string $newBaseUrl,
+        string $expectedRawUrl
+    ): void {
+        $processor = new StructuredBlockMarkupUrlProcessor(
+            '<a href="' . $rawUrl . '"></a>',
+            $oldBaseUrl
+        );
+
+        $this->assertTrue($processor->next_url());
+        $this->assertSame($rawUrl, $processor->get_raw_url());
+        $this->assertTrue($processor->replace_base_url($newBaseUrl));
+        $this->assertSame($expectedRawUrl, $processor->get_raw_url());
+
+        $semanticResult = WPURL::replace_base_url(
+            WPURL::parse($rawUrl, $oldBaseUrl),
+            [
+                'old_base_url' => $oldBaseUrl,
+                'new_base_url' => $newBaseUrl,
+                'raw_url'      => $rawUrl,
+                'is_relative'  => ! WPURL::can_parse($rawUrl),
+            ]
+        );
+        $this->assertNotFalse($semanticResult);
+        $this->assertSame(
+            WPURL::parse( (string) $semanticResult, $newBaseUrl)->toString(),
+            $processor->get_parsed_url()->toString()
+        );
+    }
+
+    public static function decodedUrlCasesProvider(): array
+    {
+        return [
+            'absolute' => [
+                'http://old.example/media/file?x=1#section',
+                'http://old.example/media',
+                'https://new.example/assets',
+                'https://new.example/assets/file?x=1#section',
+            ],
+            'protocol-relative' => [
+                '//old.example/media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+                '//new.example/assets/file',
+            ],
+            'root-relative' => [
+                '/media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+                '/assets/file',
+            ],
+            'percent-encoded source segment' => [
+                '/m%65dia/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+                '/assets/file',
+            ],
+            'path-relative' => [
+                'file',
+                'http://old.example/',
+                'https://new.example/assets/',
+                '/assets/file',
+            ],
+            'query-only' => [
+                '?x=1',
+                'http://old.example/media',
+                'https://new.example/assets',
+                '/assets/?x=1',
+            ],
+            'empty relative URL' => [
+                '',
+                'http://old.example/media/',
+                'https://new.example/assets/',
+                '/assets/',
+            ],
+            'exact absolute base' => [
+                'http://old.example/media',
+                'http://old.example/media',
+                'https://new.example/assets',
+                'https://new.example/assets',
+            ],
+            'explicit default port' => [
+                'http://old.example:80/media/file',
+                'http://old.example/media',
+                'https://old.example/assets',
+                'https://old.example/assets/file',
+            ],
+            'non-default source port' => [
+                'http://old.example:81/media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+                'https://new.example/assets/file',
+            ],
+            'no-op keeps same input' => [
+                'http://OLD.example/media/%7euser',
+                'http://old.example/media',
+                'http://old.example/media',
+                'http://OLD.example/media/%7euser',
+            ],
+        ];
+    }
+
+    #[DataProvider('ambiguousDecodedUrlProvider')]
+    public function testBaseReplacementRejectsAmbiguousDecodedUrlBoundaries(
+        string $rawUrl,
+        string $oldBaseUrl,
+        string $newBaseUrl
+    ): void {
+        $markup = '<a href="' . $rawUrl . '"></a>';
+        $processor = new StructuredBlockMarkupUrlProcessor($markup, $oldBaseUrl);
+
+        $this->assertTrue($processor->next_url());
+        $this->assertFalse($processor->replace_base_url($newBaseUrl));
+        $this->assertSame($markup, $processor->get_updated_html());
+    }
+
+    public static function ambiguousDecodedUrlProvider(): array
+    {
+        return [
+            'file URL' => [
+                'file://old.example/media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+            ],
+            'explicit scheme without slashes' => [
+                'http:media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+            ],
+            'parent-directory-relative path' => [
+                '../file',
+                'http://old.example/media',
+                'https://new.example/assets',
+            ],
+            'backslashes in mapped components' => [
+                'http://old.example\media/file',
+                'http://old.example/media',
+                'https://new.example/assets',
+            ],
+            'encoded slash at the mapped boundary' => [
+                '/media%2Fa',
+                'http://old.example/media',
+                'https://new.example/',
+            ],
+            'parent segment hides a different lexical base' => [
+                'http://old.example/x/../media/file',
+                'http://old.example/media',
+                'http://old.example/foo/media',
+            ],
+            'encoded slash and dot hide different lexical segments' => [
+                '/a%2Fb/./file',
+                'http://old.example/a/b',
+                'https://new.example/assets',
+            ],
+        ];
+    }
+
+    public function testProtocolRelativeUrlUpdatesParsedStateWithoutChangingMarkup(): void
+    {
+        $markup = '<A HREF=\'//old.example/media/file\'></A>';
+        $processor = new StructuredBlockMarkupUrlProcessor(
+            $markup,
+            'http://old.example/media'
+        );
+
+        $this->assertTrue($processor->next_url());
+        $this->assertTrue($processor->replace_base_url('https://old.example/media'));
+        $this->assertSame(
+            'https://old.example/media/file',
+            $processor->get_parsed_url()->toString()
+        );
+        $this->assertSame($markup, $processor->get_updated_html());
+    }
+
+    public function testRewritesLaterCssUrlsAfterRenderingAnEarlierBaseReplacement(): void
+    {
+        $processor = new StructuredBlockMarkupUrlProcessor(
+            '<div style="background:url(http://very-long-old.example/very/long/base/one),' .
+            'url(http://very-long-old.example/very/long/base/two)"></div>',
+            'http://very-long-old.example/very/long/base'
+        );
+
+        $this->assertTrue($processor->next_url());
+        $this->assertTrue($processor->replace_base_url('https://n.example/x'));
+        $processor->get_updated_html();
+
+        $this->assertTrue($processor->next_url());
+        $this->assertTrue($processor->replace_base_url('https://n.example/x'));
+        $this->assertSame(
+            '<div style="background:url(&quot;https://n.example/x/one&quot;),' .
+            'url(&quot;https://n.example/x/two&quot;)"></div>',
+            $processor->get_updated_html()
+        );
+    }
+
+    public function testAmbiguousStructuredUrlAlsoSkipsTheCautiousTokenPass(): void
+    {
+        $markup = '<a href="http://old.example/media%2Fa" ' .
+            'data-note="http://old.example/media/opaque"></a>';
+        $processor = new StructuredBlockMarkupUrlProcessor(
+            $markup,
+            'http://old.example/media'
+        );
+        $mapping = new CautiousURLBaseRewriteMapping(
+            [
+                'http://old.example/media' => 'https://new.example/assets',
+            ]
+        );
+
+        $this->assertTrue($processor->next_token());
+        $this->assertTrue($processor->next_url_in_current_token());
+        $this->assertFalse(
+            $processor->replace_base_url(
+                WPURL::parse('https://new.example/assets'),
+                WPURL::parse('http://old.example/media')
+            )
+        );
+        $this->assertFalse($processor->next_url_in_current_token());
+        $this->assertFalse($processor->replace_url_bases_in_current_token($mapping));
+        $this->assertSame($markup, $processor->get_updated_html());
+    }
+
     #[DataProvider('cssUrlDetectionProvider')]
     public function testDetectsCssUrls(
         string $expectedUrl,

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -571,6 +571,57 @@ class StructuredDataUrlRewriterTest extends TestCase
         ];
     }
 
+    public function testStructuredReplacementUsesTheMatchedSourceBase(): void
+    {
+        $rewriter = $this->createRewriter([
+            'http://first.example/base' => 'https://first-new.example/root',
+            'http://old.example/media' => 'https://new.example/assets',
+        ]);
+        $input = '<a href="http://old.example/m%65dia/a/./b?raw=%2f">Link</a>';
+        $expected = '<a href="https://new.example/assets/a/./b?raw=%2f">Link</a>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testStructuredMappingCacheDoesNotReuseRenderedUrlSpelling(): void
+    {
+        $rewriter = $this->createRewriter([
+            'http://old.example/media' => 'https://new.example/assets',
+        ]);
+        $input = '<a href="http://old.example/media/a/./b?raw=%2f">Dots</a>'
+            . '<a href="HTTP://OLD.EXAMPLE:80/media/a/b?raw=%2f">No dots</a>';
+        $expected = '<a href="https://new.example/assets/a/./b?raw=%2f">Dots</a>'
+            . '<a href="https://new.example/assets/a/b?raw=%2f">No dots</a>';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    #[DataProvider('ambiguous_structured_source_cases')]
+    public function testAmbiguousStructuredSourceIsNotRewritten(string $url): void
+    {
+        $rewriter = $this->createRewriter([
+            'http://old.example/media' => 'https://new.example/assets',
+        ]);
+        $input = '<a href="' . $url . '">Link</a>';
+
+        $this->assertSame($input, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    /**
+     * @return array<string, array{0:string}>
+     */
+    public static function ambiguous_structured_source_cases(): array
+    {
+        return [
+            'parent segment hides a different lexical base' => [
+                'http://old.example/x/../media/file',
+            ],
+            'encoded slash crosses the mapped boundary' => [
+                'http://old.example/media%2Ffile',
+            ],
+        ];
+    }
+
     public function testBlockMarkupCautiouslyRewritesEncodedSiteOriginInputValue(): void
     {
         $rewriter = $this->createRewriter();
@@ -636,7 +687,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $result = $rewriter->rewrite_known_block_markup_value($input);
 
         $this->assertStringContainsString('https://new-site.com/literal', $result);
-        $this->assertStringContainsString('https://new-site.com/case-variant', $result);
+        $this->assertStringContainsString('HTTPS://new-site.com/case-variant', $result);
         $this->assertStringNotContainsString('old-site.com', strtolower($result));
     }
 
@@ -690,7 +741,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $result = $rewriter->rewrite_known_block_markup_value($input);
 
         $this->assertStringContainsString('https:\/\/new-site.com\/img.jpg', $result);
-        $this->assertStringContainsString('src="https://new-site.com/img.jpg"', $result);
+        $this->assertStringContainsString('src="HTTPS://new-site.com/img.jpg"', $result);
         $this->assertStringNotContainsString('old-site.com', strtolower($result));
     }
 


### PR DESCRIPTION
Structured block URLs now replace only the mapped scheme, authority, and pathname prefix in the decoded URL value. The unmatched path, query, and fragment bytes reach the existing HTML, CSS, or block serializer unchanged.

`StructuredBlockMarkupUrlProcessor` uses `WPURL::replace_base_url()` as the semantic result, locates only source boundaries marked by literal delimiters, and reparses the edited URL before accepting it. Ambiguous source spellings stay unchanged, and the cautious token pass is skipped for that token so it cannot bypass the failed boundary check.

The rewriter caches only the selected mapping index. Each occurrence still computes its own source-preserving URL, so equal parsed URLs with different source spellings do not share rendered output. The selected mapping’s own source base is used instead of the first configured base.

## Testing

```
cd tests
../vendor/bin/phpunit UrlRewriting
```

The URL-rewriting suite passes with 431 tests and 2,722 assertions (7 pre-existing skips). PHPStan, PHPCompatibility 7.4+, targeted PHPCS, and `git diff --check` pass.
