### PR TITLE
[PHP] Render ports in cautious target URLs

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -310,6 +310,9 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             }
             $target_port = '';
             if ($mapping['target_port'] !== null) {
+                // No escaped colon is available here. Use an unescaped colon.
+                // This risks breaking an unknown format, but ':' is not a
+                // common string terminator in popular formats.
                 $target_port_colon = $matches['scheme_colon'][1] === -1
                     ? ':'
                     : $matches['scheme_colon'][0];

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -63,8 +63,12 @@
  *   the first available spelling from the URL prefix, configured source path,
  *   or following candidate path. A scheme-less authority with no slash stays
  *   unchanged when the target has a path.
- * - Target ports, user information, queries, fragments, IPv4/IPv6 addresses,
- *   and Unicode domains are not supported. Punycode domains are supported.
+ * - A target port copies the colon spelling after the matched scheme. A
+ *   protocol-relative or scheme-less candidate has no scheme colon to copy, so
+ *   its target port uses a literal `:`. This may not match the escaping rules
+ *   of the surrounding text.
+ * - Target user information, queries, fragments, IPv4/IPv6 addresses, and
+ *   Unicode domains are not supported. Punycode domains are supported.
  * - Unicode source domains and paths are not supported.
  *
  * CSS hexadecimal escapes such as https\3a \2f \2f ... and percent-encoded
@@ -108,6 +112,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     target_domain: string,
      *     target_scheme: string,
      *     target_path: string,
+     *     target_port: int|null,
      *     pattern: string
      * }>
      */
@@ -125,6 +130,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     target_domain: string,
      *     target_scheme: string,
      *     target_path: string,
+     *     target_port: int|null,
      *     pattern: string,
      *     start: int,
      *     base_length: int,
@@ -144,7 +150,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *
      * A source may include an initial path containing only bytes from `!`
      * (0x21) through `~` (0x7E). A target must be an HTTP(S) URL with a
