### PR TITLE
[PHP] Add a `merge-wp-content` command

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -80,6 +80,9 @@ require_once __DIR__ . '/lib/host/load.php';
 // Load target runtime appliers (consume a manifest, write server config)
 require_once __DIR__ . '/lib/target-runtime/load.php';
 
+// Load the wp-content merge engine
+require_once __DIR__ . '/lib/merge/load.php';
+
 require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
@@ -160,6 +163,7 @@ class ImportClient
         "preflight",
         "preflight-assert",
         "flat-docroot",
+        "merge-wp-content",
         "apply-runtime",
     ];
 
@@ -1140,6 +1144,10 @@ class ImportClient
         }
         if ($command === "flat-docroot") {
             $this->run_flat_document_root($options);
+            return;
+        }
+        if ($command === "merge-wp-content") {
+            $this->run_merge_wp_content($options);
             return;
         }
         if ($command === "apply-runtime") {
@@ -4663,6 +4671,170 @@ class ImportClient
 
         return null;
     }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions carry CLI option values and filesystem paths, never HTML output.
+    /**
+     * Command: merge-wp-content
+     *
+     * Folds the wp-content directory under --from into the one the file pull
+     * wrote, so entries only the local site has survive whatever the caller
+     * does to that directory next. flat-docroot replacing it with a symlink is
+     * the case this exists for, but the merge itself has nothing to do with
+     * flattening.
+     *
+     * --from names a site directory and this appends wp-content to it. The
+     * destination comes from preflight rather than the caller: reprint already
+     * knows where the source site kept wp-content, its plugins, its mu-plugins
+     * and its uploads, and asking every caller to re-derive that is how the WP
+     * Cloud layouts go quietly wrong.
+     */
+    public function run_merge_wp_content(array $options): void
+    {
+        $from = $options["from"] ?? null;
+        if (empty($from)) {
+            throw new InvalidArgumentException(
+                "merge-wp-content requires --from=DIR, the site directory whose wp-content is merged in.",
+            );
+        }
+
+        $this->require_preflight();
+        $this->assert_file_pull_completed();
+        $state = $this->get_state();
+
+        // Where the source site kept wp-content. WordPress falls back to
+        // ABSPATH/wp-content when WP_CONTENT_DIR is unset, and so does
+        // flat-docroot, which sources wp-content from its ABSPATH scan.
+        $content_dir = $this->clean_preflight_path(
+            $state->get('preflight.database.wp.paths_urls.content_dir')
+        );
+        if ($content_dir === null) {
+            $abspath = $this->clean_preflight_path(
+                $state->get('preflight.database.wp.paths_urls.abspath')
+            );
+            if ($abspath === null) {
+                throw new RuntimeException(
+                    "Cannot determine where wp-content lives from preflight data. " .
+                        "Run preflight first to detect the WordPress installation.",
+                );
+            }
+            $content_dir = wp_join_unix_paths($abspath, "wp-content");
+        }
+
+        $destination_wp_content = wp_join_unix_paths($this->filesystem_root, $content_dir);
+        $source_wp_content = wp_join_unix_paths(trim_right_slash($from), "wp-content");
+
+        $component_destinations = [];
+        foreach ([
+            "plugins" => 'preflight.database.wp.paths_urls.plugins_dir',
+            "mu-plugins" => 'preflight.database.wp.paths_urls.mu_plugins_dir',
+            "uploads" => 'preflight.database.wp.paths_urls.uploads.basedir',
+        ] as $conventional_name => $preflight_path) {
+            $component_dir = $this->clean_preflight_path($state->get($preflight_path));
+            if ($component_dir !== null) {
+                $component_destinations[$conventional_name] = wp_join_unix_paths(
+                    $this->filesystem_root,
+                    $component_dir
+                );
+            }
+        }
+
+        // A source which is not a real directory holds nothing of its own, so
+        // there is nothing to merge and nothing to guard. Checking that first
+        // is what keeps a second run harmless once flat-docroot has replaced
+        // the site's wp-content with a symlink into the destination: resolving
+        // symlinks, the guard below would see the two sides as one path.
+        if (!is_link($source_wp_content) && is_dir($source_wp_content)) {
+            foreach (array_merge([$destination_wp_content], array_values($component_destinations)) as $destination) {
+                $this->assert_merge_paths_do_not_overlap($source_wp_content, $destination);
+            }
+        }
+
+        $this->audit_log(
+            "MERGE-WP-CONTENT | {$source_wp_content} -> {$destination_wp_content}",
+        );
+        $merger = new WpContentMerger(
+            $source_wp_content,
+            $destination_wp_content,
+            $component_destinations,
+            function (string $line): void {
+                $this->audit_log("MERGE-WP-CONTENT | {$line}");
+            }
+        );
+        $moved = $merger->merge();
+
+        $this->audit_log(
+            "MERGE-WP-CONTENT | Complete: {$moved} moved",
+            true,
+        );
+
+        // The audit log already holds one line per moved entry, so the result
+        // reports a count: a merged uploads tree runs to thousands of paths.
+        $result = [
+            "status" => "complete",
+            "from" => $source_wp_content,
+            "to" => $destination_wp_content,
+            "fs_root" => $this->filesystem_root,
+            "content_dir" => $content_dir,
+            "moved" => $moved,
+        ];
+        if (!$this->progress->is_mode('pipeline')) {
+            fwrite($this->progress_fd, json_encode($result) . "\n");
+        }
+        $this->output_progress(array_merge(["type" => "merge_wp_content_complete"], $result));
+    }
+
+    /**
+     * Refuse to merge while the destination is still missing pulled files.
+     *
+     * Mid-download every unfetched path looks absent, so local copies move in
+     * and the pull then writes the remote version over them. Inside
+     * flat-docroot the ordering was structural; as a command of its own it is
+     * not, and these two files are what say the file pull ran and finished.
+     * PullIndexJournal::open() creates pull/index.wal and only
+     * remove_empty_wal(), at the end of run_files_pull(), removes it;
+     * ensure_local_index_exists() in that same method is what guarantees
+     * local_index.jsonl afterwards.
+     */
+    private function assert_file_pull_completed(): void
+    {
+        if (is_file($this->pull_index_wal_path)) {
+            throw new RuntimeException(
+                "Finish or abort the interrupted files-pull before running merge-wp-content.",
+            );
+        }
+        if (!is_file($this->local_index_file)) {
+            throw new RuntimeException(
+                "merge-wp-content requires a completed file pull: {$this->local_index_file} " .
+                    "does not exist yet. Run files-pull first.",
+            );
+        }
+    }
+
+    /**
+     * Refuse a --from which is the destination, holds it, or sits inside it.
+     *
+     * Any of those walks a tree into itself: the merge would read entries it
+     * has already moved and move them again, deeper each time.
+     */
+    private function assert_merge_paths_do_not_overlap(
+        string $source_wp_content,
+        string $destination
+    ): void {
+        $resolved_source = realpath_with_missing_tail($source_wp_content);
+        $resolved_destination = realpath_with_missing_tail($destination);
+        if (
+            !path_is_same_as_or_descendant_of($resolved_source, $resolved_destination)
+            && !path_is_same_as_or_descendant_of($resolved_destination, $resolved_source)
+        ) {
+            return;
+        }
+        throw new InvalidArgumentException(
+            "merge-wp-content cannot merge {$source_wp_content} into {$destination}: " .
+                "they resolve to {$resolved_source} and {$resolved_destination}, " .
+                "so one holds the other.",
+        );
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
     /**
      * Command: flat-docroot
@@ -11377,7 +11549,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'merge-wp-content', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11661,6 +11833,16 @@ if (
             'target' => 'force',
             'help' => 'Remove conflicting non-symlink files and replace with symlinks',
             'commands' => ['pull', 'flat-docroot'],
+        ],
+
+        // ── merge-wp-content options ─────────────────────────────
+        [
+            'name' => 'from',
+            'type' => 'value',
+            'target' => 'from',
+            'placeholder' => 'DIR',
+            'help' => 'Site directory whose wp-content is merged into the pulled one',
+            'commands' => ['merge-wp-content'],
         ],
 
         // ── apply-runtime options ────────────────────────────────
@@ -12457,6 +12639,41 @@ if (
                 "If a path that should be a symlink is a regular file or directory,\n" .
                 "the command stops with an error unless --force is specified.\n",
             "extra" => null,
+        ],
+        "merge-wp-content" => [
+            "level" => "low",
+            "short" => "Move wp-content entries only the local site has into the pulled tree",
+            "usage" =>
+                "reprint merge-wp-content <remote-reprint-api-url> --state-dir=DIR " .
+                "--fs-root=DIR --from=DIR",
+            "description" =>
+                "Folds the wp-content directory under --from into the one the file\n" .
+                "pull wrote under --fs-root. --from names a site directory; the\n" .
+                "command appends wp-content to it.\n" .
+                "\n" .
+                "Entries the pulled tree does not have move there. Entries it has\n" .
+                "stay as they are, so the pulled copy always wins. Nothing is\n" .
+                "deleted, and entries move rather than copy: after a run they no\n" .
+                "longer exist under --from.\n" .
+                "\n" .
+                "Run this before flat-docroot, which replaces the wp-content under\n" .
+                "--from with a symlink and would otherwise delete whatever only that\n" .
+                "directory held. The remote Reprint API URL selects the state that\n" .
+                "says where the source site kept wp-content, its plugins, its\n" .
+                "mu-plugins and its uploads; no network calls are made.\n",
+            "extra" =>
+                "What counts as one entry:\n" .
+                "  plugins, mu-plugins, themes  one level down, each child whole\n" .
+                "  uploads                      all the way down, each file its own\n" .
+                "  anything else                whole\n" .
+                "\n" .
+                "A plugin or theme both sides have is never merged: keeping the\n" .
+                "files the pulled version dropped would leave a directory matching\n" .
+                "no release, and push them to the source site later.\n" .
+                "\n" .
+                "Example:\n" .
+                "  reprint merge-wp-content https://example.com --state-dir=./state \\\n" .
+                "    --fs-root=./files --from=./site\n",
         ],
         "apply-runtime" => [
             "level" => "low",

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4678,15 +4678,7 @@ class ImportClient
      *
      * Folds the wp-content directory under --from into the one the file pull
      * wrote, so entries only the local site has survive whatever the caller
-     * does to that directory next. flat-docroot replacing it with a symlink is
-     * the case this exists for, but the merge itself has nothing to do with
-     * flattening.
-     *
-     * --from names a site directory and this appends wp-content to it. The
-     * destination comes from preflight rather than the caller: reprint already
-     * knows where the source site kept wp-content, its plugins, its mu-plugins
-     * and its uploads, and asking every caller to re-derive that is how the WP
-     * Cloud layouts go quietly wrong.
+     * does to that directory next.
      */
     public function run_merge_wp_content(array $options): void
     {

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4678,13 +4678,23 @@ class ImportClient
         $from = $options["from"] ?? null;
         if (empty($from)) {
             throw new InvalidArgumentException(
-                "merge-wp-content requires --from=DIR, the site directory whose wp-content is merged in.",
+                "merge-wp-content requires --from=DIR, the wp-content directory to merge in.",
             );
         }
         // Keep a lexical absolute path because --from may not exist yet.
         $from = trim_right_slash($from);
         if (strpos($from, "/") !== 0) {
             $from = normalize_path(wp_join_unix_paths(getcwd(), $from));
+        }
+        // A WordPress root passed by mistake would move wp-admin, wp-includes
+        // and wp-config.php into the pulled wp-content.
+        if (is_file(wp_join_unix_paths($from, "wp-load.php"))
+            || is_dir(wp_join_unix_paths($from, "wp-includes"))
+        ) {
+            throw new InvalidArgumentException(
+                "--from must name a wp-content directory, but {$from} is a WordPress root. " .
+                    "Pass the content directory inside it.",
+            );
         }
 
         $this->require_preflight();
@@ -4709,7 +4719,7 @@ class ImportClient
         }
 
         $destination_wp_content = wp_join_unix_paths($this->filesystem_root, $content_dir);
-        $source_wp_content = wp_join_unix_paths($from, "wp-content");
+        $source_wp_content = $from;
 
         $component_destinations = [];
         foreach ([
@@ -11808,7 +11818,7 @@ if (
             'type' => 'value',
             'target' => 'from',
             'placeholder' => 'DIR',
-            'help' => 'Site directory whose wp-content is merged into the pulled one',
+            'help' => 'Local wp-content directory to merge into the pulled one',
             'commands' => ['merge-wp-content'],
         ],
 
@@ -12614,17 +12624,18 @@ if (
                 "reprint merge-wp-content <remote-reprint-api-url> --state-dir=DIR " .
                 "--fs-root=DIR --from=DIR",
             "description" =>
-                "Folds the wp-content directory under --from into the one the file\n" .
-                "pull wrote under --fs-root. --from names a site directory; the\n" .
-                "command appends wp-content to it.\n" .
+                "Folds the wp-content directory named by --from into the one the\n" .
+                "file pull wrote under --fs-root. --from is that directory itself,\n" .
+                "whatever it is called, so a site which moved WP_CONTENT_DIR works\n" .
+                "the same as a conventional one.\n" .
                 "\n" .
                 "Entries the pulled tree does not have move there. Entries it has\n" .
                 "stay as they are, so the pulled copy always wins. Nothing is\n" .
                 "deleted, and entries move rather than copy: after a run they no\n" .
                 "longer exist under --from.\n" .
                 "\n" .
-                "Run this before flat-docroot, which replaces the wp-content under\n" .
-                "--from with a symlink and would otherwise delete whatever only that\n" .
+                "Run this before flat-docroot, which replaces the local wp-content\n" .
+                "with a symlink and would otherwise delete whatever only that\n" .
                 "directory held. The remote Reprint API URL selects the state that\n" .
                 "says where the source site kept wp-content, its plugins, its\n" .
                 "mu-plugins and its uploads; no network calls are made.\n",
@@ -12640,7 +12651,7 @@ if (
                 "\n" .
                 "Example:\n" .
                 "  reprint merge-wp-content https://example.com --state-dir=./state \\\n" .
-                "    --fs-root=./files --from=./site\n",
+                "    --fs-root=./files --from=./site/wp-content\n",
         ],
         "apply-runtime" => [
             "level" => "low",

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -80,7 +80,6 @@ require_once __DIR__ . '/lib/host/load.php';
 // Load target runtime appliers (consume a manifest, write server config)
 require_once __DIR__ . '/lib/target-runtime/load.php';
 
-// Load the wp-content merge engine
 require_once __DIR__ . '/lib/merge/load.php';
 
 require_once __DIR__ . '/lib/sort-index-file.php';
@@ -4673,13 +4672,7 @@ class ImportClient
     }
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions carry CLI option values and filesystem paths, never HTML output.
-    /**
-     * Command: merge-wp-content
-     *
-     * Folds the wp-content directory under --from into the one the file pull
-     * wrote, so entries only the local site has survive whatever the caller
-     * does to that directory next.
-     */
+    /** Move source-only wp-content entries into the pulled tree. */
     public function run_merge_wp_content(array $options): void
     {
         $from = $options["from"] ?? null;
@@ -4688,12 +4681,7 @@ class ImportClient
                 "merge-wp-content requires --from=DIR, the site directory whose wp-content is merged in.",
             );
         }
-        // Everything below works in absolute paths: the overlap guard and the
-        // symlink rewrite both resolve against the real filesystem, and the
-        // audit log and the result are read after the command has exited, when
-        // the working directory it ran in is gone. realpath() cannot do this —
-        // --from need not exist yet, and realpath() returns false for a path
-        // that does not.
+        // Keep a lexical absolute path because --from may not exist yet.
         $from = trim_right_slash($from);
         if (strpos($from, "/") !== 0) {
             $from = normalize_path(wp_join_unix_paths(getcwd(), $from));
@@ -4703,9 +4691,7 @@ class ImportClient
         $this->assert_file_pull_completed();
         $state = $this->get_state();
 
-        // Where the source site kept wp-content. WordPress falls back to
-        // ABSPATH/wp-content when WP_CONTENT_DIR is unset, and so does
-        // flat-docroot, which sources wp-content from its ABSPATH scan.
+        // WP_CONTENT_DIR defaults to ABSPATH/wp-content.
         $content_dir = $this->clean_preflight_path(
             $state->get('preflight.database.wp.paths_urls.content_dir')
         );
@@ -4740,11 +4726,8 @@ class ImportClient
             }
         }
 
-        // A source which is not a real directory holds nothing of its own, so
-        // there is nothing to merge and nothing to guard. Checking that first
-        // is what keeps a second run harmless once flat-docroot has replaced
-        // the site's wp-content with a symlink into the destination: resolving
-        // symlinks, the guard below would see the two sides as one path.
+        // Guard only a real source directory. A flattened one resolves to the
+        // destination, and the merge below already does nothing with it.
         if (!is_link($source_wp_content) && is_dir($source_wp_content)) {
             foreach (array_merge([$destination_wp_content], array_values($component_destinations)) as $destination) {
                 $this->assert_merge_paths_do_not_overlap($source_wp_content, $destination);
@@ -4769,8 +4752,6 @@ class ImportClient
             true,
         );
 
-        // The audit log already holds one line per moved entry, so the result
-        // reports a count: a merged uploads tree runs to thousands of paths.
         $result = [
             "status" => "complete",
             "from" => $source_wp_content,
@@ -4785,18 +4766,7 @@ class ImportClient
         $this->output_progress(array_merge(["type" => "merge_wp_content_complete"], $result));
     }
 
-    /**
-     * Refuse to merge while the destination is still missing pulled files.
-     *
-     * Mid-download every unfetched path looks absent, so local copies move in
-     * and the pull then writes the remote version over them. Inside
-     * flat-docroot the ordering was structural; as a command of its own it is
-     * not, and these two files are what say the file pull ran and finished.
-     * PullIndexJournal::open() creates pull/index.wal and only
-     * remove_empty_wal(), at the end of run_files_pull(), removes it;
-     * ensure_local_index_exists() in that same method is what guarantees
-     * local_index.jsonl afterwards.
-     */
+    /** Refuse to merge until files-pull has completed. */
     private function assert_file_pull_completed(): void
     {
         if (is_file($this->pull_index_wal_path)) {
@@ -4812,12 +4782,7 @@ class ImportClient
         }
     }
 
-    /**
-     * Refuse a --from which is the destination, holds it, or sits inside it.
-     *
-     * Any of those walks a tree into itself: the merge would read entries it
-     * has already moved and move them again, deeper each time.
-     */
+    /** Refuse overlapping source and destination paths. */
     private function assert_merge_paths_do_not_overlap(
         string $source_wp_content,
         string $destination

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4688,6 +4688,16 @@ class ImportClient
                 "merge-wp-content requires --from=DIR, the site directory whose wp-content is merged in.",
             );
         }
+        // Everything below works in absolute paths: the overlap guard and the
+        // symlink rewrite both resolve against the real filesystem, and the
+        // audit log and the result are read after the command has exited, when
+        // the working directory it ran in is gone. realpath() cannot do this —
+        // --from need not exist yet, and realpath() returns false for a path
+        // that does not.
+        $from = trim_right_slash($from);
+        if (strpos($from, "/") !== 0) {
+            $from = normalize_path(wp_join_unix_paths(getcwd(), $from));
+        }
 
         $this->require_preflight();
         $this->assert_file_pull_completed();
@@ -4713,7 +4723,7 @@ class ImportClient
         }
 
         $destination_wp_content = wp_join_unix_paths($this->filesystem_root, $content_dir);
-        $source_wp_content = wp_join_unix_paths(trim_right_slash($from), "wp-content");
+        $source_wp_content = wp_join_unix_paths($from, "wp-content");
 
         $component_destinations = [];
         foreach ([

--- a/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
+++ b/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
@@ -11,18 +11,14 @@ use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 /**
  * Folds one wp-content directory into another.
  *
- * Entries the destination does not have move there. Entries it has stay as
- * they are, so the destination copy always wins. Nothing is deleted: a run
- * either moves an entry or leaves both sides alone.
+ * Entries that only exist in the source move to the destination. Entries that
+ * already exist in destination are untouched on both sides. Nothing is deleted.
  *
  * ## The unit boundary
  *
- * Merging stops at whole units. A plugin or a theme belongs to one side or the
- * other: descending into one both sides have would keep the files the
- * destination's version dropped, leaving a directory that matches no release
- * and pushing those files to the source site later. So the walk passes through
- * the directories that hold independent things and stops at the things
- * themselves:
+ * Plugins, mu-plugins, and themes (so called units) are shallowly merged to
+ * ensure we don't mix versions. So, if they are a directory (and not a file),
+ * the merge only moves the directory as a whole.
  *
  *   plugins, mu-plugins, themes -> one level, each child whole
  *   uploads                     -> all the way down, each file its own
@@ -52,6 +48,12 @@ class WpContentMerger
      */
     private const STAGING_SUFFIX = ".reprint-merge-incomplete";
 
+    /** Rule for an entry whose own children are whole plugins or themes. */
+    private const UNIT_CONTAINER = "unit";
+
+    /** Rule for an entry whose contents merge file by file. */
+    private const FILE_CONTAINER = "file";
+
     /** @var string wp-content directory whose entries move away. */
     private string $source_wp_content;
 
@@ -65,11 +67,23 @@ class WpContentMerger
      */
     private array $routed_destinations = [];
 
-    /** @var string[] Entry names whose own children are whole plugins or themes. */
-    private array $unit_container_names = ["plugins", "mu-plugins", "themes"];
-
-    /** @var string[] Entry names whose contents merge file by file. */
-    private array $file_container_names = ["uploads"];
+    /**
+     * How far the merge walks into an entry. An entry named by no rule moves
+     * whole, because nothing says what is inside it.
+     *
+     * The constructor gives each basename preflight reported the rule of the
+     * component it belongs to, so a site that renamed a component directory
+     * still gets that component's rule.
+     *
+     * @var array<string,string> Entry name mapped to UNIT_CONTAINER or
+     *                           FILE_CONTAINER.
+     */
+    private array $container_rules = [
+        "plugins" => self::UNIT_CONTAINER,
+        "mu-plugins" => self::UNIT_CONTAINER,
+        "themes" => self::UNIT_CONTAINER,
+        "uploads" => self::FILE_CONTAINER,
+    ];
 
     /**
      * @var callable Receives one audit line per moved entry.
@@ -111,19 +125,15 @@ class WpContentMerger
             if (!is_string($destination) || $destination === "") {
                 continue;
             }
-            // Both names route to the same place: the wp-content being merged
-            // in may use the name WordPress conventionally uses, or the one
-            // the destination site gave that component.
+            // Both names route to the same place, and the second inherits the
+            // first's rule: the wp-content being merged in may use the name
+            // WordPress conventionally uses, or the one the destination site
+            // gave that component.
             $this->routed_destinations[$conventional_name] = $destination;
             $this->routed_destinations[basename($destination)] = $destination;
-            if ($conventional_name === "uploads") {
-                $this->file_container_names[] = basename($destination);
-            } else {
-                $this->unit_container_names[] = basename($destination);
-            }
+            $this->container_rules[basename($destination)] =
+                $this->container_rules[$conventional_name];
         }
-        $this->unit_container_names = array_values(array_unique($this->unit_container_names));
-        $this->file_container_names = array_values(array_unique($this->file_container_names));
     }
 
     /**
@@ -162,11 +172,12 @@ class WpContentMerger
                 $this->move_entry($source_entry, $destination_entry);
                 continue;
             }
-            if (in_array($entry, $this->unit_container_names, true)) {
+            $rule = $this->container_rules[$entry] ?? null;
+            if ($rule === self::UNIT_CONTAINER) {
                 $this->merge_unit_container($source_entry, $destination_entry);
                 continue;
             }
-            if (in_array($entry, $this->file_container_names, true)) {
+            if ($rule === self::FILE_CONTAINER) {
                 $this->merge_file_tree($source_entry, $destination_entry);
             }
         }

--- a/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
+++ b/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
@@ -10,43 +10,17 @@ use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
 
 /**
- * Folds one wp-content directory into another.
+ * Moves local-only wp-content entries into a pulled tree.
  *
- * Entries that only exist in the source move to the destination. Entries that
- * already exist in destination are untouched on both sides. Nothing is deleted.
+ * Existing destination entries win. To avoid mixing plugin or theme versions,
+ * plugins, mu-plugins, and themes move by child; uploads move by leaf; other
+ * entries move whole.
  *
- * ## The unit boundary
- *
- * Plugins, mu-plugins, and themes (so called units) are shallowly merged to
- * ensure we don't mix versions. So, if they are a directory (and not a file),
- * the merge only moves the directory as a whole.
- *
- *   plugins, mu-plugins, themes -> one level, each child whole
- *   uploads                     -> all the way down, each file its own
- *   anything else               -> whole, because its insides are unknown
- *
- * Per entry at the wp-content level:
- *
- *   - absent from the destination -> move it there
- *   - a container above           -> walk it under that container's rule
- *   - anything else               -> leave it, the destination copy wins
- *
- * ## Component directories
- *
- * WordPress lets plugins, mu-plugins and uploads live outside wp-content, and
- * hosts use that: on WP Cloud the uploads base directory sits on its own
- * volume. `$component_destinations` says where each one lives on the
- * destination side, so `uploads` moves to that directory rather than to
- * `<destination>/uploads`. Their basenames also join the container names, so a
- * site that renamed a component directory still gets the right rule.
+ * Component destinations may be outside wp-content.
  */
 class WpContentMerger
 {
-    /**
-     * Suffix for the path a cross-filesystem copy writes before it renames the
-     * finished entry into place. Derived from the destination rather than
-     * random so a later run clears what an interrupted one abandoned.
-     */
+    /** Temporary sibling used by the cross-filesystem copy fallback. */
     private const STAGING_SUFFIX = ".reprint-merge-incomplete";
 
     /** Rule for an entry whose own children are whole plugins or themes. */
@@ -55,30 +29,18 @@ class WpContentMerger
     /** Rule for an entry whose contents merge file by file. */
     private const FILE_CONTAINER = "file";
 
-    /** @var string wp-content directory whose entries move away. */
     private string $source_wp_content;
 
-    /** @var string wp-content directory the entries move into. */
     private string $destination_wp_content;
 
     /**
-     * @var array<string,string> Source entry name mapped to the destination
-     *                           path that entry moves to, for the components
-     *                           which live outside wp-content.
+     * Routes components whose preflight destination is outside wp-content.
+     *
+     * @var array<string,string>
      */
     private array $routed_destinations = [];
 
-    /**
-     * How far the merge walks into an entry. An entry named by no rule moves
-     * whole, because nothing says what is inside it.
-     *
-     * The constructor gives each basename preflight reported the rule of the
-     * component it belongs to, so a site that renamed a component directory
-     * still gets that component's rule.
-     *
-     * @var array<string,string> Entry name mapped to UNIT_CONTAINER or
-     *                           FILE_CONTAINER.
-     */
+    /** @var array<string,string> Traversal rule by source entry name. */
     private array $container_rules = [
         "plugins" => self::UNIT_CONTAINER,
         "mu-plugins" => self::UNIT_CONTAINER,
@@ -86,28 +48,20 @@ class WpContentMerger
         "uploads" => self::FILE_CONTAINER,
     ];
 
-    /**
-     * @var callable Receives one audit line per moved entry.
-     * @phpstan-var callable(string): void
-     */
+    /** @var callable(string):void */
     private $record_move;
 
-    /** @var int Entries moved by the current merge() call. */
     private int $moved = 0;
 
     /**
-     * @param string   $source_wp_content      wp-content directory whose entries move away.
-     * @param string   $destination_wp_content wp-content directory the entries move into.
+     * @param string   $source_wp_content      Source wp-content directory.
+     * @param string   $destination_wp_content Destination wp-content directory.
      * @param array    $component_destinations {
-     *     Destination directory for each component which may live outside
-     *     wp-content. An absent or null key leaves that component at its
-     *     conventional name under $destination_wp_content.
-     *
      *     @type string|null $plugins    Destination plugins directory.
      *     @type string|null $mu-plugins Destination mu-plugins directory.
      *     @type string|null $uploads    Destination uploads base directory.
      * }
-     * @param callable $record_move            Called with one audit line per moved entry.
+     * @param callable $record_move            Receives moved entries.
      *
      * @phpstan-param array<string,string|null> $component_destinations
      * @phpstan-param callable(string): void   $record_move
@@ -126,10 +80,7 @@ class WpContentMerger
             if (!is_string($destination) || $destination === "") {
                 continue;
             }
-            // Both names route to the same place, and the second inherits the
-            // first's rule: the wp-content being merged in may use the name
-            // WordPress conventionally uses, or the one the destination site
-            // gave that component.
+            // Accept both the conventional and destination component names.
             $this->routed_destinations[$conventional_name] = $destination;
             $this->routed_destinations[basename($destination)] = $destination;
             $this->container_rules[basename($destination)] =
@@ -137,13 +88,6 @@ class WpContentMerger
         }
     }
 
-    /**
-     * Move every entry the destination lacks, and report how many moved.
-     *
-     * A side which is not a real directory has nothing to compare, so the
-     * merge is a no-op. That is what makes a second run harmless once
-     * flat-docroot has replaced the source wp-content with a symlink.
-     */
     public function merge(): int
     {
         $this->moved = 0;
@@ -163,12 +107,7 @@ class WpContentMerger
                 ?? wp_join_unix_paths($this->destination_wp_content, $entry);
 
             if (!file_exists($destination_entry) && !is_link($destination_entry)) {
-                // A routed component can sit outside the destination
-                // wp-content, and the file pull creates the directories
-                // leading to it only when the source site had content there.
-                // rename() into a missing parent fails, which would send a
-                // whole uploads tree down the copy fallback for want of one
-                // mkdir.
+                // A detached component may not yet have a destination parent.
                 $this->create_parent_directory($destination_entry);
                 $this->move_entry($source_entry, $destination_entry);
                 continue;
@@ -186,13 +125,7 @@ class WpContentMerger
         return $this->moved;
     }
 
-    /**
-     * Move whole plugins or themes the destination lacks.
-     *
-     * Each child is one unit. A name the destination also has stays the
-     * destination's, down to the last file, so two versions of the same plugin
-     * never merge.
-     */
+    /** Move plugin or theme children without mixing their contents. */
     private function merge_unit_container(string $source, string $destination): void
     {
         if (!$this->is_real_directory($source) || !$this->is_real_directory($destination)) {
@@ -211,12 +144,7 @@ class WpContentMerger
         }
     }
 
-    /**
-     * Move the files the destination lacks, to the leaf.
-     *
-     * For uploads, where each file stands alone: a photo the destination does
-     * not have is its own thing, not part of some larger version.
-     */
+    /** Merge a file container, such as uploads, to the leaf. */
     private function merge_file_tree(string $source, string $destination): void
     {
         if (!$this->is_real_directory($source) || !$this->is_real_directory($destination)) {
@@ -239,23 +167,12 @@ class WpContentMerger
     }
 
     /**
-     * Move one entry to its place on the destination side.
+     * Move an entry, falling back to a staged copy across filesystems.
      *
-     * A symlink is recreated rather than moved, and a relative value is kept
-     * or recomputed depending on where it points. One that resolves inside the
-     * tree being merged keeps its value, because the whole tree moves
-     * together. One that resolves outside it is read against a parent which
-     * has changed depth, so it is recomputed to reach the same target. An
-     * absolute value resolves the same from either parent and moves untouched.
-     *
-     * rename() reports EXDEV when the two sides are on different filesystems,
-     * which nothing stops the caller from choosing, so a copy is the fallback
-     * rather than the error.
-     *
-     * Only the moved entry's own value is rewritten. A relative symlink deeper
-     * in a moved directory keeps its value, which still resolves when it
-     * points within that directory and breaks when it points out of it. No
-     * move can preserve the second kind.
+     * A moved link keeps its relative value when the target is inside the
+     * source tree, which moves with it; an external target is rebased.
+     * Absolute values, and links nested inside a moved entry, travel
+     * unchanged.
      */
     private function move_entry(string $source_entry, string $destination_entry): void
     {
@@ -270,12 +187,7 @@ class WpContentMerger
                 $resolved_target = normalize_path(
                     wp_join_unix_paths(dirname($source_entry), $link_value)
                 );
-                // A target inside the tree being merged keeps its value: it
-                // either moves in this same run, or the destination already
-                // holds its own copy at that name, and the value finds
-                // whichever is there. A target outside the tree stays where it
-                // is while the link's parent changes depth, so the value has to
-                // be recomputed to still reach it.
+                // The source tree moves; an external target does not.
                 if (
                     !path_is_same_as_or_descendant_of(
                         $resolved_target,
@@ -300,12 +212,7 @@ class WpContentMerger
                 );
             }
         } elseif (!@rename($source_entry, $destination_entry)) {
-            // Copy beside the destination and rename it into place, never into
-            // the destination itself. A copy that dies partway — a full disk,
-            // an unreadable file, a signal during a large one — would otherwise
-            // leave a partial entry that the next run reads as the destination
-            // copy and skips. Both paths sit in the same directory, so the
-            // rename is atomic.
+            // A sibling rename prevents a partial copy from occupying the destination.
             $staging_path = $destination_entry . self::STAGING_SUFFIX;
             $this->remove_path_without_following_symlinks($staging_path);
             try {
@@ -335,20 +242,7 @@ class WpContentMerger
         );
     }
 
-    /**
-     * Copy a file, symlink, or directory tree to a path that does not exist yet.
-     *
-     * This is the cross-filesystem half of a move, so it reproduces a symlink
-     * as a symlink instead of following it into its target. Values are kept
-     * verbatim: an entry and everything below it move together, so a relative
-     * value that resolves within the tree still resolves after the copy.
-     *
-     * copy() creates the destination under the umask and mkdir() takes the
-     * mode it is given, so both are followed by a chmod to the source's own
-     * permissions. Without it an executable script or a deliberately 0700
-     * directory would come out different on this path and unchanged on the
-     * rename() path.
-     */
+    /** Copy an entry without following symlinks and preserve its permissions. */
     private function copy_path(string $from, string $to): void
     {
         if (is_link($from)) {
@@ -366,8 +260,6 @@ class WpContentMerger
             return;
         }
 
-        // A failed copy or mkdir here is reported as an exception naming both
-        // paths, so the raw PHP warning would only duplicate it.
         if (!is_dir($from)) {
             if (!@copy($from, $to)) {
                 throw new RuntimeException("Failed to copy {$from} to {$to}.");
@@ -391,7 +283,7 @@ class WpContentMerger
         }
     }
 
-    /** Give $to the permission bits $from carries. */
+    /** Copy permission bits. */
     private function copy_permissions(string $from, string $to): void
     {
         $permissions = @fileperms($from);
@@ -403,13 +295,7 @@ class WpContentMerger
         }
     }
 
-    /**
-     * Create the directories leading to $path.
-     *
-     * mkdir() is given the conventional directory mode rather than one copied
-     * from the source: these directories exist on the destination side only,
-     * and no source directory corresponds to them.
-     */
+    /** Create a destination parent directory. */
     private function create_parent_directory(string $path): void
     {
         $parent = dirname($path);
@@ -427,12 +313,7 @@ class WpContentMerger
         return !is_link($path) && is_dir($path);
     }
 
-    /**
-     * Delete a file, symlink, or directory tree without following symlinks.
-     *
-     * Returns false rather than throwing so the caller can name the path in
-     * an error which says what it had already done.
-     */
+    /** Remove a path without following symlinks. */
     private function remove_path_without_following_symlinks(string $path): bool
     {
         if (!file_exists($path) && !is_link($path)) {
@@ -462,14 +343,7 @@ class WpContentMerger
         return true === @rmdir($path);
     }
 
-    /**
-     * Compute a relative path from $from to $to.
-     *
-     * Both paths must be absolute. Returns a relative path such that a symlink
-     * at $from/$name pointing to the result resolves to $to.
-     *
-     * Example: compute_relative_path('/a/b/c', '/a/d/e') => '../../d/e'
-     */
+    /** Compute a relative path between absolute paths. */
     private static function compute_relative_path(string $from, string $to): string
     {
         $from_parts = explode("/", trim($from, "/"));

--- a/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
+++ b/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
@@ -2,6 +2,7 @@
 
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\normalize_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Merge failures carry CLI filesystem paths, never HTML output.
@@ -240,12 +241,12 @@ class WpContentMerger
     /**
      * Move one entry to its place on the destination side.
      *
-     * A symlink is recreated rather than moved: a relative value is read
-     * against its own parent directory, and the two parents sit at different
-     * depths. The new value stays relative because files-push transmits
-     * symlink values verbatim and the target recreates them as given, so an
-     * absolute value would write a local path onto the source server. An
-     * absolute value already resolves the same from either parent.
+     * A symlink is recreated rather than moved, and a relative value is kept
+     * or recomputed depending on where it points. One that resolves inside the
+     * tree being merged keeps its value, because the whole tree moves
+     * together. One that resolves outside it is read against a parent which
+     * has changed depth, so it is recomputed to reach the same target. An
+     * absolute value resolves the same from either parent and moves untouched.
      *
      * rename() reports EXDEV when the two sides are on different filesystems,
      * which nothing stops the caller from choosing, so a copy is the fallback
@@ -266,12 +267,26 @@ class WpContentMerger
                 );
             }
             if (strpos($link_value, "/") !== 0) {
-                $link_value = self::compute_relative_path(
-                    realpath_with_missing_tail(dirname($destination_entry)),
-                    normalize_path(
-                        wp_join_unix_paths(dirname($source_entry), $link_value)
-                    )
+                $resolved_target = normalize_path(
+                    wp_join_unix_paths(dirname($source_entry), $link_value)
                 );
+                // A target inside the tree being merged keeps its value: it
+                // either moves in this same run, or the destination already
+                // holds its own copy at that name, and the value finds
+                // whichever is there. A target outside the tree stays where it
+                // is while the link's parent changes depth, so the value has to
+                // be recomputed to still reach it.
+                if (
+                    !path_is_same_as_or_descendant_of(
+                        $resolved_target,
+                        $this->source_wp_content
+                    )
+                ) {
+                    $link_value = self::compute_relative_path(
+                        realpath_with_missing_tail(dirname($destination_entry)),
+                        $resolved_target
+                    );
+                }
             }
             if (!symlink($link_value, $destination_entry)) {
                 throw new RuntimeException(

--- a/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
+++ b/packages/reprint-client/src/lib/merge/class-wp-content-merger.php
@@ -1,0 +1,468 @@
+<?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\normalize_path;
+use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Merge failures carry CLI filesystem paths, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Folds one wp-content directory into another.
+ *
+ * Entries the destination does not have move there. Entries it has stay as
+ * they are, so the destination copy always wins. Nothing is deleted: a run
+ * either moves an entry or leaves both sides alone.
+ *
+ * ## The unit boundary
+ *
+ * Merging stops at whole units. A plugin or a theme belongs to one side or the
+ * other: descending into one both sides have would keep the files the
+ * destination's version dropped, leaving a directory that matches no release
+ * and pushing those files to the source site later. So the walk passes through
+ * the directories that hold independent things and stops at the things
+ * themselves:
+ *
+ *   plugins, mu-plugins, themes -> one level, each child whole
+ *   uploads                     -> all the way down, each file its own
+ *   anything else               -> whole, because its insides are unknown
+ *
+ * Per entry at the wp-content level:
+ *
+ *   - absent from the destination -> move it there
+ *   - a container above           -> walk it under that container's rule
+ *   - anything else               -> leave it, the destination copy wins
+ *
+ * ## Component directories
+ *
+ * WordPress lets plugins, mu-plugins and uploads live outside wp-content, and
+ * hosts use that: on WP Cloud the uploads base directory sits on its own
+ * volume. `$component_destinations` says where each one lives on the
+ * destination side, so `uploads` moves to that directory rather than to
+ * `<destination>/uploads`. Their basenames also join the container names, so a
+ * site that renamed a component directory still gets the right rule.
+ */
+class WpContentMerger
+{
+    /**
+     * Suffix for the path a cross-filesystem copy writes before it renames the
+     * finished entry into place. Derived from the destination rather than
+     * random so a later run clears what an interrupted one abandoned.
+     */
+    private const STAGING_SUFFIX = ".reprint-merge-incomplete";
+
+    /** @var string wp-content directory whose entries move away. */
+    private string $source_wp_content;
+
+    /** @var string wp-content directory the entries move into. */
+    private string $destination_wp_content;
+
+    /**
+     * @var array<string,string> Source entry name mapped to the destination
+     *                           path that entry moves to, for the components
+     *                           which live outside wp-content.
+     */
+    private array $routed_destinations = [];
+
+    /** @var string[] Entry names whose own children are whole plugins or themes. */
+    private array $unit_container_names = ["plugins", "mu-plugins", "themes"];
+
+    /** @var string[] Entry names whose contents merge file by file. */
+    private array $file_container_names = ["uploads"];
+
+    /**
+     * @var callable Receives one audit line per moved entry.
+     * @phpstan-var callable(string): void
+     */
+    private $record_move;
+
+    /** @var int Entries moved by the current merge() call. */
+    private int $moved = 0;
+
+    /**
+     * @param string   $source_wp_content      wp-content directory whose entries move away.
+     * @param string   $destination_wp_content wp-content directory the entries move into.
+     * @param array    $component_destinations {
+     *     Destination directory for each component which may live outside
+     *     wp-content. An absent or null key leaves that component at its
+     *     conventional name under $destination_wp_content.
+     *
+     *     @type string|null $plugins    Destination plugins directory.
+     *     @type string|null $mu-plugins Destination mu-plugins directory.
+     *     @type string|null $uploads    Destination uploads base directory.
+     * }
+     * @param callable $record_move            Called with one audit line per moved entry.
+     *
+     * @phpstan-param array<string,string|null> $component_destinations
+     * @phpstan-param callable(string): void   $record_move
+     */
+    public function __construct(
+        string $source_wp_content,
+        string $destination_wp_content,
+        array $component_destinations,
+        callable $record_move
+    ) {
+        $this->source_wp_content = $source_wp_content;
+        $this->destination_wp_content = $destination_wp_content;
+        $this->record_move = $record_move;
+
+        foreach ($component_destinations as $conventional_name => $destination) {
+            if (!is_string($destination) || $destination === "") {
+                continue;
+            }
+            // Both names route to the same place: the wp-content being merged
+            // in may use the name WordPress conventionally uses, or the one
+            // the destination site gave that component.
+            $this->routed_destinations[$conventional_name] = $destination;
+            $this->routed_destinations[basename($destination)] = $destination;
+            if ($conventional_name === "uploads") {
+                $this->file_container_names[] = basename($destination);
+            } else {
+                $this->unit_container_names[] = basename($destination);
+            }
+        }
+        $this->unit_container_names = array_values(array_unique($this->unit_container_names));
+        $this->file_container_names = array_values(array_unique($this->file_container_names));
+    }
+
+    /**
+     * Move every entry the destination lacks, and report how many moved.
+     *
+     * A side which is not a real directory has nothing to compare, so the
+     * merge is a no-op. That is what makes a second run harmless once
+     * flat-docroot has replaced the source wp-content with a symlink.
+     */
+    public function merge(): int
+    {
+        $this->moved = 0;
+        if (
+            !$this->is_real_directory($this->source_wp_content)
+            || !$this->is_real_directory($this->destination_wp_content)
+        ) {
+            return 0;
+        }
+
+        foreach (@scandir($this->source_wp_content) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $source_entry = wp_join_unix_paths($this->source_wp_content, $entry);
+            $destination_entry = $this->routed_destinations[$entry]
+                ?? wp_join_unix_paths($this->destination_wp_content, $entry);
+
+            if (!file_exists($destination_entry) && !is_link($destination_entry)) {
+                // A routed component can sit outside the destination
+                // wp-content, and the file pull creates the directories
+                // leading to it only when the source site had content there.
+                // rename() into a missing parent fails, which would send a
+                // whole uploads tree down the copy fallback for want of one
+                // mkdir.
+                $this->create_parent_directory($destination_entry);
+                $this->move_entry($source_entry, $destination_entry);
+                continue;
+            }
+            if (in_array($entry, $this->unit_container_names, true)) {
+                $this->merge_unit_container($source_entry, $destination_entry);
+                continue;
+            }
+            if (in_array($entry, $this->file_container_names, true)) {
+                $this->merge_file_tree($source_entry, $destination_entry);
+            }
+        }
+
+        return $this->moved;
+    }
+
+    /**
+     * Move whole plugins or themes the destination lacks.
+     *
+     * Each child is one unit. A name the destination also has stays the
+     * destination's, down to the last file, so two versions of the same plugin
+     * never merge.
+     */
+    private function merge_unit_container(string $source, string $destination): void
+    {
+        if (!$this->is_real_directory($source) || !$this->is_real_directory($destination)) {
+            return;
+        }
+
+        foreach (@scandir($source) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $destination_entry = wp_join_unix_paths($destination, $entry);
+            if (file_exists($destination_entry) || is_link($destination_entry)) {
+                continue;
+            }
+            $this->move_entry(wp_join_unix_paths($source, $entry), $destination_entry);
+        }
+    }
+
+    /**
+     * Move the files the destination lacks, to the leaf.
+     *
+     * For uploads, where each file stands alone: a photo the destination does
+     * not have is its own thing, not part of some larger version.
+     */
+    private function merge_file_tree(string $source, string $destination): void
+    {
+        if (!$this->is_real_directory($source) || !$this->is_real_directory($destination)) {
+            return;
+        }
+
+        foreach (@scandir($source) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $source_entry = wp_join_unix_paths($source, $entry);
+            $destination_entry = wp_join_unix_paths($destination, $entry);
+
+            if (!file_exists($destination_entry) && !is_link($destination_entry)) {
+                $this->move_entry($source_entry, $destination_entry);
+                continue;
+            }
+            $this->merge_file_tree($source_entry, $destination_entry);
+        }
+    }
+
+    /**
+     * Move one entry to its place on the destination side.
+     *
+     * A symlink is recreated rather than moved: a relative value is read
+     * against its own parent directory, and the two parents sit at different
+     * depths. The new value stays relative because files-push transmits
+     * symlink values verbatim and the target recreates them as given, so an
+     * absolute value would write a local path onto the source server. An
+     * absolute value already resolves the same from either parent.
+     *
+     * rename() reports EXDEV when the two sides are on different filesystems,
+     * which nothing stops the caller from choosing, so a copy is the fallback
+     * rather than the error.
+     *
+     * Only the moved entry's own value is rewritten. A relative symlink deeper
+     * in a moved directory keeps its value, which still resolves when it
+     * points within that directory and breaks when it points out of it. No
+     * move can preserve the second kind.
+     */
+    private function move_entry(string $source_entry, string $destination_entry): void
+    {
+        if (is_link($source_entry)) {
+            $link_value = readlink($source_entry);
+            if ($link_value === false) {
+                throw new RuntimeException(
+                    "Could not read the symlink value at {$source_entry}.",
+                );
+            }
+            if (strpos($link_value, "/") !== 0) {
+                $link_value = self::compute_relative_path(
+                    realpath_with_missing_tail(dirname($destination_entry)),
+                    normalize_path(
+                        wp_join_unix_paths(dirname($source_entry), $link_value)
+                    )
+                );
+            }
+            if (!symlink($link_value, $destination_entry)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$destination_entry} -> {$link_value}",
+                );
+            }
+            if (!unlink($source_entry)) {
+                throw new RuntimeException(
+                    "Created {$destination_entry} but could not remove the original " .
+                        "symlink at {$source_entry}.",
+                );
+            }
+        } elseif (!@rename($source_entry, $destination_entry)) {
+            // Copy beside the destination and rename it into place, never into
+            // the destination itself. A copy that dies partway — a full disk,
+            // an unreadable file, a signal during a large one — would otherwise
+            // leave a partial entry that the next run reads as the destination
+            // copy and skips. Both paths sit in the same directory, so the
+            // rename is atomic.
+            $staging_path = $destination_entry . self::STAGING_SUFFIX;
+            $this->remove_path_without_following_symlinks($staging_path);
+            try {
+                $this->copy_path($source_entry, $staging_path);
+                if (!@rename($staging_path, $destination_entry)) {
+                    throw new RuntimeException(
+                        "Copied {$source_entry} to {$staging_path} but could not move it " .
+                            "to {$destination_entry}.",
+                    );
+                }
+            } catch (Throwable $copy_failure) {
+                $this->remove_path_without_following_symlinks($staging_path);
+                throw $copy_failure;
+            }
+            if (!$this->remove_path_without_following_symlinks($source_entry)) {
+                throw new RuntimeException(
+                    "Copied {$source_entry} to {$destination_entry} but could not remove " .
+                        "the original at {$source_entry}.",
+                );
+            }
+        }
+
+        ++$this->moved;
+        call_user_func(
+            $this->record_move,
+            "Moved: {$source_entry} -> {$destination_entry}"
+        );
+    }
+
+    /**
+     * Copy a file, symlink, or directory tree to a path that does not exist yet.
+     *
+     * This is the cross-filesystem half of a move, so it reproduces a symlink
+     * as a symlink instead of following it into its target. Values are kept
+     * verbatim: an entry and everything below it move together, so a relative
+     * value that resolves within the tree still resolves after the copy.
+     *
+     * copy() creates the destination under the umask and mkdir() takes the
+     * mode it is given, so both are followed by a chmod to the source's own
+     * permissions. Without it an executable script or a deliberately 0700
+     * directory would come out different on this path and unchanged on the
+     * rename() path.
+     */
+    private function copy_path(string $from, string $to): void
+    {
+        if (is_link($from)) {
+            $link_value = readlink($from);
+            if ($link_value === false) {
+                throw new RuntimeException(
+                    "Could not read the symlink value at {$from}.",
+                );
+            }
+            if (!symlink($link_value, $to)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$to} -> {$link_value}",
+                );
+            }
+            return;
+        }
+
+        // A failed copy or mkdir here is reported as an exception naming both
+        // paths, so the raw PHP warning would only duplicate it.
+        if (!is_dir($from)) {
+            if (!@copy($from, $to)) {
+                throw new RuntimeException("Failed to copy {$from} to {$to}.");
+            }
+            $this->copy_permissions($from, $to);
+            return;
+        }
+
+        if (!@mkdir($to, 0755, true)) {
+            throw new RuntimeException("Failed to create directory: {$to}");
+        }
+        $this->copy_permissions($from, $to);
+        foreach (@scandir($from) ?: [] as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $this->copy_path(
+                wp_join_unix_paths($from, $entry),
+                wp_join_unix_paths($to, $entry)
+            );
+        }
+    }
+
+    /** Give $to the permission bits $from carries. */
+    private function copy_permissions(string $from, string $to): void
+    {
+        $permissions = @fileperms($from);
+        if ($permissions === false) {
+            throw new RuntimeException("Could not read the permissions of {$from}.");
+        }
+        if (!@chmod($to, $permissions & 0777)) {
+            throw new RuntimeException("Failed to set the permissions of {$to}.");
+        }
+    }
+
+    /**
+     * Create the directories leading to $path.
+     *
+     * mkdir() is given the conventional directory mode rather than one copied
+     * from the source: these directories exist on the destination side only,
+     * and no source directory corresponds to them.
+     */
+    private function create_parent_directory(string $path): void
+    {
+        $parent = dirname($path);
+        if (is_dir($parent)) {
+            return;
+        }
+        if (!@mkdir($parent, 0755, true) && !is_dir($parent)) {
+            throw new RuntimeException("Failed to create directory: {$parent}");
+        }
+    }
+
+    /** Whether $path is a directory rather than a symlink to one. */
+    private function is_real_directory(string $path): bool
+    {
+        return !is_link($path) && is_dir($path);
+    }
+
+    /**
+     * Delete a file, symlink, or directory tree without following symlinks.
+     *
+     * Returns false rather than throwing so the caller can name the path in
+     * an error which says what it had already done.
+     */
+    private function remove_path_without_following_symlinks(string $path): bool
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return true;
+        }
+
+        if (is_link($path) || !is_dir($path)) {
+            return true === @unlink($path);
+        }
+
+        $entries = @scandir($path);
+        if ($entries === false) {
+            return false;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            if (
+                !$this->remove_path_without_following_symlinks(
+                    wp_join_unix_paths($path, $entry)
+                )
+            ) {
+                return false;
+            }
+        }
+        return true === @rmdir($path);
+    }
+
+    /**
+     * Compute a relative path from $from to $to.
+     *
+     * Both paths must be absolute. Returns a relative path such that a symlink
+     * at $from/$name pointing to the result resolves to $to.
+     *
+     * Example: compute_relative_path('/a/b/c', '/a/d/e') => '../../d/e'
+     */
+    private static function compute_relative_path(string $from, string $to): string
+    {
+        $from_parts = explode("/", trim($from, "/"));
+        $to_parts = explode("/", trim($to, "/"));
+
+        $common = 0;
+        $max = min(count($from_parts), count($to_parts));
+        while ($common < $max && $from_parts[$common] === $to_parts[$common]) {
+            ++$common;
+        }
+
+        $up = count($from_parts) - $common;
+        $down = array_slice($to_parts, $common);
+
+        $parts = array_merge(array_fill(0, $up, ".."), $down);
+        return implode("/", $parts) ?: ".";
+    }
+}
+
+// phpcs:enable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/packages/reprint-client/src/lib/merge/load.php
+++ b/packages/reprint-client/src/lib/merge/load.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * wp-content merge loader.
+ */
+
+require_once __DIR__ . '/class-wp-content-merger.php';

--- a/tests/Import/MergeWpContentTest.php
+++ b/tests/Import/MergeWpContentTest.php
@@ -413,7 +413,7 @@ class MergeWpContentTest extends TestCase
         $workingDirectory = getcwd();
         try {
             chdir($this->tempDir);
-            $this->merge([], './site');
+            $this->merge([], './site/wp-content');
         } finally {
             chdir($workingDirectory);
         }
@@ -459,14 +459,36 @@ class MergeWpContentTest extends TestCase
         $this->assertFileExists($this->localWpContent . '/plugins/local-only/plugin.php');
     }
 
+    public function testTheCommandRefusesAWordPressRootAsFrom(): void
+    {
+        // The mistake --from invites: naming the site directory. Merging it
+        // would move wp-admin, wp-includes and wp-config.php into wp-content.
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        $this->writeFile($this->siteDir . '/wp-load.php', '<?php // wp-load');
+
+        try {
+            $this->merge([], $this->siteDir);
+            $this->fail('a WordPress root should have been refused');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString('is a WordPress root', $exception->getMessage());
+        }
+
+        $this->assertFileExists(
+            $this->localWpContent . '/plugins/local-only/plugin.php',
+            'and nothing moved',
+        );
+        $this->assertFileDoesNotExist($this->pulledWpContent . '/wp-load.php');
+    }
+
     public function testTheCommandRefusesWhenFromAndTheDestinationOverlap(): void
     {
         $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('one holds the other');
-        // --from/wp-content is the destination.
-        $this->merge([], $this->filesystemRoot . self::ABSPATH);
+        // --from is the destination itself.
+        $this->merge([], $this->pulledWpContent);
     }
 
     private function merge(array $pathsUrls = [], ?string $from = null): void
@@ -489,7 +511,7 @@ class MergeWpContentTest extends TestCase
 
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $client->run_merge_wp_content(['from' => $from ?? $this->siteDir]);
+        $client->run_merge_wp_content(['from' => $from ?? $this->localWpContent]);
     }
 
     private function writePulled(string $relative, string $contents): void

