### PR TITLE
[PHP] Extract resumable fresh local index processing from PushPlan

### DIFF
--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -135,15 +135,14 @@ A push plan is an internal part of the sender lifecycle:
    create stores the exclusions in `excluded_paths.json` after creating the
    active `plan/` directory.
 2. The sender starts one internal `PushPlan`. The plan copies the exclusions to
-   `plan/excluded_paths.json`, then opens
-   `plan/fresh_local_index.jsonl` and a `FileIndexProcessor`. Each internal
-   `indexing` step advances one traversal event, appends its JSONL entries when
-   applicable, and updates its traversal cursor and fresh-index byte offset.
+   `plan/excluded_paths.json`, then starts a `FreshLocalIndexProcessor`. Each
+   internal `indexing` step advances one filesystem traversal event. The
+   processor writes `plan/fresh_local_index.jsonl` and updates its cursor.
    One sender step runs at most 256 internal planning steps without crossing
    an internal phase boundary, flushes their output, and stores the resulting
    cursor in `sender.json` before returning.
 3. Once traversal is complete, the plan enters `starting_diff`. The next step
-   starts the index diff and enters `diffing`.
+   sorts the fresh local index, starts the index diff, and enters `diffing`.
 4. Each later `next_step()` compares at most one path represented by either
    index. It returns true while another planning step remains and false when
    both indexes reach EOF. It
@@ -175,10 +174,10 @@ sender run. Keeping another cursor and retained handle for this post-commit copy
 is not justified until measurements from materially larger installations show
 that it matters.
 
-The cursor contains the plan directory, filesystem root, local index file,
-document root's local relative path, and current planning position. During
-indexing, that position contains the `FileIndexProcessor` cursor and committed
-fresh-index byte offset. During diffing, each step flushes only the path list or
+The cursor contains the plan directory, local index file, document root's local
+relative path, and current planning position. During
+indexing, that position contains the complete `FreshLocalIndexProcessor`
+cursor. During diffing, each step flushes only the path list or
 append-only active deletion roots file changed by that step before updating
 the two output byte offsets and the nested FileSyncPatchPlanner cursor. Each
 active deletion root links to the preceding one, so continuation reads only
@@ -348,9 +347,9 @@ without closing, the next process uses the preceding sender boundary and
 receiver-confirmed cursors to account for later remote work.
 
 During PushPlan's internal `indexing` phase, the plan retains one
-`FileIndexProcessor` and the open fresh local index across steps. A
-newly opened plan truncates that file to the byte offset stored with the
-processor cursor before continuing. The sender lazily opens
+`FreshLocalIndexProcessor` across steps. A resumed processor truncates the
+fresh local index to the byte offset stored with its filesystem traversal
+cursor before continuing. The sender lazily opens
 `local_paths_to_push.jsonl`, `local_paths_to_delete`, and the current local file.
 It retains those handles across `next_step()` calls, lets each handle advance
 with the work, and seeks only when a newly opened or receiver-confirmed offset

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -56,8 +56,8 @@ local relative path to a document-root-relative path.
   state directory. Files-pull advances only the entries for completed local
   mutations; files-push atomically replaces the local index only after the
   target confirms commit. Use `$local_index_file`.
-- A **fresh local index** is the current filesystem-root scan created while
-  planning a push. Use `$fresh_local_index_file`.
+- A **fresh local index** is the current filesystem-root scan used for sync
+  planning. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
 - A **file sync patch planner** compares a patch base index with a patch result
@@ -312,12 +312,11 @@ active deletion roots file. That file remembers directory deletions which
 cover index paths the planner has not processed yet.
 
 The PushPlan cursor is stored in `sender.json`. It contains `plan_directory`,
-`filesystem_root`, `local_index_file`, and the current
-planning position. During `indexing`, that position contains the
-FileIndexProcessor cursor and the committed byte offset in
-`fresh_local_index.jsonl`. During `diffing`, it contains the output offsets
-and the complete FileSyncPatchPlanner cursor. PushPlan
-stores that nested cursor without unpacking or rebuilding it. The active
+`local_index_file`, and the current
+planning position. During `indexing`, that position contains the complete
+FreshLocalIndexProcessor cursor. During `diffing`, it contains the output
+offsets and the complete FileSyncPatchPlanner cursor. PushPlan stores either
+nested cursor without unpacking or rebuilding it. The active
 deletion roots file is append-only; each entry links to the preceding active
 directory. The exclusions have a maximum of 100 paths. The `sender.json`
 phases are `creating`, `finishing_previous_commit`,
@@ -524,8 +523,8 @@ Use these names verbatim inside `PushPlan`:
 | Index entry and shape | `$index_entry`, `$local_index_entry`, `$local_index_entry_shape`, `index_entry_shape()` |
 | Cursor | `$cursor`, `get_cursor()` |
 | Plan-owned excluded paths | `$excluded_paths_file` |
-| Fresh local index processor | `$file_index_processor`, `next_file_index_step()` |
-| Fresh local indexing cursor | `IndexingCursor`, `file_index_cursor` |
+| Fresh local index processor | `FreshLocalIndexProcessor`, `$fresh_local_index_processor` |
+| Fresh local indexing cursor | `fresh_local_index_cursor`, `$fresh_local_index_cursor` |
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |
 | Open fresh local index | `$fresh_local_index_handle` |
 | Combined index bytes | `$index_bytes_total` |

