### PR TITLE
[PHP] Match consistent cautious URL slash escaping

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -47,8 +47,8 @@
  *   https://source.example/media/logo.png to
  *   https://destination.example/logo.png.
  * - Literal, protocol-relative, scheme-less, and slash-escaped URL spellings.
- *   The recognized separators may have one or three preceding backslashes,
- *   including https:\/\/, https\:\/\/, and https:\\\/\\\/.
+ *   A separator may have up to eight preceding backslashes. The two slashes
+ *   before an authority must use the same spelling.
  * - Other parts of the URL may surround the configured base. For example,
  *   https://user:password@source.example/logo.png?download=1#preview becomes
  *   https://user:password@destination.example/logo.png?download=1#preview.
@@ -339,27 +339,27 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
         bool $requires_path_slash
     ): string
     {
-        $escaped_separator = '(?:\\\\{1}|\\\\{3})?';
+        $separator_escape = '\\\\{0,8}';
         $source_path_pattern = '';
         if ($source_path !== '') {
             $source_path_pattern =
-                '(?<path_slash>' . $escaped_separator . '/)'
+                '(?<path_slash>' . $separator_escape . '/)'
                 . str_replace(
                     '/',
-                    $escaped_separator . '/',
+                    $separator_escape . '/',
                     preg_quote(substr($source_path, 1), '~')
                 );
         }
         $candidate_boundary_pattern = '(?=
             $
-            | ' . $escaped_separator . '/
+            | ' . $separator_escape . '/
             | [/?# \t\r\n,!;)\]}>"\']
         )';
         if ($requires_path_slash && $source_path === '') {
             $candidate_boundary_pattern = '(?(url_slash)
                 ' . $candidate_boundary_pattern . '
                 |
-                (?=(?<path_slash>' . $escaped_separator . '/))
+                (?=(?<path_slash>' . $separator_escape . '/))
             )';
         }
 
@@ -368,12 +368,12 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
             (?:
                 (?:
                     (?<scheme>(?i:' . preg_quote($source_scheme, '~') . '))
-                    ' . $escaped_separator . ':
+                    ' . $separator_escape . ':
                     |
                     (?<!:)
                 )
-                (?<url_slash>' . $escaped_separator . '/)
-                ' . $escaped_separator . '/
+                (?<url_slash>(?<url_slash_escape>' . $separator_escape . ')/)
+                \k<url_slash_escape>/
                 (?:[^\s<>@/\\\\]+@)?
             )?
             (?<base>

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -40,6 +40,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
      */
     public static function supported_cases(): array
     {
+        $eight_backslash_separator = str_repeat('\\', 8) . '/';
+
         return [
             'unquoted CSS URL preserves its terminator' => [
                 '.hero{background-image:url(https://source.example/wp-content/uploads/2026/01/hero.jpg);}',
@@ -80,6 +82,25 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 '[builder_data value="{\\\"url\\\":\\\"https:\\\\\\/\\\\\\/source.example\\\\\\/wp-content\\\\\\/uploads\\\\\\/2026\\\\\\/01\\\\\\/hero.jpg\\\"}"]',
                 '[builder_data value="{\\\"url\\\":\\\"https:\\\\\\/\\\\\\/destination.example\\\\\\/wp-content\\\\\\/uploads\\\\\\/2026\\\\\\/01\\\\\\/hero.jpg\\\"}"]',
                 ['https://source.example' => 'https://destination.example'],
+            ],
+            'two-backslash URL separators' => [
+                'https:\\\\/\\\\/source.example\\\\/media\\\\/logo.png',
+                'https:\\\\/\\\\/destination.example\\\\/assets\\\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'four-backslash URL separators' => [
+                'https:\\\\\\\\/\\\\\\\\/source.example\\\\\\\\/media\\\\\\\\/logo.png',
+                'https:\\\\\\\\/\\\\\\\\/destination.example\\\\\\\\/assets\\\\\\\\/logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
+            ],
+            'eight-backslash URL separators' => [
+                'https:' . $eight_backslash_separator . $eight_backslash_separator
+                    . 'source.example' . $eight_backslash_separator . 'media'
+                    . $eight_backslash_separator . 'logo.png',
+                'https:' . $eight_backslash_separator . $eight_backslash_separator
+                    . 'destination.example' . $eight_backslash_separator . 'assets'
+                    . $eight_backslash_separator . 'logo.png',
+                ['https://source.example/media' => 'https://destination.example/assets'],
             ],
             'username, password, and suffix remain unchanged' => [
                 'url("https://user:password@source.example/wp-content/uploads/logo.png?download=1#preview");',
@@ -294,6 +315,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
      */
     public static function unsupported_cases(): array
     {
+        $nine_backslash_separator = str_repeat('\\', 9) . '/';
+
         return [
             'configured source path differs by case' => [
                 'https://SOURCE.EXAMPLE/Media/logo.png',
@@ -495,9 +518,16 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 "https://source.example/media\x80archive/logo.png",
                 ["https://source.example/media\x80archive" => 'https://destination.example'],
             ],
-            'protocol separators use two backslashes' => [
-                'https:\\\\/\\\\/source.example\\\\/media\\\\/logo.png',
-                'https:\\\\/\\\\/source.example\\\\/media\\\\/logo.png',
+            'protocol slashes use different escaping' => [
+                'https:\\/\\\\/source.example\\/media\\/logo.png',
+                'https:\\/\\\\/source.example\\/media\\/logo.png',
+                ['https://source.example' => 'https://destination.example'],
+            ],
+            'protocol separators use nine backslashes' => [
+                'https:' . $nine_backslash_separator . $nine_backslash_separator
+                    . 'source.example' . $nine_backslash_separator . 'media/logo.png',
+                'https:' . $nine_backslash_separator . $nine_backslash_separator
+                    . 'source.example' . $nine_backslash_separator . 'media/logo.png',
                 ['https://source.example' => 'https://destination.example'],
             ],
             'protocol separators are percent encoded' => [


### PR DESCRIPTION
Rewrites cautious URLs whose slash separators carry zero through eight backslashes.

The matcher captures the backslashes before the first slash in `//` and requires the second slash to use the same bytes. This accepts forms from `https://source.example` through eight-backslash separators without guessing which enclosing format produced them. A pair with different escaping remains unchanged.

When a target has a path, its slashes continue to copy the complete first protocol slash.

## Testing

The cautious URL cases cover the eight-backslash limit, reject nine backslashes, and reject a mismatched slash pair. The complete URL-rewriting suite passes.