--- a/tests/Import/MergeWpContentTest.php
+++ b/tests/Import/MergeWpContentTest.php
@@ -1,0 +1,584 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/**
+ * Verify the merge-wp-content command.
+ *
+ * The command folds the wp-content under --from into the one the file pull
+ * wrote, so entries only the local site holds survive whatever the caller does
+ * to that directory next — flat-docroot replacing it with a symlink being the
+ * case it exists for.
+ */
+class MergeWpContentTest extends TestCase
+{
+    private const REMOTE_URL = 'https://source.example/export.php';
+    private const ABSPATH = '/srv/htdocs/wordpress/';
+
+    private string $tempDir;
+    private string $stateDir;
+    private string $filesystemRoot;
+    private string $siteDir;
+    private string $remoteStateDir;
+    private string $pulledWpContent;
+    private string $localWpContent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/merge-wp-content-' . uniqid('', true);
+        $this->stateDir = $this->tempDir . '/state';
+        $this->filesystemRoot = $this->tempDir . '/fs-root';
+        $this->siteDir = $this->tempDir . '/site';
+        $this->remoteStateDir = $this->stateDir . '/remotes/' . md5(self::REMOTE_URL);
+        $this->pulledWpContent = $this->filesystemRoot . self::ABSPATH . 'wp-content';
+        $this->localWpContent = $this->siteDir . '/wp-content';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->pulledWpContent, 0755, true);
+        mkdir($this->localWpContent, 0755, true);
+        // The guard reads this file as the record of a finished file pull.
+        mkdir($this->remoteStateDir, 0755, true);
+        file_put_contents($this->remoteStateDir . '/local_index.jsonl', '');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testEntriesOnlyTheLocalSiteHoldsReachThePulledTree(): void
+    {
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php // pulled');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        $this->writeLocal('themes/local-theme/style.css', '/* local */');
+        $this->writeLocal('custom-folder/note.txt', 'keep me');
+
+        $this->merge();
+
+        $this->assertFileExists(
+            $this->pulledWpContent . '/plugins/local-only/plugin.php',
+            'a local-only plugin now lives under the filesystem root, where files-push reads',
+        );
+        $this->assertFileExists($this->pulledWpContent . '/themes/local-theme/style.css');
+        $this->assertFileExists($this->pulledWpContent . '/custom-folder/note.txt');
+        $this->assertFileDoesNotExist(
+            $this->localWpContent . '/plugins/local-only/plugin.php',
+            'and no longer under --from: entries move, they are not copied',
+        );
+        $this->assertFileExists($this->pulledWpContent . '/plugins/from-the-pull/plugin.php');
+    }
+
+    public function testAPluginBothSidesHaveIsNeverMerged(): void
+    {
+        // The pull carries WooCommerce 9.2; the local site has 8.5. Merging
+        // them would leave files 9.0 dropped inside a directory claiming to
+        // be 9.2, and push those files to the source site later.
+        $this->writePulled('plugins/woocommerce/woocommerce.php', 'Version: 9.2');
+        $this->writePulled('plugins/woocommerce/includes/class-wc-new.php', 'new');
+        $this->writeLocal('plugins/woocommerce/woocommerce.php', 'Version: 8.5');
+        $this->writeLocal('plugins/woocommerce/includes/class-wc-legacy.php', 'old');
+        $this->writeLocal('plugins/woocommerce/legacy-assets/old.js', 'old');
+        $this->writeLocal('plugins/my-dev-plugin/plugin.php', 'mine');
+
+        $this->merge();
+
+        $plugins = $this->pulledWpContent . '/plugins';
+        $this->assertFileDoesNotExist(
+            $plugins . '/woocommerce/includes/class-wc-legacy.php',
+            'a file the pulled version dropped is not carried into it',
+        );
+        $this->assertFileDoesNotExist(
+            $plugins . '/woocommerce/legacy-assets/old.js',
+            'nor is a whole directory the pulled version dropped',
+        );
+        $this->assertFileExists($plugins . '/woocommerce/includes/class-wc-new.php');
+        $this->assertSame('Version: 9.2', file_get_contents($plugins . '/woocommerce/woocommerce.php'));
+        $this->assertFileExists(
+            $plugins . '/my-dev-plugin/plugin.php',
+            'a plugin only the local site has still moves whole',
+        );
+    }
+
+    public function testAThemeBothSidesHaveIsNeverMerged(): void
+    {
+        $this->writePulled('themes/twentytwentyfive/style.css', 'Version: 1.3');
+        $this->writeLocal('themes/twentytwentyfive/style.css', 'Version: 1.0');
+        $this->writeLocal('themes/twentytwentyfive/patterns/dropped.php', 'old');
+        $this->writeLocal('themes/my-child-theme/style.css', 'mine');
+
+        $this->merge();
+
+        $themes = $this->pulledWpContent . '/themes';
+        $this->assertFileDoesNotExist($themes . '/twentytwentyfive/patterns/dropped.php');
+        $this->assertSame('Version: 1.3', file_get_contents($themes . '/twentytwentyfive/style.css'));
+        $this->assertFileExists($themes . '/my-child-theme/style.css');
+    }
+
+    public function testUploadsMergeFileByFile(): void
+    {
+        // Media is not a versioned payload: a photo the pull lacks is its own
+        // thing, so uploads merges to the leaf where plugins does not.
+        $this->writePulled('uploads/2026/01/pulled.jpg', 'pulled');
+        $this->writeLocal('uploads/2026/01/local.jpg', 'local');
+        $this->writeLocal('uploads/2025/12/older.jpg', 'local');
+
+        $this->merge();
+
+        $uploads = $this->pulledWpContent . '/uploads';
+        $this->assertFileExists(
+            $uploads . '/2026/01/local.jpg',
+            'a local-only file inside a month both sides have is kept',
+        );
+        $this->assertFileExists($uploads . '/2025/12/older.jpg');
+        $this->assertFileExists($uploads . '/2026/01/pulled.jpg');
+    }
+
+    public function testAnUnknownDirectoryBothSidesHaveIsLeftToThePull(): void
+    {
+        // Nothing here says what the directory holds, so it is treated as one
+        // unit. The local-only file inside it stays where it is; a directory
+        // only the local site has still moves.
+        $this->writePulled('languages/admin-en_GB.mo', 'pulled');
+        $this->writeLocal('languages/plugins/local-only.mo', 'local');
+        $this->writeLocal('my-own-folder/keep.txt', 'local');
+
+        $this->merge();
+
+        $this->assertFileDoesNotExist(
+            $this->pulledWpContent . '/languages/plugins/local-only.mo',
+        );
+        $this->assertFileExists($this->pulledWpContent . '/my-own-folder/keep.txt');
+    }
+
+    public function testAMovedSymlinkStillResolvesFromItsNewDepth(): void
+    {
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeFile($this->siteDir . '/shared-store/local-plugin/plugin.php', '<?php // shared store');
+        mkdir($this->localWpContent . '/plugins', 0755, true);
+        // A relative value read against a parent two levels below the site
+        // directory; the destination parent sits at a different depth.
+        symlink(
+            '../../shared-store/local-plugin',
+            $this->localWpContent . '/plugins/linked-plugin',
+        );
+
+        $this->merge();
+
+        $moved = $this->pulledWpContent . '/plugins/linked-plugin';
+        $this->assertTrue(is_link($moved), 'the entry is still a symlink, not a copy of its target');
+        $this->assertStringNotContainsString(
+            '/',
+            substr(readlink($moved), 0, 1),
+            'and its value is still relative, because files-push sends it verbatim',
+        );
+        $this->assertFileExists(
+            $moved . '/plugin.php',
+            'and it resolves from the deeper parent',
+        );
+        $this->assertStringContainsString(
+            'shared store',
+            file_get_contents($moved . '/plugin.php'),
+        );
+    }
+
+    public function testTheExplodedLayoutRoutesEachComponentToItsOwnSource(): void
+    {
+        // uploads outside content_dir is the WP Cloud shape: each component
+        // has to land under the directory preflight reports for it.
+        $this->writeFile(
+            $this->filesystemRoot . '/srv/htdocs/wp-content/plugins/from-the-pull/plugin.php',
+            '<?php',
+        );
+        $this->writeFile($this->filesystemRoot . '/srv/uploads/2026/01/pulled.jpg', 'pulled');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        $this->writeLocal('uploads/2026/02/local.jpg', 'local');
+        $this->writeLocal('local-folder/note.txt', 'keep me');
+
+        $this->merge([
+            'content_dir' => '/srv/htdocs/wp-content',
+            'uploads' => ['basedir' => '/srv/uploads'],
+        ]);
+
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/htdocs/wp-content/plugins/local-only/plugin.php',
+            'a local-only plugin lands under the plugins source',
+        );
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/uploads/2026/02/local.jpg',
+            'a local-only upload lands under the detached uploads source, not under content_dir',
+        );
+        $this->assertFileExists(
+            $this->filesystemRoot . '/srv/htdocs/wp-content/local-folder/note.txt',
+            'an entry belonging to no component lands under content_dir',
+        );
+    }
+
+    public function testARoutedComponentDirectoryIsRenamedIntoAPathThePullNeverWrote(): void
+    {
+        // A pull scoped with --only can leave the uploads directory absent
+        // while preflight still reports where it belongs. The uploads volume
+        // sits on its own path here, so nothing the pull wrote shares a parent
+        // with it.
+        $this->writeFile(
+            $this->filesystemRoot . '/var/www/wp-content/plugins/from-the-pull/plugin.php',
+            '<?php',
+        );
+        $this->writeLocal('uploads/2026/02/local.jpg', 'local');
+        $inodeBefore = fileinode($this->localWpContent . '/uploads/2026/02/local.jpg');
+
+        $this->merge([
+            'content_dir' => '/var/www/wp-content',
+            'uploads' => ['basedir' => '/mnt/uploads'],
+        ]);
+
+        $moved = $this->filesystemRoot . '/mnt/uploads/2026/02/local.jpg';
+        $this->assertFileExists(
+            $moved,
+            'the whole local uploads tree moves to the directory preflight names',
+        );
+        $this->assertDirectoryDoesNotExist(
+            $this->filesystemRoot . '/var/www/wp-content/uploads',
+            'and not to the conventional place inside wp-content',
+        );
+        $this->assertSame(
+            $inodeBefore,
+            fileinode($moved),
+            'and it was renamed there, not copied file by file into a path rename could not reach',
+        );
+    }
+
+    public function testASecondRunChangesNothing(): void
+    {
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+
+        $this->merge();
+        $firstPass = $this->describeTree($this->filesystemRoot);
+
+        $this->merge();
+
+        $this->assertSame(
+            $firstPass,
+            $this->describeTree($this->filesystemRoot),
+            're-running moves nothing further: everything the local site had is already there',
+        );
+    }
+
+    public function testASecondRunAfterFlatteningIsANoOp(): void
+    {
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+
+        $this->merge();
+
+        // What flat-docroot leaves behind: the site's wp-content is a symlink
+        // into the filesystem root, so both sides are the same tree.
+        $this->recursiveDelete($this->localWpContent);
+        symlink($this->pulledWpContent, $this->localWpContent);
+        $beforeSecondRun = $this->describeTree($this->filesystemRoot);
+
+        $this->merge();
+
+        $this->assertSame(
+            $beforeSecondRun,
+            $this->describeTree($this->filesystemRoot),
+            'a symlinked source holds nothing of its own, so nothing moves',
+        );
+    }
+
+    public function testAMoveThatCannotCompleteLeavesTheLocalSiteUntouched(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            $this->markTestSkipped('Directory permissions do not stop root from writing.');
+        }
+
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        // rename() into a read-only plugins directory fails, and so does the
+        // copy fallback, because both write there.
+        chmod($this->pulledWpContent . '/plugins', 0555);
+
+        try {
+            $this->merge();
+            $this->fail('the failed move should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            // Expected.
+        } finally {
+            chmod($this->pulledWpContent . '/plugins', 0755);
+        }
+
+        $this->assertFileExists(
+            $this->localWpContent . '/plugins/local-only/plugin.php',
+            'the entry that could not move is still where it was',
+        );
+    }
+
+    public function testACopyThatFailsPartwayLeavesNothingAtTheDestination(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            $this->markTestSkipped('File permissions do not stop root from reading.');
+        }
+
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/first.php', '<?php // copied');
+        $this->writeLocal('plugins/local-only/second.php', '<?php // unreadable');
+        $this->writeLocal('plugins/local-only/third.php', '<?php // never reached');
+        // rename() needs to write to the entry's parent, so a read-only parent
+        // sends the move down the cross-filesystem copy path, and an unreadable
+        // file part-way through that copy fails it after it has written some.
+        chmod($this->localWpContent . '/plugins/local-only/second.php', 0000);
+        chmod($this->localWpContent . '/plugins', 0555);
+
+        try {
+            $this->merge();
+            $this->fail('the failed copy should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            // Expected.
+        } finally {
+            chmod($this->localWpContent . '/plugins', 0755);
+            chmod($this->localWpContent . '/plugins/local-only/second.php', 0644);
+        }
+
+        $plugins = $this->pulledWpContent . '/plugins';
+        $this->assertFileDoesNotExist(
+            $plugins . '/local-only',
+            'a half-copied entry must not sit at the name the next run reads as the pulled copy',
+        );
+        $this->assertSame(
+            [],
+            glob($plugins . '/*.reprint-merge-incomplete') ?: [],
+            'and the staging path it copied into is cleared',
+        );
+        $this->assertFileExists(
+            $this->localWpContent . '/plugins/local-only/first.php',
+            'the original is untouched, so a later run can try again',
+        );
+    }
+
+    /**
+     * rename() keeps permissions; the copy behind EXDEV has to reproduce them.
+     *
+     * A second filesystem is not something a test can rely on having, so this
+     * exercises the copy itself, which is the only part of a move that ever
+     * creates a file.
+     */
+    public function testTheCopyFallbackKeepsPermissions(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            $this->markTestSkipped('The umask a root process runs under is not the point here.');
+        }
+
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        $this->writeLocal('plugins/local-only/bin/run.sh', '#!/bin/sh');
+        $this->writeLocal('plugins/local-only/private/secret.key', 'key');
+        chmod($this->localWpContent . '/plugins/local-only/bin/run.sh', 0755);
+        chmod($this->localWpContent . '/plugins/local-only/private', 0700);
+
+        $merger = new \WpContentMerger(
+            $this->localWpContent,
+            $this->pulledWpContent,
+            [],
+            function (string $line): void {}
+        );
+        $copy = (new \ReflectionClass($merger))->getMethod('copy_path');
+        $copied = $this->tempDir . '/copied-plugin';
+        $copy->invoke($merger, $this->localWpContent . '/plugins/local-only', $copied);
+
+        $this->assertSame('0755', $this->permissionsOf($copied . '/bin/run.sh'));
+        $this->assertSame('0700', $this->permissionsOf($copied . '/private'));
+        $this->assertSame(
+            $this->permissionsOf($this->localWpContent . '/plugins/local-only/plugin.php'),
+            $this->permissionsOf($copied . '/plugin.php'),
+            'an ordinary file keeps what it had rather than taking the umask',
+        );
+    }
+
+    public function testTheCommandRefusesWhileAFilePullIsUnfinished(): void
+    {
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        mkdir($this->remoteStateDir . '/pull', 0755, true);
+        file_put_contents($this->remoteStateDir . '/pull/index.wal', '');
+
+        try {
+            $this->merge();
+            $this->fail('an open files-pull lifecycle should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString('interrupted files-pull', $exception->getMessage());
+        }
+
+        $this->assertFileExists(
+            $this->localWpContent . '/plugins/local-only/plugin.php',
+            'nothing moved: mid-download every unfetched path looks absent',
+        );
+    }
+
+    public function testTheCommandRefusesWhenNoFilePullHasCompleted(): void
+    {
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+        unlink($this->remoteStateDir . '/local_index.jsonl');
+
+        try {
+            $this->merge();
+            $this->fail('a missing local index should have stopped the command');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString('requires a completed file pull', $exception->getMessage());
+        }
+
+        $this->assertFileExists($this->localWpContent . '/plugins/local-only/plugin.php');
+    }
+
+    public function testTheCommandRefusesWhenFromAndTheDestinationOverlap(): void
+    {
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('one holds the other');
+        // The site directory the pull itself wrote: --from/wp-content is the
+        // destination, so the walk would read what it had just moved.
+        $this->merge([], $this->filesystemRoot . self::ABSPATH);
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Run merge-wp-content against the layout built by the write helpers.
+     *
+     * @param array  $pathsUrls Extra preflight paths_urls keys, for layouts
+     *                          where wp-content or its sub-components sit
+     *                          outside ABSPATH.
+     * @param string $from      Site directory to merge from; the site
+     *                          directory the tests build by default.
+     */
+    private function merge(array $pathsUrls = [], ?string $from = null): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'table_prefix' => 'wp_',
+                            'paths_urls' => array_merge(
+                                ['abspath' => self::ABSPATH],
+                                $pathsUrls,
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $client->run_merge_wp_content(['from' => $from ?? $this->siteDir]);
+    }
+
+    private function writePulled(string $relative, string $contents): void
+    {
+        $this->writeFile($this->pulledWpContent . '/' . $relative, $contents);
+    }
+
+    private function writeLocal(string $relative, string $contents): void
+    {
+        $this->writeFile($this->localWpContent . '/' . $relative, $contents);
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    /** The permission bits of $path as four octal digits. */
+    private function permissionsOf(string $path): string
+    {
+        clearstatcache(true, $path);
+        return substr(sprintf('%o', fileperms($path)), -4);
+    }
+
+    /**
+     * List every path under $dir with its type, for comparing two runs.
+     *
+     * @return string[] Sorted "type relative/path" lines.
+     */
+    private function describeTree(string $dir): array
+    {
+        $described = [];
+        $stack = [$dir];
+        while ($stack !== []) {
+            $current = array_pop($stack);
+            foreach (scandir($current) ?: [] as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $path = $current . '/' . $entry;
+                $relative = substr($path, strlen($dir));
+                if (is_link($path)) {
+                    $described[] = 'link ' . $relative . ' -> ' . readlink($path);
+                    continue;
+                }
+                if (is_dir($path)) {
+                    $described[] = 'dir  ' . $relative;
+                    $stack[] = $path;
+                    continue;
+                }
+                $described[] = 'file ' . $relative . ' ' . md5_file($path);
+            }
+        }
+        sort($described);
+        return $described;
+    }
+
+    private function writeState(array $state): void
+    {
+        \write_current_pull_state($this->makeClient(), $state);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient(
+            self::REMOTE_URL,
+            $this->stateDir,
+            $this->filesystemRoot,
+        );
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $reflection = new \ReflectionClass($client);
+        $method = $reflection->getMethod('load_state');
+        $property = $reflection->getProperty('state');
+        $property->setValue($client, $method->invoke($client));
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir) || is_link($dir)) {
+            if (is_link($dir)) {
+                unlink($dir);
+            }
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                @chmod($path, 0755);
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/MergeWpContentTest.php
+++ b/tests/Import/MergeWpContentTest.php
@@ -6,14 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
-/**
- * Verify the merge-wp-content command.
- *
- * The command folds the wp-content under --from into the one the file pull
- * wrote, so entries only the local site holds survive whatever the caller does
- * to that directory next — flat-docroot replacing it with a symlink being the
- * case it exists for.
- */
 class MergeWpContentTest extends TestCase
 {
     private const REMOTE_URL = 'https://source.example/export.php';
@@ -40,7 +32,6 @@ class MergeWpContentTest extends TestCase
         mkdir($this->stateDir, 0755, true);
         mkdir($this->pulledWpContent, 0755, true);
         mkdir($this->localWpContent, 0755, true);
-        // The guard reads this file as the record of a finished file pull.
         mkdir($this->remoteStateDir, 0755, true);
         file_put_contents($this->remoteStateDir . '/local_index.jsonl', '');
     }
@@ -75,9 +66,7 @@ class MergeWpContentTest extends TestCase
 
     public function testAPluginBothSidesHaveIsNeverMerged(): void
     {
-        // The pull carries WooCommerce 9.2; the local site has 8.5. Merging
-        // them would leave files 9.0 dropped inside a directory claiming to
-        // be 9.2, and push those files to the source site later.
+        // A same-name plugin is a whole unit.
         $this->writePulled('plugins/woocommerce/woocommerce.php', 'Version: 9.2');
         $this->writePulled('plugins/woocommerce/includes/class-wc-new.php', 'new');
         $this->writeLocal('plugins/woocommerce/woocommerce.php', 'Version: 8.5');
@@ -121,8 +110,6 @@ class MergeWpContentTest extends TestCase
 
     public function testUploadsMergeFileByFile(): void
     {
-        // Media is not a versioned payload: a photo the pull lacks is its own
-        // thing, so uploads merges to the leaf where plugins does not.
         $this->writePulled('uploads/2026/01/pulled.jpg', 'pulled');
         $this->writeLocal('uploads/2026/01/local.jpg', 'local');
         $this->writeLocal('uploads/2025/12/older.jpg', 'local');
@@ -140,9 +127,6 @@ class MergeWpContentTest extends TestCase
 
     public function testAnUnknownDirectoryBothSidesHaveIsLeftToThePull(): void
     {
-        // Nothing here says what the directory holds, so it is treated as one
-        // unit. The local-only file inside it stays where it is; a directory
-        // only the local site has still moves.
         $this->writePulled('languages/admin-en_GB.mo', 'pulled');
         $this->writeLocal('languages/plugins/local-only.mo', 'local');
         $this->writeLocal('my-own-folder/keep.txt', 'local');
@@ -160,8 +144,7 @@ class MergeWpContentTest extends TestCase
         $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
         $this->writeFile($this->siteDir . '/shared-store/local-plugin/plugin.php', '<?php // shared store');
         mkdir($this->localWpContent . '/plugins', 0755, true);
-        // A relative value read against a parent two levels below the site
-        // directory; the destination parent sits at a different depth.
+        // The destination parent is at a different depth.
         symlink(
             '../../shared-store/local-plugin',
             $this->localWpContent . '/plugins/linked-plugin',
@@ -188,11 +171,7 @@ class MergeWpContentTest extends TestCase
 
     public function testASymlinkToASiblingStillResolvesAfterBothMove(): void
     {
-        // A child theme pointing at its parent. Both move in the same run, so
-        // a value recomputed against where the parent used to be would dangle
-        // the moment the parent left. The destination needs a theme of its own
-        // for the merge to descend into the container and move each child
-        // separately, rather than renaming the whole directory across.
+        // A destination theme makes the merger move each source child.
         $this->writePulled('themes/twentytwentyfive/style.css', '/* pulled */');
         $this->writeLocal('themes/parent-theme/style.css', '/* parent */');
         symlink('parent-theme', $this->localWpContent . '/themes/child-theme');
@@ -214,9 +193,6 @@ class MergeWpContentTest extends TestCase
 
     public function testASymlinkToASkippedSiblingResolvesToThePulledCopy(): void
     {
-        // The destination already has its own parent theme, so that one never
-        // moves. The kept value finds the pulled copy, which is the one the
-        // site should be using.
         $this->writePulled('themes/parent-theme/style.css', '/* pulled parent */');
         $this->writeLocal('themes/parent-theme/style.css', '/* local parent */');
         symlink('parent-theme', $this->localWpContent . '/themes/child-theme');
@@ -233,8 +209,7 @@ class MergeWpContentTest extends TestCase
 
     public function testTheExplodedLayoutRoutesEachComponentToItsOwnSource(): void
     {
-        // uploads outside content_dir is the WP Cloud shape: each component
-        // has to land under the directory preflight reports for it.
+        // Uploads are detached from wp-content.
         $this->writeFile(
             $this->filesystemRoot . '/srv/htdocs/wp-content/plugins/from-the-pull/plugin.php',
             '<?php',
@@ -265,10 +240,7 @@ class MergeWpContentTest extends TestCase
 
     public function testARoutedComponentDirectoryIsRenamedIntoAPathThePullNeverWrote(): void
     {
-        // A pull scoped with --only can leave the uploads directory absent
-        // while preflight still reports where it belongs. The uploads volume
-        // sits on its own path here, so nothing the pull wrote shares a parent
-        // with it.
+        // A scoped pull can leave a detached destination absent.
         $this->writeFile(
             $this->filesystemRoot . '/var/www/wp-content/plugins/from-the-pull/plugin.php',
             '<?php',
@@ -321,8 +293,7 @@ class MergeWpContentTest extends TestCase
 
         $this->merge();
 
-        // What flat-docroot leaves behind: the site's wp-content is a symlink
-        // into the filesystem root, so both sides are the same tree.
+        // flat-docroot replaces wp-content with a symlink into the pulled tree.
         $this->recursiveDelete($this->localWpContent);
         symlink($this->pulledWpContent, $this->localWpContent);
         $beforeSecondRun = $this->describeTree($this->filesystemRoot);
@@ -344,8 +315,7 @@ class MergeWpContentTest extends TestCase
 
         $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
         $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
-        // rename() into a read-only plugins directory fails, and so does the
-        // copy fallback, because both write there.
+        // Both rename and the copy fallback write to this directory.
         chmod($this->pulledWpContent . '/plugins', 0555);
 
         try {
@@ -373,9 +343,7 @@ class MergeWpContentTest extends TestCase
         $this->writeLocal('plugins/local-only/first.php', '<?php // copied');
         $this->writeLocal('plugins/local-only/second.php', '<?php // unreadable');
         $this->writeLocal('plugins/local-only/third.php', '<?php // never reached');
-        // rename() needs to write to the entry's parent, so a read-only parent
-        // sends the move down the cross-filesystem copy path, and an unreadable
-        // file part-way through that copy fails it after it has written some.
+        // Force the copy fallback to encounter an unreadable file.
         chmod($this->localWpContent . '/plugins/local-only/second.php', 0000);
         chmod($this->localWpContent . '/plugins', 0555);
 
@@ -405,13 +373,7 @@ class MergeWpContentTest extends TestCase
         );
     }
 
-    /**
-     * rename() keeps permissions; the copy behind EXDEV has to reproduce them.
-     *
-     * A second filesystem is not something a test can rely on having, so this
-     * exercises the copy itself, which is the only part of a move that ever
-     * creates a file.
-     */
+    /** Exercise the copy path directly because filesystem boundaries are not portable. */
     public function testTheCopyFallbackKeepsPermissions(): void
     {
         if (function_exists('posix_getuid') && posix_getuid() === 0) {
@@ -445,8 +407,6 @@ class MergeWpContentTest extends TestCase
 
     public function testARelativeFromIsResolvedAgainstTheWorkingDirectory(): void
     {
-        // The form the command's own help documents: --from=./site, run from
-        // the directory holding it.
         $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
         $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
 
@@ -505,22 +465,10 @@ class MergeWpContentTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('one holds the other');
-        // The site directory the pull itself wrote: --from/wp-content is the
-        // destination, so the walk would read what it had just moved.
+        // --from/wp-content is the destination.
         $this->merge([], $this->filesystemRoot . self::ABSPATH);
     }
 
-    // ---- helpers ----
-
-    /**
-     * Run merge-wp-content against the layout built by the write helpers.
-     *
-     * @param array  $pathsUrls Extra preflight paths_urls keys, for layouts
-     *                          where wp-content or its sub-components sit
-     *                          outside ABSPATH.
-     * @param string $from      Site directory to merge from; the site
-     *                          directory the tests build by default.
-     */
     private function merge(array $pathsUrls = [], ?string $from = null): void
     {
         $this->writeState([
@@ -562,18 +510,13 @@ class MergeWpContentTest extends TestCase
         file_put_contents($path, $contents);
     }
 
-    /** The permission bits of $path as four octal digits. */
     private function permissionsOf(string $path): string
     {
         clearstatcache(true, $path);
         return substr(sprintf('%o', fileperms($path)), -4);
     }
 
-    /**
-     * List every path under $dir with its type, for comparing two runs.
-     *
-     * @return string[] Sorted "type relative/path" lines.
-     */
+    /** @return string[] */
     private function describeTree(string $dir): array
     {
         $described = [];

--- a/tests/Import/MergeWpContentTest.php
+++ b/tests/Import/MergeWpContentTest.php
@@ -186,6 +186,51 @@ class MergeWpContentTest extends TestCase
         );
     }
 
+    public function testASymlinkToASiblingStillResolvesAfterBothMove(): void
+    {
+        // A child theme pointing at its parent. Both move in the same run, so
+        // a value recomputed against where the parent used to be would dangle
+        // the moment the parent left. The destination needs a theme of its own
+        // for the merge to descend into the container and move each child
+        // separately, rather than renaming the whole directory across.
+        $this->writePulled('themes/twentytwentyfive/style.css', '/* pulled */');
+        $this->writeLocal('themes/parent-theme/style.css', '/* parent */');
+        symlink('parent-theme', $this->localWpContent . '/themes/child-theme');
+
+        $this->merge();
+
+        $moved = $this->pulledWpContent . '/themes/child-theme';
+        $this->assertTrue(is_link($moved));
+        $this->assertSame(
+            'parent-theme',
+            readlink($moved),
+            'a value pointing inside the merged tree is kept as it was',
+        );
+        $this->assertFileExists(
+            $moved . '/style.css',
+            'so it finds the parent at the parent\'s new home',
+        );
+    }
+
+    public function testASymlinkToASkippedSiblingResolvesToThePulledCopy(): void
+    {
+        // The destination already has its own parent theme, so that one never
+        // moves. The kept value finds the pulled copy, which is the one the
+        // site should be using.
+        $this->writePulled('themes/parent-theme/style.css', '/* pulled parent */');
+        $this->writeLocal('themes/parent-theme/style.css', '/* local parent */');
+        symlink('parent-theme', $this->localWpContent . '/themes/child-theme');
+
+        $this->merge();
+
+        $moved = $this->pulledWpContent . '/themes/child-theme';
+        $this->assertSame('parent-theme', readlink($moved));
+        $this->assertSame(
+            '/* pulled parent */',
+            file_get_contents($moved . '/style.css'),
+        );
+    }
+
     public function testTheExplodedLayoutRoutesEachComponentToItsOwnSource(): void
     {
         // uploads outside content_dir is the WP Cloud shape: each component
@@ -396,6 +441,28 @@ class MergeWpContentTest extends TestCase
             $this->permissionsOf($copied . '/plugin.php'),
             'an ordinary file keeps what it had rather than taking the umask',
         );
+    }
+
+    public function testARelativeFromIsResolvedAgainstTheWorkingDirectory(): void
+    {
+        // The form the command's own help documents: --from=./site, run from
+        // the directory holding it.
+        $this->writePulled('plugins/from-the-pull/plugin.php', '<?php');
+        $this->writeLocal('plugins/local-only/plugin.php', '<?php // local');
+
+        $workingDirectory = getcwd();
+        try {
+            chdir($this->tempDir);
+            $this->merge([], './site');
+        } finally {
+            chdir($workingDirectory);
+        }
+
+        $this->assertFileExists(
+            $this->pulledWpContent . '/plugins/local-only/plugin.php',
+            'a relative --from moves entries just as an absolute one does',
+        );
+        $this->assertFileDoesNotExist($this->localWpContent . '/plugins/local-only/plugin.php');
     }
 
     public function testTheCommandRefusesWhileAFilePullIsUnfinished(): void


### PR DESCRIPTION
This PR addresses the same fundamental issue as https://github.com/WordPress/reprint/pull/383 and https://github.com/WordPress/reprint/pull/557, but takes a new approach: a new `merge-wp-content` command strategically walks `wp-content` in the `--from` directory and merges it into the `wp-content` dir in `fs-root`. Studio will use this in conjunction with `flatten-to --force` to get a merged, vanilla WordPress site layout in the directory the Studio site lived to begin with.

## Background

In Studio, there's always a local WordPress site that we use Reprint to pull into. That local site can be freshly minted and contain nothing but the default WordPress placeholder content, or it can contain a bunch of existing plugins/themes/uploads. When it does have pre-existing content, we want that content to be preserved on the first Reprint pull.

`flat-docroot --force` would wipe it, which is exactly what we don't want. 

https://github.com/WordPress/reprint/pull/383 is not a good solution to this problem, as anything that lives only in the `flatten_to` dir is invisible to Reprint when pushing back to the site (we will soon also implement Reprint-based pushes in Studio). 

https://github.com/WordPress/reprint/pull/557 also wasn't ideal, as merging `wp-content` directories could potentially be desirable even in cases when `flat-docroot` is not used.

## Exact behavior

- Any immediate descendant of `wp-content` in flatten-to that **is not** present in fs-root **is moved** wholesale. Example: a `debug.log` file, a `plugins` dir that exists only in flatten-to, or any custom directory.
- Any immediate descendant of `wp-content` in flatten-to that **is** present in fs-root is **not moved**. 
- In the `plugins`, `themes`, and `mu-plugins` directories, immediate descendants **are moved** from flatten-to into fs-root only if the same name does not exist in fs-root. Example: flatten-to has a `woocommerce` plugin, and so does fs-root. In this case, fs-root wins, which prevents problems if the plugin/theme versions do not match.
- In the `uploads` directory, all descendants (not only immediate ones) that exist in flatten-to but not in fs-root **are moved** into fs-root.
- Symlinks that are moved from flatten-to into fs-root are recreated if the target path is relative, so that they keep pointing to the right path.