--- a/packages/reprint-client/src/lib/index/class-fresh-local-index-processor.php
+++ b/packages/reprint-client/src/lib/index/class-fresh-local-index-processor.php
@@ -1,0 +1,374 @@
+<?php
+
+use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\write_local_index_entry;
+use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
+
+require_once __DIR__ . '/../sort-index-file.php';
+require_once __DIR__ . '/../local-index-update-functions.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing streaming classes.
+
+/**
+ * Builds one sorted fresh local index in resumable steps.
+ *
+ * FileIndexProcessor walks the filesystem. This processor writes its entries
+ * in local-relative coordinates, stores the output byte offset with the
+ * traversal cursor, and sorts the completed index. Callers store get_cursor()
+ * after each step and pass that cursor unchanged to resume().
+ *
+ * A resumed indexing phase truncates the fresh local index to its saved byte
+ * offset before continuing the filesystem traversal. Bytes written by a step
+ * whose cursor was not stored are written again from the same traversal point.
+ *
+ * Each next_step() call performs one filesystem traversal event or sorts the
+ * completed index. False means the index is complete and remains false.
+ *
+ *     $processor = FreshLocalIndexProcessor::start(
+ *         $fresh_local_index_file,
+ *         $filesystem_root,
+ *         $storage_path
+ *     );
+ *     do {
+ *         $has_next_step = $processor->next_step();
+ *         $processor->flush_pending_output();
+ *         save_cursor($processor->get_cursor());
+ *     } while ($has_next_step);
+ *     $processor->close();
+ *
+ * A later process continues with
+ * `FreshLocalIndexProcessor::resume($saved_cursor)`.
+ *
+ * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
+ * @phpstan-type IndexingPosition array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
+ * @phpstan-type SortingPosition array{phase:'sorting'}
+ * @phpstan-type CompletePosition array{phase:'complete'}
+ * @phpstan-type Position IndexingPosition|SortingPosition|CompletePosition
+ * @phpstan-type Cursor array{fresh_local_index_file:string,filesystem_root:string,storage_path:string,position:Position}
+ */
+final class FreshLocalIndexProcessor
+{
+    /** @var Cursor Current cursor returned to the caller. */
+    private array $cursor;
+
+    /** Filesystem traversal retained during indexing. */
+    private FileIndexProcessor $file_index_processor;
+
+    /** @var resource|null Fresh local index retained during indexing. */
+    private $fresh_local_index_handle = null;
+
+    /** Whether close() released this processor's handles. */
+    private bool $closed = false;
+
+    /**
+     * Starts a fresh local index before its first filesystem path.
+     *
+     * The output file is replaced. The filesystem root must resolve to a real
+     * directory and may not itself be a symlink.
+     *
+     * @param string $fresh_local_index_file Output JSONL file.
+     * @param string $filesystem_root        Filesystem root represented by the index.
+     * @param string $storage_path           Reprint storage path omitted by FileIndexProcessor.
+     */
+    public static function start(
+        string $fresh_local_index_file,
+        string $filesystem_root,
+        string $storage_path
+    ): self {
+        $processor = new self();
+        $filesystem_root = $processor->resolve_filesystem_root($filesystem_root);
+        $processor->fresh_local_index_handle = fopen(
+            $fresh_local_index_file,
+            "w+b"
+        );
+        if (!is_resource($processor->fresh_local_index_handle)) {
+            throw new RuntimeException(
+                "Failed to open the fresh local index: {$fresh_local_index_file}"
+            );
+        }
+        $processor->file_index_processor = FileIndexProcessor::start(
+            [$filesystem_root],
+            $filesystem_root,
+            false,
+            false,
+            $storage_path
+        );
+        $processor->cursor = [
+            "fresh_local_index_file" => $fresh_local_index_file,
+            "filesystem_root" => $filesystem_root,
+            "storage_path" => $storage_path,
+            "position" => [
+                "phase" => "indexing",
+                "file_index_cursor" =>
+                    $processor->file_index_processor->get_cursor(),
+                "fresh_local_index_byte_offset" => 0,
+            ],
+        ];
+        return $processor;
+    }
+
+    /**
+     * Resumes from a cursor returned by get_cursor().
+     *
+     * During indexing, bytes after the saved output offset are discarded and
+     * FileIndexProcessor resumes from the traversal cursor stored with it.
+     * Sorting starts again from the complete unsorted file. A complete cursor
+     * opens no files.
+     *
+     * @phpstan-param Cursor $cursor
+     */
+    public static function resume(array $cursor): self
+    {
+        $processor = new self();
+        $processor->cursor = $cursor;
+        $position = $cursor["position"];
+        if ($position["phase"] !== "indexing") {
+            return $processor;
+        }
+
+        $filesystem_root = $processor->resolve_filesystem_root(
+            $cursor["filesystem_root"]
+        );
+        if ($filesystem_root !== $cursor["filesystem_root"]) {
+            throw new RuntimeException(
+                "The fresh local index filesystem root no longer resolves to its saved path."
+            );
+        }
+        $processor->fresh_local_index_handle = fopen(
+            $cursor["fresh_local_index_file"],
+            "r+b"
+        );
+        if (!is_resource($processor->fresh_local_index_handle)) {
+            throw new RuntimeException(
+                "Failed to reopen the fresh local index: "
+                . $cursor["fresh_local_index_file"]
+            );
+        }
+        if (
+            !ftruncate(
+                $processor->fresh_local_index_handle,
+                $position["fresh_local_index_byte_offset"]
+            )
+            || fseek(
+                $processor->fresh_local_index_handle,
+                $position["fresh_local_index_byte_offset"]
+            ) !== 0
+        ) {
+            fclose($processor->fresh_local_index_handle);
+            $processor->fresh_local_index_handle = null;
+            throw new RuntimeException(
+                "Failed to truncate and seek the fresh local index to byte "
+                . $position["fresh_local_index_byte_offset"]
+                . "."
+            );
+        }
+        $processor->file_index_processor = FileIndexProcessor::resume(
+            [$filesystem_root],
+            json_encode(
+                $position["file_index_cursor"],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ),
+            false,
+            false,
+            $cursor["storage_path"]
+        );
+        return $processor;
+    }
+
+    /**
+     * Performs one filesystem traversal event or sorts the completed index.
+     *
+     * True means another step may be performed. False means the fresh local
+     * index is complete.
+     */
+    public function next_step(): bool
+    {
+        $position = $this->cursor["position"];
+        if ($position["phase"] === "complete") {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException(
+                "Cannot take a fresh local index step after close()."
+            );
+        }
+
+        if ($position["phase"] === "sorting") {
+            if (!sort_index_file($this->cursor["fresh_local_index_file"])) {
+                throw new RuntimeException(
+                    "Failed to sort the fresh local index: "
+                    . $this->cursor["fresh_local_index_file"]
+                );
+            }
+            $this->cursor["position"] = ["phase" => "complete"];
+            return false;
+        }
+
+        if (!$this->file_index_processor->next_index_step()) {
+            if (!fflush($this->fresh_local_index_handle)) {
+                throw new RuntimeException(
+                    "Failed to flush the fresh local index."
+                );
+            }
+            $this->file_index_processor->close();
+            $this->close_fresh_local_index_handle();
+            $this->cursor["position"] = ["phase" => "sorting"];
+            return true;
+        }
+
+        switch ($this->file_index_processor->get_step_status()) {
+            case FileIndexProcessor::STATUS_INDEXED:
+                foreach (
+                    $this->file_index_processor->get_index_entries()
+                    as $file_index_processor_entry
+                ) {
+                    if ($file_index_processor_entry["type"] === "other") {
+                        throw new RuntimeException(
+                            "Cannot index the unsupported local path: "
+                            . base64_encode(
+                                $file_index_processor_entry["path"]
+                            )
+                            . "."
+                        );
+                    }
+                    if (
+                        $file_index_processor_entry["type"] === "dir"
+                        && !array_key_exists(
+                            "empty",
+                            $file_index_processor_entry
+                        )
+                    ) {
+                        throw new RuntimeException(
+                            "Could not inspect the local directory: "
+                            . base64_encode(
+                                $file_index_processor_entry["path"]
+                            )
+                            . "."
+                        );
+                    }
+
+                    $local_relative_path = relative_path_under(
+                        $file_index_processor_entry["path"],
+                        $this->cursor["filesystem_root"]
+                    );
+                    if ($local_relative_path === null) {
+                        throw new LogicException(
+                            "File index path is outside the filesystem root."
+                        );
+                    }
+                    $fresh_local_index_entry = [
+                        "path" => $local_relative_path,
+                        "ctime" => $file_index_processor_entry["ctime"],
+                        "size" => $file_index_processor_entry["size"],
+                        "type" => $file_index_processor_entry["type"],
+                    ];
+                    if ($file_index_processor_entry["type"] === "dir") {
+                        $fresh_local_index_entry["empty"] =
+                            $file_index_processor_entry["empty"];
+                    }
+                    write_local_index_entry(
+                        $this->fresh_local_index_handle,
+                        $fresh_local_index_entry
+                    );
+                }
+                break;
+
+            case FileIndexProcessor::STATUS_DIRECTORY_ERROR:
+                $directory_error =
+                    $this->file_index_processor->get_directory_error();
+                throw new RuntimeException(
+                    $directory_error["message"]
+                    . ": "
+                    . base64_encode($directory_error["path"])
+                    . "."
+                );
+
+            case FileIndexProcessor::STATUS_SKIPPED:
+            case FileIndexProcessor::STATUS_PATH_UNAVAILABLE:
+            case FileIndexProcessor::STATUS_DIRECTORY_COMPLETE:
+                break;
+        }
+
+        $fresh_local_index_byte_offset = ftell(
+            $this->fresh_local_index_handle
+        );
+        if (!is_int($fresh_local_index_byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the fresh local index byte offset."
+            );
+        }
+        $this->cursor["position"] = [
+            "phase" => "indexing",
+            "file_index_cursor" =>
+                $this->file_index_processor->get_cursor(),
+            "fresh_local_index_byte_offset" =>
+                $fresh_local_index_byte_offset,
+        ];
+        return true;
+    }
+
+    /** @phpstan-return Cursor Current cursor after the latest completed step. */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Returns the current phase from the resumable cursor. */
+    public function get_phase(): string
+    {
+        return $this->cursor["position"]["phase"];
+    }
+
+    /** Flushes fresh-index bytes before the caller stores get_cursor(). */
+    public function flush_pending_output(): void
+    {
+        if (
+            is_resource($this->fresh_local_index_handle)
+            && !fflush($this->fresh_local_index_handle)
+        ) {
+            throw new RuntimeException("Failed to flush the fresh local index.");
+        }
+    }
+
+    /** Closes retained handles. Repeated calls do nothing. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        if (isset($this->file_index_processor)) {
+            $this->file_index_processor->close();
+        }
+        $this->close_fresh_local_index_handle();
+        $this->closed = true;
+    }
+
+    /** Returns the resolved real directory represented by the index. */
+    private function resolve_filesystem_root(string $filesystem_root): string
+    {
+        clearstatcache(true, $filesystem_root);
+        $resolved_filesystem_root = realpath($filesystem_root);
+        if (
+            $resolved_filesystem_root === false
+            || !is_dir($resolved_filesystem_root)
+            || is_link($filesystem_root)
+        ) {
+            throw new InvalidArgumentException(
+                "FreshLocalIndexProcessor requires the filesystem root to be a real directory."
+            );
+        }
+        return trim_right_slash($resolved_filesystem_root);
+    }
+
+    /** Closes the fresh local index retained during filesystem traversal. */
+    private function close_fresh_local_index_handle(): void
+    {
+        if (is_resource($this->fresh_local_index_handle)) {
+            fclose($this->fresh_local_index_handle);
+        }
+        $this->fresh_local_index_handle = null;
+    }
+}

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -1,11 +1,11 @@
 <?php
 
