### PR TITLE
db-rewrite-urls command: Rewrite URLs in a live databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
+* `db-rewrite-urls` — Rewrites URLs in an existing MySQL or SQLite database one primary-keyed record at a time. It saves a record cursor after each bounded step and resumes without scanning completed records again.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
 * `pull-metadata` — Prints pull lifecycle and source-site metadata as JSON. The remote Reprint API URL selects the pull state; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -11,9 +11,11 @@
  */
 
 use Reprint\Importer\CurlTimeoutException;
+use Reprint\Importer\DatabaseUrlRewriteProcessor;
 use Reprint\Importer\PreserveLocalSkipException;
 use Reprint\Importer\Pull\PullFailureReportedException;
 use Reprint\Importer\State\DatabaseApplyCommandState;
+use Reprint\Importer\State\DatabaseUrlRewriteCommandState;
 use Reprint\Importer\State\DatabaseTableIndexState;
 use Reprint\Importer\State\FetchListProgressState;
 use Reprint\Importer\State\FileDiffProgressState;
@@ -158,6 +160,7 @@ class ImportClient
         "db-pull",
         "db-index",
         "db-apply",
+        "db-rewrite-urls",
         "pull-metadata",
         "preflight",
         "preflight-assert",
@@ -452,7 +455,8 @@ class ImportClient
         string $remote_reprint_api_url,
         string $state_dir,
         string $filesystem_root,
