### PR TITLE
[PHP] Stop pull-db cleanly during database apply

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -285,6 +285,9 @@ class ImportClient
     /** @var bool Set to true by SIGTERM/SIGINT handler to finish the current chunk and exit cleanly. */
     private $shutdown_requested = false;
 
+    /** @var string|null Top-level command whose signal policy is restored after a scoped stage. */
+    private $signal_handling_command;
+
     /** @var int|null First signal asking files-push to stop after its active sender step. */
     private $files_push_stop_signal = null;
 
@@ -462,38 +465,8 @@ class ImportClient
     {
         // Register the command's signal behavior before constructor work can
         // create state or receive a signal under another command's policy.
-        if (function_exists("pcntl_signal")) {
-            if ($signal_handling_command === 'db-apply') {
-                // PDO drivers and the SQLite compatibility layer are not safe
-                // to interrupt inside an executing SQL file chunk. The apply
-                // loop dispatches pending signals between chunks.
-                if (function_exists('pcntl_sigprocmask')) {
-                    pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
-                }
-                if (function_exists('pcntl_async_signals')) {
-                    pcntl_async_signals(false);
-                }
-                pcntl_signal(SIGINT, [$this, 'handle_database_apply_shutdown']);
-                pcntl_signal(SIGTERM, [$this, 'handle_database_apply_shutdown']);
-                // pcntl_signal() unblocks the signal whose handler it installs.
-                if (function_exists('pcntl_sigprocmask')) {
-                    pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
-                }
-            } else {
-                // Enable async signals (PHP 7.1+) so signals work during blocking operations
-                if (function_exists("pcntl_async_signals")) {
-                    pcntl_async_signals(true);
-                }
-                if ($signal_handling_command === 'files-push') {
-                    $this->enable_files_push_signal_handling();
-                } elseif ($signal_handling_command !== 'files-diff') {
-                    // files-diff must not save the pull command's state from a
-                    // shutdown handler; default signal behavior ends the report.
-                    pcntl_signal(SIGINT, [$this, "handle_shutdown"]);
-                    pcntl_signal(SIGTERM, [$this, "handle_shutdown"]);
-                }
-            }
-        }
+        $this->signal_handling_command = $signal_handling_command;
+        $this->install_signal_handling_for_command($signal_handling_command);
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = trim_right_slash($state_dir);
@@ -2302,6 +2275,64 @@ class ImportClient
             posix_kill(posix_getpid(), SIGKILL);
         }
         die("\nForced exit.\n");
+    }
+
+    /** Installs the deferred signal policy for a db-apply stage. */
+    public function enable_database_apply_signal_handling(): void
+    {
+        $this->install_signal_handling_for_command('db-apply');
+    }
+
+    /** Restores the signal policy selected by the top-level command. */
+    public function restore_command_signal_handling(): void
+    {
+        $this->install_signal_handling_for_command($this->signal_handling_command);
+    }
+
+    /** Installs one command's handlers, async mode, and SIGINT/SIGTERM mask. */
+    private function install_signal_handling_for_command(?string $command): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+        if (function_exists('pcntl_sigprocmask')) {
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+        }
+        if (function_exists('pcntl_async_signals')) {
+            pcntl_async_signals(false);
+        }
+
+        if ($command === 'files-push') {
+            $this->enable_files_push_signal_handling();
+        } elseif ($command === 'db-apply') {
+            // PDO drivers and the SQLite compatibility layer are not safe to
+            // interrupt inside an executing SQL file chunk. The apply loop
+            // explicitly dispatches a pending signal between chunks.
+            pcntl_signal(SIGINT, [$this, 'handle_database_apply_shutdown']);
+            pcntl_signal(SIGTERM, [$this, 'handle_database_apply_shutdown']);
+            // pcntl_signal() unblocks the signal whose handler it installs.
+            if (function_exists('pcntl_sigprocmask')) {
+                pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            }
+            return;
+        } elseif ($command === 'files-diff') {
+            // files-diff must not save the pull command's state from a
+            // shutdown handler; default signal behavior ends the report.
+            pcntl_signal(SIGINT, SIG_DFL);
+            pcntl_signal(SIGTERM, SIG_DFL);
+        } else {
+            // Enable the generic command shutdown handler outside scoped stages.
+            pcntl_signal(SIGINT, [$this, 'handle_shutdown']);
+            pcntl_signal(SIGTERM, [$this, 'handle_shutdown']);
+        }
+
+        // Enable async signals (PHP 7.1+) so signals work during blocking operations
+        if (function_exists('pcntl_async_signals')) {
+            pcntl_async_signals(true);
+        }
+        if (function_exists('pcntl_sigprocmask')) {
+            pcntl_sigprocmask(SIG_UNBLOCK, [SIGINT, SIGTERM]);
+        }
     }
 
     /** Installs the files-push first-signal stop behavior when PCNTL exists. */

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -382,10 +382,14 @@ class Pull
             $this->print_stage_header($stage);
 
             try {
-                $this->run_stage($stage, $options, $step, $total);
+                $stage_completed = $this->run_stage($stage, $options, $step, $total);
             } catch (\Exception $e) {
                 $this->report_failure($command, $stage, $stages, $i, $e);
                 throw new PullFailureReportedException($e->getMessage(), 0, $e);
+            }
+
+            if (!$stage_completed) {
+                return;
             }
 
             $this->client->mark_pull_stage_complete($stage, $command, $stages);