-use function Reprint\Importer\sort_index_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
 require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
+require_once __DIR__ . '/../index/class-fresh-local-index-processor.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -19,9 +19,9 @@ require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
- * FileIndexProcessor, FileSyncPatchPlanner, the fresh local index, the
- * meaning of its cursor, and the two completed path lists. A caller which
- * resumes across processes stores the cursor returned by get_cursor().
+ * FreshLocalIndexProcessor, FileSyncPatchPlanner, the meaning of its cursor,
+ * and the two completed path lists. A caller which resumes across processes
+ * stores the cursor returned by get_cursor().
  *
  * ## Durable boundary
  *
@@ -48,10 +48,9 @@ require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
  *
  * ## Durability and memory
  *
- * Each indexing step advances one FileIndexProcessor traversal event and
- * updates the traversal cursor and fresh-index byte offset returned to the
- * caller. A separate step starts the index diff. Each diff step compares at
- * most one path represented by either index and updates its next cursor.
+ * Each indexing step advances FreshLocalIndexProcessor once and stores its
+ * cursor unchanged. A separate step starts the index diff. Each diff step
+ * compares at most one path represented by either index and updates its next cursor.
  * The owner flushes pending output before storing a cursor. `resume()` discards
  * bytes beyond saved offsets, so an interrupted step cannot leave duplicate
  * durable entries.