-        ?string $signal_handling_command = null
+        ?string $signal_handling_command = null,
+        ?string $selected_remote_state_directory = null
     )
     {
         // Register the command's signal behavior before constructor work can
@@ -464,6 +468,9 @@ class ImportClient
             }
             if ($signal_handling_command === 'files-push') {
                 $this->enable_files_push_signal_handling();
+            } elseif ($signal_handling_command === 'db-rewrite-urls') {
+                pcntl_signal(SIGINT, [$this, 'handle_database_url_rewrite_shutdown']);
+                pcntl_signal(SIGTERM, [$this, 'handle_database_url_rewrite_shutdown']);
             } elseif ($signal_handling_command !== 'files-diff') {
                 // files-diff must not save the pull command's state from a
                 // shutdown handler; default signal behavior ends the report.
@@ -475,10 +482,12 @@ class ImportClient
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = trim_right_slash($state_dir);
         $this->filesystem_root = trim_right_slash($filesystem_root);
-        $remote_state_directory = self::remote_state_directory_path(
-            $this->remote_reprint_api_url,
-            $this->state_dir
-        );
+        $remote_state_directory = $selected_remote_state_directory === null
+            ? self::remote_state_directory_path(
+                $this->remote_reprint_api_url,
+                $this->state_dir
+            )
+            : trim_right_slash($selected_remote_state_directory);
         $this->pull_state_directory = wp_join_unix_paths($remote_state_directory, "pull");
         $this->local_index_file = wp_join_unix_paths($remote_state_directory, "local_index.jsonl");
         $this->pull_state_file = wp_join_unix_paths($this->pull_state_directory, "state.json");
@@ -643,9 +652,9 @@ class ImportClient
      */
     public function audit_log_argv(string $command, array $argv): void
     {
-        // Mask the remote URL (argv[2]) to avoid logging secrets embedded in query strings.
+        // Mask the positional remote URL to avoid logging secrets embedded in query strings.
         $masked = $argv;
-        if (isset($masked[2])) {
+        if (isset($masked[2]) && strpos($masked[2], '-') !== 0) {
             $masked[2] = preg_replace('/SECRET_KEY=[^&\s]+/', 'SECRET_KEY=***', $masked[2]);
             if ($command === 'files-push') {
                 $masked[2] = self::mask_url_credentials($masked[2]);
@@ -1165,6 +1174,32 @@ class ImportClient
                     "status" => "error",
                     "error" => $e->getMessage(),
                     "error_code" => $this->last_error_code,
+                    "message" => "Error: " . $e->getMessage(),
+                ]);
+                $this->write_progress_file($e->getMessage());
+                throw $e;
+            }
+            return;
+        }
+        if ($command === "db-rewrite-urls") {
+            if ($abort) {
+                $this->handle_abort($command);
+                return;
+            }
+            try {
+                $this->run_db_rewrite_urls($options);
+                $final_status = $this->get_state()->active_resumable_command->completion_state ?? "complete";
+                $this->output_progress([
+                    "status" => $final_status,
+                    "message" => "db-rewrite-urls {$final_status}",
+                ]);
+                if ($final_status === "partial") {
+                    $this->exit_code = 2;
+                }
+            } catch (Exception $e) {
+                $this->output_progress([
+                    "status" => "error",
+                    "error" => $e->getMessage(),
                     "message" => "Error: " . $e->getMessage(),
                 ]);
                 $this->write_progress_file($e->getMessage());
@@ -2163,6 +2198,20 @@ class ImportClient
         die("\nForced exit.\n");
     }
 
+    /** Stops after the active database record step reaches its durable cursor. */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- PHP passes the signal number to handlers.
+    public function handle_database_url_rewrite_shutdown(int $signal): void
+    {
+        if (!$this->shutdown_requested) {
+            $this->shutdown_requested = true;
+            return;
+        }
+        if (function_exists('posix_kill') && function_exists('posix_getpid')) {
+            posix_kill(posix_getpid(), SIGKILL);
+        }
+        die("\nForced exit.\n");
+    }
+
     /** Installs the files-push first-signal stop behavior when PCNTL exists. */
     public function enable_files_push_signal_handling(): void
     {
@@ -2272,6 +2321,28 @@ class ImportClient
                     true,
                 );
                 $this->reset_state();
+                $this->save_state();
+                break;
+
+            case "db-rewrite-urls":
+                $active_command = $this->get_state()->active_resumable_command;
+                if (
+                    $active_command->command_name !== null
+                    && $active_command->command_name !== 'db-rewrite-urls'
+                    && $active_command->completion_state !== 'complete'
+                ) {
+                    throw new RuntimeException(
+                        // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error, never HTML.
+                        "Cannot abort db-rewrite-urls while {$active_command->command_name} is incomplete."
+                    );
+                }
+                $this->audit_log(
+                    "RESTART | Clearing db-rewrite-urls state",
+                    true,
+                );
+                $this->get_state()->active_resumable_command =
+                    new \Reprint\Importer\State\ResumableCommandCheckpointState();
+                $this->get_state()->database_url_rewrite = new DatabaseUrlRewriteCommandState();
                 $this->save_state();
                 break;
         }
@@ -4135,7 +4206,62 @@ class ImportClient
         // checks, so a bad --target-* value fails before the output directory
         // is created. The target is either stated on the command line or read
         // from what db-apply connected to.
-        $target = $this->resolve_apply_runtime_database_target($options);
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI option values and filesystem paths, never HTML output.
+        $stated_engine = $options["target_engine"] ?? null;
+        if ($stated_engine === null || $stated_engine === "") {
+            $target_flags = [
+                "target_db" => "--target-db",
+                "target_sqlite_path" => "--target-sqlite-path",
+                "target_host" => "--target-host",
+                "target_port" => "--target-port",
+                "target_user" => "--target-user",
+                "target_pass" => "--target-pass",
+            ];
+            foreach ($target_flags as $option_key => $flag) {
+                $value = $options[$option_key] ?? null;
+                if ($value === null || $value === "") {
+                    continue;
+                }
+                throw new InvalidArgumentException(
+                    "apply-runtime received {$flag} without --target-engine. " .
+                    "Add --target-engine=mysql or --target-engine=sqlite to state the database target.",
+                );
+            }
+        }
+
+        $target = $this->resolve_database_target(
+            $options,
+            $this->get_local_site_database_target(),
+            null,
+            "apply-runtime",
+        );
+
+        // DB_DIR reaches runtime.php verbatim, so absolutize a stated path
+        // here; a relative one would resolve against the server's working
+        // directory. A recorded path is used as-is — flat-docroot may have
+        // moved the tree since db-apply saved it, and apply-runtime without a
+        // new path accepts that.
+        $stated_sqlite_path = $options["target_sqlite_path"] ?? null;
+        if (
+            $target["engine"] === "sqlite"
+            && $stated_sqlite_path !== null
+            && $stated_sqlite_path !== ""
+        ) {
+            $stated_sqlite_path = (string) $stated_sqlite_path;
+            $directory = dirname($stated_sqlite_path);
+            $absolute_directory = is_dir($directory) ? realpath($directory) : false;
+            if ($absolute_directory === false) {
+                throw new InvalidArgumentException(
+                    "The directory for --target-sqlite-path={$stated_sqlite_path} does not exist: {$directory}. " .
+                    "Create it first; the database file itself is created on the first request.",
+                );
+            }
+            $target["sqlite_path"] = wp_join_unix_paths(
+                $absolute_directory,
+                basename($stated_sqlite_path),
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
         // Resolve the local document root from either --flat-document-root
         // (used as-is) or --fs-root (prefixed with the remote document_root).
@@ -4371,19 +4497,33 @@ class ImportClient
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI option values and filesystem paths, never HTML output.
     /**
-     * Resolve the database target the generated runtime should point at.
+     * Resolve command options and recorded state into one database target.
      *
-     * Without an explicit engine, apply-runtime uses the database target
-     * db-apply recorded. An explicit engine lets a caller name a database it
-     * keeps outside Reprint's db-apply stage. Options fill missing values from
-     * matching recorded state; a different engine ignores it entirely.
+     * Options fill missing values from matching recorded state. A different
+     * explicitly stated engine ignores the recorded target entirely.
      *
-     * @param array<string,mixed> $options
-     * @return array<string,mixed>
+     * @param array<string,mixed> $options Command options.
+     * @param array $recorded_target {
+     *     Previously recorded database target.
+     *
+     *     @type string|null $engine      mysql, sqlite, or null.
+     *     @type string      $db          MySQL database or SQLite logical database name.
+     *     @type string|null $sqlite_path SQLite database path.
+     *     @type string      $host        MySQL host.
+     *     @type int         $port        MySQL port.
+     *     @type string      $user        MySQL user.
+     *     @type string      $pass        MySQL password.
+     * }
+     * @param string|null $default_engine Engine used when neither options nor state specify one.
+     * @param string      $command        Command name used in errors.
+     * @return array<string,mixed> Canonical database target.
      */
-    private function resolve_apply_runtime_database_target(array $options): array
-    {
-        $recorded_target = $this->get_state()->apply;
+    private function resolve_database_target(
+        array $options,
+        array $recorded_target,
+        ?string $default_engine,
+        string $command
+    ): array {
         $stated_engine = $options["target_engine"] ?? null;
         $engine_was_stated = $stated_engine !== null && $stated_engine !== "";
 
@@ -4394,29 +4534,11 @@ class ImportClient
                     "Invalid --target-engine value: {$stated_engine}. Valid engines: mysql, sqlite.",
                 );
             }
-            if ($recorded_target->target_engine !== $engine) {
-                $recorded_target = null;
+            if (($recorded_target["engine"] ?? null) !== $engine) {
+                $recorded_target = [];
             }
         } else {
-            $target_flags = [
-                "target_db" => "--target-db",
-                "target_sqlite_path" => "--target-sqlite-path",
-                "target_host" => "--target-host",
-                "target_port" => "--target-port",
-                "target_user" => "--target-user",
-                "target_pass" => "--target-pass",
-            ];
-            foreach ($target_flags as $option_key => $flag) {
-                $value = $options[$option_key] ?? null;
-                if ($value === null || $value === "") {
-                    continue;
-                }
-                throw new InvalidArgumentException(
-                    "apply-runtime received {$flag} without --target-engine. " .
-                    "Add --target-engine=mysql or --target-engine=sqlite to state the database target.",
-                );
-            }
-            $engine = $recorded_target->target_engine;
+            $engine = $recorded_target["engine"] ?? $default_engine;
         }
 
         if ($engine === null) {
@@ -4433,40 +4555,20 @@ class ImportClient
         };
 
         if ($engine === "sqlite") {
-            // DB_DIR reaches runtime.php verbatim, so absolutize a stated path
-            // here; a relative one would resolve against the server's working
-            // directory. A recorded path is used as db-apply wrote it —
-            // flat-docroot may have moved the tree since, and apply-runtime
-            // without options accepts that.
-            $stated_sqlite_path = $options["target_sqlite_path"] ?? null;
-            if ($stated_sqlite_path !== null && $stated_sqlite_path !== "") {
-                $stated_sqlite_path = (string) $stated_sqlite_path;
-                $directory = dirname($stated_sqlite_path);
-                $absolute_directory = is_dir($directory) ? realpath($directory) : false;
-                if ($absolute_directory === false) {
-                    throw new InvalidArgumentException(
-                        "The directory for --target-sqlite-path={$stated_sqlite_path} does not exist: {$directory}. " .
-                        "Create it first; the database file itself is created on the first request.",
-                    );
-                }
-                $sqlite_path = wp_join_unix_paths(
-                    $absolute_directory,
-                    basename($stated_sqlite_path),
-                );
-            } else {
-                $sqlite_path = $recorded_target === null
-                    ? null
-                    : $recorded_target->target_sqlite_path;
-                if ($sqlite_path === "") {
-                    $sqlite_path = null;
-                }
+            $sqlite_path = $option_then_recorded(
+                $options["target_sqlite_path"] ?? null,
+                $recorded_target["sqlite_path"] ?? null,
+                null,
+            );
+            if ($sqlite_path === "") {
+                $sqlite_path = null;
             }
 
             return [
                 "engine" => "sqlite",
                 "db" => (string) $option_then_recorded(
                     $options["target_db"] ?? null,
-                    $recorded_target === null ? null : $recorded_target->target_db,
+                    $recorded_target["db"] ?? null,
                     "sqlite_database",
                 ),
                 "sqlite_path" => $sqlite_path === null ? null : (string) $sqlite_path,
@@ -4477,43 +4579,83 @@ class ImportClient
             "engine" => "mysql",
             "db" => (string) $option_then_recorded(
                 $options["target_db"] ?? null,
-                $recorded_target === null ? null : $recorded_target->target_db,
+                $recorded_target["db"] ?? null,
                 "",
             ),
             "host" => (string) $option_then_recorded(
                 $options["target_host"] ?? null,
-                $recorded_target === null ? null : $recorded_target->target_host,
+                $recorded_target["host"] ?? null,
                 "127.0.0.1",
             ),
             "port" => (int) $option_then_recorded(
                 $options["target_port"] ?? null,
-                $recorded_target === null ? null : $recorded_target->target_port,
+                $recorded_target["port"] ?? null,
                 3306,
             ),
             "user" => (string) $option_then_recorded(
                 $options["target_user"] ?? null,
-                $recorded_target === null ? null : $recorded_target->target_user,
+                $recorded_target["user"] ?? null,
                 "",
             ),
             "pass" => (string) $option_then_recorded(
                 $options["target_pass"] ?? null,
-                $recorded_target === null ? null : $recorded_target->target_pass,
+                $recorded_target["pass"] ?? null,
                 "",
             ),
         ];
 
-        if ($engine_was_stated) {
+        if ($default_engine !== null || $engine_was_stated) {
             foreach (["user" => "--target-user", "db" => "--target-db"] as $field => $flag) {
                 if ($target[$field] === "") {
                     throw new InvalidArgumentException(
-                        "apply-runtime with --target-engine=mysql requires {$flag}: " .
-                        "neither the command line nor the recorded db-apply target supplied one.",
+                        "{$command} with --target-engine=mysql requires {$flag}: " .
+                        "neither the command line nor the recorded database target supplied one.",
                     );
                 }
             }
         }
 
         return $target;
+    }
+
+    /**
+     * Return the local site database target recorded by db-apply.
+     *
+     * @return array {
+     *     Recorded database target.
+     *
+     *     @type string|null $engine      mysql, sqlite, or null.
+     *     @type string      $db          MySQL database or SQLite logical database name.
+     *     @type string|null $sqlite_path SQLite database path.
+     *     @type string      $host        MySQL host.
+     *     @type int         $port        MySQL port.
+     *     @type string      $user        MySQL user.
+     *     @type string      $pass        MySQL password.
+     * }
+     */
+    private function get_local_site_database_target(): array
+    {
+        $apply_state = $this->get_state()->apply;
+        if ($apply_state->target_engine === null) {
+            return ["engine" => null];
+        }
+
+        if ($apply_state->target_engine === "sqlite") {
+            return [
+                "engine" => "sqlite",
+                "db" => $apply_state->target_db,
+                "sqlite_path" => $apply_state->target_sqlite_path,
+            ];
+        }
+
+        return [
+            "engine" => "mysql",
+            "db" => $apply_state->target_db,
+            "host" => $apply_state->target_host,
+            "port" => $apply_state->target_port,
+            "user" => $apply_state->target_user,
+            "pass" => $apply_state->target_pass,
+        ];
     }
 
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
@@ -5341,10 +5483,227 @@ class ImportClient
         rmdir($dir);
     }
 
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI errors are never HTML.
+    /** Rewrite URL-bearing values in an existing database one record at a time. */
+    public function run_db_rewrite_urls(array $options): void
+    {
+        $this->resolve_new_site_url_option($options);
+        $url_mapping = [];
+        if (!empty($options['rewrite_url'])) {
+            foreach ($options['rewrite_url'] as [$source_url, $target_url]) {
+                $url_mapping[$source_url] = $target_url;
+            }
+        }
+
+        $active_command = $this->get_state()->active_resumable_command;
+        if (
+            $active_command->command_name !== null
+            && $active_command->command_name !== 'db-rewrite-urls'
+            && $active_command->completion_state !== 'complete'
+        ) {
+            throw new RuntimeException(
+                "Finish or abort the incomplete {$active_command->command_name} command "
+                . 'before running db-rewrite-urls.'
+            );
+        }
+        $current_status = $active_command->command_name === 'db-rewrite-urls'
+            ? $active_command->completion_state
+            : null;
+        if ($current_status === 'complete') {
+            throw new RuntimeException(
+                'db-rewrite-urls already completed. Use --abort to start another lifecycle.'
+            );
+        }
+
+        $rewrite_state = $this->get_state()->database_url_rewrite;
+        $is_resume = in_array($current_status, ['in_progress', 'partial'], true);
+
+        $local_site_database_target = $this->get_local_site_database_target();
+        $recorded_target = $is_resume ? ( $rewrite_state->target ?? [] ) : $local_site_database_target;
+        if ($is_resume && ($recorded_target['engine'] ?? null) === 'mysql') {
+            $local_site_database_identity = $local_site_database_target;
+            unset($local_site_database_identity['pass']);
+            if ($local_site_database_identity === $recorded_target) {
+                $recorded_target['pass'] = $local_site_database_target['pass'];
+            }
+        }
+
+        if ($is_resume) {
+            if ($url_mapping === []) {
+                $url_mapping = $rewrite_state->rewrite_url ?? [];
+            } elseif ($url_mapping !== $rewrite_state->rewrite_url) {
+                throw new RuntimeException(
+                    'Cannot change --rewrite-url while db-rewrite-urls is incomplete. '
+                    . 'Finish it or use --abort.'
+                );
+            }
+        } elseif ($url_mapping === []) {
+            throw new InvalidArgumentException(
+                'db-rewrite-urls requires --rewrite-url FROM TO or --new-site-url=URL.'
+            );
+        }
+        if ($url_mapping === []) {
+            throw new RuntimeException(
+                'The saved db-rewrite-urls lifecycle has no URL mapping. Use --abort.'
+            );
+        }
+
+        $target = $this->resolve_database_target(
+            $options,
+            $recorded_target,
+            'mysql',
+            'db-rewrite-urls'
+        );
+        if ($target['engine'] === 'sqlite') {
+            $target_path = $target['sqlite_path'];
+            $resolved_target_path = is_string($target_path) ? realpath($target_path) : false;
+            if ($resolved_target_path === false || !is_file($resolved_target_path)) {
+                throw new InvalidArgumentException(
+                    'db-rewrite-urls requires an existing live SQLite database: '
+                    . (string) $target_path
+                );
+            }
+            $target['sqlite_path'] = $resolved_target_path;
+        }
+
+        $target_identity = $target;
+        unset($target_identity['pass']);
+
+        if ($is_resume) {
+            if ($target_identity !== $rewrite_state->target) {
+                throw new RuntimeException(
+                    'Cannot change the target database while db-rewrite-urls is incomplete. '
+                    . 'Reconnect to the original database or use --abort.'
+                );
+            }
+        }
+
+        [$database, $connection_label] = $this->create_target_database_connection($target, false);
+
+        if (!$is_resume) {
+            $rewrite_state = new DatabaseUrlRewriteCommandState();
+            $rewrite_state->rewrite_url = $url_mapping;
+            $rewrite_state->target = $target_identity;
+            $this->get_state()->database_url_rewrite = $rewrite_state;
+            $active_command->command_name = 'db-rewrite-urls';
+            $active_command->completion_state = 'in_progress';
+            $active_command->current_stage = 'database-records';
+            $this->save_state();
+        }
+
+        $statement_rewriter = new SqlStatementRewriter(
+            new StructuredDataUrlRewriter($url_mapping),
+            $this->get_state()->get('preflight.database.wp.table_prefix'),
+        );
+
+        $cursor = null;
+        if ($rewrite_state->cursor !== null) {
+            $cursor = json_decode($rewrite_state->cursor, true);
+            if (!is_array($cursor)) {
+                throw new RuntimeException(
+                    'The saved db-rewrite-urls record cursor is invalid. Use --abort.'
+                );
+            }
+        }
+        $processor = new DatabaseUrlRewriteProcessor(
+            $database,
+            $statement_rewriter,
+            $cursor
+        );
+
+        $lifecycle_event = $is_resume ? 'resuming' : 'starting';
+        $this->audit_log(
+            strtoupper($lifecycle_event) . " db-rewrite-urls | {$connection_label}",
+            true
+        );
+        $this->output_progress([
+            'type' => 'lifecycle',
+            'event' => $lifecycle_event,
+            'command' => 'db-rewrite-urls',
+            'records_processed' => $rewrite_state->records_processed,
+            'records_changed' => $rewrite_state->records_changed,
+            'message' => ucfirst($lifecycle_event) . ' db-rewrite-urls',
+        ], true);
+
+        while (true) {
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+            if ($this->shutdown_requested) {
+                break;
+            }
+
+            $has_more_steps = $processor->next_step();
+            $progress = $processor->get_progress();
+            $encoded_cursor = json_encode($processor->get_cursor());
+            if ($encoded_cursor === false) {
+                throw new RuntimeException(
+                    'Failed to encode the db-rewrite-urls record cursor: '
+                    . json_last_error_msg()
+                );
+            }
+
+            $rewrite_state->cursor = $encoded_cursor;
+            $rewrite_state->records_processed = $progress['records_processed'];
+            $rewrite_state->records_changed = $progress['records_changed'];
+            $rewrite_state->tables_started = $progress['tables_started'];
+            $rewrite_state->current_table = $progress['current_table'];
+            $this->save_state();
+
+            $message = sprintf(
+                '%s records checked, %s changed',
+                number_format($rewrite_state->records_processed),
+                number_format($rewrite_state->records_changed)
+            );
+            $this->output_progress([
+                'phase' => 'database-records',
+                'records_processed' => $rewrite_state->records_processed,
+                'records_changed' => $rewrite_state->records_changed,
+                'tables_started' => $rewrite_state->tables_started,
+                'current_table' => $rewrite_state->current_table,
+                'message' => $message,
+            ]);
+            $this->progress->show_progress_line($message);
+
+            if (!$has_more_steps) {
+                break;
+            }
+        }
+
+        if ($this->shutdown_requested) {
+            $active_command->completion_state = 'partial';
+            $status = 'partial';
+        } else {
+            $active_command->completion_state = 'complete';
+            $status = 'complete';
+        }
+        $this->save_state();
+
+        $message = sprintf(
+            'db-rewrite-urls %s (%d records checked, %d changed)',
+            $status,
+            $rewrite_state->records_processed,
+            $rewrite_state->records_changed
+        );
+        $this->audit_log($message, true);
+        $this->output_progress([
+            'status' => $status,
+            'phase' => 'database-records',
+            'records_processed' => $rewrite_state->records_processed,
+            'records_changed' => $rewrite_state->records_changed,
+            'tables_started' => $rewrite_state->tables_started,
+            'current_table' => $rewrite_state->current_table,
+            'message' => $message,
+        ], true);
+        $this->progress->clear_progress_line();
+        $this->progress->show_lifecycle_line($message . "\n");
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
     /**
      * If --new-site-url is set, derive the source origin from the export URL
      * and append implicit --rewrite-url mappings for both HTTP and HTTPS
-     * variants of the old URL to $options. The new URL is used verbatim.
+     * variants. The new URL is used verbatim.
      */
     private function resolve_new_site_url_option(array &$options): void
     {
@@ -5354,6 +5713,12 @@ class ImportClient
 
         $parsed_url = parse_url($this->remote_reprint_api_url);
         if (!$parsed_url || !isset($parsed_url['scheme'], $parsed_url['host'])) {
+            if ($this->remote_reprint_api_url === '') {
+                throw new InvalidArgumentException(
+                    '--new-site-url requires a positional remote Reprint API URL. '
+                    . 'Use --rewrite-url FROM TO when no remote URL is available.'
+                );
+            }
             throw new InvalidArgumentException(
                 "--new-site-url requires a valid export URL to derive the remote site origin.",
             );
@@ -5456,18 +5821,36 @@ class ImportClient
         return $pdo;
     }
 
-    private function create_target_db_apply_connection(array $options): array
+    /**
+     * @param array $target {
+     *     Resolved database target.
+     *
+     *     @type string      $engine      mysql or sqlite.
+     *     @type string      $db          MySQL database or SQLite logical database name.
+     *     @type string|null $sqlite_path SQLite database path.
+     *     @type string      $host        MySQL host.
+     *     @type int         $port        MySQL port.
+     *     @type string      $user        MySQL user.
+     *     @type string      $pass        MySQL password.
+     * }
+     * @param bool $save_runtime_target Whether to save the target for apply-runtime.
+     * @return array {
+     *     Target database connection details.
+     *
+     *     @type mixed  $0 PDO or a PDO-compatible adapter.
+     *     @type string $1 Human-readable connection label.
+     * }
+     */
+    private function create_target_database_connection(
+        array $target,
+        bool $save_runtime_target = true
+    ): array
     {
-        $target_engine = strtolower((string) ($options["target_engine"] ?? "mysql"));
-        if (!in_array($target_engine, ["mysql", "sqlite"], true)) {
-            throw new InvalidArgumentException(
-                "Invalid --target-engine value: {$target_engine}. Valid engines: mysql, sqlite.",
-            );
-        }
+        $target_engine = $target["engine"];
 
         if ($target_engine === "sqlite") {
-            $target_path = $options["target_sqlite_path"] ?? null;
-            $target_db = $options["target_db"] ?? "sqlite_database";
+            $target_path = $target["sqlite_path"];
+            $target_db = $target["db"];
 
             if (!$target_path) {
                 $content_dir = $this->clean_preflight_path(
@@ -5486,14 +5869,18 @@ class ImportClient
                     'database',
                     '.ht.sqlite'
                 );
-                $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
+                $this->audit_log(
+                    "DB-APPLY | defaulting SQLite path to: {$target_path}"
+                );
                 $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
             }
 
-            // Persist target database configuration for apply-runtime.
-            $this->get_state()->apply->target_engine = "sqlite";
-            $this->get_state()->apply->target_db = $target_db;
-            $this->get_state()->apply->target_sqlite_path = $target_path;
+            if ($save_runtime_target) {
+                // Persist target database configuration for apply-runtime.
+                $this->get_state()->apply->target_engine = "sqlite";
+                $this->get_state()->apply->target_db = $target_db;
+                $this->get_state()->apply->target_sqlite_path = $target_path;
+            }
 
             return [
                 $this->create_sqlite_target_pdo($target_path, $target_db),
@@ -5505,25 +5892,21 @@ class ImportClient
             ];
         }
 
-        $target_host = $options["target_host"] ?? "127.0.0.1";
-        $target_port = (int) ($options["target_port"] ?? 3306);
-        $target_user = $options["target_user"] ?? null;
-        $target_pass = $options["target_pass"] ?? "";
-        $target_db = $options["target_db"] ?? null;
+        $target_host = $target["host"];
+        $target_port = $target["port"];
+        $target_user = $target["user"];
+        $target_pass = $target["pass"];
+        $target_db = $target["db"];
 
-        if (!$target_user || !$target_db) {
-            throw new InvalidArgumentException(
-                "db-apply with --target-engine=mysql requires --target-user and --target-db.",
-            );
+        if ($save_runtime_target) {
+            // Persist target database configuration for apply-runtime.
+            $this->get_state()->apply->target_engine = "mysql";
+            $this->get_state()->apply->target_db = $target_db;
+            $this->get_state()->apply->target_host = $target_host;
+            $this->get_state()->apply->target_port = $target_port;
+            $this->get_state()->apply->target_user = $target_user;
+            $this->get_state()->apply->target_pass = $target_pass;
         }
-
-        // Persist target database configuration for apply-runtime.
-        $this->get_state()->apply->target_engine = "mysql";
-        $this->get_state()->apply->target_db = $target_db;
-        $this->get_state()->apply->target_host = $target_host;
-        $this->get_state()->apply->target_port = $target_port;
-        $this->get_state()->apply->target_user = $target_user;
-        $this->get_state()->apply->target_pass = $target_pass;
 
         $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
         try {
@@ -5598,6 +5981,13 @@ class ImportClient
             );
         }
 
+        $target = $this->resolve_database_target(
+            $options,
+            $this->get_local_site_database_target(),
+            'mysql',
+            'db-apply'
+        );
+
         $apply_state = $this->get_state()->apply;
         $statements_executed = $apply_state->statements_executed;
         $bytes_read = $apply_state->bytes_read;
@@ -5669,12 +6059,12 @@ class ImportClient
             );
         }
 
-        [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
+        [$pdo, $connection_label] = $this->create_target_database_connection($target);
         $sqlite_prepared_pdo = null;
         $sqlite_prepared_statement_cache = [];
         $sqlite_prepared_statement_cache_order = [];
         if (
-            strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
+            $target["engine"] === "sqlite"
             && method_exists($pdo, 'get_connection')
         ) {
             $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
@@ -11190,7 +11580,7 @@ if (
             'target' => 'abort',
             'help' => 'Abort current sync and exit (preserves downloaded files)',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'db-rewrite-urls'],
         ],
         [
             'name' => 'verbose',
@@ -11199,7 +11589,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'merge-wp-content', 'apply-runtime'],
+            'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'db-apply', 'db-rewrite-urls', 'flat-docroot', 'merge-wp-content', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -11370,7 +11760,7 @@ if (
             'target' => 'target_engine',
             'placeholder' => 'ENGINE',
             'help' => 'Target database engine: mysql or sqlite',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-host',
@@ -11378,7 +11768,7 @@ if (
             'target' => 'target_host',
             'placeholder' => 'HOST',
             'help' => 'Target MySQL host (default: 127.0.0.1)',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-port',
@@ -11387,7 +11777,7 @@ if (
             'placeholder' => 'PORT',
             'cast' => 'int',
             'help' => 'Target MySQL port (default: 3306)',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-user',
@@ -11395,7 +11785,7 @@ if (
             'target' => 'target_user',
             'placeholder' => 'USER',
             'help' => 'Target MySQL user (required for mysql)',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-pass',
@@ -11403,7 +11793,7 @@ if (
             'target' => 'target_pass',
             'placeholder' => 'PASS',
             'help' => 'Target MySQL password',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-db',
@@ -11411,7 +11801,7 @@ if (
             'target' => 'target_db',
             'placeholder' => 'NAME',
             'help' => 'Target DB name (required for mysql, optional for sqlite)',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'target-sqlite-path',
@@ -11419,7 +11809,7 @@ if (
             'target' => 'target_sqlite_path',
             'placeholder' => 'PATH',
             'help' => 'Target SQLite database file (default: <wp-content>/database/.ht.sqlite)',
-            'commands' => ['pull', 'pull-db', 'db-apply', 'apply-runtime'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls', 'apply-runtime'],
         ],
         [
             'name' => 'rewrite-url',
@@ -11427,7 +11817,7 @@ if (
             'target' => 'rewrite_url',
             'argument_labels' => 'FROM TO',
             'help' => 'Rewrite FROM to TO (repeatable)',
-            'commands' => ['pull', 'pull-db', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls'],
         ],
         [
             'name' => 'new-site-url',
@@ -11435,7 +11825,7 @@ if (
             'target' => 'new_site_url',
             'placeholder' => 'URL',
             'help' => 'New site URL (auto-creates --rewrite-url from export URL origin)',
-            'commands' => ['pull', 'pull-db', 'db-apply'],
+            'commands' => ['pull', 'pull-db', 'db-apply', 'db-rewrite-urls'],
         ],
         [
             'name' => 'remap',
@@ -12257,6 +12647,31 @@ if (
                 "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
+        "db-rewrite-urls" => [
+            "level" => "low",
+            "short" => "Rewrite URLs in an existing live database",
+            "usage" =>
+                "reprint db-rewrite-urls [<remote-reprint-api-url>] " .
+                "--state-dir=DIR [options]",
+            "description" =>
+                "Rewrites URL-bearing values in a live MySQL or SQLite database,\n" .
+                "one primary-keyed record at a time. Each bounded step reads one\n" .
+                "record and updates only columns whose rewritten value changed.\n" .
+                "\n" .
+                "Resumes from the last saved record cursor and reports records\n" .
+                "checked, records changed, tables started, and the current table.\n" .
+                "Tables containing records must have a primary key. --fs-root is\n" .
+                "not used.\n",
+            "extra" =>
+                "The positional URL selects prior state when --state-dir contains\n" .
+                "more than one remote. With one remote it is optional; with none,\n" .
+                "the command creates its own state. Target options default to the\n" .
+                "database recorded by db-apply.\n" .
+                "\n" .
+                "Example:\n" .
+                "  reprint db-rewrite-urls --state-dir=./state \\\n" .
+                "    --rewrite-url https://old.com https://new.com\n",
+        ],
         "flat-docroot" => [
             "level" => "low",
             "short" => "Reassemble pulled files into a standard WordPress layout",
@@ -12422,19 +12837,22 @@ if (
         exit(0);
     }
 
-    // Every command which reads or writes state names the remote Reprint API
-    // URL whose remote state directory it uses. Local commands use the URL to
-    // select state without making a network request.
-    $remote_reprint_api_url = $argv[2] ?? null;
-    if (
-        !$remote_reprint_api_url
-        || strpos($remote_reprint_api_url, '-') === 0
-    ) {
+    // Most commands name the remote Reprint API URL whose state they use.
+    // db-rewrite-urls can select the only saved remote or use command-local state.
+    $reprint_remote_reprint_api_url_argument = $argv[2] ?? null;
+    $reprint_has_remote_reprint_api_url =
+        is_string($reprint_remote_reprint_api_url_argument)
+        && $reprint_remote_reprint_api_url_argument !== ''
+        && strpos($reprint_remote_reprint_api_url_argument, '-') !== 0;
+    if (!$reprint_has_remote_reprint_api_url && $command !== 'db-rewrite-urls') {
         fwrite(STDERR, "Error: <remote-reprint-api-url> is required\n");
         fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
-    $option_start_index = 3;
+    $remote_reprint_api_url = $reprint_has_remote_reprint_api_url
+        ? $reprint_remote_reprint_api_url_argument
+        : '';
+    $option_start_index = $reprint_has_remote_reprint_api_url ? 3 : 2;
 
     [$state_dir, $filesystem_root, $options] = _cli_parse_options(
         $argv, $argc, $option_start_index, $option_defs
@@ -12478,12 +12896,59 @@ if (
 
     if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
-        fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        if ($command === 'db-rewrite-urls') {
+            fwrite(STDERR, "Usage: reprint db-rewrite-urls [<remote-reprint-api-url>] --state-dir=DIR [options]\n");
+        } else {
+            fwrite(STDERR, "Usage: reprint {$command} <remote-reprint-api-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        }
         exit(1);
     }
 
     // apply-runtime accepts --flat-document-root as an alternative to --fs-root.
     $flat_document_root = $options["flat_document_root"] ?? null;
+    $reprint_selected_remote_state_directory = null;
+    if ($command === 'db-rewrite-urls') {
+        if ($filesystem_root || $flat_document_root) {
+            fwrite(STDERR, "Error: db-rewrite-urls does not accept --fs-root or --flat-document-root.\n");
+            exit(1);
+        }
+        $filesystem_root = $state_dir; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+        if (!$reprint_has_remote_reprint_api_url) {
+            $reprint_command_local_state_directory =
+                wp_join_unix_paths($state_dir, 'db-rewrite-urls');
+            if (
+                is_file(
+                    wp_join_unix_paths(
+                        $reprint_command_local_state_directory,
+                        'pull',
+                        'state.json'
+                    )
+                )
+            ) {
+                $reprint_selected_remote_state_directory =
+                    $reprint_command_local_state_directory;
+            } else {
+                $reprint_saved_remote_state_files = glob(
+                    wp_join_unix_paths($state_dir, 'remotes', '*', 'pull', 'state.json')
+                );
+                $reprint_saved_remote_state_files = $reprint_saved_remote_state_files === false
+                    ? []
+                    : array_values(array_filter($reprint_saved_remote_state_files, 'is_file'));
+                if (count($reprint_saved_remote_state_files) > 1) {
+                    fwrite(
+                        STDERR,
+                        "Error: --state-dir contains more than one saved remote. "
+                        . "Provide <remote-reprint-api-url> to select one.\n"
+                    );
+                    exit(1);
+                }
+                $reprint_selected_remote_state_directory =
+                    count($reprint_saved_remote_state_files) === 1
+                        ? dirname(dirname($reprint_saved_remote_state_files[0]))
+                        : $reprint_command_local_state_directory;
+            }
+        }
+    }
     if ($filesystem_root && $flat_document_root) {
         fwrite(STDERR, "Error: --fs-root and --flat-document-root are mutually exclusive.\n");
         fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
@@ -12524,7 +12989,13 @@ if (
                 'files-diff'
             );
         }
-        $client = new ImportClient($remote_reprint_api_url, $state_dir, $filesystem_root, $command);
+        $client = new ImportClient(
+            $remote_reprint_api_url,
+            $state_dir,
+            $filesystem_root,
+            $command,
+            $reprint_selected_remote_state_directory
+        );
         $client->audit_log_argv($command, $argv);
         $client->run(
             $options

--- a/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
+++ b/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Reprint\Importer\State;
+
+/** Durable progress for db-rewrite-urls. */
+class DatabaseUrlRewriteCommandState {
+
+    /** @var string|null MySQLDumpProducer cursor after the last completed step. */
+    public ?string $cursor = null;
+
+    /** @var int Database records whose rewrite decision is complete. */
+    public int $records_processed = 0;
+
+    /** @var int Database records changed by this lifecycle. */
+    public int $records_changed = 0;
+
+    /** @var int Tables in which at least one record was processed. */
+    public int $tables_started = 0;
+
+    /** @var string|null Table containing the last processed record. */
+    public ?string $current_table = null;
+
+    /** @var array<string,string>|null URL rewrite map fixed for this lifecycle. */
+    public ?array $rewrite_url = null;
+
+    /** @var array<string,mixed>|null Database identity fixed for this lifecycle. */
+    public ?array $target = null;
+
+    public static function from_array(array $data): self
+    {
+        $state = new self();
+        \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
+        $state->cursor = $data['cursor'];
+        $state->records_processed = $data['records_processed'];
+        $state->records_changed = $data['records_changed'];
+        $state->tables_started = $data['tables_started'];
+        $state->current_table = $data['current_table'];
+        $state->rewrite_url = $data['rewrite_url'];
+        $state->target = $data['target'];
+        return $state;
+    }
+
+    public function to_array(): array
+    {
+        return [
+            'cursor' => $this->cursor,
+            'records_processed' => $this->records_processed,
+            'records_changed' => $this->records_changed,
+            'tables_started' => $this->tables_started,
+            'current_table' => $this->current_table,
+            'rewrite_url' => $this->rewrite_url,
+            'target' => $this->target,
+        ];
+    }
+}

--- a/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
+++ b/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
@@ -6,7 +6,7 @@ namespace Reprint\Importer\State;
 /** Durable progress for db-rewrite-urls. */
 class DatabaseUrlRewriteCommandState {
 
-    /** @var string|null MySQLDumpProducer cursor after the last completed step. */
+    /** @var string|null DatabaseUrlRewriteProcessor cursor after the last completed step. */
     public ?string $cursor = null;
 
     /** @var int Database records whose rewrite decision is complete. */

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Reprint\Importer\State\AdaptiveTuningState;
 use Reprint\Importer\State\DatabaseApplyCommandState;
+use Reprint\Importer\State\DatabaseUrlRewriteCommandState;
 use Reprint\Importer\State\DatabaseTableIndexState;
 use Reprint\Importer\State\FetchListProgressState;
 use Reprint\Importer\State\FileDiffProgressState;
@@ -74,6 +75,8 @@ class PullState
     /** @var int SQL statements counted while streaming db.sql. */
     public int $sql_statements_counted = 0;
     public DatabaseApplyCommandState $apply;
+    /** Live database URL rewrite cursor and counters. */
+    public DatabaseUrlRewriteCommandState $database_url_rewrite;
     /** @var string|null SQL output mode persisted for resume: file, stdout, or mysql. */
     public ?string $sql_output = null;
     /**
@@ -104,6 +107,7 @@ class PullState
         $this->fetch = new FetchListProgressState();
         $this->files_pull_summary = new FilesPullSummaryState();
         $this->apply = new DatabaseApplyCommandState();
+        $this->database_url_rewrite = new DatabaseUrlRewriteCommandState();
         $this->tuning = new AdaptiveTuningState();
         $this->pull_pipeline = new PullPipelineCheckpointState();
     }
@@ -135,6 +139,7 @@ class PullState
         $state->sql_bytes = $data['sql_bytes'];
         $state->sql_statements_counted = $data['sql_statements_counted'];
         $state->apply = DatabaseApplyCommandState::from_array($data['apply']);
+        $state->database_url_rewrite = DatabaseUrlRewriteCommandState::from_array($data['database_url_rewrite']);
         $state->sql_output = $data['sql_output'];
         $state->mysql_host = $data['mysql_host'];
         $state->mysql_port = $data['mysql_port'];
@@ -239,6 +244,7 @@ class PullState
             'sql_bytes' => $this->sql_bytes,
             'sql_statements_counted' => $this->sql_statements_counted,
             'apply' => $this->apply->to_array(),
+            'database_url_rewrite' => $this->database_url_rewrite->to_array(),
             'sql_output' => $this->sql_output,
             'mysql_host' => $this->mysql_host,
             'mysql_port' => $this->mysql_port,

--- a/packages/reprint-client/src/lib/state/load.php
+++ b/packages/reprint-client/src/lib/state/load.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/class-remote-file-index-cursor-state.php';
 require_once __DIR__ . '/class-fetch-list-progress-state.php';
 require_once __DIR__ . '/class-files-pull-summary-state.php';
 require_once __DIR__ . '/class-database-apply-command-state.php';
+require_once __DIR__ . '/class-database-url-rewrite-command-state.php';
 require_once __DIR__ . '/class-adaptive-tuning-state.php';
 require_once __DIR__ . '/class-pull-pipeline-checkpoint-state.php';
 require_once __DIR__ . '/class-pull-state.php';

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Reprint\Importer;
 
-use PDO;
 use RuntimeException;
 use SqlStatementRewriter;
 use WordPress\DataLiberation\DatabaseRowsReader;
@@ -273,52 +272,10 @@ class DatabaseUrlRewriteProcessor {
         if ($statement === false || $statement->execute($params) === false) {
             throw new RuntimeException("Failed to update the selected {$table} record.");
         }
-        if ($statement->rowCount() === 1) {
-            return;
-        }
-
-        $select_parts = [];
-        $params = [];
-        foreach ($changes as $column => $rewritten_value) {
-            $quoted_column = $this->quote_identifier($column);
-            $select_parts[] = "HEX({$quoted_column}) = ? AS {$quoted_column}";
-            $params[] = strtoupper( bin2hex( $rewritten_value ) );
-        }
-        $where_parts = [];
-        foreach ($primary_key_columns as $column) {
-            $this->add_primary_key_condition(
-                $where_parts,
-                $params,
-                $column,
-                $record[$column]
-            );
-        }
-        $sql = 'SELECT ' . implode(', ', $select_parts)
-            . " FROM {$this->quote_identifier($table)}"
-            . ' WHERE ' . implode(' AND ', $where_parts);
-        $statement = $this->update_database->prepare($sql);
-        if ($statement === false || $statement->execute($params) === false) {
-            throw new RuntimeException("Failed to verify the selected {$table} record.");
-        }
-        $current_values = $statement->fetch(PDO::FETCH_ASSOC);
-        if (is_array($current_values)) {
-            foreach (array_keys($changes) as $column) {
-                if (
-                    !array_key_exists($column, $current_values)
-                    || (int) $current_values[$column] !== 1
-                ) {
-                    $current_values = false;
-                    break;
-                }
-            }
-        }
-        if ($current_values !== false) {
-            return;
-        }
-
-        throw new RuntimeException(
-            "The selected {$table} record changed before its URLs could be rewritten. Run the command again."
-        );
+        // Zero rows means either that an earlier attempt committed before its
+        // cursor was saved, or that the selected values changed or disappeared.
+        // These cases cannot be distinguished for overlapping URL mappings.
+        // Complete the pending decision without rewriting the current bytes.
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Reprint\Importer;
 
+use PDO;
 use RuntimeException;
 use SqlStatementRewriter;
 use WordPress\DataLiberation\DatabaseRowsReader;
@@ -20,6 +21,7 @@ class DatabaseUrlRewriteProcessor {
 
     private const READER_PHASE_NEXT_TABLE = 'next_table';
     private const READER_PHASE_NEXT_RECORD = 'next_record';
+    private const READER_PHASE_PROCESS_RECORD = 'process_record';
 
     /** Native PDO connection used for bound updates. */
     private $update_database;
@@ -63,6 +65,7 @@ class DatabaseUrlRewriteProcessor {
             if (!in_array($this->reader_phase, [
                 self::READER_PHASE_NEXT_TABLE,
                 self::READER_PHASE_NEXT_RECORD,
+                self::READER_PHASE_PROCESS_RECORD,
             ], true)) {
                 throw new RuntimeException(
                     'The saved db-rewrite-urls reader phase is invalid. Use --abort.'
@@ -109,13 +112,25 @@ class DatabaseUrlRewriteProcessor {
             return true;
         }
 
-        if ($this->row_reader->next_record()) {
+        if ($this->reader_phase === self::READER_PHASE_PROCESS_RECORD) {
+            $record = $this->row_reader->get_current_record();
+            if (!is_array($record)) {
+                throw new RuntimeException(
+                    'The saved db-rewrite-urls record is missing. Use --abort.'
+                );
+            }
             $this->rewrite_record(
                 $this->row_reader->get_current_table(),
-                $this->row_reader->get_current_record(),
+                $record,
                 $this->row_reader->get_current_primary_key_columns()
             );
             $this->row_reader->clear_current_record();
+            $this->reader_phase = self::READER_PHASE_NEXT_RECORD;
+            return true;
+        }
+
+        if ($this->row_reader->next_record()) {
+            $this->reader_phase = self::READER_PHASE_PROCESS_RECORD;
             return true;
         }
 
@@ -258,11 +273,52 @@ class DatabaseUrlRewriteProcessor {
         if ($statement === false || $statement->execute($params) === false) {
             throw new RuntimeException("Failed to update the selected {$table} record.");
         }
-        if ($statement->rowCount() !== 1) {
-            throw new RuntimeException(
-                "The selected {$table} record changed before its URLs could be rewritten. Run the command again."
+        if ($statement->rowCount() === 1) {
+            return;
+        }
+
+        $select_parts = [];
+        $params = [];
+        foreach ($changes as $column => $rewritten_value) {
+            $quoted_column = $this->quote_identifier($column);
+            $select_parts[] = "HEX({$quoted_column}) = ? AS {$quoted_column}";
+            $params[] = strtoupper( bin2hex( $rewritten_value ) );
+        }
+        $where_parts = [];
+        foreach ($primary_key_columns as $column) {
+            $this->add_primary_key_condition(
+                $where_parts,
+                $params,
+                $column,
+                $record[$column]
             );
         }
+        $sql = 'SELECT ' . implode(', ', $select_parts)
+            . " FROM {$this->quote_identifier($table)}"
+            . ' WHERE ' . implode(' AND ', $where_parts);
+        $statement = $this->update_database->prepare($sql);
+        if ($statement === false || $statement->execute($params) === false) {
+            throw new RuntimeException("Failed to verify the selected {$table} record.");
+        }
+        $current_values = $statement->fetch(PDO::FETCH_ASSOC);
+        if (is_array($current_values)) {
+            foreach (array_keys($changes) as $column) {
+                if (
+                    !array_key_exists($column, $current_values)
+                    || (int) $current_values[$column] !== 1
+                ) {
+                    $current_values = false;
+                    break;
+                }
+            }
+        }
+        if ($current_values !== false) {
+            return;
+        }
+
+        throw new RuntimeException(
+            "The selected {$table} record changed before its URLs could be rewritten. Run the command again."
+        );
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
@@ -1,0 +1,312 @@
+<?php
+declare(strict_types=1);
+
+namespace Reprint\Importer;
+
+use RuntimeException;
+use SqlStatementRewriter;
+use WordPress\DataLiberation\DatabaseRowsReader;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI errors contain database identifiers, never HTML.
+
+/**
+ * Rewrites one live database record per step through a structured row reader.
+ *
+ * The reader supplies primary-key-ordered, byte-preserving records. This
+ * processor applies only changed non-key columns with a primary-key-scoped
+ * UPDATE. It never opens a transaction across steps or requests a table lock.
+ */
+class DatabaseUrlRewriteProcessor {
+
+    private const READER_PHASE_NEXT_TABLE = 'next_table';
+    private const READER_PHASE_NEXT_RECORD = 'next_record';
+
+    /** Native PDO connection used for bound updates. */
+    private $update_database;
+
+    private SqlStatementRewriter $statement_rewriter;
+    private DatabaseRowsReader $row_reader;
+    private string $reader_phase = self::READER_PHASE_NEXT_TABLE;
+    private int $records_processed;
+    private int $records_changed;
+    private int $tables_started;
+    private ?string $current_table;
+    private bool $complete = false;
+
+    /**
+     * @param mixed        $database           PDO or a PDO-compatible adapter.
+     * @param array|null   $cursor             Cursor returned by get_cursor().
+     */
+    public function __construct(
+        $database,
+        SqlStatementRewriter $statement_rewriter,
+        ?array $cursor = null
+    ) {
+        $this->update_database = $database;
+        if (method_exists($database, 'get_connection')) {
+            $this->update_database = $database->get_connection()->get_pdo();
+        }
+        $this->statement_rewriter = $statement_rewriter;
+        if (
+            $cursor !== null &&
+            ( ! isset( $cursor['reader_cursor'] ) || ! is_array( $cursor['reader_cursor'] ) )
+        ) {
+            throw new RuntimeException(
+                'The saved db-rewrite-urls reader cursor is missing. Use --abort.'
+            );
+        }
+        $this->row_reader = new DatabaseRowsReader($database, [
+            'batch_size' => 1,
+        ]);
+        if ($cursor !== null) {
+            $this->reader_phase = $cursor['reader_phase'] ?? '';
+            if (!in_array($this->reader_phase, [
+                self::READER_PHASE_NEXT_TABLE,
+                self::READER_PHASE_NEXT_RECORD,
+            ], true)) {
+                throw new RuntimeException(
+                    'The saved db-rewrite-urls reader phase is invalid. Use --abort.'
+                );
+            }
+            $reader_cursor = $cursor['reader_cursor'];
+            $current_table = $reader_cursor['current_table'] ?? null;
+            if (!$this->row_reader->restore_cursor_state($reader_cursor)) {
+                throw new RuntimeException(
+                    'Cannot resume db-rewrite-urls because table ' .
+                    $this->row_reader->quote_identifier($current_table) . ' no longer exists.'
+                );
+            }
+        }
+        $this->records_processed = (int) ( $cursor['records_processed'] ?? 0 );
+        $this->records_changed = (int) ( $cursor['records_changed'] ?? 0 );
+        $this->tables_started = (int) ( $cursor['tables_started'] ?? 0 );
+        $this->current_table = isset($cursor['current_table'])
+            ? (string) $cursor['current_table']
+            : null;
+        $this->complete = (bool) ( $cursor['complete'] ?? false );
+    }
+
+    /**
+     * Performs one producer phase transition or one database-record rewrite.
+     *
+     * @return bool True when another step may be attempted; false after completion.
+     */
+    public function next_step(): bool
+    {
+        if ($this->complete) {
+            return false;
+        }
+
+        if ($this->reader_phase === self::READER_PHASE_NEXT_TABLE) {
+            if (!$this->row_reader->has_initialized_tables()) {
+                $this->row_reader->initialize_tables_to_process();
+            }
+            if (!$this->row_reader->move_to_next_table()) {
+                $this->complete = true;
+                return false;
+            }
+            $this->reader_phase = self::READER_PHASE_NEXT_RECORD;
+            return true;
+        }
+
+        if ($this->row_reader->next_record()) {
+            $this->rewrite_record(
+                $this->row_reader->get_current_table(),
+                $this->row_reader->get_current_record(),
+                $this->row_reader->get_current_primary_key_columns()
+            );
+            $this->row_reader->clear_current_record();
+            return true;
+        }
+
+        $this->reader_phase = self::READER_PHASE_NEXT_TABLE;
+        return true;
+    }
+
+    /**
+     * @return array {
+     *     Durable cursor after the latest completed step.
+     *
+     *     @type array       $reader_cursor   Structured database row cursor.
+     *     @type string      $reader_phase    Next reader action.
+     *     @type int         $records_processed Records whose rewrite decision is complete.
+     *     @type int         $records_changed  Records changed by this lifecycle.
+     *     @type int         $tables_started   Tables in which a record was processed.
+     *     @type string|null $current_table    Table containing the last processed record.
+     *     @type bool        $complete         Whether the processor is terminal.
+     * }
+     */
+    public function get_cursor(): array
+    {
+        return [
+            'reader_cursor' => $this->row_reader->get_cursor_state(),
+            'reader_phase' => $this->reader_phase,
+            'records_processed' => $this->records_processed,
+            'records_changed' => $this->records_changed,
+            'tables_started' => $this->tables_started,
+            'current_table' => $this->current_table,
+            'complete' => $this->complete,
+        ];
+    }
+
+    /**
+     * @return array {
+     *     Current live database rewrite progress.
+     *
+     *     @type int         $records_processed Records whose rewrite decision is complete.
+     *     @type int         $records_changed  Records changed by this lifecycle.
+     *     @type int         $tables_started   Tables in which a record was processed.
+     *     @type string|null $current_table    Table containing the last processed record.
+     * }
+     */
+    public function get_progress(): array
+    {
+        return [
+            'records_processed' => $this->records_processed,
+            'records_changed' => $this->records_changed,
+            'tables_started' => $this->tables_started,
+            'current_table' => $this->current_table,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $record
+     * @param list<string>        $primary_key_columns
+     */
+    private function rewrite_record(
+        string $table,
+        array $record,
+        array $primary_key_columns
+    ): void
+    {
+        if ($primary_key_columns === []) {
+            throw new RuntimeException(
+                "Cannot rewrite URLs in {$table} because it has records but no primary key."
+            );
+        }
+
+        $changes = [];
+        foreach ($record as $column => $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+            $rewritten = $this->statement_rewriter->rewrite_value($value, $table, $column);
+            if ($rewritten === $value) {
+                continue;
+            }
+            if (in_array($column, $primary_key_columns, true)) {
+                throw new RuntimeException(
+                    "Cannot rewrite {$table}.{$column} because it is part of the record cursor's primary key."
+                );
+            }
+            $changes[$column] = $rewritten;
+        }
+
+        if ($changes !== []) {
+            $this->update_record($table, $record, $primary_key_columns, $changes);
+            ++$this->records_changed;
+        }
+        ++$this->records_processed;
+        if ($this->current_table !== $table) {
+            $this->current_table = $table;
+            ++$this->tables_started;
+        }
+    }
+
+    /**
+     * @param array<string,mixed>  $record
+     * @param list<string>         $primary_key_columns
+     * @param array<string,string> $changes
+     */
+    private function update_record(
+        string $table,
+        array $record,
+        array $primary_key_columns,
+        array $changes
+    ): void {
+        $set_parts = [];
+        $where_parts = [];
+        $params = [];
+
+        foreach ($changes as $column => $rewritten_value) {
+            $set_parts[] = "{$this->quote_identifier($column)} = ?";
+            $params[] = $rewritten_value;
+        }
+        foreach ($primary_key_columns as $column) {
+            $this->add_primary_key_condition(
+                $where_parts,
+                $params,
+                $column,
+                $record[$column]
+            );
+        }
+        // If another connection changes a selected value before this bounded
+        // UPDATE, do not overwrite it with a rewrite of the older bytes.
+        foreach (array_keys($changes) as $column) {
+            $this->add_original_value_condition(
+                $where_parts,
+                $params,
+                $column,
+                $record[$column]
+            );
+        }
+
+        $sql = "UPDATE {$this->quote_identifier($table)} "
+            . 'SET ' . implode(', ', $set_parts)
+            . ' WHERE ' . implode(' AND ', $where_parts);
+        $statement = $this->update_database->prepare($sql);
+        if ($statement === false || $statement->execute($params) === false) {
+            throw new RuntimeException("Failed to update the selected {$table} record.");
+        }
+        if ($statement->rowCount() !== 1) {
+            throw new RuntimeException(
+                "The selected {$table} record changed before its URLs could be rewritten. Run the command again."
+            );
+        }
+    }
+
+    /**
+     * @param list<string> $where_parts
+     * @param list<mixed>  $params
+     * @param mixed        $value
+     */
+    private function add_original_value_condition(
+        array &$where_parts,
+        array &$params,
+        string $column,
+        $value
+    ): void {
+        $quoted_column = $this->quote_identifier($column);
+        if ($value === null) {
+            $where_parts[] = $quoted_column . ' IS NULL';
+            return;
+        }
+        $where_parts[] = "HEX({$quoted_column}) = ?";
+        $params[] = strtoupper( bin2hex( (string) $value ) );
+    }
+
+    /**
+     * @param list<string> $where_parts
+     * @param list<mixed>  $params
+     * @param mixed        $value
+     */
+    private function add_primary_key_condition(
+        array &$where_parts,
+        array &$params,
+        string $column,
+        $value
+    ): void {
+        $quoted_column = $this->quote_identifier($column);
+        if ($value === null) {
+            $where_parts[] = $quoted_column . ' IS NULL';
+            return;
+        }
+        $where_parts[] = "{$quoted_column} = ?";
+        $params[] = $value;
+    }
+
+    private function quote_identifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+}

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -178,12 +178,13 @@ class SqlStatementRewriter
         return SQLitePreparedInsertBuilder::build(
             $sql,
             function (string $value, string $table, ?string $column): string {
-                return $this->rewrite_value_for_column($value, $table, $column);
+                return $this->rewrite_value($value, $table, $column);
             }
         );
     }
 
-    private function rewrite_value_for_column(string $value, string $table, ?string $column): string
+    /** Rewrite one decoded database value with the same column rules as rewrite(). */
+    public function rewrite_value(string $value, string $table, ?string $column): string
     {
         if (strpos($value, 'http') === false) {
             return $value;
@@ -245,7 +246,7 @@ class SqlStatementRewriter
                 );
             }
 
-            $rewritten = $this->rewrite_value_for_column(
+            $rewritten = $this->rewrite_value(
                 $value,
                 $value_to_column_map['table'] ?? '',
                 $column_name

--- a/packages/reprint-client/src/lib/url-rewrite/load.php
+++ b/packages/reprint-client/src/lib/url-rewrite/load.php
@@ -26,3 +26,4 @@ require_once __DIR__ . '/class-structured-data-url-rewriter.php';
 
 // Depends on StructuredDataUrlRewriter + Base64ValueScanner
 require_once __DIR__ . '/class-sql-statement-rewriter.php';
+require_once __DIR__ . '/class-database-url-rewrite-processor.php';

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -72,6 +72,85 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--new-site-url=URL', $output);
     }
 
+    public function testDatabaseUrlRewriteHelpDescribesTheBoundedLiveDatabaseOperation(): void
+    {
+        $output = $this->runHelp('db-rewrite-urls');
+
+        $this->assertStringContainsString('live MySQL or SQLite database', $output);
+        $this->assertStringContainsString('--rewrite-url FROM TO', $output);
+        $this->assertStringContainsString('--target-engine=ENGINE', $output);
+        $this->assertStringContainsString('--abort', $output);
+        $this->assertStringContainsString('one primary-keyed record at a time', $output);
+        $this->assertStringContainsString('Resumes from the last saved record cursor', $output);
+        $this->assertStringContainsString(
+            'Usage: reprint db-rewrite-urls [<remote-reprint-api-url>] --state-dir=DIR',
+            $output
+        );
+        $this->assertStringContainsString('database recorded by db-apply', $output);
+        $this->assertStringNotContainsString('--fs-root=DIR', $output);
+    }
+
+    public function testDatabaseUrlRewriteRequiresAUrlToChooseAmongSavedRemotes(): void
+    {
+        $entry = __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+        $state_directory =
+            sys_get_temp_dir() . '/db-rewrite-multiple-remotes-' . uniqid('', true);
+        foreach (['first', 'second'] as $remote_directory) {
+            $pull_directory =
+                $state_directory . '/remotes/' . $remote_directory . '/pull';
+            mkdir($pull_directory, 0755, true);
+            file_put_contents($pull_directory . '/state.json', '{}');
+        }
+        $command =
+            escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($entry)
+            . ' db-rewrite-urls --state-dir='
+            . escapeshellarg($state_directory)
+            . ' --rewrite-url https://old.example https://new.example 2>&1';
+
+        try {
+            $output = shell_exec($command) ?? '';
+            $this->assertStringContainsString(
+                '--state-dir contains more than one saved remote',
+                $output
+            );
+        } finally {
+            foreach (['first', 'second'] as $remote_directory) {
+                unlink(
+                    $state_directory . '/remotes/' . $remote_directory . '/pull/state.json'
+                );
+                rmdir($state_directory . '/remotes/' . $remote_directory . '/pull');
+                rmdir($state_directory . '/remotes/' . $remote_directory);
+            }
+            rmdir($state_directory . '/remotes');
+            rmdir($state_directory);
+        }
+    }
+
+    public function testDatabaseUrlRewriteRejectsAnUnusedFilesystemRoot(): void
+    {
+        $entry = __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+        $state_directory =
+            sys_get_temp_dir() . '/db-rewrite-fs-root-' . uniqid('', true);
+        $command =
+            escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($entry)
+            . ' db-rewrite-urls --state-dir='
+            . escapeshellarg($state_directory)
+            . ' --fs-root='
+            . escapeshellarg($state_directory . '/files')
+            . ' 2>&1';
+        $output = shell_exec($command) ?? '';
+
+        $this->assertStringContainsString(
+            'db-rewrite-urls does not accept --fs-root',
+            $output
+        );
+        $this->assertDirectoryDoesNotExist($state_directory);
+    }
+
     public function testImportMetadataAliasShowsPullMetadataHelp(): void
     {
         $output = $this->runHelp('import-metadata');

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -433,6 +433,82 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         $this->assertSame(1, $resumed_processor->get_progress()['records_changed']);
     }
 
+    public function testProcessorAdvancesPastADeletedPendingRecord(): void
+    {
+        $statement_rewriter = new \SqlStatementRewriter(
+            new \StructuredDataUrlRewriter([
+                'https://old.example' => 'https://new.example',
+            ]),
+            'wp_'
+        );
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $this->open_mysql_on_sqlite_database(),
+            $statement_rewriter
+        );
+        $processor->next_step();
+        $processor->next_step();
+        $cursor_before_update = $processor->get_cursor();
+
+        $sqlite = new \PDO('sqlite:' . $this->database_path);
+        $sqlite->exec('DELETE FROM wp_posts WHERE ID = 1');
+
+        $resumed_processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $this->open_mysql_on_sqlite_database(),
+            $statement_rewriter,
+            $cursor_before_update
+        );
+        $resumed_processor->next_step();
+        $resumed_processor->next_step();
+        $resumed_processor->next_step();
+
+        $this->assertSame(2, $resumed_processor->get_progress()['records_processed']);
+        $this->assertSame(
+            'a:1:{s:3:"url";s:31:"https://new.example/serialized";}',
+            $sqlite->query('SELECT post_content FROM wp_posts WHERE ID = 2')->fetchColumn()
+        );
+    }
+
+    public function testProcessorAdvancesPastAChangedPendingRecord(): void
+    {
+        $statement_rewriter = new \SqlStatementRewriter(
+            new \StructuredDataUrlRewriter([
+                'https://old.example' => 'https://new.example',
+            ]),
+            'wp_'
+        );
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $this->open_mysql_on_sqlite_database(),
+            $statement_rewriter
+        );
+        $processor->next_step();
+        $processor->next_step();
+        $cursor_before_update = $processor->get_cursor();
+
+        $sqlite = new \PDO('sqlite:' . $this->database_path);
+        $sqlite->exec(
+            "UPDATE wp_posts SET post_content = 'https://concurrent.example' WHERE ID = 1"
+        );
+
+        $resumed_processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $this->open_mysql_on_sqlite_database(),
+            $statement_rewriter,
+            $cursor_before_update
+        );
+        $resumed_processor->next_step();
+        $resumed_processor->next_step();
+        $resumed_processor->next_step();
+
+        $this->assertSame(2, $resumed_processor->get_progress()['records_processed']);
+        $this->assertSame(
+            'https://concurrent.example',
+            $sqlite->query('SELECT post_content FROM wp_posts WHERE ID = 1')->fetchColumn()
+        );
+        $this->assertSame(
+            'a:1:{s:3:"url";s:31:"https://new.example/serialized";}',
+            $sqlite->query('SELECT post_content FROM wp_posts WHERE ID = 2')->fetchColumn()
+        );
+    }
+
     public function testStateRoundTripsTheLiveRewriteCursorAndCounters(): void
     {
         $state = new DatabaseUrlRewriteCommandState();

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -486,7 +486,7 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
 
         $sqlite = new \PDO('sqlite:' . $this->database_path);
         $sqlite->exec(
-            "UPDATE wp_posts SET post_content = 'https://concurrent.example' WHERE ID = 1"
+            "UPDATE wp_posts SET post_content = 'https://concurrent.example https://old.example' WHERE ID = 1"
         );
 
         $resumed_processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
@@ -500,7 +500,7 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
 
         $this->assertSame(2, $resumed_processor->get_progress()['records_processed']);
         $this->assertSame(
-            'https://concurrent.example',
+            'https://concurrent.example https://old.example',
             $sqlite->query('SELECT post_content FROM wp_posts WHERE ID = 1')->fetchColumn()
         );
         $this->assertSame(

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -391,6 +391,48 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         );
     }
 
+    public function testProcessorReplaysAnUncheckpointedUpdateWithoutRewritingItsResult(): void
+    {
+        $database = $this->open_mysql_on_sqlite_database();
+        $statement_rewriter = new \SqlStatementRewriter(
+            new \StructuredDataUrlRewriter([
+                'https://old.example' => 'https://new.example',
+                'https://new.example' => 'https://processed-twice.example',
+            ]),
+            'wp_'
+        );
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $database,
+            $statement_rewriter
+        );
+
+        $processor->next_step();
+        $processor->next_step();
+        $cursor_before_update = $processor->get_cursor();
+
+        $this->assertSame(0, $processor->get_progress()['records_processed']);
+
+        $processor->next_step();
+        $resumed_processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $this->open_mysql_on_sqlite_database(),
+            $statement_rewriter,
+            $cursor_before_update
+        );
+        $resumed_processor->next_step();
+
+        $sqlite = new \PDO('sqlite:' . $this->database_path);
+        $this->assertSame(
+            'https://new.example/one',
+            $sqlite->query('SELECT post_content FROM wp_posts WHERE ID = 1')->fetchColumn()
+        );
+        $this->assertSame(
+            1,
+            $sqlite->query('SELECT updates FROM z_rewrite_counts WHERE record_id = 1')->fetchColumn()
+        );
+        $this->assertSame(1, $resumed_processor->get_progress()['records_processed']);
+        $this->assertSame(1, $resumed_processor->get_progress()['records_changed']);
+    }
+
     public function testStateRoundTripsTheLiveRewriteCursorAndCounters(): void
     {
         $state = new DatabaseUrlRewriteCommandState();

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -1,0 +1,521 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\State\DatabaseUrlRewriteCommandState;
+use function Reprint\Importer\resolve_sqlite_integration_path;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/InterruptingDatabaseUrlRewriteClient.php';
+
+class DatabaseUrlRewriteCommandTest extends TestCase {
+
+    private string $temp_dir;
+    private string $database_path;
+    private string $remote_reprint_api_url = 'https://old.example/?reprint-api';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->temp_dir = sys_get_temp_dir() . '/reprint-live-url-rewrite-' . uniqid('', true);
+        $this->database_path = $this->temp_dir . '/database/wordpress.sqlite';
+        mkdir($this->temp_dir . '/fs-root', 0755, true);
+        mkdir(dirname($this->database_path), 0755, true);
+        $this->create_database();
+
+        write_current_pull_state(
+            new \ImportClient(
+                $this->remote_reprint_api_url,
+                $this->temp_dir,
+                $this->temp_dir . '/fs-root'
+            ),
+            [
+                'preflight' => [
+                    'data' => [
+                        'database' => ['wp' => ['table_prefix' => 'wp_']],
+                    ],
+                ],
+                'apply' => [
+                    'target_engine' => 'sqlite',
+                    'target_db' => 'wp_test',
+                    'target_sqlite_path' => $this->database_path,
+                ],
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_directory($this->temp_dir);
+        parent::tearDown();
+    }
+
+    public function testRewritesLiveRowsAndPersistsCompletionProgress(): void
+    {
+        $client = $this->new_client();
+        $client->run($this->command_options());
+
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $rows = $database->query('SELECT ID, post_content, post_title FROM wp_posts ORDER BY ID')
+            ->fetchAll(\PDO::FETCH_ASSOC);
+
+        $this->assertSame('https://new.example/one', $rows[0]['post_content']);
+        $this->assertSame(
+            'a:1:{s:3:"url";s:31:"https://new.example/serialized";}',
+            $rows[1]['post_content']
+        );
+        $this->assertSame('No URL here', $rows[2]['post_content']);
+        $this->assertSame('Unchanged title', $rows[0]['post_title']);
+
+        $state = $this->read_state($client);
+        $this->assertSame('db-rewrite-urls', $state['active_resumable_command']['command_name']);
+        $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
+        $this->assertSame(6, $state['database_url_rewrite']['records_processed']);
+        $this->assertSame(2, $state['database_url_rewrite']['records_changed']);
+        $this->assertNotEmpty($state['database_url_rewrite']['cursor']);
+    }
+
+    public function testInterruptedCommandResumesWithoutUpdatingARecordTwice(): void
+    {
+        $client = new InterruptingDatabaseUrlRewriteClient(
+            $this->remote_reprint_api_url,
+            $this->temp_dir,
+            $this->temp_dir . '/fs-root',
+            2
+        );
+        $client->run($this->command_options());
+
+        $partial_state = $this->read_state($client);
+        $this->assertSame('partial', $partial_state['active_resumable_command']['completion_state']);
+        $this->assertSame(2, $partial_state['database_url_rewrite']['records_processed']);
+
+        $resuming_client = $this->new_client();
+        $resume_options = $this->command_options();
+        unset(
+            $resume_options['rewrite_url'],
+            $resume_options['target_engine'],
+            $resume_options['target_sqlite_path'],
+            $resume_options['target_db']
+        );
+        $resuming_client->run($resume_options);
+
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $update_counts = $database->query(
+            'SELECT record_id, updates FROM z_rewrite_counts ORDER BY record_id'
+        )->fetchAll(\PDO::FETCH_KEY_PAIR);
+
+        $this->assertSame([1 => 1, 2 => 1, 3 => 0], $update_counts);
+
+        $complete_state = $this->read_state($resuming_client);
+        $this->assertSame('complete', $complete_state['active_resumable_command']['completion_state']);
+        $this->assertSame(6, $complete_state['database_url_rewrite']['records_processed']);
+        $this->assertSame(2, $complete_state['database_url_rewrite']['records_changed']);
+    }
+
+    public function testUsesTheDatabaseTargetRecordedByDbApply(): void
+    {
+        $options = $this->command_options();
+        unset(
+            $options['target_engine'],
+            $options['target_sqlite_path'],
+            $options['target_db']
+        );
+
+        $this->new_client()->run($options);
+
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $this->assertSame(
+            'https://new.example/one',
+            $database->query('SELECT post_content FROM wp_posts WHERE ID = 1')->fetchColumn()
+        );
+    }
+
+    public function testExplicitTargetOptionsOverrideTheDatabaseRecordedByDbApply(): void
+    {
+        $other_database_path = $this->temp_dir . '/database/other.sqlite';
+        copy($this->database_path, $other_database_path);
+        $options = $this->command_options();
+        $options['target_sqlite_path'] = $other_database_path;
+
+        $this->new_client()->run($options);
+
+        $recorded_database = new \PDO('sqlite:' . $this->database_path);
+        $other_database = new \PDO('sqlite:' . $other_database_path);
+        $this->assertSame(
+            'https://old.example/one',
+            $recorded_database->query(
+                'SELECT post_content FROM wp_posts WHERE ID = 1'
+            )->fetchColumn()
+        );
+        $this->assertSame(
+            'https://new.example/one',
+            $other_database->query(
+                'SELECT post_content FROM wp_posts WHERE ID = 1'
+            )->fetchColumn()
+        );
+    }
+
+    public function testCliUsesTheOnlySavedRemoteWithoutAUrlOrFilesystemRoot(): void
+    {
+        $entry = __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+        $command = implode(' ', [
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($entry),
+            'db-rewrite-urls',
+            '--state-dir=' . escapeshellarg($this->temp_dir),
+            '--progress=jsonl',
+            '--rewrite-url',
+            escapeshellarg('https://old.example'),
+            escapeshellarg('https://new.example'),
+            '2>&1',
+        ]);
+        $output = [];
+        $exit_code = null;
+        exec($command, $output, $exit_code);
+
+        $this->assertSame(0, $exit_code, implode("\n", $output));
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $this->assertSame(
+            'https://new.example/one',
+            $database->query('SELECT post_content FROM wp_posts WHERE ID = 1')->fetchColumn()
+        );
+    }
+
+    public function testNewSiteUrlWithoutARemoteUrlRequiresAnExplicitRewriteMapping(): void
+    {
+        $entry = __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+        $command = implode(' ', [
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($entry),
+            'db-rewrite-urls',
+            '--state-dir=' . escapeshellarg($this->temp_dir),
+            '--progress=jsonl',
+            '--new-site-url=' . escapeshellarg('https://new.example'),
+            '2>&1',
+        ]);
+        $output = [];
+        $exit_code = null;
+        exec($command, $output, $exit_code);
+
+        $this->assertSame(1, $exit_code);
+        $this->assertStringContainsString(
+            'Use --rewrite-url FROM TO when no remote URL is available.',
+            implode("\n", $output)
+        );
+    }
+
+    public function testCliCreatesCommandLocalStateWhenNoRemoteWasSaved(): void
+    {
+        $entry = __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+        $state_directory = $this->temp_dir . '/standalone-state';
+        $command = implode(' ', [
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($entry),
+            'db-rewrite-urls',
+            '--state-dir=' . escapeshellarg($state_directory),
+            '--progress=jsonl',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . escapeshellarg($this->database_path),
+            '--target-db=wp_test',
+            '--rewrite-url',
+            escapeshellarg('https://old.example'),
+            escapeshellarg('https://new.example'),
+            '2>&1',
+        ]);
+        $output = [];
+        $exit_code = null;
+        exec($command, $output, $exit_code);
+
+        $this->assertSame(0, $exit_code, implode("\n", $output));
+        $this->assertFileExists(
+            $state_directory . '/db-rewrite-urls/pull/state.json'
+        );
+    }
+
+    public function testIncompleteCommandRejectsAChangedUrlMapping(): void
+    {
+        $client = new InterruptingDatabaseUrlRewriteClient(
+            $this->remote_reprint_api_url,
+            $this->temp_dir,
+            $this->temp_dir . '/fs-root',
+            1
+        );
+        $client->run($this->command_options());
+
+        $options = $this->command_options();
+        $options['rewrite_url'] = [
+            ['https://old.example', 'https://different.example'],
+        ];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Cannot change --rewrite-url while db-rewrite-urls is incomplete.'
+        );
+        $this->new_client()->run($options);
+    }
+
+    public function testCommandResumesFromTheInitialSavedBoundary(): void
+    {
+        $client = new InterruptingDatabaseUrlRewriteClient(
+            $this->remote_reprint_api_url,
+            $this->temp_dir,
+            $this->temp_dir . '/fs-root',
+            0
+        );
+        $client->run($this->command_options());
+
+        $partial_state = $this->read_state($client);
+        $this->assertSame('partial', $partial_state['active_resumable_command']['completion_state']);
+        $this->assertNull($partial_state['database_url_rewrite']['cursor']);
+
+        $options = $this->command_options();
+        unset($options['rewrite_url']);
+        $resuming_client = $this->new_client();
+        $resuming_client->run($options);
+
+        $complete_state = $this->read_state($resuming_client);
+        $this->assertSame('complete', $complete_state['active_resumable_command']['completion_state']);
+        $this->assertSame(6, $complete_state['database_url_rewrite']['records_processed']);
+    }
+
+    public function testRejectsLiveTableRowsWithoutAPrimaryKey(): void
+    {
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $database->exec('CREATE TABLE wp_unkeyed (content TEXT NOT NULL)');
+        $database->exec("INSERT INTO wp_unkeyed VALUES ('https://old.example/unkeyed')");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Cannot rewrite URLs in wp_unkeyed because it has records but no primary key.'
+        );
+
+        $this->new_client()->run($this->command_options());
+    }
+
+    public function testSqliteMetadataQuotesATableNameContainingSqlPunctuation(): void
+    {
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $database->exec(
+            "CREATE TABLE \"wp_odd'?\" ("
+            . '"record-id?" INTEGER PRIMARY KEY, "content-url?" TEXT NOT NULL)'
+        );
+        $database->exec(
+            "INSERT INTO \"wp_odd'?\" VALUES (1, 'https://old.example/odd')"
+        );
+
+        $this->new_client()->run($this->command_options());
+
+        $this->assertSame(
+            'https://new.example/odd',
+            $database->query("SELECT \"content-url?\" FROM \"wp_odd'?\"")->fetchColumn()
+        );
+    }
+
+    public function testSqliteMetadataUsesPublicMysqlQueries(): void
+    {
+        $driver = $this->open_mysql_on_sqlite_database();
+        $database = new class($driver) {
+            private $driver;
+            public array $queries = [];
+
+            public function __construct($driver)
+            {
+                $this->driver = $driver;
+            }
+
+            public function query(string $sql)
+            {
+                $this->queries[] = $sql;
+                return $this->driver->query($sql);
+            }
+
+            public function get_connection()
+            {
+                return $this->driver->get_connection();
+            }
+        };
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $database,
+            new \SqlStatementRewriter(
+                new \StructuredDataUrlRewriter([
+                    'https://old.example' => 'https://new.example',
+                ]),
+                'wp_'
+            )
+        );
+
+        do {
+            $has_more_steps = $processor->next_step();
+        } while ($has_more_steps && $processor->get_progress()['records_processed'] < 1);
+
+        $this->assertContains('SHOW FULL TABLES', $database->queries);
+        $this->assertNotEmpty(array_filter($database->queries, static function ($query) {
+            return strpos($query, 'SHOW INDEX FROM ') === 0;
+        }));
+        $this->assertNotEmpty(array_filter($database->queries, static function ($query) {
+            return strpos($query, 'SHOW FULL COLUMNS FROM ') === 0;
+        }));
+    }
+
+    public function testProcessorDoesNotRetainASqliteReadLockBetweenRecords(): void
+    {
+        $database = $this->open_mysql_on_sqlite_database();
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $database,
+            new \SqlStatementRewriter(
+                new \StructuredDataUrlRewriter([
+                    'https://old.example' => 'https://new.example',
+                ]),
+                'wp_'
+            )
+        );
+
+        do {
+            $has_more_steps = $processor->next_step();
+            $progress = $processor->get_progress();
+        } while ($has_more_steps && $progress['records_processed'] < 1);
+
+        $other_connection = new \PDO('sqlite:' . $this->database_path);
+        $other_connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $other_connection->setAttribute(\PDO::ATTR_TIMEOUT, 1);
+        $this->assertSame(
+            1,
+            $other_connection->exec("UPDATE wp_posts SET post_title = 'Concurrent' WHERE ID = 3")
+        );
+    }
+
+    public function testStateRoundTripsTheLiveRewriteCursorAndCounters(): void
+    {
+        $state = new DatabaseUrlRewriteCommandState();
+        $state->cursor = '{"state":"emit_row"}';
+        $state->records_processed = 12;
+        $state->records_changed = 4;
+        $state->tables_started = 3;
+        $state->current_table = 'wp_posts';
+        $state->rewrite_url = ['https://old.example' => 'https://new.example'];
+        $state->target = [
+            'engine' => 'sqlite',
+            'db' => 'wp_test',
+            'sqlite_path' => '/tmp/wordpress.sqlite',
+        ];
+
+        $this->assertSame(
+            $state->to_array(),
+            DatabaseUrlRewriteCommandState::from_array($state->to_array())->to_array()
+        );
+    }
+
+    private function create_database(): void
+    {
+        $polyfills = resolve_sqlite_integration_path('/packages/mysql-on-sqlite/src/php-polyfills.php');
+        $driver = resolve_sqlite_integration_path('/packages/mysql-on-sqlite/src/load.php');
+        require_once $polyfills;
+        require_once $driver;
+
+        $database = new \PDO('sqlite:' . $this->database_path);
+        $database->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $database->exec(
+            'CREATE TABLE wp_posts ('
+            . 'ID INTEGER PRIMARY KEY, '
+            . 'post_content TEXT NOT NULL, '
+            . 'post_title TEXT NOT NULL'
+            . ')'
+        );
+
+        $serialized = 'a:1:{s:3:"url";s:31:"https://old.example/serialized";}';
+        $insert = $database->prepare(
+            'INSERT INTO wp_posts (ID, post_content, post_title) VALUES (?, ?, ?)'
+        );
+        $insert->execute([1, 'https://old.example/one', 'Unchanged title']);
+        $insert->execute([2, $serialized, 'Serialized']);
+        $insert->execute([3, 'No URL here', 'Plain']);
+
+        $database->exec(
+            'CREATE TABLE z_rewrite_counts ('
+            . 'record_id INTEGER PRIMARY KEY, '
+            . 'updates INTEGER NOT NULL DEFAULT 0'
+            . ')'
+        );
+        $database->exec('INSERT INTO z_rewrite_counts (record_id) VALUES (1), (2), (3)');
+        $database->exec(
+            'CREATE TRIGGER count_post_content_rewrites '
+            . 'AFTER UPDATE OF post_content ON wp_posts '
+            . 'BEGIN '
+            . 'UPDATE z_rewrite_counts SET updates = updates + 1 WHERE record_id = NEW.ID; '
+            . 'END'
+        );
+    }
+
+    private function open_mysql_on_sqlite_database(): \WP_PDO_MySQL_On_SQLite
+    {
+        $dsn = "mysql-on-sqlite:path={$this->database_path};dbname=wp_test";
+        $database = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $sqlite_pdo = $database->get_connection()->get_pdo();
+        \Reprint\Importer\register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
+            return $data === null ? null : base64_decode($data);
+        });
+        return $database;
+    }
+
+    private function command_options(): array
+    {
+        return [
+            'command' => 'db-rewrite-urls',
+            'abort' => false,
+            'verbose' => false,
+            'progress' => 'jsonl',
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $this->database_path,
+            'target_db' => 'wp_test',
+            'rewrite_url' => [
+                ['https://old.example', 'https://new.example'],
+            ],
+        ];
+    }
+
+    private function new_client(): \ImportClient
+    {
+        return new \ImportClient(
+            $this->remote_reprint_api_url,
+            $this->temp_dir,
+            $this->temp_dir . '/fs-root'
+        );
+    }
+
+    private function read_state(\ImportClient $client): array
+    {
+        return json_decode(
+            file_get_contents($client->pull_state_directory . '/state.json'),
+            true
+        );
+    }
+
+    private function remove_directory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (scandir($directory) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->remove_directory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/InterruptingDatabaseUrlRewriteClient.php
+++ b/tests/Import/InterruptingDatabaseUrlRewriteClient.php
@@ -1,0 +1,36 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace ImportTests;
+
+class InterruptingDatabaseUrlRewriteClient extends \ImportClient {
+
+    private int $stop_after_records;
+    private bool $stop_requested = false;
+
+    public function __construct(
+        string $remote_reprint_api_url,
+        string $state_dir,
+        string $filesystem_root,
+        int $stop_after_records
+    ) {
+        parent::__construct($remote_reprint_api_url, $state_dir, $filesystem_root);
+        $this->stop_after_records = $stop_after_records;
+    }
+
+    public function save_state(): void
+    {
+        parent::save_state();
+
+        if (
+            !$this->stop_requested
+            && $this->get_state()->database_url_rewrite->records_processed >= $this->stop_after_records
+        ) {
+            $shutdown_requested = ( new \ReflectionClass(\ImportClient::class) )
+                ->getProperty('shutdown_requested');
+            $shutdown_requested->setAccessible(true);
+            $shutdown_requested->setValue($this, true);
+            $this->stop_requested = true;
+        }
+    }
+}

--- a/tests/Import/NewSiteUrlTest.php
+++ b/tests/Import/NewSiteUrlTest.php
@@ -185,6 +185,40 @@ class NewSiteUrlTest extends TestCase
         $this->callResolve($client, $options);
     }
 
+    public function testUsesTheSourceSiteUrlFromPriorStateWithoutAnExportUrl(): void
+    {
+        $client = new \ImportClient(
+            '',
+            $this->tempDir,
+            $this->tempDir . '/fs-root'
+        );
+        write_current_pull_state($client, [
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'paths_urls' => [
+                                'home_url' => 'https://saved-source.example:8443/wordpress',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $options = $this->callResolve($client, [
+            'new_site_url' => 'https://new-site.example.com',
+        ]);
+
+        $this->assertSame(
+            [
+                ['https://saved-source.example:8443', 'https://new-site.example.com'],
+                ['http://saved-source.example:8443', 'https://new-site.example.com'],
+            ],
+            $options['rewrite_url']
+        );
+    }
+
     public function testNewUrlUsedVerbatim(): void
     {
         $client = new \ImportClient(

--- a/tests/Import/NewSiteUrlTest.php
+++ b/tests/Import/NewSiteUrlTest.php
@@ -185,7 +185,7 @@ class NewSiteUrlTest extends TestCase
         $this->callResolve($client, $options);
     }
 
-    public function testUsesTheSourceSiteUrlFromPriorStateWithoutAnExportUrl(): void
+    public function testRequiresAnExplicitMappingWithoutARemoteUrl(): void
     {
         $client = new \ImportClient(
             '',
@@ -206,17 +206,15 @@ class NewSiteUrlTest extends TestCase
             ],
         ]);
 
-        $options = $this->callResolve($client, [
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '--new-site-url requires a positional remote Reprint API URL. ' .
+            'Use --rewrite-url FROM TO when no remote URL is available.'
+        );
+
+        $this->callResolve($client, [
             'new_site_url' => 'https://new-site.example.com',
         ]);
-
-        $this->assertSame(
-            [
-                ['https://saved-source.example:8443', 'https://new-site.example.com'],
-                ['http://saved-source.example:8443', 'https://new-site.example.com'],
-            ],
-            $options['rewrite_url']
-        );
     }
 
     public function testNewUrlUsedVerbatim(): void

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -388,10 +388,15 @@ class SqliteRuntimeConfigTest extends TestCase
             $this->fsRoot,
         );
         $this->loadClientState($client);
+        $target = $this->callPrivate(
+            $client,
+            'resolve_database_target',
+            [['target_engine' => 'sqlite'], [], 'mysql', 'db-apply'],
+        );
         [$connection] = $this->callPrivate(
             $client,
-            'create_target_db_apply_connection',
-            [['target_engine' => 'sqlite']],
+            'create_target_database_connection',
+            [$target],
         );
         $resolved_filesystem_root = realpath($this->fsRoot);
         $this->assertIsString($resolved_filesystem_root);

--- a/tests/e2e/tests/import-56-db-rewrite-urls-resume.test.js
+++ b/tests/e2e/tests/import-56-db-rewrite-urls-resume.test.js
@@ -1,0 +1,289 @@
+/**
+ * Test 56: Live database URL rewrite interruption and resume.
+ *
+ * A real db-rewrite-urls CLI process receives SIGTERM after it has saved a
+ * record boundary. A new process resumes the same lifecycle. Update triggers
+ * and the final processed-record count confirm that no content row is handled
+ * twice across the two processes.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    createTempDir, cleanupTempDir, createMysqlConnection, PHP_BINARY,
+} from '../lib/test-helpers.js';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+const IMPORTER_PATH = process.env.IMPORTER_PATH || join(
+    PROJECT_ROOT,
+    'packages',
+    'reprint-client',
+    'bin',
+    'reprint-client',
+);
+
+// Playground PHP runs inside the Node process and does not expose PHP's pcntl
+// signal handler. The native PHP matrix covers the real SIGTERM lifecycle.
+const describeWithSignals = PHP_BINARY.includes('playground-php.sh')
+    ? describe.skip
+    : describe;
+describeWithSignals(
+    'Import: live database URL rewrite interruption and resume',
+    { timeout: 300000 },
+    () => {
+        const databaseName = 'e2e_db_rewrite_urls_resume_56';
+        const contentTable = 'a_rewrite_content';
+        const updateTable = 'z_rewrite_updates';
+        const rowCount = 1000;
+        const sourceUrl = 'https://resume-source.example.test';
+        const targetUrl = 'https://resume-target.example.test';
+        // The second mapping makes repeated processing visible: the first
+        // decision produces targetUrl, while a second would produce this URL.
+        const duplicateTargetUrl = 'https://processed-twice.example.test';
+        let tempDir;
+        let runningProcess = null;
+
+        beforeAll(async () => {
+            tempDir = createTempDir('e2e-db-rewrite-urls-resume');
+            const connection = await createMysqlConnection();
+            await connection.query(`DROP DATABASE IF EXISTS \`${databaseName}\``);
+            await connection.query(`CREATE DATABASE \`${databaseName}\``);
+            await connection.query(
+                `CREATE TABLE \`${databaseName}\`.\`${contentTable}\` (` +
+                '`id` int NOT NULL, ' +
+                '`content` text NOT NULL, ' +
+                'PRIMARY KEY (`id`))'
+            );
+            await connection.query(
+                `CREATE TABLE \`${databaseName}\`.\`${updateTable}\` (` +
+                '`id` int NOT NULL, ' +
+                '`updates` int NOT NULL DEFAULT 0, ' +
+                'PRIMARY KEY (`id`))'
+            );
+
+            const contentValues = [];
+            const updateValues = [];
+            const contentParams = [];
+            const updateParams = [];
+            for (let id = 1; id <= rowCount; id++) {
+                contentValues.push('(?, ?)');
+                contentParams.push(id, `${sourceUrl}/content/${id}`);
+                updateValues.push('(?, 0)');
+                updateParams.push(id);
+            }
+            await connection.query(
+                `INSERT INTO \`${databaseName}\`.\`${contentTable}\` (` +
+                '`id`, `content`) VALUES ' + contentValues.join(', '),
+                contentParams,
+            );
+            await connection.query(
+                `INSERT INTO \`${databaseName}\`.\`${updateTable}\` (` +
+                '`id`, `updates`) VALUES ' + updateValues.join(', '),
+                updateParams,
+            );
+            await connection.query(
+                `CREATE TRIGGER \`${databaseName}\`.\`count_rewrite_updates\` ` +
+                `AFTER UPDATE ON \`${databaseName}\`.\`${contentTable}\` ` +
+                `FOR EACH ROW UPDATE \`${databaseName}\`.\`${updateTable}\` ` +
+                'SET `updates` = `updates` + 1 WHERE `id` = NEW.`id`'
+            );
+            await connection.end();
+        });
+
+        afterAll(async () => {
+            if (runningProcess && runningProcess.exitCode === null) {
+                const child = runningProcess;
+                child.kill('SIGKILL');
+                await new Promise(resolve => child.once('close', resolve));
+            }
+            cleanupTempDir(tempDir);
+            const connection = await createMysqlConnection();
+            await connection.query(`DROP DATABASE IF EXISTS \`${databaseName}\``);
+            await connection.end();
+        });
+
+        it('resumes after SIGTERM without processing or updating content twice', async () => {
+            const firstProcess = startRewrite([
+                '--target-engine=mysql',
+                '--target-host=127.0.0.1',
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${databaseName}`,
+                '--rewrite-url', sourceUrl, targetUrl,
+                '--rewrite-url', targetUrl, duplicateTargetUrl,
+            ]);
+
+            const progressDeadline = Date.now() + 120000;
+            let progressBeforeStop = null;
+            while (Date.now() < progressDeadline) {
+                const state = readState();
+                const rewriteState = state?.database_url_rewrite;
+                if (
+                    rewriteState?.current_table === contentTable &&
+                    rewriteState.records_changed > 0 &&
+                    rewriteState.records_changed < rowCount
+                ) {
+                    progressBeforeStop = rewriteState.records_processed;
+                    assert.equal(
+                        firstProcess.child.kill('SIGTERM'),
+                        true,
+                        'Expected to deliver SIGTERM to db-rewrite-urls',
+                    );
+                    break;
+                }
+                if (
+                    firstProcess.child.exitCode !== null ||
+                    firstProcess.child.signalCode !== null
+                ) {
+                    break;
+                }
+                await sleep(10);
+            }
+
+            assert.ok(
+                progressBeforeStop !== null,
+                'Expected the first process to save partial content progress before it completed',
+            );
+            const stopped = await waitForCompletion(firstProcess, 30000);
+            assert.equal(
+                stopped.exitCode,
+                2,
+                `Expected SIGTERM to stop at a durable boundary with exit 2\n` +
+                `stdout: ${stopped.stdout}\nstderr: ${stopped.stderr}`,
+            );
+            assert.equal(stopped.signal, null, 'Expected the PHP signal handler to finish the step');
+
+            const partialState = readState();
+            assert.equal(
+                partialState.active_resumable_command.completion_state,
+                'partial',
+                'Expected the stopped lifecycle to retain partial progress',
+            );
+            assert.ok(
+                partialState.database_url_rewrite.records_processed >= progressBeforeStop,
+                'Expected the stopped process to retain its last durable record boundary',
+            );
+            assert.ok(
+                partialState.database_url_rewrite.records_changed < rowCount,
+                'Expected interruption before the content table completed',
+            );
+
+            const resumedProcess = startRewrite([
+                // Target identity and URL mapping come from the partial state;
+                // only the password must be supplied again.
+                '--target-pass=e2e_password',
+            ]);
+            const resumed = await waitForCompletion(resumedProcess, 120000);
+            assert.equal(
+                resumed.exitCode,
+                0,
+                `Expected resume to complete\nstdout: ${resumed.stdout}\nstderr: ${resumed.stderr}`,
+            );
+
+            const connection = await createMysqlConnection(databaseName);
+            const [[contentCounts]] = await connection.query(
+                `SELECT COUNT(*) AS total, ` +
+                `SUM(\`content\` = CONCAT(?, '/content/', \`id\`)) AS rewritten_once, ` +
+                `SUM(\`content\` = CONCAT(?, '/content/', \`id\`)) AS rewritten_twice ` +
+                `FROM \`${contentTable}\``,
+                [targetUrl, duplicateTargetUrl],
+            );
+            const [[updateCounts]] = await connection.query(
+                `SELECT SUM(\`updates\`) AS total, ` +
+                `MIN(\`updates\`) AS minimum, MAX(\`updates\`) AS maximum ` +
+                `FROM \`${updateTable}\``
+            );
+            await connection.end();
+
+            assert.equal(Number(contentCounts.total), rowCount);
+            assert.equal(Number(contentCounts.rewritten_once), rowCount);
+            assert.equal(Number(contentCounts.rewritten_twice), 0);
+            assert.deepEqual(
+                {
+                    total: Number(updateCounts.total),
+                    minimum: Number(updateCounts.minimum),
+                    maximum: Number(updateCounts.maximum),
+                },
+                { total: rowCount, minimum: 1, maximum: 1 },
+                'Expected every changed content row to receive exactly one UPDATE',
+            );
+
+            const completeState = readState();
+            assert.equal(
+                completeState.active_resumable_command.completion_state,
+                'complete',
+            );
+            assert.equal(
+                completeState.database_url_rewrite.records_processed,
+                rowCount * 2,
+                'Expected one record decision for each row in the two tables',
+            );
+            assert.equal(
+                completeState.database_url_rewrite.records_changed,
+                rowCount,
+                'Expected each URL-bearing content row to change exactly once',
+            );
+        });
+
+        function statePath() {
+            return join(tempDir, 'db-rewrite-urls', 'pull', 'state.json');
+        }
+
+        function readState() {
+            if (!existsSync(statePath())) {
+                return null;
+            }
+            try {
+                return JSON.parse(readFileSync(statePath(), 'utf8'));
+            } catch {
+                return null;
+            }
+        }
+
+        function startRewrite(extraArgs) {
+            const child = spawn(PHP_BINARY, [
+                IMPORTER_PATH,
+                'db-rewrite-urls',
+                `--state-dir=${tempDir}`,
+                '--progress=jsonl',
+                ...extraArgs,
+            ], {
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            runningProcess = child;
+
+            let stdout = '';
+            let stderr = '';
+            child.stdout.on('data', chunk => { stdout += chunk.toString(); });
+            child.stderr.on('data', chunk => { stderr += chunk.toString(); });
+
+            const completion = new Promise((resolve, reject) => {
+                child.once('error', reject);
+                child.once('close', (exitCode, signal) => {
+                    if (runningProcess === child) {
+                        runningProcess = null;
+                    }
+                    resolve({ exitCode, signal, stdout, stderr });
+                });
+            });
+
+            return { child, completion };
+        }
+
+        async function waitForCompletion(process, timeoutMilliseconds) {
+            return Promise.race([
+                process.completion,
+                sleep(timeoutMilliseconds).then(() => {
+                    process.child.kill('SIGKILL');
+                    throw new Error(
+                        `db-rewrite-urls did not exit within ${timeoutMilliseconds}ms`
+                    );
+                }),
+            ]);
+        }
+    },
+);


### PR DESCRIPTION
Adds `db-rewrite-urls` to rewrite URL-bearing values in a live MySQL or SQLite database without exporting or parsing SQL.

Using the `DatabaseRowsReader` introduced in #623, `DatabaseUrlRewriteProcessor` reads structured records and performs one bounded record step at a time. Changed records use primary-key-scoped prepared `UPDATE` statements with positional bindings. It takes no table lock and keeps no transaction open between steps.

The positional Reprint API URL is optional, and this command does not use `--fs-root`. Omitted database options use the local site database recorded by `db-apply` when available. Without a remote URL, provide explicit `--rewrite-url FROM TO` mappings.

## Examples

```sh
reprint db-rewrite-urls --state-dir=./state \
  --rewrite-url https://old.example https://new.example

reprint db-rewrite-urls --state-dir=./state \
  --target-engine=sqlite --target-sqlite-path=./wordpress.sqlite \
  --rewrite-url https://old.example https://new.example
```

## Resume

Progress is saved after each record decision. SIGINT or SIGTERM finishes the active step, saves the cursor, and exits with status 2; rerun the command to resume. An update interrupted before its cursor is saved may be read again, but the saved original bytes prevent a second replacement. If that record disappeared or its selected values changed, the cursor advances without rewriting its current bytes.

A non-empty table without a primary key stops the command. An incomplete run also rejects a changed database target or URL mapping.

## Testing

Importer tests cover bound updates, identifier quoting, saved database targets, interruption, resume, deletion, and concurrent modification. An E2E test sends SIGTERM mid-table, resumes in a new process, and confirms each unchanged content row is processed and updated once.