-     * supported domain and an optional restricted path:
+     * supported domain, optional port, and optional restricted path:
      *
      * ```
      * [
@@ -266,6 +272,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     target_domain: string,
      *     target_scheme: string,
      *     target_path: string,
+     *     target_port: int|null,
      *     pattern: string,
      *     start: int,
      *     base_length: int,
@@ -301,13 +308,20 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                     ? $matches['path_slash'][0]
                     : $matches['url_slash'][0];
             }
+            $target_port = '';
+            if ($mapping['target_port'] !== null) {
+                $target_port_colon = $matches['scheme_colon'][1] === -1
+                    ? ':'
+                    : $matches['scheme_colon'][0];
+                $target_port = $target_port_colon . $mapping['target_port'];
+            }
 
             $next_match = array_merge(
                 $mapping,
                 [
                     'start'         => $authority_start,
                     'base_length'   => strlen($matches['base'][0]),
-                    'replacement'   => $mapping['target_domain'] . str_replace(
+                    'replacement'   => $mapping['target_domain'] . $target_port . str_replace(
                         '/',
                         $target_path_slash,
                         $mapping['target_path']
@@ -368,7 +382,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             (?:
                 (?:
                     (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
-                    ' . $separator_escape . ':
+                    (?<scheme_colon>' . $separator_escape . ':)
                     |
                     (?<!:)
                 )
@@ -392,6 +406,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     target_domain: string,
      *     target_scheme: string,
      *     target_path: string,
+     *     target_port: int|null,
      *     pattern: string
      * }|null
      */
@@ -414,6 +429,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             'target_domain'    => $target['host'],
             'target_scheme'    => $target['scheme'],
             'target_path'      => $target['path'],
+            'target_port'      => $target['port'],
             'pattern'          => $this->create_url_candidate_pattern(
                 $source['scheme'],
                 $source['authority'],
@@ -424,7 +440,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     }
 
     /**
-     * @return array{scheme: string, host: string, authority: string, path: string}|null
+     * @return array{scheme: string, host: string, authority: string, path: string, port: int|null}|null
      */
     private function get_supported_url_parts(string $url, bool $is_source_url): ?array
     {
@@ -447,7 +463,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             && $path !== ''
             && preg_match('#^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$#', $path) !== 1;
         if (( $scheme !== 'http' && $scheme !== 'https' )
-            || ( !$is_source_url && ( array_key_exists('port', $parts) || $has_unsupported_target_path ) )
+            || ( !$is_source_url && $has_unsupported_target_path )
             || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
             || !$this->contains_only_exclamation_mark_through_tilde_bytes($path)) {
             return null;
@@ -458,6 +474,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             'host'      => $host,
             'authority' => $host . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ),
             'path'      => $path,
+            'port'      => isset($parts['port']) ? (int) $parts['port'] : null,
         ];
     }
 

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -307,6 +307,31 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'not-the-source.com/media/logo.png destination.com/assets/media/logo.png',
                 ['https://source.com' => 'https://destination.com/assets'],
             ],
+            'literal target port' => [
+                'https://source.example/media/logo.png',
+                'https://destination.example:8443/media/logo.png',
+                ['https://source.example' => 'https://destination.example:8443'],
+            ],
+            'target port copies the scheme colon spelling' => [
+                'https\\:\\/\\/source.example\\/media\\/logo.png',
+                'https\\:\\/\\/destination.example\\:8443\\/media\\/logo.png',
+                ['https://source.example' => 'https://destination.example:8443'],
+            ],
+            'protocol-relative target port uses a literal colon' => [
+                '\\/\\/source.example\\/media\\/logo.png',
+                '\\/\\/destination.example:8443\\/media\\/logo.png',
+                ['https://source.example' => 'https://destination.example:8443'],
+            ],
+            'scheme-less target port uses a literal colon' => [
+                'source.example\\/media\\/logo.png',
+                'destination.example:8443\\/media\\/logo.png',
+                ['https://source.example' => 'https://destination.example:8443'],
+            ],
+            'target port and path use their captured spellings' => [
+                'https\\:\\/\\/source.example\\/media\\/logo.png',
+                'https\\:\\/\\/destination.example\\:8443\\/assets\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example:8443/assets'],
+            ],
         ];
     }
 
@@ -372,11 +397,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
                 ['https://source.example/media' => 'https://destination.example/über-uns'],
-            ],
-            'target has a port' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
-                ['https://source.example/media' => 'https://destination.example:8443'],
             ],
             'target has a username and password' => [
                 'https://source.example/media/logo.png',

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -550,7 +550,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ],
             'port' => [
                 '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
-                '<a href="https://new.example:8443/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://new.example:8443/media/image.jpg">Image</a>[vc_video link="https:\/\/new.example:8443\/media\/video.mp4"]',
                 ['https://old-site.com' => 'https://new.example:8443'],
             ],
             'IPv4 address' => [


### PR DESCRIPTION
Cautious URL rewriting now supports a port in the destination URL.

For an absolute candidate, the matcher captures the colon after the scheme and gives the target port the same spelling:

```text
https\:\/\/source.example\/media\/logo.png
https\:\/\/destination.example\:8443\/media\/logo.png
```

A protocol-relative or scheme-less candidate has no scheme colon from which to infer escaping. Those forms insert a literal colon:

```text
\/\/source.example\/media\/logo.png
\/\/destination.example:8443\/media\/logo.png

source.example\/media\/logo.png
destination.example:8443\/media\/logo.png
```

That literal colon is an intentional risk in opaque text: the surrounding format may have escaped a colon if one had originally been present. The processor has no colon spelling to copy in these two forms.

Ports compose with target paths and protocol changes. Existing source-port matching and target-domain restrictions remain unchanged.

## Testing

```
cd tests
../vendor/bin/phpunit UrlRewriting
```

PHPStan and focused PHPCS checks pass.