@@ -61,21 +60,20 @@ require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
  * deletions. PushPlan stores its cursor without unpacking it. Neither class
  * loads an index, path list, or the active deletion roots file in full.
  *
- * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
- * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
- * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
+ * @phpstan-type FreshLocalIndexFileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
+ * @phpstan-type FreshLocalIndexPosition array{phase:'indexing',file_index_cursor:FreshLocalIndexFileIndexCursor,fresh_local_index_byte_offset:int}|array{phase:'sorting'}|array{phase:'complete'}
+ * @phpstan-type FreshLocalIndexCursor array{fresh_local_index_file:string,filesystem_root:string,storage_path:string,position:FreshLocalIndexPosition}
+ * @phpstan-type IndexingCursor array{phase:'indexing',fresh_local_index_cursor:FreshLocalIndexCursor}
+ * @phpstan-type StartingDiffCursor array{phase:'starting_diff',fresh_local_index_cursor:FreshLocalIndexCursor}
  * @phpstan-type FileSyncPlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  * @phpstan-type FileSyncPlannerCursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:FileSyncPlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
  * @phpstan-type IndexDiffCursor array{phase:'diffing',file_sync_planner_cursor:FileSyncPlannerCursor,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
- * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
+ * @phpstan-type PushPlanCursor array{plan_directory:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
  */
 class PushPlan
 {
-    /** @var string Resolved filesystem root inspected while building the fresh local index. */
-    private string $filesystem_root;
-
     /** @var string Document root relative to the local filesystem root. */
     private string $document_root_local_relative_path;
 
@@ -109,14 +107,12 @@ class PushPlan
     /** @var bool Whether close() has closed this plan's file handles. */
     private bool $closed = false;
 
-    /** @var FileIndexProcessor Fresh local index traversal retained during indexing. */
-    private FileIndexProcessor $file_index_processor;
+    /** Fresh local index retained during indexing. */
+    private FreshLocalIndexProcessor $fresh_local_index_processor;
 
     /** File-sync patch planner retained during the diff phase. */
     private FileSyncPatchPlanner $patch_planner;
 
-    /** @var resource|null Open fresh local index retained during indexing. */
-    private $fresh_local_index_handle = null;
     /** @var resource|null */
     private $local_paths_to_push_handle = null;
     /** @var resource|null */
@@ -147,7 +143,6 @@ class PushPlan
     ): self {
         $plan = new self(
             $plan_directory,
-            $filesystem_root,
             $local_index_file,
             $document_root_local_relative_path
         );
@@ -155,26 +150,19 @@ class PushPlan
             throw new RuntimeException("Failed to copy excluded paths into the push plan: {$excluded_paths_path}");
         }
         $plan->excluded_paths = $plan->load_excluded_paths();
-        $plan->fresh_local_index_handle = fopen($plan->fresh_local_index_file, "w+b");
-        if (!is_resource($plan->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to open the fresh local index: {$plan->fresh_local_index_file}");
-        }
-        $plan->file_index_processor = FileIndexProcessor::start(
-            [$plan->filesystem_root],
-            $plan->filesystem_root,
-            false,
-            false,
+        $plan->fresh_local_index_processor = FreshLocalIndexProcessor::start(
+            $plan->fresh_local_index_file,
+            $filesystem_root,
             $plan->plan_directory
         );
         $plan->cursor = [
             "plan_directory" => $plan->plan_directory,
-            "filesystem_root" => $plan->filesystem_root,
             "local_index_file" => $plan->local_index_file,
             "document_root_local_relative_path" => $plan->document_root_local_relative_path,
             "position" => [
                 "phase" => "indexing",
-                "file_index_cursor" => $plan->file_index_processor->get_cursor(),
-                "fresh_local_index_byte_offset" => 0,
+                "fresh_local_index_cursor" =>
+                    $plan->fresh_local_index_processor->get_cursor(),
             ],
         ];
         return $plan;
@@ -215,7 +203,6 @@ class PushPlan
 
         $plan = new self(
             $cursor["plan_directory"],
-            $cursor["filesystem_root"],
             $cursor["local_index_file"],
             $cursor["document_root_local_relative_path"]
         );
@@ -224,8 +211,14 @@ class PushPlan
         if ($position["phase"] !== "complete") {
             $plan->excluded_paths = $plan->load_excluded_paths();
         }
-        if ($position["phase"] === "indexing") {
-            $plan->open_fresh_local_index_for_continuation();
+        if (
+            $position["phase"] === "indexing"
+            || $position["phase"] === "starting_diff"
+        ) {
+            $plan->fresh_local_index_processor =
+                FreshLocalIndexProcessor::resume(
+                    $position["fresh_local_index_cursor"]
+                );
         } elseif ($position["phase"] === "diffing") {
             $plan->open_plan_output_files(
                 $position["byte_offset_in_local_paths_to_push"],
@@ -314,11 +307,8 @@ class PushPlan
      */
     public function flush_pending_outputs(): void
     {
-        if (
-            is_resource($this->fresh_local_index_handle)
-            && !fflush($this->fresh_local_index_handle)
-        ) {
-            throw new RuntimeException("Failed to flush the fresh local index.");
+        if (isset($this->fresh_local_index_processor)) {
+            $this->fresh_local_index_processor->flush_pending_output();
         }
         if (
             ( is_resource($this->local_paths_to_push_handle) && !fflush($this->local_paths_to_push_handle) )
@@ -335,13 +325,11 @@ class PushPlan
      * Initializes paths in the caller-owned active plan directory.
      *
      * @param string $plan_directory   Caller-owned active plan directory.
-     * @param string $filesystem_root  Resolved filesystem root.
      * @param string $local_index_file Local index file this plan diffs against.
      * @param string $document_root_local_relative_path Document root relative to the local filesystem root.
      */
     private function __construct(
         string $plan_directory,
-        string $filesystem_root,
         string $local_index_file,
         string $document_root_local_relative_path
     ) {
@@ -350,7 +338,6 @@ class PushPlan
             throw new LogicException("Cannot open a push plan without its directory: {$plan_directory}");
         }
         $this->plan_directory = $plan_directory;
-        $this->set_filesystem_root($filesystem_root);
         $this->local_index_file = $local_index_file;
         $this->document_root_local_relative_path =
             rtrim($document_root_local_relative_path, "/");
@@ -359,50 +346,6 @@ class PushPlan
         $this->fresh_local_index_file = wp_join_unix_paths($plan_directory, "fresh_local_index.jsonl");
         $this->excluded_paths_file = wp_join_unix_paths($plan_directory, "excluded_paths.json");
         $this->active_deletion_roots_file = wp_join_unix_paths($plan_directory, "deleted_directories_stack.jsonl");
-    }
-
-    /**
-     * Stores the resolved filesystem root represented by this plan.
-     *
-     * @param string $filesystem_root Filesystem root selected by the caller.
-     */
-    private function set_filesystem_root(string $filesystem_root): void
-    {
-        clearstatcache(true, $filesystem_root);
-        $resolved_local_filesystem_root = realpath($filesystem_root);
-        if ($resolved_local_filesystem_root === false || !is_dir($resolved_local_filesystem_root) || is_link($filesystem_root)) {
-            throw new InvalidArgumentException("PushPlan requires the filesystem root to be a real directory.");
-        }
-        $this->filesystem_root = trim_right_slash($resolved_local_filesystem_root);
-    }
-
-    /**
-     * Reopens the fresh local index at the byte offset stored with its traversal cursor.
-     *
-     * Any bytes appended after the cursor last stored by the caller are
-     * discarded before FileIndexProcessor continues from that same step.
-     */
-    private function open_fresh_local_index_for_continuation(): void
-    {
-        /** @var IndexingCursor $cursor */
-        $cursor = $this->cursor["position"];
-        $this->fresh_local_index_handle = fopen($this->fresh_local_index_file, "r+b");
-        if (!is_resource($this->fresh_local_index_handle)) {
-            throw new RuntimeException("Failed to reopen the fresh local index: {$this->fresh_local_index_file}");
-        }
-        if (!ftruncate($this->fresh_local_index_handle, $cursor["fresh_local_index_byte_offset"])) {
-            throw new RuntimeException("Failed to discard uncommitted fresh-local-index bytes.");
-        }
-        if (fseek($this->fresh_local_index_handle, $cursor["fresh_local_index_byte_offset"]) !== 0) {
-            throw new RuntimeException("Failed to seek to the fresh local index byte offset.");
-        }
-        $this->file_index_processor = FileIndexProcessor::resume(
-            [$this->filesystem_root],
-            json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
-            false,
-            false,
-            $this->plan_directory
-        );
     }
 
     /**
@@ -425,7 +368,22 @@ class PushPlan
 
         switch ($position["phase"]) {
             case "indexing":
-                $this->next_file_index_step();
+                $this->fresh_local_index_processor->next_step();
+                $fresh_local_index_cursor =
+                    $this->fresh_local_index_processor->get_cursor();
+                $this->cursor["position"] =
+                    $this->fresh_local_index_processor->get_phase()
+                        === "sorting"
+                    ? [
+                        "phase" => "starting_diff",
+                        "fresh_local_index_cursor" =>
+                            $fresh_local_index_cursor,
+                    ]
+                    : [
+                        "phase" => "indexing",
+                        "fresh_local_index_cursor" =>
+                            $fresh_local_index_cursor,
+                    ];
                 return true;
             case "starting_diff":
                 $this->start_index_diff();
@@ -436,65 +394,16 @@ class PushPlan
     }
 
     /**
-     * Performs one filesystem traversal step and updates its exact continuation point.
-     *
-     * Completed index entries are appended and flushed before the cursor moves
-     * past them. Steps which omit a path still update the changed traversal
-     * cursor. A directory failure leaves the caller's stored cursor unchanged,
-     * so the next plan run attempts that same directory again.
-     */
-    private function next_file_index_step(): void
-    {
-        if (!$this->file_index_processor->next_index_step()) {
-            if (!fflush($this->fresh_local_index_handle)) {
-                throw new RuntimeException("Failed to flush the fresh local index.");
-            }
-            $this->file_index_processor->close();
-            $this->close_fresh_local_index_handle();
-            $this->cursor["position"] = ["phase" => "starting_diff"];
-            return;
-        }
-
-        switch ($this->file_index_processor->get_step_status()) {
-            case FileIndexProcessor::STATUS_INDEXED:
-                foreach ($this->file_index_processor->get_index_entries() as $file_index_processor_entry) {
-                    $this->append_fresh_local_index_entry($file_index_processor_entry);
-                }
-                break;
-
-            case FileIndexProcessor::STATUS_DIRECTORY_ERROR:
-                $directory_error = $this->file_index_processor->get_directory_error();
-                throw new RuntimeException(
-                    $directory_error["message"] . ": " . base64_encode($directory_error["path"]) . "."
-                );
-
-            case FileIndexProcessor::STATUS_SKIPPED:
-            case FileIndexProcessor::STATUS_PATH_UNAVAILABLE:
-            case FileIndexProcessor::STATUS_DIRECTORY_COMPLETE:
-                break;
-        }
-
-        $fresh_local_index_byte_offset = ftell($this->fresh_local_index_handle);
-        if (!is_int($fresh_local_index_byte_offset)) {
-            throw new RuntimeException("Failed to determine the fresh local index byte offset.");
-        }
-        $this->cursor["position"] = [
-            "phase" => "indexing",
-            "file_index_cursor" => $this->file_index_processor->get_cursor(),
-            "fresh_local_index_byte_offset" => $fresh_local_index_byte_offset,
-        ];
-    }
-
-    /**
      * Sorts the fresh local index by raw path, then starts the index diff.
      */
     private function start_index_diff(): void
     {
-        if (!sort_index_file($this->fresh_local_index_file)) {
-            throw new RuntimeException(
-                "Failed to sort the fresh local index: {$this->fresh_local_index_file}"
+        if ($this->fresh_local_index_processor->next_step()) {
+            throw new LogicException(
+                "Fresh local index sorting did not complete in one step."
             );
         }
+        $this->fresh_local_index_processor->close();
         $this->open_plan_output_files(0, 0);
         $this->patch_planner = FileSyncPatchPlanner::create(
             $this->local_index_file,
@@ -557,60 +466,6 @@ class PushPlan
         if (is_int($fresh_local_index_bytes) && is_int($local_index_bytes)) {
             $this->index_bytes_total = $fresh_local_index_bytes
                 + $local_index_bytes;
-        }
-    }
-
-    /**
-     * Appends one FileIndexProcessor entry in the JSONL format consumed by the
-     * index diff.
-     *
-     * @param array<string,mixed> $file_index_processor_entry Filesystem path details from FileIndexProcessor.
-     */
-    private function append_fresh_local_index_entry(array $file_index_processor_entry): void
-    {
-        if ($file_index_processor_entry["type"] === "other") {
-            throw new RuntimeException(
-                "Cannot push the unsupported local path: "
-                . base64_encode($file_index_processor_entry["path"])
-                . "."
-            );
-        }
-        if (
-            $file_index_processor_entry["type"] === "dir"
-            && !array_key_exists("empty", $file_index_processor_entry)
-        ) {
-            throw new RuntimeException(
-                "Could not inspect the local directory: "
-                . base64_encode($file_index_processor_entry["path"])
-                . "."
-            );
-        }
-
-        $local_relative_path = relative_path_under(
-            $file_index_processor_entry["path"],
-            $this->filesystem_root
-        );
-        if ($local_relative_path === null) {
-            throw new LogicException("File index path is outside the filesystem root.");
-        }
-        $fresh_local_index_entry = [
-            "path" => base64_encode($local_relative_path),
-            "ctime" => $file_index_processor_entry["ctime"],
-            "size" => $file_index_processor_entry["size"],
-            "type" => $file_index_processor_entry["type"],
-        ];
-        if ($file_index_processor_entry["type"] === "dir") {
-            $fresh_local_index_entry["empty"] = $file_index_processor_entry["empty"];
-        }
-        $fresh_local_index_json_line = json_encode(
-            $fresh_local_index_entry,
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (
-            fwrite($this->fresh_local_index_handle, $fresh_local_index_json_line)
-            !== strlen($fresh_local_index_json_line)
-        ) {
-            throw new RuntimeException("Failed to write a fresh local index entry.");
         }
     }
 
@@ -704,13 +559,12 @@ class PushPlan
      */
     public function close(): void
     {
-        if (isset($this->file_index_processor)) {
-            $this->file_index_processor->close();
+        if (isset($this->fresh_local_index_processor)) {
+            $this->fresh_local_index_processor->close();
         }
         if (isset($this->patch_planner)) {
             $this->patch_planner->close();
         }
-        $this->close_fresh_local_index_handle();
         if (is_resource($this->local_paths_to_push_handle)) {
             fclose($this->local_paths_to_push_handle);
         }
@@ -720,17 +574,6 @@ class PushPlan
         $this->local_paths_to_push_handle = null;
         $this->local_paths_to_delete_handle = null;
         $this->closed = true;
-    }
-
-    /**
-     * Closes the fresh local index retained while indexing or diffing the indexes.
-     */
-    private function close_fresh_local_index_handle(): void
-    {
-        if (is_resource($this->fresh_local_index_handle)) {
-            fclose($this->fresh_local_index_handle);
-        }
-        $this->fresh_local_index_handle = null;
     }
 
     /**

--- a/tests/Import/FreshLocalIndexProcessorTest.php
+++ b/tests/Import/FreshLocalIndexProcessorTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-server/src/utils.php';
+require_once __DIR__ . '/../../packages/reprint-server/src/class-file-index-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-fresh-local-index-processor.php';
+
+final class FreshLocalIndexProcessorTest extends TestCase {
+    private string $temporary_directory;
+    private string $filesystem_root;
+    private string $fresh_local_index_file;
+    private string $storage_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporary_directory = sys_get_temp_dir()
+            . '/fresh-local-index-processor-test-'
+            . uniqid();
+        $this->filesystem_root =
+            $this->temporary_directory . '/filesystem-root';
+        $this->fresh_local_index_file =
+            $this->temporary_directory . '/fresh-local-index.jsonl';
+        $this->storage_path = $this->temporary_directory . '/state';
+        mkdir($this->filesystem_root, 0755, true);
+        mkdir($this->storage_path, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_path($this->temporary_directory);
+        parent::tearDown();
+    }
+
+    public function testBuildsASortedLocalRelativeIndex(): void
+    {
+        mkdir($this->filesystem_root . '/empty');
+        mkdir($this->filesystem_root . '/full');
+        file_put_contents($this->filesystem_root . '/full/child.txt', 'child');
+        file_put_contents($this->filesystem_root . '/z.txt', 'z');
+        file_put_contents($this->filesystem_root . '/a.txt', 'a');
+
+        $processor = FreshLocalIndexProcessor::start(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path
+        );
+        $this->run_to_completion($processor);
+
+        $entries = $this->read_index_entries();
+        $this->assertSame(
+            ['a.txt', 'empty', 'full/child.txt', 'z.txt'],
+            array_column($entries, 'decoded_path')
+        );
+        $this->assertTrue($entries[1]['empty']);
+        $this->assertArrayNotHasKey('empty', $entries[2]);
+        $this->assertArrayNotHasKey('decoded_path', $entries[0]['stored']);
+        $this->assertSame(base64_encode('a.txt'), $entries[0]['stored']['path']);
+    }
+
+    public function testResumeDiscardsBytesWrittenAfterTheSavedCursor(): void
+    {
+        file_put_contents($this->filesystem_root . '/a.txt', 'a');
+        file_put_contents($this->filesystem_root . '/b.txt', 'b');
+
+        $processor = FreshLocalIndexProcessor::start(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path
+        );
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $saved_cursor = $processor->get_cursor();
+
+        $this->assertTrue($processor->next_step());
+        $processor->close();
+        $this->assertGreaterThan(
+            $saved_cursor['position']['fresh_local_index_byte_offset'],
+            filesize($this->fresh_local_index_file)
+        );
+
+        $resumed_processor = FreshLocalIndexProcessor::resume($saved_cursor);
+        $this->run_to_completion($resumed_processor);
+
+        $this->assertSame(
+            ['a.txt', 'b.txt'],
+            array_column($this->read_index_entries(), 'decoded_path')
+        );
+    }
+
+    public function testSortingIsASeparateResumableStep(): void
+    {
+        file_put_contents($this->filesystem_root . '/value.txt', 'value');
+        $processor = FreshLocalIndexProcessor::start(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path
+        );
+
+        while ($processor->get_phase() === 'indexing') {
+            $this->assertTrue($processor->next_step());
+        }
+        $this->assertSame('sorting', $processor->get_phase());
+        $sorting_cursor = $processor->get_cursor();
+        $processor->close();
+
+        $resumed_processor = FreshLocalIndexProcessor::resume($sorting_cursor);
+        $this->assertFalse($resumed_processor->next_step());
+        $this->assertSame('complete', $resumed_processor->get_phase());
+        $this->assertFalse($resumed_processor->next_step());
+        $resumed_processor->close();
+    }
+
+    private function run_to_completion(
+        FreshLocalIndexProcessor $processor
+    ): void {
+        for ($step = 0; $step < 100; ++$step) {
+            if (!$processor->next_step()) {
+                $processor->close();
+                return;
+            }
+        }
+        $this->fail('Fresh local index did not complete within 100 steps.');
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function read_index_entries(): array
+    {
+        $lines = file(
+            $this->fresh_local_index_file,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        $entries = [];
+        foreach ($lines as $line) {
+            $stored = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $decoded_path = base64_decode($stored['path'], true);
+            $this->assertIsString($decoded_path);
+            $entry = [
+                'decoded_path' => $decoded_path,
+                'stored' => $stored,
+                'type' => $stored['type'],
+            ];
+            if (array_key_exists('empty', $stored)) {
+                $entry['empty'] = $stored['empty'];
+            }
+            $entries[] = $entry;
+        }
+        return $entries;
+    }
+
+    private function remove_path(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        $children = scandir($path);
+        if (is_array($children)) {
+            foreach ($children as $child) {
+                if ($child !== '.' && $child !== '..') {
+                    $this->remove_path($path . '/' . $child);
+                }
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -499,27 +499,6 @@ final class PushPlanTest extends TestCase
         $resumedPlan->close();
     }
 
-    public function testResumesCursorWrittenBeforeDocumentRootMappingAndProgressTotals(): void
-    {
-        $entries = $this->manyFileEntries(2);
-        $current = $this->writeIndex($entries);
-        $plan = $this->startPlan($current);
-
-        $this->assertTrue($this->nextPlanStep($plan));
-        $plan->close();
-
-        unset($this->cursor['document_root_local_relative_path']);
-        unset($this->cursor['position']['local_paths_to_push_count']);
-        unset($this->cursor['position']['local_file_bytes_to_push']);
-
-        $resumedPlan = $this->resumePlan();
-        $this->planToCompletion($resumedPlan);
-
-        $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertNull($this->planCursor()['local_paths_to_push_count']);
-        $this->assertNull($this->planCursor()['local_file_bytes_to_push']);
-    }
-
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
@@ -609,13 +588,11 @@ final class PushPlanTest extends TestCase
         $cursor = $plan->get_cursor();
         $this->assertSame([
             'plan_directory',
-            'filesystem_root',
             'local_index_file',
             'document_root_local_relative_path',
             'position',
         ], array_keys($cursor));
         $this->assertSame($this->planDirectory(), $cursor['plan_directory']);
-        $this->assertSame(realpath($this->filesystemRoot()), $cursor['filesystem_root']);
         $this->assertSame($this->localIndexFile(), $cursor['local_index_file']);
         $this->assertSame('', $cursor['document_root_local_relative_path']);
         $this->assertSame([
@@ -662,7 +639,12 @@ final class PushPlanTest extends TestCase
         );
 
         try {
-            $this->assertSame('/', $plan->get_cursor()['filesystem_root']);
+            $this->assertSame(
+                '/',
+                $plan->get_cursor()['position'][
+                    'fresh_local_index_cursor'
+                ]['filesystem_root']
+            );
         } finally {
             $plan->close();
         }

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1885,8 +1885,12 @@ final class PushEndpointsTest extends TestCase {
         $push_state_directory = $this->root . '/retained-plan-state';
         $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
-        $fresh_local_index_handle_property = new ReflectionProperty(
+        $fresh_local_index_processor_property = new ReflectionProperty(
             PushPlan::class,
+            'fresh_local_index_processor'
+        );
+        $fresh_local_index_handle_property = new ReflectionProperty(
+            FreshLocalIndexProcessor::class,
             'fresh_local_index_handle'
         );
         $fresh_local_index_handle = null;
@@ -1900,7 +1904,12 @@ final class PushEndpointsTest extends TestCase {
             $this->assertSame('planning', $create_result['phase']);
             $plan = $plan_property->getValue($sender);
             $this->assertInstanceOf(PushPlan::class, $plan);
-            $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
+            $fresh_local_index_processor =
+                $fresh_local_index_processor_property->getValue($plan);
+            $fresh_local_index_handle =
+                $fresh_local_index_handle_property->getValue(
+                    $fresh_local_index_processor
+                );
             $this->assertIsResource($fresh_local_index_handle);
 
             $cursor_before_step = $this->loadPlanPosition($push_state_directory);
@@ -1951,9 +1960,16 @@ final class PushEndpointsTest extends TestCase {
         $fresh_local_index_path = $push_state_directory . '/plan/fresh_local_index.jsonl';
         $options = $this->senderOptions($local_docroot, $push_state_directory);
         $plan_property = new ReflectionProperty(PushFilesSender::class, 'plan');
-        $file_index_processor_property = new ReflectionProperty(PushPlan::class, 'file_index_processor');
-        $fresh_local_index_handle_property = new ReflectionProperty(
+        $fresh_local_index_processor_property = new ReflectionProperty(
             PushPlan::class,
+            'fresh_local_index_processor'
+        );
+        $file_index_processor_property = new ReflectionProperty(
+            FreshLocalIndexProcessor::class,
+            'file_index_processor'
+        );
+        $fresh_local_index_handle_property = new ReflectionProperty(
+            FreshLocalIndexProcessor::class,
             'fresh_local_index_handle'
         );
 
@@ -1970,20 +1986,50 @@ final class PushEndpointsTest extends TestCase {
             );
             $plan = $plan_property->getValue($sender);
             $this->assertInstanceOf(PushPlan::class, $plan);
-            $file_index_processor = $file_index_processor_property->getValue($plan);
-            $fresh_local_index_handle = $fresh_local_index_handle_property->getValue($plan);
+            $fresh_local_index_processor =
+                $fresh_local_index_processor_property->getValue($plan);
+            $file_index_processor = $file_index_processor_property->getValue(
+                $fresh_local_index_processor
+            );
+            $fresh_local_index_handle =
+                $fresh_local_index_handle_property->getValue(
+                    $fresh_local_index_processor
+                );
             $this->assertInstanceOf(FileIndexProcessor::class, $file_index_processor);
             $this->assertIsResource($fresh_local_index_handle);
 
             $this->assertTrue($sender->next_step());
             $this->assertSame('planning', $sender->get_phase());
             $this->assertSame($plan, $plan_property->getValue($sender));
-            $this->assertSame($file_index_processor, $file_index_processor_property->getValue($plan));
-            $this->assertSame($fresh_local_index_handle, $fresh_local_index_handle_property->getValue($plan));
+            $this->assertSame(
+                $fresh_local_index_processor,
+                $fresh_local_index_processor_property->getValue($plan)
+            );
+            $this->assertSame(
+                $file_index_processor,
+                $file_index_processor_property->getValue(
+                    $fresh_local_index_processor
+                )
+            );
+            $this->assertSame(
+                $fresh_local_index_handle,
+                $fresh_local_index_handle_property->getValue(
+                    $fresh_local_index_processor
+                )
+            );
             $plan_cursor = $this->loadPlanPosition($push_state_directory);
             $this->assertSame('indexing', $plan_cursor['phase']);
-            $this->assertSame(ftell($fresh_local_index_handle), $plan_cursor['fresh_local_index_byte_offset']);
-            $this->assertNotEmpty($plan_cursor['file_index_cursor']['stack']);
+            $this->assertSame(
+                ftell($fresh_local_index_handle),
+                $plan_cursor['fresh_local_index_cursor']['position'][
+                    'fresh_local_index_byte_offset'
+                ]
+            );
+            $this->assertNotEmpty(
+                $plan_cursor['fresh_local_index_cursor']['position'][
+                    'file_index_cursor'
+                ]['stack']
+            );
             $state = $this->loadActiveState($push_state_directory);
             $this->assertIsArray($state);
             $this->assertArrayNotHasKey('file_index_cursor', $state);
@@ -1997,7 +2043,13 @@ final class PushEndpointsTest extends TestCase {
         try {
             $this->assertSame('planning', $sender->get_phase());
             $resumed_plan = $plan_property->getValue($sender);
-            $this->assertIsResource($fresh_local_index_handle_property->getValue($resumed_plan));
+            $resumed_fresh_local_index_processor =
+                $fresh_local_index_processor_property->getValue($resumed_plan);
+            $this->assertIsResource(
+                $fresh_local_index_handle_property->getValue(
+                    $resumed_fresh_local_index_processor
+                )
+            );
             $this->takeSenderStepsUntilPlanPhase($sender, $push_state_directory, 'starting_diff');
             $this->assertFileExists($fresh_local_index_path);
 
@@ -2073,7 +2125,12 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame('planning', $state['phase']);
         $plan_cursor = $this->loadPlanPosition($push_state_directory);
         $this->assertSame('indexing', $plan_cursor['phase']);
-        $this->assertGreaterThan(0, $plan_cursor['fresh_local_index_byte_offset']);
+        $this->assertGreaterThan(
+            0,
+            $plan_cursor['fresh_local_index_cursor']['position'][
+                'fresh_local_index_byte_offset'
+            ]
+        );
 
         $result = $this->runSender($local_docroot, $push_state_directory);
 


### PR DESCRIPTION
Moves fresh local index construction out of `PushPlan` so pull and push can use the same resumable filesystem scan.

`FreshLocalIndexProcessor` owns `FileIndexProcessor`, the fresh local index file, its saved byte offset, and the final sort. Its cursor contains every value needed by `resume()`:

```php
$processor = FreshLocalIndexProcessor::start(
    $fresh_local_index_file,
    $filesystem_root,
    $storage_path
);

do {
    $has_next_step = $processor->next_step();
    $processor->flush_pending_output();
    save_cursor($processor->get_cursor());
} while ($has_next_step);

$processor->close();
```

`PushPlan` now stores that cursor unchanged. It keeps the existing phase boundary between traversal and sorting, then starts `FileSyncPatchPlanner` exactly as before. The raw traversal, JSONL writing, output truncation, and sorting code are removed from `PushPlan`.

## Testing

The focused tests cover sorted local-relative index entries, empty directories, resume after an uncommitted output tail, the separate sorting step, PushPlan behavior, bounded sender steps, and process-death resume.
