### PR TITLE
[PHP] Use FileIndexDiffProcessor for files-pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,10 +699,14 @@ fresh.
     "updated_at": "2025-01-15T10:30:00Z"
   },
   "diff": {
-    // Byte offset into the next remote index.
-    "next_remote_index_byte_offset": 1024,
-    // Last remote index entry path consumed before that byte offset.
-    "last_consumed_remote_index_entry_path": "base64..."
+    "index_diff_cursor": {
+      "old_index_byte_offset": 512,
+      "new_index_byte_offset": 1024,
+      "preceding_new_index_entry_path_b64": "base64..."
+    },
+    // Output bytes covered by the index-diff cursor.
+    "fetch_list_byte_offset": 256,
+    "pull_index_wal_byte_offset": 128
   },
   "index": {
     "cursor": "..."               // file_index cursor

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -6933,7 +6933,7 @@ class ImportClient
             ) {
                 throw new RuntimeException("Failed to resume the fetch list.");
             }
-            $this->pull_index_journal->open_at_saved_byte_offset(
+            $this->pull_index_journal->open_and_truncate_to_saved_byte_offset(
                 $file_diff_progress_state->pull_index_wal_byte_offset
             );
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -84,6 +84,7 @@ require_once __DIR__ . '/lib/merge/load.php';
 
 require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
+require_once __DIR__ . '/lib/index/class-file-index-diff-processor.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
@@ -2293,9 +2294,6 @@ class ImportClient
             "RESTART | Clearing files-pull progress (keeping remote index and files)",
             true,
         );