@@ -414,11 +418,11 @@ class Pull
      * Runs one pipeline stage and prints its completion summary.
      *
      * Stages that delegate to lower-level commands rely on those commands for
-     * their own resume state. The pipeline checkpoint is saved by the caller
-     * after this method returns, so a thrown exception leaves the stage
-     * unfinished at the orchestration level.
+     * their own resume state. True lets the caller save the pipeline checkpoint;
+     * false leaves a partial stage unfinished and returns control to the process.
+     * A thrown exception also leaves the stage unfinished.
      */
-    private function run_stage(string $stage, array $options, int $step, int $total): void
+    private function run_stage(string $stage, array $options, int $step, int $total): bool
     {
         switch ($stage) {
             case 'preflight':
@@ -495,9 +499,18 @@ class Pull
                     $state->active_resumable_command->command_name !== 'db-apply' ||
                     $state->active_resumable_command->completion_state !== 'complete'
                 ) {
-                    $this->run_until_complete('db-apply', function () use ($options) {
+                    $this->client->enable_database_apply_signal_handling();
+                    try {
                         $this->client->run_db_apply($options);
-                    });
+                    } finally {
+                        $this->client->restore_command_signal_handling();
+                    }
+                    $completion_state =
+                        $this->client->get_state()->active_resumable_command->completion_state;
+                    if ($completion_state === 'partial') {
+                        $this->client->exit_code = 2;
+                        return false;
+                    }
                 }
                 $stmts = $state->apply->statements_executed;
                 $this->print_done($stage, $stmts > 0 ? number_format($stmts) . " statements" : null);
@@ -517,6 +530,7 @@ class Pull
                 $this->start_server($options);
                 break;
         }
