### PR TITLE
[PHP] Share remote-to-local pull path mapping

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -107,6 +107,7 @@ require_once __DIR__ . '/lib/pull/class-pull.php';
 
 // Pull index reader and the WAL for completed files-pull mutations.
 require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
+require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
 
 /**
@@ -9003,31 +9004,12 @@ class ImportClient
     private function map_remote_absolute_path_to_local_absolute_path(
         string $remote_absolute_path
     ): string {
-        assert_valid_path($remote_absolute_path, "remote absolute path");
-        $local_absolute_path = null;
-        $longest_remote_prefix_length = -1;
-        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
-            $remainder = path_remainder_under($remote_absolute_path, $remote_prefix);
-            if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
-                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
-                $longest_remote_prefix_length = strlen($remote_prefix);
-            }
-        }
-        if ($local_absolute_path !== null) {
-            return $local_absolute_path;
-        }
-
-        // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
-        // Use the same local followed symlinks root for copied content and rewritten symlink targets so the links do not dangle.
-        if ($this->local_followed_symlinks_root !== null
-            && !$this->path_is_within_original_export_scope($remote_absolute_path)) {
-            return wp_join_unix_paths(
-                $this->local_followed_symlinks_root,
-                $remote_absolute_path
-            );
-        }
-
-        return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
+        return ( new RemoteToLocalPathMapper(
+            $this->filesystem_root,
+            $this->get_export_directories(),
+            $this->resolved_path_mappings,
+            $this->local_followed_symlinks_root
+        ) )->map_path($remote_absolute_path);
     }
 
 
@@ -9814,22 +9796,6 @@ class ImportClient
             );
         }
         return $dirs;
-    }
-
-    /**
-     * Whether $path falls under one of the ORIGINAL export directories (the
-     * --include prefixes, or the base roots without --include) — i.e. it was going to
-     * be pulled anyway. Evaluated against the pre-follow scope; a followed
-     * target outside all of these is "escaping" and eligible for symlink bundling.
-     */
-    private function path_is_within_original_export_scope(string $path): bool
-    {
-        foreach ($this->get_export_directories() as $root) {
-            if (path_is_same_as_or_descendant_of($path, $root)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -1,0 +1,124 @@
+<?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\path_remainder_under;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Filesystem paths are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Maps remote paths into one local filesystem tree.
+ *
+ * map_path() is the write-path mapping used by a files pull. An explicit
+ * remap wins first. If several remaps match, the longest remote prefix wins.
+ * An unmatched path from the original pull scope keeps its remote spelling
+ * under the local filesystem root. A followed symlink target outside that
+ * scope goes under the configured local followed-symlinks root instead.
+ * Copied targets and rewritten symlink destinations both use this mapping,
+ * so each rewritten link points to the place where its target was copied.
+ *
+ *     $mapper = new RemoteToLocalPathMapper(
+ *         '/local',
+ *         ['/srv/site'],
+ *         ['/srv/site/wp-content' => '/local/content']
+ *     );
+ *
+ *     $mapper->map_path('/srv/site/index.php');
+ *     // /local/srv/site/index.php
+ *
+ *     $mapper->map_path('/srv/site/wp-content/plugin.php');
+ *     // /local/content/plugin.php
+ *
+ * Paths remain byte strings in memory. This class does not encode them as
+ * JSON or require them to be valid UTF-8.
+ */
+final class RemoteToLocalPathMapper
+{
+    /** Local filesystem root beneath which pulled paths are written. */
+    private string $filesystem_root;
+
+    /** @var list<string> Remote roots selected before following symlinks. */
+    private array $original_remote_roots;
+
+    /** @var array<string,string> Remote absolute prefix to local absolute prefix. */
+    private array $resolved_path_mappings;
+
+    /** Local root for followed targets outside the original pull scope. */
+    private ?string $local_followed_symlinks_root;
+
+    /**
+     * Stores the resolved path settings used by one files pull.
+     *
+     * The caller resolves and validates these settings before constructing the
+     * mapper. Local prefixes and the followed-symlinks root must be equal to or
+     * below the filesystem root.
+     *
+     * @param string               $filesystem_root             Local filesystem root.
+     * @param list<string>         $original_remote_roots       Remote roots selected before following symlinks.
+     * @param array<string,string> $resolved_path_mappings      Remote absolute prefix to local absolute prefix.
+     * @param string|null          $local_followed_symlinks_root Local root for followed targets outside the original scope.
+     */
+    public function __construct(
+        string $filesystem_root,
+        array $original_remote_roots,
+        array $resolved_path_mappings = [],
+        ?string $local_followed_symlinks_root = null
+    ) {
+        $this->filesystem_root = $filesystem_root;
+        $this->original_remote_roots = $original_remote_roots;
+        $this->resolved_path_mappings = $resolved_path_mappings;
+        $this->local_followed_symlinks_root = $local_followed_symlinks_root;
+    }
+
+    /**
+     * Maps one remote absolute path to its local absolute path.
+     *
+     * @param string $remote_absolute_path Remote absolute path.
+     * @return string Local absolute path under the filesystem root.
+     */
+    public function map_path(string $remote_absolute_path): string
+    {
+        assert_valid_path($remote_absolute_path, "remote absolute path");
+        $local_absolute_path = null;
+        $longest_remote_prefix_length = -1;
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = path_remainder_under($remote_absolute_path, $remote_prefix);
+            if (
+                $remainder !== null
+                && strlen($remote_prefix) > $longest_remote_prefix_length
+            ) {
+                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
+                $longest_remote_prefix_length = strlen($remote_prefix);
+            }
+        }
+        if ($local_absolute_path !== null) {
+            return $local_absolute_path;
+        }
+
+        if ($this->local_followed_symlinks_root !== null) {
+            $path_is_within_original_remote_roots = false;
+            foreach ($this->original_remote_roots as $original_remote_root) {
+                if (
+                    path_is_same_as_or_descendant_of(
+                        $remote_absolute_path,
+                        $original_remote_root
+                    )
+                ) {
+                    $path_is_within_original_remote_roots = true;
+                    break;
+                }
+            }
+            if (!$path_is_within_original_remote_roots) {
+                return wp_join_unix_paths(
+                    $this->local_followed_symlinks_root,
+                    $remote_absolute_path
+                );
+            }
+        }
+
+        return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
+    }
+}

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -99,10 +99,13 @@ class FollowedSymlinksRootTest extends TestCase
 
     private function inScope(array $onlyPrefixes, string $path): bool
     {
-        $c = $this->newClient();
-        $rc = new \ReflectionClass($c);
-        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $onlyPrefixes);
-        return $rc->getMethod('path_is_within_original_export_scope')->invoke($c, $path);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->root,
+            $onlyPrefixes,
+            [],
+            $this->root . '/followed'
+        );
+        return $mapper->map_path($path) === $this->root . $path;
     }
 
     public function testTargetUnderScopeIsInScope(): void