-        // Replay the pull index WAL before clearing the cursor which made its records durable.
-        $this->pull_index_journal->apply_pending_records();
-        $this->pull_index_journal->remove_empty_wal();
         $this->reset_state();
 
         if (file_exists($this->next_remote_index_file)) {
@@ -2313,7 +2311,12 @@ class ImportClient
         $this->get_state()->index = new RemoteFileIndexCursorState();
         $this->get_state()->fetch = new FetchListProgressState();
 
+        // Save the cleared cursor before applying records which rewrite the
+        // remote index. A stopped abort can then repeat the WAL merge, but it
+        // can never resume a byte-offset cursor against the rewritten index.
         $this->save_state();
+        $this->pull_index_journal->apply_pending_records();
+        $this->pull_index_journal->remove_empty_wal();
     }
 
     /**
@@ -2939,18 +2942,25 @@ class ImportClient
             );
         }
 
-        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
+        $active_resumable_command =
+            $this->get_state()->active_resumable_command;
+        $state_command = $active_resumable_command->command_name ?? null;
 
         $current_status =
             $state_command === "files-pull"
-                ? $this->get_state()->active_resumable_command->completion_state ?? null
+                ? $active_resumable_command->completion_state ?? null
                 : null;
         $has_progress =
             $state_command === "files-pull" &&
             $current_status !== null &&
             $current_status !== "complete";
 
-        $this->pull_index_journal->apply_pending_records();
+        $resuming_diff =
+            $has_progress
+            && $active_resumable_command->current_stage === "diff";
+        if (!$resuming_diff) {
+            $this->pull_index_journal->apply_pending_records();
+        }
         $this->assert_files_pull_path_selection_unchanged_while_resuming($has_progress);
         $this->assert_local_followed_symlinks_root_unchanged();
 
@@ -3087,8 +3097,10 @@ class ImportClient
         $this->get_state()->active_resumable_command->completion_state = "in_progress";
         $this->save_state();
 
-        $this->pull_index_journal->open();
         $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
+        if ($stage !== "diff") {
+            $this->pull_index_journal->open();
+        }
 
         if ($stage === "index") {
             $complete = $this->fetch_next_remote_index();
@@ -3108,6 +3120,7 @@ class ImportClient
             $this->sort_next_remote_index_file();
             $this->get_state()->active_resumable_command->current_stage = "diff";
             $this->get_state()->diff = new FileDiffProgressState();
+            $this->pull_index_journal->close();
             if (file_exists($this->fetch_list_file)) {
                 @unlink($this->fetch_list_file);
                 $this->audit_log(
@@ -3129,9 +3142,12 @@ class ImportClient
             $has_files_to_fetch =
                 file_exists($this->fetch_list_file) &&
                 filesize($this->fetch_list_file) > 0;
-            $stage = $has_files_to_fetch ? "fetch" : null;
+            $stage = "fetch";
             $this->get_state()->active_resumable_command->current_stage = $stage;
+            // The diff cursor points into the retained remote index. Save the
+            // fetch stage before the WAL rewrites that index.
             $this->save_state();
+            $this->pull_index_journal->apply_pending_records();
 
             // In pull mode, finalize the scanning line with a checkmark
             // and start the download progress on a fresh line.
@@ -3174,8 +3190,6 @@ class ImportClient
                 );
             }
 
-            $this->get_state()->active_resumable_command->current_stage = null;
-            $this->save_state();
         }
 
         // Recreate intermediate path symlinks so the full symlink chain
@@ -3188,6 +3202,7 @@ class ImportClient
 
         $this->ensure_local_index_exists();
         $this->get_state()->active_resumable_command->completion_state = "complete";
+        $this->get_state()->active_resumable_command->current_stage = null;
         $this->save_state();
         $this->pull_index_journal->remove_empty_wal();
 
@@ -6889,211 +6904,166 @@ class ImportClient
         }
 
         $file_diff_progress_state = $this->get_state()->diff;
-        $next_remote_index_byte_offset =
-            $file_diff_progress_state->next_remote_index_byte_offset;
-        $last_consumed_remote_index_entry_path =
-            $file_diff_progress_state->last_consumed_remote_index_entry_path;
-        $last_processed_next_remote_index_entry_path =
-            $file_diff_progress_state->last_processed_next_remote_index_entry_path;
-        $fetch_list_file_mode = $next_remote_index_byte_offset > 0 ? "a" : "w";
-        if ($fetch_list_file_mode === "w") {
-            $this->audit_log(
-                "FILE CREATE | {$this->fetch_list_file} | building fetch list",
-            );
-        } else {
-            $this->audit_log(
-                "FILE APPEND | {$this->fetch_list_file} | resuming fetch list build",
-            );
-        }
-        $fetch_list_file_handle = fopen(
-            $this->fetch_list_file,
-            $fetch_list_file_mode,
+        $index_diff = FileIndexDiffProcessor::resume(
+            $this->remote_index_file,
+            $this->next_remote_index_file,
+            $file_diff_progress_state->index_diff_cursor,
+            [RemoteIndexReader::class, "decode_index_line"]
         );
-        if (!$fetch_list_file_handle) {
-            throw new RuntimeException("Failed to open fetch list file");
-        }
-
-        $next_remote_index_reader = new RemoteIndexReader(
-            $this->next_remote_index_file
-        );
+        $fetch_list_file_handle = null;
         try {
-            $next_remote_index_reader->open();
-            if ($next_remote_index_byte_offset > 0) {
-                $next_remote_index_reader->seek_to_byte_offset(
-                    $next_remote_index_byte_offset
-                );
-            }
-        } catch (RuntimeException $exception) {
-            $next_remote_index_reader->close();
-            fclose($fetch_list_file_handle);
-            throw $exception;
-        }
-
-        $remote_index_reader = new RemoteIndexReader($this->remote_index_file);
-        try {
-            $remote_index_reader->open();
-        } catch (RuntimeException $exception) {
-            $next_remote_index_reader->close();
-            fclose($fetch_list_file_handle);
-            throw $exception;
-        }
-        $remote_index_entry = $remote_index_reader->next_entry();
-        if ($last_consumed_remote_index_entry_path) {
-            while (
-                $remote_index_entry !== null &&
-                strcmp(
-                    $remote_index_entry["path"],
-                    $last_consumed_remote_index_entry_path,
-                ) <= 0
-            ) {
-                $remote_index_entry = $remote_index_reader->next_entry();
-            }
-        }
-        $this->pull_index_journal->open();
-        $next_remote_index_entries_processed = 0;
-
-        while (($next_remote_index_entry = $next_remote_index_reader->next_entry()) !== null) {
-            if ($this->shutdown_requested) {
-                break;
-            }
-
-            if (function_exists("pcntl_signal_dispatch")) {
-                pcntl_signal_dispatch();
-            }
-
-            $next_remote_index_byte_offset = $next_remote_index_reader->byte_offset();
-
-            while (
-                $remote_index_entry !== null &&
-                strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) < 0
-            ) {
-                // The remote index is a union across files-pull path selections.
-                // Keep entries outside this run's selection.
-                if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
-                    $missing_remote_index_entry_path = $remote_index_entry["path"];
-                    $remote_deletion_root = $this->derive_remote_deletion_root_from_sparse_index(
-                        $missing_remote_index_entry_path,
-                        $last_processed_next_remote_index_entry_path,
-                        $next_remote_index_entry["path"],
-                    );
-                    $local_absolute_path = $this->remove_remote_path_locally(
-                        $remote_deletion_root
-                    );
-                    if ($local_absolute_path === null) {
-                        $this->pull_index_journal->record_remote_invalidation(
-                            $missing_remote_index_entry_path
-                        );
-                    } else {
-                        $this->pull_index_journal->record_successful_deletion(
-                            $missing_remote_index_entry_path,
-                            $local_absolute_path
-                        );
-                    }
-                }
-                $last_consumed_remote_index_entry_path =
-                    $remote_index_entry["path"];
-                $remote_index_entry = $remote_index_reader->next_entry();
-            }
-
+            $fetch_list_file_handle = fopen($this->fetch_list_file, "c+b");
+            $fetch_list_file_stat = is_resource($fetch_list_file_handle)
+                ? fstat($fetch_list_file_handle)
+                : false;
             if (
-                $remote_index_entry !== null &&
-                $remote_index_entry["path"] === $next_remote_index_entry["path"]
-            ) {
-                if (
-                    $remote_index_entry["ctime"] !== $next_remote_index_entry["ctime"] ||
-                    $remote_index_entry["size"] !== $next_remote_index_entry["size"] ||
-                    $remote_index_entry["type"] !== $next_remote_index_entry["type"]
-                ) {
-                    // Re-download it when selected — the remote index confirms
-                    // that an earlier files-pull accounted for this path, so
-                    // preserve-local does not protect it.
-                    if ($this->is_selected_for_pulling($next_remote_index_entry["path"], true)) {
-                        $this->append_to_fetch_list(
-                            $next_remote_index_entry["path"],
-                            $fetch_list_file_handle,
-                        );
-                    }
-                }
-                $last_consumed_remote_index_entry_path =
-                    $remote_index_entry["path"];
-                $remote_index_entry = $remote_index_reader->next_entry();
-            } elseif (
-                $this->is_selected_for_pulling($next_remote_index_entry["path"], true) &&
-                (
-                    $remote_index_entry === null ||
-                    strcmp($remote_index_entry["path"], $next_remote_index_entry["path"]) > 0
+                !is_resource($fetch_list_file_handle)
+                || $file_diff_progress_state->fetch_list_byte_offset < 0
+                || $fetch_list_file_stat === false
+                || $file_diff_progress_state->fetch_list_byte_offset
+                    > $fetch_list_file_stat["size"]
+                || !ftruncate(
+                    $fetch_list_file_handle,
+                    $file_diff_progress_state->fetch_list_byte_offset
                 )
+                || fseek(
+                    $fetch_list_file_handle,
+                    $file_diff_progress_state->fetch_list_byte_offset
+                ) !== 0
             ) {
-                $preserve_local_skip_reason =
-                    $this->should_skip_for_preserve_local(
-                        $next_remote_index_entry["path"],
-                    );
-                if ($preserve_local_skip_reason) {
-                    $this->audit_log($preserve_local_skip_reason, true);
-                    $this->emit_skip_progress($next_remote_index_entry["path"]);
-                } else {
-                    $this->append_to_fetch_list(
-                        $next_remote_index_entry["path"],
-                        $fetch_list_file_handle,
-                    );
-                }
+                throw new RuntimeException("Failed to resume the fetch list.");
+            }
+            $this->pull_index_journal->open_at_saved_byte_offset(
+                $file_diff_progress_state->pull_index_wal_byte_offset
+            );
+
+            if ($file_diff_progress_state->fetch_list_byte_offset === 0) {
+                $this->audit_log(
+                    "FILE CREATE | {$this->fetch_list_file} | building fetch list",
+                );
+            } else {
+                $this->audit_log(
+                    "FILE APPEND | {$this->fetch_list_file} | resuming fetch list build",
+                );
             }
 
-            $last_processed_next_remote_index_entry_path =
-                $next_remote_index_entry["path"];
-            $next_remote_index_entries_processed++;
-            if ($next_remote_index_entries_processed % 200 === 0) {
-                $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
-                $this->get_state()->diff->last_consumed_remote_index_entry_path =
-                    $last_consumed_remote_index_entry_path;
-                $this->get_state()->diff->last_processed_next_remote_index_entry_path =
-                    $last_processed_next_remote_index_entry_path;
+            $has_path = $index_diff->next_path();
+            while ($has_path) {
+                $paths_processed = 0;
+                while ($has_path && $paths_processed < 200) {
+                    if (function_exists("pcntl_signal_dispatch")) {
+                        pcntl_signal_dispatch();
+                    }
+                    if ($this->shutdown_requested) {
+                        break;
+                    }
+
+                    $remote_absolute_path = $index_diff->get_path();
+                    $transition = $index_diff->get_path_transition();
+                    if ($transition === "deleted") {
+                        // The remote index is a union across files-pull path
+                        // selections. Keep paths outside this run's selection.
+                        if (
+                            $this->is_selected_for_pulling(
+                                $remote_absolute_path,
+                                false
+                            )
+                        ) {
+                            $remote_deletion_root =
+                                $this->derive_remote_deletion_root_from_sparse_index(
+                                    $remote_absolute_path,
+                                    $index_diff->get_preceding_path_in_new_index(),
+                                    $index_diff->get_following_path_in_new_index()
+                                );
+                            $local_absolute_path =
+                                $this->remove_remote_path_locally(
+                                    $remote_deletion_root
+                                );
+                            if ($local_absolute_path === null) {
+                                $this->pull_index_journal->record_remote_invalidation(
+                                    $remote_absolute_path
+                                );
+                            } else {
+                                $this->pull_index_journal->record_successful_deletion(
+                                    $remote_absolute_path,
+                                    $local_absolute_path
+                                );
+                            }
+                        }
+                    } elseif (
+                        $transition !== "unchanged"
+                        && $this->is_selected_for_pulling(
+                            $remote_absolute_path,
+                            true
+                        )
+                    ) {
+                        // Preserve-local protects only paths which no earlier
+                        // files-pull recorded in the remote index.
+                        $preserve_local_skip_reason = $transition === "added"
+                            ? $this->should_skip_for_preserve_local(
+                                $remote_absolute_path
+                            )
+                            : null;
+                        if ($preserve_local_skip_reason) {
+                            $this->audit_log(
+                                $preserve_local_skip_reason,
+                                true
+                            );
+                            $this->emit_skip_progress($remote_absolute_path);
+                        } else {
+                            $this->append_to_fetch_list(
+                                $remote_absolute_path,
+                                $fetch_list_file_handle
+                            );
+                        }
+                    }
+
+                    $has_path = $index_diff->next_path();
+                    ++$paths_processed;
+                }
+
+                if ($paths_processed === 0) {
+                    break;
+                }
+                if (!fflush($fetch_list_file_handle)) {
+                    throw new RuntimeException(
+                        "Failed to flush the fetch list."
+                    );
+                }
                 $this->pull_index_journal->flush();
-                $this->save_state();
-                $this->progress->tick_spinner();
-            }
-        }
-
-        while ($remote_index_entry !== null) {
-            if ($this->is_selected_for_pulling($remote_index_entry["path"], false)) {
-                $missing_remote_index_entry_path = $remote_index_entry["path"];
-                $remote_deletion_root = $this->derive_remote_deletion_root_from_sparse_index(
-                    $missing_remote_index_entry_path,
-                    $last_processed_next_remote_index_entry_path,
-                    null,
+                $fetch_list_byte_offset = ftell(
+                    $fetch_list_file_handle
                 );
-                $local_absolute_path = $this->remove_remote_path_locally(
-                    $remote_deletion_root
-                );
-                if ($local_absolute_path === null) {
-                    $this->pull_index_journal->record_remote_invalidation(
-                        $missing_remote_index_entry_path
-                    );
-                } else {
-                    $this->pull_index_journal->record_successful_deletion(
-                        $missing_remote_index_entry_path,
-                        $local_absolute_path
+                if (!is_int($fetch_list_byte_offset)) {
+                    throw new RuntimeException(
+                        "Failed to read the fetch-list byte offset."
                     );
                 }
+                // These three positions describe one boundary. Build it off
+                // the live state so an async signal saves either the old
+                // boundary or the complete new one, never a mixture.
+                $next_file_diff_progress_state = new FileDiffProgressState();
+                $next_file_diff_progress_state->index_diff_cursor =
+                    $index_diff->get_cursor();
+                $next_file_diff_progress_state->fetch_list_byte_offset =
+                    $fetch_list_byte_offset;
+                $next_file_diff_progress_state->pull_index_wal_byte_offset =
+                    $this->pull_index_journal->byte_offset();
+                $this->get_state()->diff = $next_file_diff_progress_state;
+                $this->save_state();
+                if ($paths_processed === 200) {
+                    $this->progress->tick_spinner();
+                }
             }
-            $last_consumed_remote_index_entry_path =
-                $remote_index_entry["path"];
-            $remote_index_entry = $remote_index_reader->next_entry();
+        } finally {
+            $index_diff->close();
+            if (is_resource($fetch_list_file_handle)) {
+                fclose($fetch_list_file_handle);
+            }
+            $this->pull_index_journal->close();
         }
 
-        $remote_index_reader->close();
-        $next_remote_index_reader->close();
-        fclose($fetch_list_file_handle);
-
-        $this->get_state()->diff->next_remote_index_byte_offset = $next_remote_index_byte_offset;
-        $this->get_state()->diff->last_consumed_remote_index_entry_path =
-            $last_consumed_remote_index_entry_path;
-        $this->get_state()->diff->last_processed_next_remote_index_entry_path =
-            $last_processed_next_remote_index_entry_path;
-        $this->pull_index_journal->apply_pending_records();
-        $this->save_state();
-
-        return !$this->shutdown_requested;
+        return !$has_path;
     }
 
     /**
@@ -7377,10 +7347,13 @@ class ImportClient
     {
         $fetch_list_json_line = json_encode(
             ["path" => base64_encode($remote_absolute_path)],
-            JSON_UNESCAPED_SLASHES,
-        );
-        if ($fetch_list_json_line !== false) {
-            fwrite($fetch_list_file_handle, $fetch_list_json_line . "\n");
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (
+            fwrite($fetch_list_file_handle, $fetch_list_json_line)
+            !== strlen($fetch_list_json_line)
+        ) {
+            throw new RuntimeException("Failed to write to the fetch list.");
         }
         $this->audit_log(
             "Added to the fetch list: {$remote_absolute_path}",
@@ -10900,12 +10873,6 @@ class ImportClient
      */
     private function encode_state_paths(array $state): array
     {
-        $state["diff"]["last_consumed_remote_index_entry_path"] = $this->encode_state_path_value(
-            $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
-        );
-        $state["diff"]["last_processed_next_remote_index_entry_path"] = $this->encode_state_path_value(
-            $state["diff"]["last_processed_next_remote_index_entry_path"] ?? null,
-        );
         $state["fetch"]["batch_file"] = $this->encode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
         );