+        return true;
     }
 
     /**

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -13,6 +13,10 @@ class PullFilterFakeClient extends \ImportClient
     public int $files_pull_runs = 0;
     public int $db_sync_runs = 0;
     public int $db_apply_runs = 0;
+    public int $database_apply_signal_enables = 0;
+    public int $command_signal_restores = 0;
+    public bool $db_apply_stops_partial_once = false;
+    public bool $db_apply_throws = false;
     public array $progress_events = [];
     public array $progress_file_errors = [];
 
@@ -128,12 +132,30 @@ class PullFilterFakeClient extends \ImportClient
     public function run_db_apply(array $options): void
     {
         $this->db_apply_runs++;
+        if ($this->db_apply_throws) {
+            throw new \RuntimeException('Injected db-apply failure.');
+        }
         $state = $this->get_state();
         $state->active_resumable_command->command_name = "db-apply";
-        $state->active_resumable_command->completion_state = "complete";
+        if ($this->db_apply_stops_partial_once) {
+            $this->db_apply_stops_partial_once = false;
+            $state->active_resumable_command->completion_state = "partial";
+        } else {
+            $state->active_resumable_command->completion_state = "complete";
+        }
         $state->active_resumable_command->current_stage = null;
         $state->apply->statements_executed = 42;
         $this->save_state();
+    }
+
+    public function enable_database_apply_signal_handling(): void
+    {
+        ++$this->database_apply_signal_enables;
+    }
+
+    public function restore_command_signal_handling(): void
+    {
+        ++$this->command_signal_restores;
     }
 }
 
@@ -647,6 +669,139 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
         $this->assertSame(42, $state["apply"]["statements_executed"]);
+    }
+
+    public function testPullDbReturnsAfterAPartialApplyWithoutAdvancingThePipeline(): void
+    {
+        $client = $this->makeClient();
+        $client->db_apply_stops_partial_once = true;
+
+        ob_start();
+        $client->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(2, $client->exit_code);
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame(1, $client->database_apply_signal_enables);
+        $this->assertSame(1, $client->command_signal_restores);
+        $this->assertSame('db-pull', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
+        $this->assertSame('partial', $state["active_resumable_command"]["completion_state"]);
+
+        $resumedClient = $this->makeClient();
+        ob_start();
+        $resumedClient->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $completedState = $this->readState();
+        $this->assertSame(0, $resumedClient->exit_code);
+        $this->assertSame(1, $resumedClient->db_apply_runs);
+        $this->assertSame(1, $resumedClient->database_apply_signal_enables);
+        $this->assertSame(1, $resumedClient->command_signal_restores);
+        $this->assertSame('db-apply', $completedState["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('complete', $completedState["active_resumable_command"]["completion_state"]);
+    }
+
+    public function testDatabaseApplySignalScopeRestoresTheWrapperPolicy(): void
+    {
+        if (
+            !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_signal')
+            || !function_exists('pcntl_signal_get_handler')
+            || !function_exists('pcntl_sigprocmask')
+        ) {
+            $this->markTestSkipped('The signal policy test requires PCNTL signal APIs.');
+        }
+
+        $originalAsyncSignals = pcntl_async_signals();
+        $originalSigintHandler = pcntl_signal_get_handler(SIGINT);
+        $originalSigtermHandler = pcntl_signal_get_handler(SIGTERM);
+        pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $originalSignalMask);
+        pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+
+        try {
+            $client = new \ImportClient(
+                'http://fake.invalid',
+                $this->stateDir,
+                $this->filesystem_root,
+                'pull-db',
+            );
+            $client->enable_database_apply_signal_handling();
+
+            $this->assertFalse(pcntl_async_signals());
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $databaseApplySignalMask);
+            pcntl_sigprocmask(SIG_SETMASK, $databaseApplySignalMask);
+            $this->assertContains(SIGINT, $databaseApplySignalMask);
+            $this->assertContains(SIGTERM, $databaseApplySignalMask);
+            $databaseApplySigintHandler = pcntl_signal_get_handler(SIGINT);
+            $databaseApplySigtermHandler = pcntl_signal_get_handler(SIGTERM);
+            $this->assertIsArray($databaseApplySigintHandler);
+            $this->assertSame($client, $databaseApplySigintHandler[0]);
+            $this->assertSame(
+                'handle_database_apply_shutdown',
+                $databaseApplySigintHandler[1],
+            );
+            $this->assertIsArray($databaseApplySigtermHandler);
+            $this->assertSame($client, $databaseApplySigtermHandler[0]);
+            $this->assertSame(
+                'handle_database_apply_shutdown',
+                $databaseApplySigtermHandler[1],
+            );
+
+            $client->restore_command_signal_handling();
+
+            $this->assertTrue(pcntl_async_signals());
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $restoredSignalMask);
+            pcntl_sigprocmask(SIG_SETMASK, $restoredSignalMask);
+            $this->assertNotContains(SIGINT, $restoredSignalMask);
+            $this->assertNotContains(SIGTERM, $restoredSignalMask);
+            $restoredSigintHandler = pcntl_signal_get_handler(SIGINT);
+            $restoredSigtermHandler = pcntl_signal_get_handler(SIGTERM);
+            $this->assertIsArray($restoredSigintHandler);
+            $this->assertSame($client, $restoredSigintHandler[0]);
+            $this->assertSame('handle_shutdown', $restoredSigintHandler[1]);
+            $this->assertIsArray($restoredSigtermHandler);
+            $this->assertSame($client, $restoredSigtermHandler[0]);
+            $this->assertSame('handle_shutdown', $restoredSigtermHandler[1]);
+        } finally {
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals(false);
+            pcntl_signal(SIGINT, $originalSigintHandler);
+            pcntl_signal(SIGTERM, $originalSigtermHandler);
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals($originalAsyncSignals);
+            pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+        }
+    }
+
+    public function testPullDbRestoresItsSignalPolicyWhenApplyFails(): void
+    {
+        $client = $this->makeClient();
+        $client->db_apply_throws = true;
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull-db",
+                "target_engine" => "sqlite",
+            ]);
+            $this->fail('Expected db-apply to fail.');
+        } catch (\RuntimeException $error) {
+            $this->assertSame('Injected db-apply failure.', $error->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame(1, $client->database_apply_signal_enables);
+        $this->assertSame(1, $client->command_signal_restores);
     }
 
     public function testPullDbRejectsConflictingInProgressPullFiles(): void

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -146,6 +146,9 @@
     "stdout-db-pull-process-death": {
       "port": 8127
     },
+    "pull-db-shutdown": {
+      "port": 8128
+    },
     "file-db-pull-artifact-guards": {
       "port": 8130
     },

--- a/tests/e2e/tests/import-58-pull-db-shutdown.test.js
+++ b/tests/e2e/tests/import-58-pull-db-shutdown.test.js
@@ -1,0 +1,262 @@
+/**
+ * A pull-db SIGTERM during db-apply must stop at the next SQL chunk boundary.
+ * The wrapper must leave db-apply unfinished instead of retrying it or marking
+ * the pipeline complete, and a later process must finish the replacement.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, compareDatabases, fsRootDir,
+    pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+// The PHP.wasm wrapper is a Node process. SIGTERM stops Node instead of being
+// delivered to PHP, so it cannot exercise the importer's deferred signal path.
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: pull-db shutdown during db-apply', { timeout: 300000 }, () => {
+    const site = 'pull-db-shutdown';
+    const lockedTable = 'aa_pull_db_shutdown_lock';
+    const payloadTable = 'ab_pull_db_shutdown_payload';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function targetArguments() {
+        return [
+            '--target-engine=mysql',
+            '--target-host=127.0.0.1',
+            '--target-user=e2e_admin',
+            '--target-pass=e2e_password',
+            `--target-db=${targetDb}`,
+            '--progress=jsonl',
+        ];
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${lockedTable}\` (id, value) VALUES (1, 'locked-row')`
+                );
+                await connection.query(
+                    `CREATE TABLE \`${payloadTable}\` (`
+                    + '`id` INT NOT NULL, `value` LONGTEXT NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${payloadTable}\` (id, value) VALUES (?, ?)`,
+                    [1, 'x'.repeat(192 * 1024)],
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-pull-db-shutdown');
+    });
+
+    afterAll(async () => {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        try {
+            await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('returns 2 without advancing the pipeline and completes in the next process', async () => {
+        const adminConnection = await createMysqlConnection();
+        let lockConnection;
+        let pullProcess;
+        let pullExit;
+        let targetThreadId = null;
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDb}\``);
+
+            const setupConnection = await createMysqlConnection(targetDb);
+            try {
+                await setupConnection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+            } finally {
+                await setupConnection.end();
+            }
+
+            lockConnection = await createMysqlConnection(targetDb);
+            await lockConnection.query(`LOCK TABLES \`${lockedTable}\` WRITE`);
+
+            const output = { stdout: '', stderr: '' };
+            pullProcess = spawn(phpBinary, [
+                importerPath,
+                'pull-db',
+                importUrl(),
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
+                `--secret=${getSiteSecret(site)}`,
+                ...targetArguments(),
+            ], {
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            pullProcess.stdout.setEncoding('utf8');
+            pullProcess.stderr.setEncoding('utf8');
+            pullProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+            pullProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+            pullExit = new Promise(resolve => {
+                pullProcess.once('exit', (code, signal) => resolve({ code, signal }));
+            });
+
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+            const lockDeadline = Date.now() + 120000;
+            while (Date.now() < lockDeadline) {
+                if (pullProcess.exitCode !== null || pullProcess.signalCode !== null) {
+                    const result = await pullExit;
+                    assert.fail(
+                        `pull-db exited before db-apply blocked (${result.code}/${result.signal}):\n`
+                        + output.stderr + output.stdout,
+                    );
+                }
+
+                let atApplyStage = false;
+                if (existsSync(statePath)) {
+                    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                    atApplyStage = state.pull_pipeline?.last_completed_stage === 'db-pull'
+                        && state.active_resumable_command?.command_name === 'db-apply';
+                }
+                const [threads] = await adminConnection.query(
+                    'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                    + 'WHERE DB = ? AND COMMAND = ? AND INFO LIKE ?',
+                    [targetDb, 'Query', `%${lockedTable}%`],
+                );
+                if (atApplyStage && threads.length === 1) {
+                    targetThreadId = Number(threads[0].ID);
+                    break;
+                }
+                await sleep(25);
+            }
+
+            assert.notEqual(targetThreadId, null, 'pull-db did not block in db-apply');
+            assert.equal(pullProcess.kill('SIGTERM'), true);
+
+            // The db-apply signal policy keeps the signal blocked during the
+            // active query. A wrapper using the generic policy exits here, so
+            // remove its abandoned target session before releasing the lock.
+            await sleep(250);
+            const processExited = pullProcess.exitCode !== null
+                || pullProcess.signalCode !== null;
+            if (processExited) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${targetThreadId}`);
+                } catch (error) {
+                    if (error.code !== 'ER_NO_SUCH_THREAD') {
+                        throw error;
+                    }
+                }
+            }
+
+            await lockConnection.query('UNLOCK TABLES');
+            await lockConnection.end();
+            lockConnection = null;
+
+            const stopped = await Promise.race([
+                pullExit,
+                sleep(60000).then(() => ({ timedOut: true })),
+            ]);
+            assert.equal(stopped.timedOut, undefined, 'pull-db did not stop after SIGTERM');
+            assert.equal(
+                stopped.code,
+                2,
+                `pull-db stopped as ${stopped.code}/${stopped.signal}:\n`
+                + output.stderr + output.stdout,
+            );
+
+            const interruptedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(interruptedState.pull_pipeline.started_by_command, 'pull-db');
+            assert.equal(interruptedState.pull_pipeline.last_completed_stage, 'db-pull');
+            assert.equal(interruptedState.active_resumable_command.command_name, 'db-apply');
+            assert.equal(interruptedState.active_resumable_command.completion_state, 'partial');
+            assert.equal(interruptedState.apply.target_engine, 'mysql');
+            assert.equal(interruptedState.apply.target_host, '127.0.0.1');
+            assert.equal(interruptedState.apply.target_port, 3306);
+            assert.equal(interruptedState.apply.target_user, 'e2e_admin');
+            assert.equal(interruptedState.apply.target_pass, 'e2e_password');
+            assert.equal(interruptedState.apply.target_db, targetDb);
+            assert.ok(
+                Number(interruptedState.apply?.statements_executed || 0) > 0,
+                'db-apply did not finish the active SQL chunk before stopping',
+            );
+
+            const resumed = runImporter(importUrl(), tempDir, 'pull-db', {
+                secret: getSiteSecret(site),
+                extraArgs: targetArguments(),
+                autoResume: false,
+                timeout: 180000,
+                wallTimeout: 240000,
+            });
+            assert.equal(
+                resumed.exitCode,
+                0,
+                `resumed pull-db failed:\n${resumed.stderr}\n${resumed.stdout}`,
+            );
+
+            const completedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(completedState.pull_pipeline.last_completed_stage, 'db-apply');
+            assert.equal(completedState.active_resumable_command.completion_state, 'complete');
+
+            const comparison = await compareDatabases(getDbName(site), targetDb);
+            assert.deepEqual(comparison.missingTables, []);
+            assert.deepEqual(comparison.extraTables, []);
+            assert.ok(
+                Object.values(comparison.rowCounts).every(counts => counts.match),
+                `row counts differ: ${JSON.stringify(comparison.rowCounts)}`,
+            );
+        } finally {
+            if (
+                pullProcess
+                && pullProcess.exitCode === null
+                && pullProcess.signalCode === null
+            ) {
+                pullProcess.kill('SIGKILL');
+                await pullExit;
+            }
+            if (targetThreadId !== null) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${targetThreadId}`);
+                } catch {}
+            }
+            if (lockConnection) {
+                try { await lockConnection.query('UNLOCK TABLES'); } catch {}
+                await lockConnection.end();
+            }
+            await adminConnection.end();
+        }
+    });
+});


### PR DESCRIPTION
`pull-db` now handles SIGINT and SIGTERM while it is applying the database, exits with code 2, and leaves the database-apply stage unfinished for the next process.

## Background

The wrapper kept its normal signal handler while `db-apply` was running. A signal could therefore kill the process during an active PDO query. If `db-apply` returned `partial`, the wrapper also called it again immediately in the same process.

## This change

The wrapper uses the database-apply signal policy only for that stage and restores its normal policy afterward. Pending signals are handled between SQL chunks, not during a target query.

`db-apply` runs once per wrapper process. A partial result sets exit code 2 and returns without marking the stage or the whole pull complete. The next process uses #595 to start `db.sql` again from the beginning.

This is PR 4 of 5: #590 → #591 → #595 → #582 → #607.

## Testing

The focused PHP tests cover the partial result, next-process completion, restoration after an exception, and the actual PCNTL handlers and signal mask. The MySQL E2E blocks a target query, sends SIGTERM, checks exit code 2 and the unchanged stage, then completes the pull in a new process.