--- a/tests/Import/RemoteToLocalPathMapperTest.php
+++ b/tests/Import/RemoteToLocalPathMapperTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php';
+
+final class RemoteToLocalPathMapperTest extends TestCase
+{
+    public function testMostSpecificRemotePrefixWins(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/srv/site'],
+            [
+                '/srv/site/wp-content' => '/local/content',
+                '/srv/site/wp-content/plugins' => '/local/plugins',
+            ]
+        );
+
+        $this->assertSame(
+            '/local/plugins/hello/plugin.php',
+            $mapper->map_path('/srv/site/wp-content/plugins/hello/plugin.php')
+        );
+    }
+
+    public function testUnmatchedPathUsesIdentityPlacement(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/srv/site'],
+            ['/srv/site/wp-content' => '/local/content']
+        );
+
+        $this->assertSame(
+            '/local/srv/site/index.php',
+            $mapper->map_path('/srv/site/index.php')
+        );
+        $this->assertSame(
+            '/local/srv/site-old/index.php',
+            $mapper->map_path('/srv/site-old/index.php')
+        );
+    }
+
+    public function testOutOfScopeFollowedTargetUsesFollowedSymlinksRoot(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/srv/site'],
+            [],
+            '/local/followed'
+        );
+
+        $this->assertSame(
+            '/local/srv/site/index.php',
+            $mapper->map_path('/srv/site/index.php')
+        );
+        $this->assertSame(
+            '/local/followed/mnt/shared/file.txt',
+            $mapper->map_path('/mnt/shared/file.txt')
+        );
+    }
+
+    public function testRemapWinsOverFollowedSymlinkPlacement(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/srv/site'],
+            ['/mnt/shared' => '/local/shared'],
+            '/local/followed'
+        );
+
+        $this->assertSame(
+            '/local/shared/file.txt',
+            $mapper->map_path('/mnt/shared/file.txt')
+        );
+    }
+
+    public function testPathBytesDoNotNeedToBeValidUtf8(): void
+    {
+        $remote_root = "/srv/site-\xff";
+        $remote_content = $remote_root . "/content-\xfe";
+        $local_content = "/local/content-\xfd";
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            [$remote_root],
+            [$remote_content => $local_content]
+        );
+
+        $this->assertSame(
+            $local_content . '/file.txt',
+            $mapper->map_path($remote_content . '/file.txt')
+        );
+    }
+}


### PR DESCRIPTION
Files pull now uses one `RemoteToLocalPathMapper` for fetched paths, rewritten symlink targets, and followed targets. This keeps the existing placement rules in one class before mirror pulls need the same rules while building a local sync plan.

The mapper keeps the current order: the longest explicit remap wins, paths in the original pull scope keep their remote path below the local filesystem root, and followed targets outside that scope go below the followed-symlinks root. Paths remain byte strings.

```php
$mapper = new RemoteToLocalPathMapper(
    "/local",
    ["/srv/site"],
    ["/srv/site/wp-content" => "/local/content"]
);

$mapper->map_path("/srv/site/index.php");
// /local/srv/site/index.php

$mapper->map_path("/srv/site/wp-content/plugin.php");
// /local/content/plugin.php
```

This is a refactor. The existing pull endpoint tests pass without changing the resulting paths.