### PR TITLE
[PHP] Support SQLite Database Integration 3.0 exports

### DIFF
--- a/packages/reprint-server/src/class-sqlite-driver-pdo.php
+++ b/packages/reprint-server/src/class-sqlite-driver-pdo.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * PDO-compatible adapter for WP_SQLite_Driver.
+ * PDO-compatible adapter for the SQLite Database Integration driver.
  *
  * MySQLDumpProducer expects a PDO connection — prepare(), query(), and the
  * statement methods fetch(), fetchAll(), fetchColumn(), execute().
- * On SQLite sites, the WP_SQLite_Driver is already loaded by WordPress
- * (via the sqlite-database-integration plugin's db.php drop-in) and is
- * available at $wpdb->dbh. This adapter wraps that driver so the dump
- * producer can use it without knowing it's talking to SQLite.
+ * On SQLite sites, the plugin's db.php drop-in loads a driver which translates
+ * MySQL queries to SQLite. This adapter supplies the PDO operations which that
+ * driver does not implement so the dump producer can use either supported
+ * plugin version without knowing it is talking to SQLite.
  *
  * Every MySQL query goes through the driver's AST-based translator, which
  * converts it to SQLite on the fly. The result is transparent: the dump
@@ -16,7 +16,7 @@
  */
 
 /**
- * Wraps a WP_SQLite_Driver instance to look like a PDO connection.
+ * Wraps a supported SQLite Database Integration driver as a PDO connection.
  *
  * Only the methods that MySQLDumpProducer and the export endpoints actually
  * use are implemented. Anything else will trigger a clear PHP error rather
@@ -24,13 +24,17 @@
  */
 class SqliteDriverPDO
 {
-    /** @var WP_SQLite_Driver */
+    /** @var object The plugin's MySQL-on-SQLite driver. */
     private $driver;
 
     /** @var PDO The raw SQLite PDO for quote() delegation. */
     private $raw_pdo;
 
-    public function __construct(WP_SQLite_Driver $driver, PDO $raw_pdo)
+    /**
+     * @param object $driver  WP_SQLite_Driver or WP_MySQL_On_SQLite.
+     * @param PDO    $raw_pdo The underlying SQLite connection.
+     */
+    public function __construct($driver, PDO $raw_pdo)
     {
         $this->driver = $driver;
         $this->raw_pdo = $raw_pdo;
@@ -68,14 +72,14 @@ class SqliteDriverPDO
 }
 
 /**
- * PDOStatement-compatible wrapper for WP_SQLite_Driver query results.
+ * PDOStatement-compatible wrapper for MySQL-on-SQLite query results.
  *
  * Collects all result rows eagerly after execution and serves them
  * through fetch/fetchAll/fetchColumn.
  */
 class SqliteDriverPDOStatement
 {
-    /** @var WP_SQLite_Driver */
+    /** @var object The plugin's MySQL-on-SQLite driver. */
     private $driver;
 
     /** @var PDO The raw SQLite PDO for quote() delegation. */
@@ -93,7 +97,12 @@ class SqliteDriverPDOStatement
     /** @var array|null Parameters bound via bindValue(). */
     private $bound_params = null;
 
-    public function __construct(WP_SQLite_Driver $driver, PDO $raw_pdo, string $sql)
+    /**
+     * @param object $driver  WP_SQLite_Driver or WP_MySQL_On_SQLite.
+     * @param PDO    $raw_pdo The underlying SQLite connection.
+     * @param string $sql     MySQL query to execute.
+     */
+    public function __construct($driver, PDO $raw_pdo, string $sql)
     {
         $this->driver = $driver;
         $this->raw_pdo = $raw_pdo;
@@ -104,7 +113,7 @@ class SqliteDriverPDOStatement
      * Executes the prepared statement.
      *
      * Substitutes bound parameters into the query, sends it through
-     * WP_SQLite_Driver::query(), and stores the result rows.
+     * the plugin's MySQL-on-SQLite driver, and stores the result rows.
      *
      * @param array|null $params Positional or named parameters.
      * @return bool True on success.
@@ -154,12 +163,16 @@ class SqliteDriverPDOStatement
             }
         }
 
-        $this->driver->query($sql);
-        $result = $this->driver->get_query_results();
-        $this->rows = is_array($result) ? $result : [];
+        $result = $this->driver->query($sql);
+        if ($result instanceof PDOStatement) {
+            $this->rows = $result->fetchAll(PDO::FETCH_ASSOC);
+        } else {
+            $result = $this->driver->get_query_results();
+            $this->rows = is_array($result) ? $result : [];
+        }
 
-        // WP_SQLite_Driver returns results as arrays of objects (PDO::FETCH_OBJ
-        // by default). Convert to associative arrays for PDO compatibility.
+        // The version 2 driver returns arrays of objects. Convert those rows
+        // to the same associative arrays returned by the version 3 driver.
         foreach ($this->rows as $i => $row) {
             if (is_object($row)) {
                 $this->rows[$i] = (array) $row;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -257,7 +257,7 @@ function resolve_db_credentials(): array
  */
 function is_sqlite_site(): bool
 {
-    // @TODO: Actually check for the WP_SQLite_Driver class being used here.
+    // Connection setup checks which supported driver WordPress loaded.
     return defined('SQLITE_DB_DROPIN_VERSION') && isset($GLOBALS['@pdo']);
 }
 
@@ -265,11 +265,10 @@ function is_sqlite_site(): bool
  * Creates a database connection appropriate for the detected backend.
  *
  * For MySQL sites, returns a standard PDO connection.
- * For SQLite sites, wraps the WP_SQLite_Driver that WordPress already
- * loaded (via $wpdb->dbh) in a PDO-compatible adapter. The driver's
- * AST-based translator converts every MySQL query to SQLite on the fly,
- * so MySQLDumpProducer sees MySQL-shaped results and produces valid
- * MySQL SQL output.
+ * For SQLite sites, wraps the MySQL-on-SQLite driver which WordPress already
+ * loaded in a PDO-compatible adapter. The driver's translator converts every
+ * MySQL query to SQLite on the fly, so MySQLDumpProducer sees MySQL-shaped
+ * results and produces valid MySQL SQL output.
  *
  * @param array $creds   Credentials from resolve_db_credentials().
  * @param array $options PDO options (only used for MySQL connections).
@@ -312,10 +311,11 @@ function create_db_connection(array $creds, array $options = [])
 }
 
 /**
- * Wraps the already-loaded WP_SQLite_Driver in a PDO-compatible adapter.
+ * Wraps the SQLite plugin's already-loaded driver in a PDO-compatible adapter.
  *
- * Validates that the sqlite-database-integration plugin version is in the
- * supported range, then extracts the driver and raw PDO from $wpdb->dbh.
+ * Version 3 exposes WP_MySQL_On_SQLite through $wpdb->get_driver(). Version 2
+ * stores WP_SQLite_Driver in $wpdb->dbh. Both drivers translate MySQL queries,
+ * but neither provides every PDO operation used by MySQLDumpProducer.
  *
  * @return object PDO-compatible adapter (SqliteDriverPDO).
  * @throws RuntimeException If the driver is not available or unsupported.
@@ -325,33 +325,49 @@ function create_sqlite_pdo_adapter()
     global $wpdb;
 
     /**
-     * Minimum sqlite-database-integration version that exposes the API we
-     * depend on: WP_SQLite_Driver::query(), get_query_results(),
-     * get_connection()->get_pdo().
+     * Minimum sqlite-database-integration version that exposes the legacy
+     * WP_SQLite_Driver API used below.
      */
     $min_version = '2.1.0';
 
     require_once __DIR__ . "/class-sqlite-driver-pdo.php";
 
-    if (!isset($wpdb) || !($wpdb->dbh instanceof WP_SQLite_Driver)) {
-        throw new RuntimeException(
-            "SQLite export requires WordPress loaded with the " .
-            "sqlite-database-integration plugin active."
-        );
-    }
+    $driver = null;
+    $raw_pdo = null;
 
-    // Verify the plugin version is in the supported range.
-    if (defined('SQLITE_DRIVER_VERSION')) {
-        if (version_compare(SQLITE_DRIVER_VERSION, $min_version, '<')) {
-            throw new RuntimeException(
-                "sqlite-database-integration plugin version " . SQLITE_DRIVER_VERSION .
-                " is too old. Minimum required: " . $min_version
-            );
+    if (isset($wpdb) && method_exists($wpdb, 'get_driver')) {
+        $candidate = $wpdb->get_driver();
+        if (is_a($candidate, 'WP_MySQL_On_SQLite')) {
+            $driver = $candidate;
+            $raw_pdo = call_user_func([$driver, 'get_sqlite_pdo']);
         }
     }
 
-    $driver = $wpdb->dbh;
-    $raw_pdo = $driver->get_connection()->get_pdo();
+    if (
+        $driver === null &&
+        isset($wpdb) &&
+        $wpdb->dbh instanceof WP_SQLite_Driver
+    ) {
+        $driver = $wpdb->dbh;
+        $raw_pdo = $driver->get_connection()->get_pdo();
+    }
+
+    if ($driver === null) {
+        throw new RuntimeException(
+            "SQLite export requires WordPress to load a supported " .
+            "sqlite-database-integration driver."
+        );
+    }
+
+    if (
+        defined('SQLITE_DRIVER_VERSION') &&
+        version_compare(SQLITE_DRIVER_VERSION, $min_version, '<')
+    ) {
+        throw new RuntimeException(
+            "sqlite-database-integration plugin version " . SQLITE_DRIVER_VERSION .
+            " is too old. Minimum required: " . $min_version
+        );
+    }
 
     return new SqliteDriverPDO($driver, $raw_pdo);
 }

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -130,6 +130,118 @@ final class CreateDbConnectionTest extends TestCase {
         );
     }
 
+    public function testSqliteDatabaseIntegrationThreeDriverSupportsPreparedQueries(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-server/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        class WP_MySQL_On_SQLite {
+            private $pdo;
+            public function __construct($pdo) {
+                $this->pdo = $pdo;
+            }
+            public function get_sqlite_pdo() {
+                return $this->pdo;
+            }
+            public function query($query) {
+                return $this->pdo->query($query);
+            }
+        }
+        class SqliteThreeWordPressDatabaseTestDouble {
+            private $driver;
+            public function __construct($driver) {
+                $this->driver = $driver;
+            }
+            public function get_driver() {
+                return $this->driver;
+            }
+        }
+        define('SQLITE_DRIVER_VERSION', '3.0.0');
+        require $argv[1];
+        require $argv[2];
+        $driver = new WP_MySQL_On_SQLite(new PDO('sqlite::memory:'));
+        $GLOBALS['wpdb'] = new SqliteThreeWordPressDatabaseTestDouble($driver);
+        $connection = create_db_connection(['db_engine' => 'sqlite']);
+        if (!($connection instanceof SqliteDriverPDO)) {
+            fwrite(STDERR, 'The active SQLite driver was not wrapped for export.');
+            exit(2);
+        }
+        $statement = $connection->prepare('SELECT ?');
+        $statement->execute(['sqlite-3']);
+        fwrite(STDOUT, $statement->fetchColumn());
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+        $this->assertSame('sqlite-3', $result['stdout']);
+    }
+
+    public function testSqliteDatabaseIntegrationTwoDriverStillWorks(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-server/src/export.php');
+        $sqlite_load_path = realpath(
+            __DIR__ . '/../lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php'
+        );
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $this->assertIsString($sqlite_load_path);
+        $connection_script = <<<'PHP'
+        class SqliteTwoWordPressDatabaseTestDouble {
+            public $dbh;
+            public function __construct($driver) {
+                $this->dbh = $driver;
+            }
+        }
+        require $argv[1];
+        require $argv[2];
+        require $argv[3];
+        $pdo = new PDO('sqlite::memory:');
+        $driver = new WP_SQLite_Driver(
+            new WP_SQLite_Connection(['pdo' => $pdo]),
+            'wp_test'
+        );
+        $GLOBALS['wpdb'] = new SqliteTwoWordPressDatabaseTestDouble($driver);
+        $connection = create_db_connection(['db_engine' => 'sqlite']);
+        fwrite(STDOUT, $connection->query('SELECT 2')->fetchColumn());
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+            $sqlite_load_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+        $this->assertSame('2', $result['stdout']);
+    }
+
     public function testBareSocketPathDbHostOpensUnixSocket(): void
     {
         $this->assertDbHostOpensUnixSocket(false);


### PR DESCRIPTION
SQLite Database Integration 3.0 sites can export their database again.

Version 3 replaced `WP_SQLite_Driver` with `WP_MySQL_On_SQLite`. Reprint now gets that driver from WordPress, wraps its query results in the existing PDO-shaped adapter, and keeps the version 2 path working.

## Testing

The focused tests cover both plugin driver APIs and prepared queries through the adapter. The existing SQLite E2E test downloads the current plugin release and checks the full export and MySQL import.