@@ -10935,12 +10902,6 @@ class ImportClient
      */
     private function decode_state_paths(array $state): array
     {
-        $state["diff"]["last_consumed_remote_index_entry_path"] = $this->decode_state_path_value(
-            $state["diff"]["last_consumed_remote_index_entry_path"] ?? null,
-        );
-        $state["diff"]["last_processed_next_remote_index_entry_path"] = $this->decode_state_path_value(
-            $state["diff"]["last_processed_next_remote_index_entry_path"] ?? null,
-        );
         $state["fetch"]["batch_file"] = $this->decode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
         );
@@ -11280,7 +11241,15 @@ class ImportClient
         $this->shutdown_requested = true;
         $this->progress->clear_progress_line();
 
-        if ($this->pull_index_journal->is_open()) {
+        $active_resumable_command =
+            $this->get_state()->active_resumable_command;
+        $applying_diff_records_would_rewrite_an_open_index =
+            $active_resumable_command->command_name === "files-pull"
+            && $active_resumable_command->current_stage === "diff";
+        if (
+            $this->pull_index_journal->is_open()
+            && !$applying_diff_records_would_rewrite_an_open_index
+        ) {
             try {
                 $this->pull_index_journal->apply_pending_records();
             } catch (Exception $e) {
@@ -11295,7 +11264,8 @@ class ImportClient
         // Log final progress before exit
         $remote_index_entry_count = $this->remote_index_entry_count();
         $files_pulled = $this->files_pulled; // Files completed in this run
-        $current_command = $this->get_state()->active_resumable_command->command_name ?? "unknown";
+        $current_command =
+            $active_resumable_command->command_name ?? "unknown";
 
         $this->audit_log(
             sprintf(

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2311,9 +2311,9 @@ class ImportClient
         $this->get_state()->index = new RemoteFileIndexCursorState();
         $this->get_state()->fetch = new FetchListProgressState();
 
-        // The diff cursor belongs to the current remote index. Applying the WAL
-        // replaces that index, so save the state without the cursor first. The
-        // WAL merge is replayable and can finish now or in a later process.
+        // Applying the WAL replaces the remote index read by the diff cursor.
+        // Save the cleared cursor first. If applying the WAL stops partway, the
+        // next run starts with the cleared cursor and applies the WAL again.
         $this->save_state();
         $this->pull_index_journal->apply_pending_records();
         $this->pull_index_journal->remove_empty_wal();
@@ -3144,8 +3144,8 @@ class ImportClient
                 filesize($this->fetch_list_file) > 0;
             $stage = "fetch";
             $this->get_state()->active_resumable_command->current_stage = $stage;
-            // The diff cursor points into the retained remote index. Save the
-            // fetch stage before the WAL rewrites that index.
+            // Save the fetch stage before applying the WAL. From this stage,
+            // startup applies any pending WAL before it resumes the fetch list.
             $this->save_state();
             $this->pull_index_journal->apply_pending_records();
 
@@ -7039,9 +7039,9 @@ class ImportClient
                         "Failed to read the fetch-list byte offset."
                     );
                 }
-                // These three positions describe one boundary. Build it off
-                // the live state so an async signal saves either the old
-                // boundary or the complete new one, never a mixture.
+                // Build the three positions in a new object, then replace the
+                // saved checkpoint in one assignment. An async signal can save
+                // either complete checkpoint.
                 $next_file_diff_progress_state = new FileDiffProgressState();
                 $next_file_diff_progress_state->index_diff_cursor =
                     $index_diff->get_cursor();

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2311,9 +2311,9 @@ class ImportClient
         $this->get_state()->index = new RemoteFileIndexCursorState();
         $this->get_state()->fetch = new FetchListProgressState();
 
-        // Save the cleared cursor before applying records which rewrite the
-        // remote index. A stopped abort can then repeat the WAL merge, but it
-        // can never resume a byte-offset cursor against the rewritten index.
+        // The diff cursor belongs to the current remote index. Applying the WAL
+        // replaces that index, so save the state without the cursor first. The
+        // WAL merge is replayable and can finish now or in a later process.
         $this->save_state();
         $this->pull_index_journal->apply_pending_records();
         $this->pull_index_journal->remove_empty_wal();

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -18,6 +18,8 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * link, or directory, its size, its inode change time (ctime), and, for some
  * directories, whether it was empty. Both indexes must use the same path
  * coordinate system; paths may be local relative paths or remote absolute paths.
+ * Each physical line must decode to one entry. A decoder cannot filter lines;
+ * blank or invalid records must throw.
  *
  * This processor opens two such lists:
  *
@@ -124,7 +126,7 @@ final class FileIndexDiffProcessor
     /** @var resource|null Stream containing the ending tree. */
     private $new_index_handle = null;
 
-    /** @var callable(string):IndexEntry|null Decodes one JSONL index line. */
+    /** @var callable(string):IndexEntry Decodes one JSONL index line. */
     private $decode_index_line;
 
     /** @var IndexEntry|null Unconsumed old entry, which may be current or following. */
@@ -163,10 +165,8 @@ final class FileIndexDiffProcessor
      *
      * @param string        $old_index_file  Old index, or a missing path for an empty index.
      * @param string        $new_index_file  New index.
-     * @param callable|null $decode_index_line Decoder for one JSONL line. A
-     *                                        null return skips that line;
-     *                                        null uses the local decoder.
-     * @phpstan-param (callable(string):IndexEntry|null)|null $decode_index_line
+     * @param callable|null $decode_index_line Decoder for one JSONL line. Null uses the local decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_index_line
      * @return self Open processor positioned before either index's first path.
      */
     public static function create(
@@ -210,10 +210,8 @@ final class FileIndexDiffProcessor
      *     @type string|null $preceding_new_index_entry_path_b64 New-index path before the next position.
      * }
      * @phpstan-param Cursor $cursor
-     * @param callable|null $decode_index_line Decoder for one JSONL line. A
-     *                                        null return skips that line;
-     *                                        null uses the local decoder.
-     * @phpstan-param (callable(string):IndexEntry|null)|null $decode_index_line
+     * @param callable|null $decode_index_line Decoder for one JSONL line. Null uses the local decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_index_line
      * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
@@ -679,19 +677,20 @@ final class FileIndexDiffProcessor
         if (!is_resource($index_handle)) {
             return null;
         }
-        while (true) {
-            $line = fgets($index_handle);
-            if ($line === false) {
-                break;
+        $line = fgets($index_handle);
+        if ($line === false) {
+            if (!feof($index_handle)) {
+                throw new RuntimeException("Failed to read a file-index entry.");
             }
-            $index_entry = ( $this->decode_index_line )($line);
-            if ($index_entry !== null) {
-                return $index_entry;
-            }
+            return null;
         }
-        if (!feof($index_handle)) {
-            throw new RuntimeException("Failed to read a file-index entry.");
+        $index_entry = ( $this->decode_index_line )($line);
+        if (!is_array($index_entry)) {
+            throw new UnexpectedValueException(
+                "The file-index decoder returned " . gettype($index_entry)
+                . "; expected one index entry for each line."
+            );
         }
-        return null;
+        return $index_entry;
     }
 }

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -14,9 +14,10 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * ## What the indexes represent
  *
  * A filesystem index is a path-sorted list describing a filesystem tree at one
- * point in time. Each index entry records one local relative path, whether that
- * path is a file, link, or directory, its size, its inode change time (ctime),
- * and, for some directories, whether it was empty.
+ * point in time. Each index entry records one path, whether that path is a file,
+ * link, or directory, its size, its inode change time (ctime), and, for some
+ * directories, whether it was empty. Both indexes must use the same path
+ * coordinate system; paths may be local relative paths or remote absolute paths.
  *
  * This processor opens two such lists:
  *
@@ -123,6 +124,9 @@ final class FileIndexDiffProcessor
     /** @var resource|null Stream containing the ending tree. */
     private $new_index_handle = null;
 
+    /** @var callable(string):IndexEntry|null Decodes one JSONL index line. */
+    private $decode_index_line;
+
     /** @var IndexEntry|null Unconsumed old entry, which may be current or following. */
     private ?array $old_index_entry = null;
 
@@ -157,12 +161,19 @@ final class FileIndexDiffProcessor
      * equivalent to an empty tree. The new file describes the ending tree and
      * must be readable. Both files remain open until `close()`.
      *
-     * @param string $old_index_file Old index, or a missing path for an empty index.
-     * @param string $new_index_file New index.
+     * @param string        $old_index_file  Old index, or a missing path for an empty index.
+     * @param string        $new_index_file  New index.
+     * @param callable|null $decode_index_line Decoder for one JSONL line. A
+     *                                        null return skips that line;
+     *                                        null uses the local decoder.
+     * @phpstan-param (callable(string):IndexEntry|null)|null $decode_index_line
      * @return self Open processor positioned before either index's first path.
      */
-    public static function create(string $old_index_file, string $new_index_file): self
-    {
+    public static function create(
+        string $old_index_file,
+        string $new_index_file,
+        ?callable $decode_index_line = null
+    ): self {
         return self::resume(
             $old_index_file,
             $new_index_file,
@@ -170,7 +181,8 @@ final class FileIndexDiffProcessor
                 "old_index_byte_offset" => 0,
                 "new_index_byte_offset" => 0,
                 "preceding_new_index_entry_path_b64" => null,
-            ]
+            ],
+            $decode_index_line
         );
     }
 
@@ -185,6 +197,8 @@ final class FileIndexDiffProcessor
      * The caller must provide the same immutable index contents used to produce
      * the cursor. This method restores positions; it does not fingerprint the
      * files or check that they still describe the same snapshots.
+     * The cursor does not store the line decoder, so the caller must pass the
+     * same decoder again when resuming.
      *
      * @param string $old_index_file Old index, or a missing path for an empty index.
      * @param string $new_index_file New index.
@@ -196,15 +210,24 @@ final class FileIndexDiffProcessor
      *     @type string|null $preceding_new_index_entry_path_b64 New-index path before the next position.
      * }
      * @phpstan-param Cursor $cursor
+     * @param callable|null $decode_index_line Decoder for one JSONL line. A
+     *                                        null return skips that line;
+     *                                        null uses the local decoder.
+     * @phpstan-param (callable(string):IndexEntry|null)|null $decode_index_line
      * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
         string $old_index_file,
         string $new_index_file,
-        array $cursor
+        array $cursor,
+        ?callable $decode_index_line = null
     ): self {
         $processor = new self();
         $processor->cursor = $cursor;
+        $processor->decode_index_line = $decode_index_line
+            ?? static function (string $line): array {
+                return decode_local_index_entry($line);
+            };
         if (is_file($old_index_file)) {
             $processor->old_index_handle = @fopen($old_index_file, "rb");
             if (!is_resource($processor->old_index_handle)) {
@@ -325,7 +348,7 @@ final class FileIndexDiffProcessor
     }
 
     /**
-     * Returns the local relative path selected by next_path().
+     * Returns the path selected by next_path().
      *
      * This method does not read either index. The returned path remains current
      * until the next call to `next_path()`.
@@ -656,13 +679,19 @@ final class FileIndexDiffProcessor
         if (!is_resource($index_handle)) {
             return null;
         }
-        $line = fgets($index_handle);
-        if ($line === false) {
-            if (!feof($index_handle)) {
-                throw new RuntimeException("Failed to read a file-index entry.");
+        while (true) {
+            $line = fgets($index_handle);
+            if ($line === false) {
+                break;
             }
-            return null;
+            $index_entry = ( $this->decode_index_line )($line);
+            if ($index_entry !== null) {
+                return $index_entry;
+            }
         }
-        return decode_local_index_entry($line);
+        if (!feof($index_handle)) {
+            throw new RuntimeException("Failed to read a file-index entry.");
+        }
+        return null;
     }
 }

--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -10,12 +10,11 @@ use function WordPress\Reprint\Exporter\relative_path_under;
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
 
 /**
- * Keeps `pull/index.wal` and applies its records to the remote and local
- * indexes.
+ * Records completed files-pull work and adds it to the retained indexes.
  *
- * Files-pull changes a local path first. It then writes one WAL record. This
- * class does not change files, links, or directories. It only records finished
- * work and updates the indexes.
+ * Files-pull first changes a file, link, or directory. It then writes one
+ * record to `pull/index.wal`. The journal later applies those records to the
+ * remote index and, when a local path is present, to the local index.
  *
  * ## WAL records
  *
@@ -72,29 +71,28 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  *
  * ## Saving and applying records
  *
- * The index-diff cursor says which path comes next. The WAL does not. It only
- * records work that files-pull has already done. Pull saves the diff cursor,
- * fetch-list byte offset, and WAL byte offset together.
+ * Pull saves one checkpoint after a group of paths:
  *
- * A process may append a WAL record and stop before it saves those three new
- * positions. The saved cursor will select that path again. On resume, remove
- * the WAL bytes after the saved offset before replaying the path. This keeps
- * the cursor and both output files at the same saved boundary.
+ * 1. Finish each local filesystem change.
+ * 2. Append its fetch-list and WAL records.
+ * 3. Flush both files.
+ * 4. Read their byte offsets.
+ * 5. Save both offsets with the index-diff cursor.
  *
- * Call flush() before saving the cursor for the recorded work. This makes
- * sure the WAL record reaches the file before the cursor moves past it.
+ * The saved offsets cover the records required by the saved cursor. A process
+ * may stop after writing more records but before saving another checkpoint.
+ * Resume truncates each file to its saved offset, then continues from the
+ * saved cursor. The first path after that checkpoint is processed again.
  *
- * apply_pending_records() closes the WAL writer, updates the remote index,
- * and then updates the local index when needed. It clears the WAL only after
- * the remote index and all local changes have been saved.
+ * Once the diff is complete, apply_pending_records() closes the WAL writer,
+ * replaces the remote index, applies any local-index changes, and clears the
+ * WAL. If the process stops during this work, the next call applies the same
+ * WAL again. Repeating a `+` replaces the same entry. Repeating a `-` for an
+ * absent entry leaves it absent.
  *
- * If the process stops before the WAL is cleared, call
- * apply_pending_records() again. It rebuilds its temporary files and applies
- * the full WAL again. A repeated `+` replaces the same entry. A repeated `-`
- * for a missing entry does nothing.
- *
- * A final line without a newline is not applied. flush() runs before the
- * matching cursor is saved, so files-pull repeats that path after it resumes.
+ * Readers stop before a final line without a newline. Such a line lies beyond
+ * the last saved WAL offset, so resume removes it and processes that path
+ * again.
  *
  * ## WAL lifecycle
  *
@@ -173,20 +171,22 @@ class PullIndexJournal
     }
 
     /**
-     * Opens the WAL after truncating it to the saved diff boundary.
+     * Opens the WAL at the last saved diff checkpoint.
      *
-     * For example, suppose the saved WAL offset is 100 but the WAL contains
-     * 140 bytes. Bytes 100 through 139 were written without the matching diff
-     * cursor being saved. This method removes those bytes and opens the writer
-     * at byte 100. The saved cursor then selects the path again and files-pull
-     * writes its WAL record once at the correct place.
+     * Resume follows these steps:
      *
-     * The previous diff invocation must close its WAL writer first. Closing an
-     * append handle may flush bytes written after the saved offset. Keeping
-     * that close in the previous invocation leaves this method one job: open
-     * the WAL, remove the unsaved tail, and continue from the saved boundary.
-     * It also keeps the journal in one clear lifecycle state when an async
-     * shutdown runs between PHP statements.
+     * 1. The previous invocation closes its WAL writer.
+     * 2. This method opens the WAL and truncates it to the saved byte offset.
+     * 3. The diff resumes from the cursor saved with that offset.
+     * 4. Files-pull writes the first path after the checkpoint again.
+     *
+     * For example, a WAL may contain 140 bytes while the saved offset is 100.
+     * The final 40 bytes were written after the last checkpoint. Truncating at
+     * byte 100 removes them before the saved cursor replays those paths.
+     *
+     * The first step happens before this method because fclose() may flush PHP
+     * stream buffers. By the time truncation starts, the WAL has its final
+     * pre-resume size and the journal owns one newly opened handle.
      *
      * @param int $byte_offset First WAL byte after the saved records.
      * @throws LogicException When the WAL is already open.
@@ -232,11 +232,11 @@ class PullIndexJournal
     }
 
     /**
-     * Idempotently closes the WAL writer without applying its records.
+     * Idempotently closes the WAL writer and leaves its records pending.
      *
-     * Closing flushes PHP's stream buffer. It does not move a saved cursor or
-     * make later bytes durable; diff resume still truncates the WAL to the
-     * saved byte offset before appending again.
+     * fclose() flushes PHP's stream buffer. Records after the last saved byte
+     * offset remain outside the checkpoint. A resumed diff truncates that tail
+     * before it opens the WAL for more writes.
      *
      * @throws RuntimeException When the open WAL cannot be closed.
      */
@@ -379,10 +379,11 @@ class PullIndexJournal
     }
 
     /**
-     * Flushes WAL records before the caller saves the matching cursor.
+     * Flushes WAL records before the caller saves the matching checkpoint.
      *
-     * A closed journal has nothing to flush. Saving the cursor first could
-     * skip a record after a process stops.
+     * The caller flushes the WAL, reads byte_offset(), and then saves that
+     * offset with the index-diff cursor. Resume can therefore trust every WAL
+     * byte covered by the saved cursor.
      *
      * @throws RuntimeException When the open WAL cannot be flushed.
      */
@@ -420,17 +421,16 @@ class PullIndexJournal
     /**
      * Applies every complete WAL record to the indexes.
      *
-     * This method closes the writer first. It replaces the remote index, then
-     * the local index when the WAL contains local changes. It clears the WAL
-     * only after both replacements finish.
+     * The method closes the writer, builds and installs the new remote index,
+     * applies the local-index changes, and then clears the WAL. The WAL stays
+     * intact until both indexes are ready.
      *
-     * If the process stops before that point, the WAL stays in place. The next
-     * call opens new `.new` and `.local` files and applies the full WAL again.
-     * A repeated `+` replaces the same entry. A repeated `-` for a missing
-     * entry writes nothing.
+     * A later call can repeat the full merge after an interrupted attempt.
+     * Each `+` selects the final entry for its path. Each `-` omits that path.
+     * The temporary `.new` and `.local` files are rebuilt for every attempt.
      *
-     * A final record without a newline is skipped. flush() runs before the
-     * caller saves its cursor, so files-pull repeats that path after resume.
+     * A final line without a newline lies beyond the last saved checkpoint.
+     * The reader leaves it pending for diff resume to remove and replay.
      *
      * @throws RuntimeException When the WAL or an index cannot be read,
      *                          replaced, or cleared.

--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -72,6 +72,15 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  *
  * ## Saving and applying records
  *
+ * The index-diff cursor says which path comes next. The WAL does not. It only
+ * records work that files-pull has already done. Pull saves the diff cursor,
+ * fetch-list byte offset, and WAL byte offset together.
+ *
+ * A process may append a WAL record and stop before it saves those three new
+ * positions. The saved cursor will select that path again. On resume, remove
+ * the WAL bytes after the saved offset before replaying the path. This keeps
+ * the cursor and both output files at the same saved boundary.
+ *
  * Call flush() before saving the cursor for the recorded work. This makes
  * sure the WAL record reaches the file before the cursor moves past it.
  *
@@ -164,25 +173,31 @@ class PullIndexJournal
     }
 
     /**
-     * Opens the WAL at the last byte covered by the saved diff cursor.
+     * Opens the WAL after truncating it to the saved diff boundary.
      *
-     * A process may stop after appending a record but before saving the cursor
-     * for that path. Bytes after the saved offset are discarded so resuming the
-     * diff can append the path again without putting the WAL out of path order.
+     * For example, suppose the saved WAL offset is 100 but the WAL contains
+     * 140 bytes. Bytes 100 through 139 were written without the matching diff
+     * cursor being saved. This method removes those bytes and opens the writer
+     * at byte 100. The saved cursor then selects the path again and files-pull
+     * writes its WAL record once at the correct place.
      *
-     * The caller must not already have this journal open. Closing an existing
-     * append handle here could flush bytes which are not covered by the saved
-     * offset while an async shutdown is inspecting the same object.
+     * The previous diff invocation must close its WAL writer first. Closing an
+     * append handle may flush bytes written after the saved offset. Keeping
+     * that close in the previous invocation leaves this method one job: open
+     * the WAL, remove the unsaved tail, and continue from the saved boundary.
+     * It also keeps the journal in one clear lifecycle state when an async
+     * shutdown runs between PHP statements.
      *
-     * @param int $byte_offset First byte not covered by the saved diff cursor.
+     * @param int $byte_offset First WAL byte after the saved records.
      * @throws LogicException When the WAL is already open.
-     * @throws RuntimeException When the WAL cannot be restored to that offset.
+     * @throws RuntimeException When the WAL cannot be truncated and positioned
+     *                          at that offset.
      */
     public function open_and_truncate_to_saved_byte_offset(int $byte_offset): void
     {
         if ($this->pull_index_wal_handle) {
             throw new LogicException(
-                "Cannot restore the byte offset of an open pull index WAL."
+                "Cannot truncate an open pull index WAL."
             );
         }
         $this->pull_index_wal_handle = fopen($this->pull_index_wal_path, "c+b");
@@ -200,7 +215,8 @@ class PullIndexJournal
             fclose($this->pull_index_wal_handle);
             $this->pull_index_wal_handle = null;
             throw new RuntimeException(
-                "Failed to restore the pull index WAL at byte offset {$byte_offset}."
+                "Failed to truncate and position the pull index WAL " .
+                    "at byte offset {$byte_offset}."
             );
         }
     }

--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -164,6 +164,48 @@ class PullIndexJournal
     }
 
     /**
+     * Opens the WAL at the last byte covered by the saved diff cursor.
+     *
+     * A process may stop after appending a record but before saving the cursor
+     * for that path. Bytes after the saved offset are discarded so resuming the
+     * diff can append the path again without putting the WAL out of path order.
+     *
+     * The caller must not already have this journal open. Closing an existing
+     * append handle here could flush bytes which are not covered by the saved
+     * offset while an async shutdown is inspecting the same object.
+     *
+     * @param int $byte_offset First byte not covered by the saved diff cursor.
+     * @throws LogicException When the WAL is already open.
+     * @throws RuntimeException When the WAL cannot be restored to that offset.
+     */
+    public function open_at_saved_byte_offset(int $byte_offset): void
+    {
+        if ($this->pull_index_wal_handle) {
+            throw new LogicException(
+                "Cannot restore the byte offset of an open pull index WAL."
+            );
+        }
+        $this->pull_index_wal_handle = fopen($this->pull_index_wal_path, "c+b");
+        if (!$this->pull_index_wal_handle) {
+            throw new RuntimeException("Failed to open the pull index WAL.");
+        }
+        $pull_index_wal_stat = fstat($this->pull_index_wal_handle);
+        if (
+            $byte_offset < 0
+            || $pull_index_wal_stat === false
+            || $byte_offset > $pull_index_wal_stat["size"]
+            || !ftruncate($this->pull_index_wal_handle, $byte_offset)
+            || fseek($this->pull_index_wal_handle, $byte_offset) !== 0
+        ) {
+            fclose($this->pull_index_wal_handle);
+            $this->pull_index_wal_handle = null;
+            throw new RuntimeException(
+                "Failed to restore the pull index WAL at byte offset {$byte_offset}."
+            );
+        }
+    }
+
+    /**
      * Checks whether the WAL is open for append.
      *
      * @return bool True when the writer handle is open.
@@ -171,6 +213,27 @@ class PullIndexJournal
     public function is_open(): bool
     {
         return is_resource($this->pull_index_wal_handle);
+    }
+
+    /**
+     * Idempotently closes the WAL writer without applying its records.
+     *
+     * Closing flushes PHP's stream buffer. It does not move a saved cursor or
+     * make later bytes durable; diff resume still truncates the WAL to the
+     * saved byte offset before appending again.
+     *
+     * @throws RuntimeException When the open WAL cannot be closed.
+     */
+    public function close(): void
+    {
+        if (!$this->pull_index_wal_handle) {
+            return;
+        }
+        if (!fclose($this->pull_index_wal_handle)) {
+            $this->pull_index_wal_handle = null;
+            throw new RuntimeException("Failed to close the pull index WAL.");
+        }
+        $this->pull_index_wal_handle = null;
     }
 
     /**
@@ -318,6 +381,27 @@ class PullIndexJournal
     }
 
     /**
+     * Returns the byte after the last record written to the open WAL.
+     *
+     * Call flush() first when this offset will be stored as a durable boundary.
+     *
+     * @return int Next byte in the WAL.
+     * @throws LogicException When the WAL is not open.
+     * @throws RuntimeException When its position cannot be read.
+     */
+    public function byte_offset(): int
+    {
+        if (!$this->pull_index_wal_handle) {
+            throw new LogicException("The pull index WAL is not open.");
+        }
+        $byte_offset = ftell($this->pull_index_wal_handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException("Failed to read the pull index WAL byte offset.");
+        }
+        return $byte_offset;
+    }
+
+    /**
      * Applies every complete WAL record to the indexes.
      *
      * This method closes the writer first. It replaces the remote index, then
@@ -338,11 +422,7 @@ class PullIndexJournal
     public function apply_pending_records(): void
     {
         if ($this->pull_index_wal_handle) {
-            $pull_index_wal_closed = fclose($this->pull_index_wal_handle);
-            $this->pull_index_wal_handle = null;
-            if (!$pull_index_wal_closed) {
-                throw new RuntimeException("Failed to flush the pull index WAL.");
-            }
+            $this->close();
         }
         clearstatcache(true, $this->pull_index_wal_path);
         if (
@@ -543,12 +623,7 @@ class PullIndexJournal
      */
     public function remove_empty_wal(): void
     {
-        if (is_resource($this->pull_index_wal_handle)) {
-            if (!fclose($this->pull_index_wal_handle)) {
-                throw new RuntimeException("Failed to flush the pull index WAL.");
-            }
-            $this->pull_index_wal_handle = null;
-        }
+        $this->close();
         clearstatcache(true, $this->pull_index_wal_path);
         if (
             is_file($this->pull_index_wal_path)

--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -178,7 +178,7 @@ class PullIndexJournal
      * @throws LogicException When the WAL is already open.
      * @throws RuntimeException When the WAL cannot be restored to that offset.
      */
-    public function open_at_saved_byte_offset(int $byte_offset): void
+    public function open_and_truncate_to_saved_byte_offset(int $byte_offset): void
     {
         if ($this->pull_index_wal_handle) {
             throw new LogicException(

--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -159,7 +159,7 @@ class RemoteIndexReader
             return null;
         }
         while (( $remote_index_json_line = fgets($this->remote_index_file_handle) ) !== false) {
-            $remote_index_entry = $this->parse_index_line($remote_index_json_line);
+            $remote_index_entry = self::decode_index_line($remote_index_json_line);
             if ($remote_index_entry !== null) {
                 return $remote_index_entry;
             }
@@ -244,7 +244,7 @@ class RemoteIndexReader
      * @throws InvalidArgumentException When the decoded path is not a valid
      *                                  remote absolute path.
      */
-    private function parse_index_line(string $line): ?array
+    public static function decode_index_line(string $line): ?array
     {
         $line = trim($line);
         if ($line === "") {

--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -159,10 +159,10 @@ class RemoteIndexReader
             return null;
         }
         while (( $remote_index_json_line = fgets($this->remote_index_file_handle) ) !== false) {
-            $remote_index_entry = self::decode_index_line($remote_index_json_line);
-            if ($remote_index_entry !== null) {
-                return $remote_index_entry;
+            if (trim($remote_index_json_line) === "") {
+                continue;
             }
+            return self::decode_index_line($remote_index_json_line);
         }
         return null;
     }
@@ -232,8 +232,8 @@ class RemoteIndexReader
      * `file`, preserving the historical remote-index parsing contract.
      *
      * @param string $line One JSONL line from a remote index file.
-     * @return array|null {
-     *     Decoded index entry, or null for an empty line.
+     * @return array {
+     *     Decoded index entry.
      *
      *     @type string $path  Decoded absolute path.
      *     @type int    $ctime Change time reported by the exporter.
@@ -244,12 +244,9 @@ class RemoteIndexReader
      * @throws InvalidArgumentException When the decoded path is not a valid
      *                                  remote absolute path.
      */
-    public static function decode_index_line(string $line): ?array
+    public static function decode_index_line(string $line): array
     {
         $line = trim($line);
-        if ($line === "") {
-            return null;
-        }
         $data = json_decode($line, true);
         if (!is_array($data)) {
             throw new RuntimeException("Invalid index line format");

--- a/packages/reprint-client/src/lib/state/class-file-diff-progress-state.php
+++ b/packages/reprint-client/src/lib/state/class-file-diff-progress-state.php
@@ -5,37 +5,50 @@ namespace Reprint\Importer\State;
 
 class FileDiffProgressState {
 
-    /** @var int Byte offset into the next remote index while diffing. */
-    public int $next_remote_index_byte_offset = 0;
+    /**
+     * File-index diff cursor.
+     *
+     * @var array{
+     *     old_index_byte_offset:int,
+     *     new_index_byte_offset:int,
+     *     preceding_new_index_entry_path_b64:string|null
+     * }
+     */
+    public array $index_diff_cursor = [
+        'old_index_byte_offset' => 0,
+        'new_index_byte_offset' => 0,
+        'preceding_new_index_entry_path_b64' => null,
+    ];
 
-    /** @var string|null Last remote index entry path consumed at the current next remote index byte offset. */
-    public ?string $last_consumed_remote_index_entry_path = null;
+    /** @var int Fetch-list byte offset covered by the saved diff cursor. */
+    public int $fetch_list_byte_offset = 0;
 
-    /** @var string|null Last next remote index entry processed before the current byte offset. */
-    public ?string $last_processed_next_remote_index_entry_path = null;
+    /** @var int Pull-index-WAL byte offset covered by the saved diff cursor. */
+    public int $pull_index_wal_byte_offset = 0;
 
     public static function from_array(array $data): self
     {
         $state = new self();
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
-        $state->next_remote_index_byte_offset =
-            $data['next_remote_index_byte_offset'];
-        $state->last_consumed_remote_index_entry_path =
-            $data['last_consumed_remote_index_entry_path'];
-        $state->last_processed_next_remote_index_entry_path =
-            $data['last_processed_next_remote_index_entry_path'];
+        \reprint_assert_state_keys(
+            $data['index_diff_cursor'],
+            array_keys($state->index_diff_cursor),
+            self::class . ' index_diff_cursor'
+        );
+        $state->index_diff_cursor = $data['index_diff_cursor'];
+        $state->fetch_list_byte_offset = $data['fetch_list_byte_offset'];
+        $state->pull_index_wal_byte_offset =
+            $data['pull_index_wal_byte_offset'];
         return $state;
     }
 
     public function to_array(): array
     {
         return [
-            'next_remote_index_byte_offset' =>
-                $this->next_remote_index_byte_offset,
-            'last_consumed_remote_index_entry_path' =>
-                $this->last_consumed_remote_index_entry_path,
-            'last_processed_next_remote_index_entry_path' =>
-                $this->last_processed_next_remote_index_entry_path,
+            'index_diff_cursor' => $this->index_diff_cursor,
+            'fetch_list_byte_offset' => $this->fetch_list_byte_offset,
+            'pull_index_wal_byte_offset' =>
+                $this->pull_index_wal_byte_offset,
         ];
     }
 }

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -327,6 +327,31 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
     }
 
+    public function testDecoderMustReturnAnEntryForEveryLine(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', []);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('new.txt'),
+        ]);
+        $processor = FileIndexDiffProcessor::create(
+            $old_index_file,
+            $new_index_file,
+            static function (string $line) {
+                return null;
+            }
+        );
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'returned NULL; expected one index entry for each line'
+        );
+        try {
+            $processor->next_path();
+        } finally {
+            $processor->close();
+        }
+    }
+
     public function testCloseIsIdempotentAndMakesTheProcessorTerminal(): void
     {
         $old_index_file = $this->write_index('old.jsonl', []);

--- a/tests/Import/FilesPullDiffResumeTest.php
+++ b/tests/Import/FilesPullDiffResumeTest.php
@@ -1,0 +1,484 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Test-only client and interruption exceptions live with their test.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+final class StopAfterFetchStageSave extends \RuntimeException
+{
+}
+
+final class StopAfterFetchListWrite extends \RuntimeException
+{
+}
+
+final class InterruptibleFilesPullClient extends \ImportClient
+{
+    public ?string $stop_after_fetch_path = null;
+    public ?string $stop_immediately_after_fetch_path = null;
+    public bool $stop_after_fetch_stage_save = false;
+
+    public function audit_log(string $message, bool $to_console = true): void
+    {
+        parent::audit_log($message, $to_console);
+        if (
+            $this->stop_immediately_after_fetch_path !== null
+            && $message === 'Added to the fetch list: '
+                . $this->stop_immediately_after_fetch_path
+        ) {
+            $this->stop_immediately_after_fetch_path = null;
+            throw new StopAfterFetchListWrite();
+        }
+        if (
+            $this->stop_after_fetch_path !== null
+            && $message === 'Added to the fetch list: '
+                . $this->stop_after_fetch_path
+        ) {
+            $this->stop_after_fetch_path = null;
+            ( new \ReflectionProperty(
+                \ImportClient::class,
+                'shutdown_requested'
+            ) )->setValue($this, true);
+        }
+    }
+
+    public function save_state(): void
+    {
+        parent::save_state();
+        if (
+            $this->stop_after_fetch_stage_save
+            && $this->get_state()->active_resumable_command->current_stage
+                === 'fetch'
+        ) {
+            $this->stop_after_fetch_stage_save = false;
+            throw new StopAfterFetchStageSave();
+        }
+    }
+}
+
+final class FilesPullDiffResumeTest extends TestCase
+{
+    private string $root;
+    private string $stateDirectory;
+    private string $pullStateDirectory;
+    private string $filesystemRoot;
+    private string $remoteReprintApiUrl =
+        'https://example.com/?site-export-api';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir()
+            . '/files-pull-diff-resume-'
+            . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->root . '/state';
+        $this->pullStateDirectory =
+            $this->stateDirectory
+            . '/remotes/'
+            . md5(rtrim($this->remoteReprintApiUrl, '?&'))
+            . '/pull';
+        $this->filesystemRoot = $this->root . '/files';
+        mkdir($this->pullStateDirectory, 0700, true);
+        mkdir($this->filesystemRoot, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testPartialDiffCanResumeOnTheSameClient(): void
+    {
+        $this->seedResumeScenario();
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+        $client->stop_after_fetch_path = '/b-change.txt';
+
+        $client->run_files_pull();
+        $this->assertSame(
+            'partial',
+            $client->get_state()->active_resumable_command->completion_state
+        );
+
+        $client->get_state()->active_resumable_command->completion_state =
+            'in_progress';
+        ( new \ReflectionProperty(
+            \ImportClient::class,
+            'shutdown_requested'
+        ) )->setValue($client, false);
+        $client->stop_after_fetch_stage_save = true;
+        try {
+            $client->run_files_pull();
+            $this->fail('Expected the test client to stop after saving the fetch stage.');
+        } catch (StopAfterFetchStageSave $exception) {
+            $this->assertSame(
+                'fetch',
+                $client->get_state()->active_resumable_command->current_stage
+            );
+        }
+
+        $this->assertSame(
+            ['/b-change.txt', '/d-add.txt'],
+            $this->readFetchPaths()
+        );
+        $this->assertSame(
+            ['/a-delete.txt', '/c-delete.txt'],
+            $this->readWalRemotePaths()
+        );
+    }
+
+    public function testResumeTruncatesOutputsAfterANonzeroCheckpoint(): void
+    {
+        $remoteIndex = '';
+        $nextRemoteIndex = '';
+        $expectedFetchPaths = [];
+        $expectedDeletedPaths = [];
+        for ($pathNumber = 1; $pathNumber <= 206; ++$pathNumber) {
+            $path = sprintf('/path-%03d.txt', $pathNumber);
+            $remoteIndex .= $this->indexLine($path, 1, 1);
+            if ($pathNumber % 2 === 0) {
+                $nextRemoteIndex .= $this->indexLine($path, 2, 2);
+                $expectedFetchPaths[] = $path;
+            } else {
+                $expectedDeletedPaths[] = $path;
+            }
+        }
+        $this->writeIndex('remote-index.jsonl', $remoteIndex);
+        $this->writeIndex('remote-index.next.jsonl', $nextRemoteIndex);
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+        $client->stop_immediately_after_fetch_path = '/path-204.txt';
+
+        try {
+            $this->runDiff($client);
+            $this->fail(
+                'Expected the test client to stop after the saved checkpoint.'
+            );
+        } catch (StopAfterFetchListWrite $exception) {
+            $this->assertCount(102, $this->readFetchPaths());
+            $this->assertCount(102, $this->readWalRemotePaths());
+        }
+        $this->assertSame(
+            $remoteIndex,
+            $this->readIndexFile('remote-index.jsonl')
+        );
+
+        $savedFetchListByteOffset =
+            $client->get_state()->diff->fetch_list_byte_offset;
+        $savedWalByteOffset =
+            $client->get_state()->diff->pull_index_wal_byte_offset;
+        $this->assertGreaterThan(0, $savedFetchListByteOffset);
+        $this->assertGreaterThan(0, $savedWalByteOffset);
+        $this->assertGreaterThan(
+            $savedFetchListByteOffset,
+            filesize($this->pullStateDirectory . '/fetch-list.jsonl')
+        );
+        $this->assertGreaterThan(
+            $savedWalByteOffset,
+            filesize($this->pullStateDirectory . '/index.wal')
+        );
+
+        $resumedClient = $this->loadClient($this->newClient());
+        $this->assertTrue($this->runDiff($resumedClient));
+
+        $this->assertSame($expectedFetchPaths, $this->readFetchPaths());
+        $this->assertSame($expectedDeletedPaths, $this->readWalRemotePaths());
+
+        $pullIndexJournal = ( new \ReflectionProperty(
+            \ImportClient::class,
+            'pull_index_journal'
+        ) )->getValue($resumedClient);
+        $this->assertInstanceOf(\PullIndexJournal::class, $pullIndexJournal);
+        $pullIndexJournal->apply_pending_records();
+
+        $remoteIndexPaths = $this->readRemoteIndexPaths();
+        $this->assertSame($expectedFetchPaths, $remoteIndexPaths);
+        $sortedRemoteIndexPaths = $remoteIndexPaths;
+        sort($sortedRemoteIndexPaths, SORT_STRING);
+        $this->assertSame($sortedRemoteIndexPaths, $remoteIndexPaths);
+    }
+
+    public function testFetchStageIsSavedBeforeTheDiffWalIsApplied(): void
+    {
+        $remoteIndex = $this->indexLine('/removed.txt', 1, 1);
+        $this->writeIndex('remote-index.jsonl', $remoteIndex);
+        $this->writeIndex('remote-index.next.jsonl', '');
+        $this->seedLocalFile('/removed.txt');
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+        $client->stop_after_fetch_stage_save = true;
+
+        try {
+            $client->run_files_pull();
+            $this->fail('Expected the test client to stop after saving the fetch stage.');
+        } catch (StopAfterFetchStageSave $exception) {
+            $this->assertSame(
+                'fetch',
+                $this->readState()['active_resumable_command']['current_stage']
+            );
+        }
+
+        $this->assertSame($remoteIndex, $this->readIndexFile('remote-index.jsonl'));
+        $this->assertNotSame('', $this->readIndexFile('index.wal'));
+        unlink($this->pullStateDirectory . '/remote-index.next.jsonl');
+
+        $resumedClient = $this->loadClient($this->newClient());
+        $resumedClient->run_files_pull();
+
+        $this->assertSame([], $this->readRemoteIndexPaths());
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/index.wal');
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testAbortAppliesTheWalFromAPartialDiff(): void
+    {
+        $this->writeIndex(
+            'remote-index.jsonl',
+            $this->indexLine('/a-delete.txt', 1, 1)
+                . $this->indexLine('/b-change.txt', 1, 1)
+                . $this->indexLine('/c-keep.txt', 1, 1)
+        );
+        $this->writeIndex(
+            'remote-index.next.jsonl',
+            $this->indexLine('/b-change.txt', 2, 2)
+                . $this->indexLine('/c-keep.txt', 1, 1)
+        );
+        foreach (['/a-delete.txt', '/b-change.txt', '/c-keep.txt'] as $path) {
+            $this->seedLocalFile($path);
+        }
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+        $client->stop_after_fetch_path = '/b-change.txt';
+        $this->assertFalse($this->runDiff($client));
+        $this->assertNotSame('', $this->readIndexFile('index.wal'));
+
+        $this->newClient()->run([
+            'command' => 'files-pull',
+            'abort' => true,
+            'follow_symlinks' => false,
+        ]);
+
+        $this->assertSame(
+            ['/b-change.txt', '/c-keep.txt'],
+            $this->readRemoteIndexPaths()
+        );
+        $this->assertFileDoesNotExist($this->pullStateDirectory . '/index.wal');
+    }
+
+    public function testDiffSkipsBlankRemoteIndexLinesAndUsesRemoteFieldDefaults(): void
+    {
+        $this->writeIndex(
+            'remote-index.jsonl',
+            "\n" . json_encode([
+                'path' => base64_encode('/same.txt'),
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+        $this->writeIndex(
+            'remote-index.next.jsonl',
+            "\n"
+                . json_encode([
+                    'path' => base64_encode('/added.txt'),
+                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+                . $this->indexLine('/same.txt', 0, 0)
+        );
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+
+        $this->assertTrue($this->runDiff($client));
+        $this->assertSame(['/added.txt'], $this->readFetchPaths());
+    }
+
+    private function newClient(): InterruptibleFilesPullClient
+    {
+        return new InterruptibleFilesPullClient(
+            $this->remoteReprintApiUrl,
+            $this->stateDirectory,
+            $this->filesystemRoot
+        );
+    }
+
+    private function writeDiffState(InterruptibleFilesPullClient $client): void
+    {
+        \write_current_pull_state($client, [
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'diff',
+            ],
+            'preflight' => [
+                'data' => ['ok' => true],
+                'http_code' => 200,
+            ],
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'files_pull_path_selection_fingerprint' => hash(
+                'sha256',
+                json_encode([
+                    'only_path_prefixes' => [],
+                    'excluded_path_prefixes' => [],
+                ], JSON_UNESCAPED_SLASHES)
+            ),
+        ]);
+    }
+
+    private function loadClient(
+        InterruptibleFilesPullClient $client
+    ): InterruptibleFilesPullClient {
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client)
+        );
+        return $client;
+    }
+
+    private function runDiff(InterruptibleFilesPullClient $client): bool
+    {
+        return ( new \ReflectionClass(\ImportClient::class) )
+            ->getMethod('compare_remote_indexes_and_build_fetch_list')
+            ->invoke($client);
+    }
+
+    private function seedLocalFile(string $path): void
+    {
+        $localPath = $this->filesystemRoot . $path;
+        if (!is_dir(dirname($localPath))) {
+            mkdir(dirname($localPath), 0700, true);
+        }
+        file_put_contents($localPath, 'x');
+    }
+
+    private function seedResumeScenario(): string
+    {
+        $remoteIndex =
+            $this->indexLine('/a-delete.txt', 1, 1)
+            . $this->indexLine('/b-change.txt', 1, 1)
+            . $this->indexLine('/c-delete.txt', 1, 1);
+        $this->writeIndex('remote-index.jsonl', $remoteIndex);
+        $this->writeIndex(
+            'remote-index.next.jsonl',
+            $this->indexLine('/b-change.txt', 2, 2)
+                . $this->indexLine('/d-add.txt', 1, 1)
+        );
+        foreach (['/a-delete.txt', '/b-change.txt', '/c-delete.txt'] as $path) {
+            $this->seedLocalFile($path);
+        }
+        return $remoteIndex;
+    }
+
+    private function writeIndex(string $name, string $contents): void
+    {
+        file_put_contents($this->pullStateDirectory . '/' . $name, $contents);
+    }
+
+    private function readIndexFile(string $name): string
+    {
+        $contents = file_get_contents($this->pullStateDirectory . '/' . $name);
+        $this->assertIsString($contents);
+        return $contents;
+    }
+
+    private function indexLine(
+        string $path,
+        int $ctime,
+        int $size,
+        string $type = 'file'
+    ): string {
+        return json_encode([
+            'path' => base64_encode($path),
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => $type,
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+    }
+
+    /** @return list<string> */
+    private function readFetchPaths(): array
+    {
+        return $this->readJsonlPaths(
+            $this->pullStateDirectory . '/fetch-list.jsonl',
+            'path'
+        );
+    }
+
+    /** @return list<string> */
+    private function readRemoteIndexPaths(): array
+    {
+        return $this->readJsonlPaths(
+            $this->pullStateDirectory . '/remote-index.jsonl',
+            'path'
+        );
+    }
+
+    /** @return list<string> */
+    private function readWalRemotePaths(): array
+    {
+        return $this->readJsonlPaths(
+            $this->pullStateDirectory . '/index.wal',
+            'remote_absolute_path_b64'
+        );
+    }
+
+    /** @return list<string> */
+    private function readJsonlPaths(string $file, string $pathKey): array
+    {
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertIsArray($lines);
+        return array_map(
+            static function (string $line) use ($pathKey): string {
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                $path = base64_decode($entry[$pathKey], true);
+                if (!is_string($path)) {
+                    throw new \RuntimeException('Failed to decode an index path.');
+                }
+                return $path;
+            },
+            $lines
+        );
+    }
+
+    /** @return array<string,mixed> */
+    private function readState(): array
+    {
+        $state = json_decode(
+            $this->readIndexFile('state.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($state);
+        return $state;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) ?: [] as $entry) {
+                if ($entry !== '.' && $entry !== '..') {
+                    $this->removeTree($path . '/' . $entry);
+                }
+            }
+            rmdir($path);
+            return;
+        }
+        unlink($path);
+    }
+}

--- a/tests/Import/FilesPullDiffResumeTest.php
+++ b/tests/Import/FilesPullDiffResumeTest.php
@@ -279,20 +279,19 @@ final class FilesPullDiffResumeTest extends TestCase
         $this->assertFileDoesNotExist($this->pullStateDirectory . '/index.wal');
     }
 
-    public function testDiffSkipsBlankRemoteIndexLinesAndUsesRemoteFieldDefaults(): void
+    public function testDiffUsesRemoteFieldDefaults(): void
     {
         $this->writeIndex(
             'remote-index.jsonl',
-            "\n" . json_encode([
+            json_encode([
                 'path' => base64_encode('/same.txt'),
             ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
         );
         $this->writeIndex(
             'remote-index.next.jsonl',
-            "\n"
-                . json_encode([
-                    'path' => base64_encode('/added.txt'),
-                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+            json_encode([
+                'path' => base64_encode('/added.txt'),
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
                 . $this->indexLine('/same.txt', 0, 0)
         );
 
@@ -301,6 +300,19 @@ final class FilesPullDiffResumeTest extends TestCase
 
         $this->assertTrue($this->runDiff($client));
         $this->assertSame(['/added.txt'], $this->readFetchPaths());
+    }
+
+    public function testDiffRejectsBlankRemoteIndexRecords(): void
+    {
+        $this->writeIndex('remote-index.jsonl', '');
+        $this->writeIndex('remote-index.next.jsonl', "\n");
+
+        $client = $this->newClient();
+        $this->writeDiffState($client);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid index line format');
+        $this->runDiff($client);
     }
 
     private function newClient(): InterruptibleFilesPullClient

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -158,6 +158,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
         [$client, $r] = $this->prepareClient(['/wp-content']);
         $r->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+        $r->getProperty('pull_index_journal')
+            ->getValue($client)
+            ->apply_pending_records();
 
         // Unselected file AND its index entry survive.
         $this->assertFileExists($unselected);
@@ -181,6 +184,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             ['/wp-content/uploads']
         );
         $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+        $reflection->getProperty('pull_index_journal')
+            ->getValue($client)
+            ->apply_pending_records();
 
         $this->assertFileExists($excluded);
         $this->assertContains(
@@ -273,6 +279,9 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
 
         [$client, $r] = $this->prepareClient(['/wp-content/themes']);
         $r->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
+        $r->getProperty('pull_index_journal')
+            ->getValue($client)
+            ->apply_pending_records();
 
         // The selected root, its matched contents, and its index entry survive…
         $this->assertDirectoryExists($this->filesystem_root . '/wp-content/themes');

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -41,9 +41,15 @@ class PullStateTest extends TestCase
         $state->active_resumable_command->command_name = 'db-pull';
         $state->active_resumable_command->completion_state = 'complete';
         $state->pull_pipeline->started_by_command = 'pull';
-        $state->diff->next_remote_index_byte_offset = 123;
-        $state->diff->last_consumed_remote_index_entry_path = '/wp-content/index.php';
-        $state->diff->last_processed_next_remote_index_entry_path = '/wp-content/themes/twentytwenty/style.css';
+        $state->diff->index_diff_cursor = [
+            'old_index_byte_offset' => 123,
+            'new_index_byte_offset' => 456,
+            'preceding_new_index_entry_path_b64' => base64_encode(
+                '/wp-content/index.php'
+            ),
+        ];
+        $state->diff->fetch_list_byte_offset = 789;
+        $state->diff->pull_index_wal_byte_offset = 321;
         $state->sql_statements_counted = 99;
 
         $array = $state->to_array();
@@ -51,12 +57,12 @@ class PullStateTest extends TestCase
         $this->assertSame('db-pull', $array['active_resumable_command']['command_name']);
         $this->assertSame('complete', $array['active_resumable_command']['completion_state']);
         $this->assertSame('pull', $array['pull_pipeline']['started_by_command']);
-        $this->assertSame(123, $array['diff']['next_remote_index_byte_offset']);
-        $this->assertSame('/wp-content/index.php', $array['diff']['last_consumed_remote_index_entry_path']);
         $this->assertSame(
-            '/wp-content/themes/twentytwenty/style.css',
-            $array['diff']['last_processed_next_remote_index_entry_path']
+            $state->diff->index_diff_cursor,
+            $array['diff']['index_diff_cursor']
         );
+        $this->assertSame(789, $array['diff']['fetch_list_byte_offset']);
+        $this->assertSame(321, $array['diff']['pull_index_wal_byte_offset']);
         $this->assertSame(99, $array['sql_statements_counted']);
     }
 
@@ -130,13 +136,22 @@ class PullStateTest extends TestCase
     public function testStateRejectsDiffFieldsFromThePreviousSchema(): void
     {
         $data = (new \PullState())->to_array();
-        unset($data['diff']['last_consumed_remote_index_entry_path']);
-        $data['diff']['last_consumed_local_index_entry_path'] =
+        unset(
+            $data['diff']['index_diff_cursor'],
+            $data['diff']['fetch_list_byte_offset'],
+            $data['diff']['pull_index_wal_byte_offset']
+        );
+        $data['diff']['next_remote_index_byte_offset'] = 123;
+        $data['diff']['last_consumed_remote_index_entry_path'] =
             '/wp-content/index.php';
+        $data['diff']['last_processed_next_remote_index_entry_path'] =
+            '/wp-content/themes/twentytwenty/style.css';
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage(
-            'missing last_consumed_remote_index_entry_path; unexpected last_consumed_local_index_entry_path'
+            'missing fetch_list_byte_offset, index_diff_cursor, pull_index_wal_byte_offset; ' .
+            'unexpected last_consumed_remote_index_entry_path, ' .
+            'last_processed_next_remote_index_entry_path, next_remote_index_byte_offset'
         );
 
         \PullState::from_array($data);

--- a/tests/Import/RemoteIndexReaderTest.php
+++ b/tests/Import/RemoteIndexReaderTest.php
@@ -139,6 +139,14 @@ final class RemoteIndexReaderTest extends TestCase
         $reader->close();
     }
 
+    public function testLineDecoderRejectsABlankRecord(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid index line format');
+
+        \RemoteIndexReader::decode_index_line("\n");
+    }
+
     private function indexLine(
         string $path,
         int $ctime,

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -224,10 +224,12 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
         const state = JSON.parse(readFileSync(statePath, 'utf-8'));
 
-        assert.equal(typeof state.diff.last_consumed_remote_index_entry_path, 'string', 'Expected diff.last_consumed_remote_index_entry_path to be persisted');
-        assert.ok(
-            state.diff.last_consumed_remote_index_entry_path.startsWith('base64:'),
-            `Expected base64-encoded diff.last_consumed_remote_index_entry_path, got: ${state.diff.last_consumed_remote_index_entry_path}`,
+        const precedingNewIndexPath = state.diff.index_diff_cursor.preceding_new_index_entry_path_b64;
+        assert.equal(typeof precedingNewIndexPath, 'string', 'Expected the preceding new-index path to be persisted');
+        assert.equal(
+            Buffer.from(precedingNewIndexPath, 'base64').toString('base64'),
+            precedingNewIndexPath,
+            'Expected the preceding new-index path to use base64',
         );
 
         if (typeof state.fetch.batch_file === 'string') {


### PR DESCRIPTION
Files-pull now uses `FileIndexDiffProcessor` instead of keeping a second index merge in `ImportClient`.

## Background

Pull and push both compare path-sorted file indexes. Push planning already uses `FileIndexDiffProcessor`. Pull still opened two `RemoteIndexReader` objects and merged their entries itself.

## This change

Pull passes the existing remote-index decoder to the shared processor. Remote absolute-path checks and field defaults stay in `RemoteIndexReader`.

The processor now requires one index entry for every physical line. Blank or invalid records fail instead of disappearing from the diff. `RemoteIndexReader::next_entry()` keeps its old blank-line handling for standalone reads, but its line decoder is strict when the diff processor uses it.

A partial diff stores one boundary:

```json
{
  "index_diff_cursor": {
    "old_index_byte_offset": 512,
    "new_index_byte_offset": 1024,
    "preceding_new_index_entry_path_b64": "L3dwLWNvbnRlbnQ="
  },
  "fetch_list_byte_offset": 256,
  "pull_index_wal_byte_offset": 128
}
```

The processor cursor and both output offsets move together. On resume, pull discards output bytes after the saved offsets and reads the next path again. The retained remote index stays unchanged during the diff. Pull saves `fetch` as the next stage before the WAL rewrites that index.

This is the first PR in the rebuilt files-pull stack. It does not add or change a CLI option.

## Testing

```sh
cd tests
../vendor/bin/phpunit Import/FileIndexDiffProcessorTest.php Import/RemoteIndexReaderTest.php Import/PullStateTest.php Import/FilesPullStateTest.php Import/OnlyFilesPathPrefixDiffTest.php Import/PullIndexWalTest.php Import/FilesPullLocalIndexTest.php Import/FilesPullDiffResumeTest.php
cd ..
vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src
git diff --check
```

