### PR TITLE
[PHP] Keep pulled deletions within selected paths

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -25,6 +25,9 @@ use Reprint\Importer\Tuning\AdaptiveTuner;
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
+use function Reprint\Importer\file_sync_index_path_may_change;
+use function Reprint\Importer\file_sync_result_contains_path_or_descendant;
+use function Reprint\Importer\find_file_sync_deletion_root;
 use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
@@ -85,6 +88,7 @@ require_once __DIR__ . '/lib/merge/load.php';
 require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/index/class-file-index-diff-processor.php';
+require_once __DIR__ . '/lib/index/file-sync-path-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
@@ -6911,6 +6915,12 @@ class ImportClient
             $file_diff_progress_state->index_diff_cursor,
             [RemoteIndexReader::class, "decode_index_line"]
         );
+        $remote_to_local_path_mapper = new RemoteToLocalPathMapper(
+            $this->filesystem_root,
+            $this->get_export_directories(),
+            $this->resolved_path_mappings,
+            $this->local_followed_symlinks_root
+        );
         $fetch_list_file_handle = null;
         try {
             $fetch_list_file_handle = fopen($this->fetch_list_file, "c+b");
@@ -6962,6 +6972,14 @@ class ImportClient
                     $remote_absolute_path = $index_diff->get_path();
                     $transition = $index_diff->get_path_transition();
                     if ($transition === "deleted") {
+                        $deleted_path_is_empty_directory = $index_diff->get_path_type_in_old_index() === "dir";
+                        $empty_directory_is_now_implied_by_a_descendant =
+                            $deleted_path_is_empty_directory
+                            && file_sync_result_contains_path_or_descendant(
+                                $remote_absolute_path,
+                                $index_diff->get_preceding_path_in_new_index(),
+                                $index_diff->get_following_path_in_new_index()
+                            );
                         // The remote index is a union across files-pull path
                         // selections. Keep paths outside this run's selection.
                         if (
@@ -6969,25 +6987,90 @@ class ImportClient
                                 $remote_absolute_path,
                                 false
                             )
+                            || $empty_directory_is_now_implied_by_a_descendant
                         ) {
-                            $remote_deletion_root =
-                                $this->derive_remote_deletion_root_from_sparse_index(
-                                    $remote_absolute_path,
-                                    $index_diff->get_preceding_path_in_new_index(),
-                                    $index_diff->get_following_path_in_new_index()
-                                );
                             $local_absolute_path =
-                                $this->remove_remote_path_locally(
-                                    $remote_deletion_root
-                                );
-                            if ($local_absolute_path === null) {
-                                $this->pull_index_journal->record_remote_invalidation(
+                                $remote_to_local_path_mapper->map_path(
                                     $remote_absolute_path
                                 );
-                            } else {
-                                $this->pull_index_journal->record_successful_deletion(
+                            $local_index_path = relative_path_under(
+                                $local_absolute_path, $this->filesystem_root
+                            );
+                            assert($local_index_path !== null);
+                            $remote_deletion_root =
+                                find_file_sync_deletion_root(
                                     $remote_absolute_path,
-                                    $local_absolute_path
+                                    $index_diff->get_preceding_path_in_new_index(),
+                                    $index_diff->get_following_path_in_new_index(),
+                                    function (string $candidate_path) use (
+                                        $local_index_path,
+                                        $remote_to_local_path_mapper
+                                    ): bool {
+                                        $candidate_local_absolute_path =
+                                            $remote_to_local_path_mapper->map_path(
+                                                $candidate_path
+                                            );
+                                        $candidate_local_index_path = relative_path_under(
+                                            $candidate_local_absolute_path, $this->filesystem_root
+                                        );
+                                        if (
+                                            $candidate_local_index_path === null
+                                            || $candidate_local_index_path === ""
+                                            || !path_is_same_as_or_descendant_of(
+                                                $local_index_path,
+                                                $candidate_local_index_path
+                                            )
+                                        ) {
+                                            return false;
+                                        }
+                                        if (
+                                            !$remote_to_local_path_mapper
+                                                ->remote_path_owns_mapped_local_subtree(
+                                                    $candidate_path
+                                                )
+                                        ) {
+                                            return false;
+                                        }
+                                        return file_sync_index_path_may_change(
+                                            $candidate_path,
+                                            $this->get_export_directories(),
+                                            $this->pull_excluded_files_with_path_prefixes
+                                        );
+                                    },
+                                    $deleted_path_is_empty_directory
+                                );
+                            if ($remote_deletion_root !== null) {
+                                $local_absolute_deletion_root =
+                                    $remote_to_local_path_mapper->map_path(
+                                        $remote_deletion_root
+                                    );
+                                if (
+                                    ( file_exists($local_absolute_deletion_root)
+                                        || is_link($local_absolute_deletion_root) )
+                                    && !$this->remove_local_absolute_path_without_following_symlinks(
+                                        $local_absolute_deletion_root
+                                    )
+                                ) {
+                                    $this->audit_log(
+                                        "Failed to delete: {$remote_deletion_root}",
+                                        true
+                                    );
+                                    $this->pull_index_journal->record_remote_invalidation(
+                                        $remote_absolute_path
+                                    );
+                                } else {
+                                    $this->audit_log(
+                                        "Deleted: {$remote_deletion_root}",
+                                        false
+                                    );
+                                    $this->pull_index_journal->record_successful_deletion(
+                                        $remote_absolute_path,
+                                        $local_absolute_deletion_root
+                                    );
+                                }
+                            } else {
+                                $this->pull_index_journal->record_remote_invalidation(
+                                    $remote_absolute_path
                                 );
                             }
                         }
@@ -7360,123 +7443,6 @@ class ImportClient
             "Added to the fetch list: {$remote_absolute_path}",
             false,
         );
-    }
-
-    /**
-     * Removes a remote deletion root from the mapped local filesystem.
-     *
-     * @return string|null The mapped local absolute path when it is absent
-     *                     after this call, or null when it could not be removed.
-     */
-    private function remove_remote_path_locally(
-        string $remote_deletion_root
-    ): ?string {
-        if ($remote_deletion_root === "") {
-            return null;
-        }
-        try {
-            $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
-                $remote_deletion_root
-            );
-        } catch (RuntimeException $e) {
-            $this->audit_log(
-                "Security: refusing to delete invalid path '{$remote_deletion_root}': " . $e->getMessage(),
-                true,
-            );
-            return null;
-        }
-        if (!file_exists($local_absolute_path) && !is_link($local_absolute_path)) {
-            return $local_absolute_path;
-        }
-
-        if ($this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)) {
-            $this->audit_log("Deleted: {$remote_deletion_root}", false);
-            return $local_absolute_path;
-        }
-
-        $this->audit_log("Failed to delete: {$remote_deletion_root}", true);
-        return null;
-    }
-
-    /**
-     * Derives the shallowest missing remote path that can be deleted locally.
-     *
-     * Whenever a path stored in the locally saved remote index is missing from the
-     * currently downloaded remote index, we must figure out the blast radius. What
-     * exactly was deleted on the remote server? This function answers that
-     * question based on the:
-     *
-     * * original missing path
-     * * the nearest path before it in the new index, if any
-     * * the nearest path after it in the new index, if any
-     *
-     * For example:
-     *
-     *     Saved index:
-     *         /srv/site/wp-config.php
-     *         /srv/site/wp-content/index.php
-     *         /srv/site/wp-content/test.php
-     *         /srv/site/wp-settings.php
-     *
-     *     Newly downloaded index:
-     *         /srv/site/wp-config.php
-     *         /srv/site/wp-settings.php
-     *
-     * When we notice `/srv/site/wp-content/index.php` is not in the new index,
-     * this function is called with:
-     *
-     *     derive_remote_deletion_root_from_sparse_index(
-     *         missing_remote_path: "/srv/site/wp-content/index.php",
-     *         nearest_existing_path_before: "/srv/site/wp-config.php",
-     *         nearest_existing_path_after: "/srv/site/wp-settings.php"
-     *     )
-     *     // returns "/srv/site/wp-content"
-     *
-     * The neighboring paths show that `/srv` and `/srv/site` still contain files,
-     * but neither path is within `/srv/site/wp-content`.
-     *
-     * @param string      $missing_remote_path           Previously recorded path that is now missing.
-     * @param string|null $nearest_existing_path_before  Nearest existing path before the missing path, if any.
-     * @param string|null $nearest_existing_path_after   Nearest existing path after the missing path, if any.
-     *
-     * @return string The shallowest missing parent, or the original path when every parent still contains an entry.
-     */
-    private function derive_remote_deletion_root_from_sparse_index(
-        string $missing_remote_path,
-        ?string $nearest_existing_path_before,
-        ?string $nearest_existing_path_after
-    ): string {
-        // Use an invalid path that cannot match any validated remote path so
-        // both comparisons below always receive strings.
-        if (null === $nearest_existing_path_before) {
-            $nearest_existing_path_before = "/\0/";
-        }
-        if (null === $nearest_existing_path_after) {
-            $nearest_existing_path_after = "/\0/";
-        }
-        $missing_remote_path_components = wp_unix_path_segments($missing_remote_path);
-        $remote_parent_components = [];
-        $remote_parent_component_count = count($missing_remote_path_components) - 1;
-        // Find the shallowest parent absent from both neighboring entries.
-        for ($component_index = 0; $component_index < $remote_parent_component_count; ++$component_index) {
-            $remote_parent_components[] = $missing_remote_path_components[$component_index];
-            $path_prefix = wp_join_unix_paths("/", ...$remote_parent_components);
-            if (
-                !path_is_same_as_or_descendant_of(
-                    $nearest_existing_path_before,
-                    $path_prefix,
-                )
-                && !path_is_same_as_or_descendant_of(
-                    $nearest_existing_path_after,
-                    $path_prefix,
-                )
-            ) {
-                return $path_prefix;
-            }
-        }
-        // Every parent still has an entry in the new index, so only the
-        // original missing entry should be deleted.
-        return $missing_remote_path;
     }
 
     /**

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -1,11 +1,12 @@
 <?php
 
-use function WordPress\Filesystem\wp_join_unix_paths;
-use function WordPress\Filesystem\wp_unix_path_segments;
+use function Reprint\Importer\file_sync_index_path_may_change;
+use function Reprint\Importer\find_file_sync_deletion_root;
 use function WordPress\Reprint\Exporter\path_is_descendant_of;
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 
 require_once __DIR__ . '/class-file-index-diff-processor.php';
+require_once __DIR__ . '/file-sync-path-functions.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
@@ -319,7 +320,11 @@ final class FileSyncPatchPlanner
                 );
             if (
                 $patch_result_entry_replaces_patch_base_subtree
-                && $this->path_may_change($index_path)
+                && file_sync_index_path_may_change(
+                    $index_path,
+                    $this->included_index_path_roots,
+                    $this->excluded_index_path_roots
+                )
                 && !$this->active_deletion_root_covers_path($index_path)
             ) {
                 $path_to_delete = $index_path;
@@ -329,53 +334,31 @@ final class FileSyncPatchPlanner
                         $active_deletion_root_byte_offset
                     );
             }
-            if ($this->path_may_change($index_path)) {
+            if (
+                file_sync_index_path_may_change(
+                    $index_path,
+                    $this->included_index_path_roots,
+                    $this->excluded_index_path_roots
+                )
+            ) {
                 $path_to_copy = $index_path;
             }
         } elseif ($path_transition === "deleted") {
-            $patch_base_empty_directory_is_implied_by_patch_result_descendant =
-                $patch_base_entry_shape === "empty_directory"
-                && $this->patch_result_index_contains_path_or_descendant(
-                    $index_path,
-                    $this->index_diff->get_preceding_path_in_new_index(),
-                    $this->index_diff->get_following_path_in_new_index()
-                );
-
-            // Find the highest patch-base directory without a patch-result
-            // entry below it which path selection allows us to delete. A
-            // higher directory may sit outside an included root or contain an
-            // excluded root, so keep looking below it. Only the adjacent
-            // result entries can neighbor each parent in byte order, so no
-            // index rescan is needed.
-            $candidate_path_to_delete =
-                $this->path_may_change($index_path) ? $index_path : null;
-            $index_path_components = wp_unix_path_segments($index_path);
-            $candidate_path_components = [];
-            for (
-                $index = 0,
-                $component_count = count($index_path_components) - 1;
-                $index < $component_count;
-                ++$index
-            ) {
-                $candidate_path_components[] = $index_path_components[$index];
-                $candidate_path = wp_join_unix_paths(
-                    ...$candidate_path_components
-                );
-                if (
-                    !$this->patch_result_index_contains_path_or_descendant(
+            $candidate_path_to_delete = find_file_sync_deletion_root(
+                $index_path,
+                $this->index_diff->get_preceding_path_in_new_index(),
+                $this->index_diff->get_following_path_in_new_index(),
+                function (string $candidate_path): bool {
+                    return file_sync_index_path_may_change(
                         $candidate_path,
-                        $this->index_diff->get_preceding_path_in_new_index(),
-                        $this->index_diff->get_following_path_in_new_index()
-                    )
-                    && $this->path_may_change($candidate_path)
-                ) {
-                    $candidate_path_to_delete = $candidate_path;
-                    break;
-                }
-            }
+                        $this->included_index_path_roots,
+                        $this->excluded_index_path_roots
+                    );
+                },
+                $patch_base_entry_shape === "empty_directory"
+            );
             if (
-                !$patch_base_empty_directory_is_implied_by_patch_result_descendant
-                && $candidate_path_to_delete !== null
+                $candidate_path_to_delete !== null
                 && !$this->active_deletion_root_covers_path($index_path)
             ) {
                 $path_to_delete = $candidate_path_to_delete;
@@ -405,7 +388,11 @@ final class FileSyncPatchPlanner
             $needs_delete =
                 $patch_result_entry_is_file_or_symlink
                 !== $patch_base_entry_is_file_or_symlink;
-            $path_may_change = $this->path_may_change($index_path);
+            $path_may_change = file_sync_index_path_may_change(
+                $index_path,
+                $this->included_index_path_roots,
+                $this->excluded_index_path_roots
+            );
 
             if (
                 $needs_delete
@@ -531,27 +518,6 @@ final class FileSyncPatchPlanner
         $this->closed = true;
     }
 
-    /** Checks adjacent patch-result entries for a path or its descendant. */
-    private function patch_result_index_contains_path_or_descendant(
-        string $index_path,
-        ?string $preceding_patch_result_index_path,
-        ?string $following_patch_result_index_path
-    ): bool {
-        // NUL cannot occur in an index path and cannot match either test.
-        $preceding_patch_result_index_path =
-            $preceding_patch_result_index_path ?? "\0";
-        $following_patch_result_index_path =
-            $following_patch_result_index_path ?? "\0";
-
-        return path_is_same_as_or_descendant_of(
-            $preceding_patch_result_index_path,
-            $index_path
-        ) || path_is_same_as_or_descendant_of(
-            $following_patch_result_index_path,
-            $index_path
-        );
-    }
-
     /** Returns the logical entry kind used by the plan transition table. */
     private function index_entry_shape(string $path_type): string
     {
@@ -656,49 +622,6 @@ final class FileSyncPatchPlanner
                 $index_path,
                 $this->active_deletion_root["path"]
             );
-    }
-
-    /**
-     * Reports whether a planned operation may change the index path.
-     *
-     * The path must be inside an included root. It must not be an excluded
-     * root, sit below one, or contain one. The last case prevents a parent
-     * deletion or replacement from changing an excluded descendant.
-     */
-    private function path_may_change(string $index_path): bool
-    {
-        $is_included = false;
-        foreach ($this->included_index_path_roots as $included_index_path_root) {
-            if (
-                $included_index_path_root === ""
-                || path_is_same_as_or_descendant_of(
-                    $index_path,
-                    $included_index_path_root
-                )
-            ) {
-                $is_included = true;
-                break;
-            }
-        }
-        if (!$is_included) {
-            return false;
-        }
-        foreach ($this->excluded_index_path_roots as $excluded_index_path_root) {
-            if (
-                $excluded_index_path_root === ""
-                || path_is_same_as_or_descendant_of(
-                    $index_path,
-                    $excluded_index_path_root
-                )
-                || path_is_same_as_or_descendant_of(
-                    $excluded_index_path_root,
-                    $index_path
-                )
-            ) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /** Decodes one arbitrary-byte path root stored in a JSON cursor. */

--- a/packages/reprint-client/src/lib/index/file-sync-path-functions.php
+++ b/packages/reprint-client/src/lib/index/file-sync-path-functions.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Reprint\Importer;
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Filesystem\wp_unix_path_segments;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+
+/**
+ * Reports whether a sync operation may change an index path.
+ *
+ * The path must be inside an included root. It must not be an excluded root,
+ * sit below one, or contain one. The last case prevents a parent deletion or
+ * replacement from changing an excluded descendant.
+ *
+ * @param string       $index_path                Path in index coordinates.
+ * @param list<string> $included_index_path_roots Roots within which changes are allowed.
+ * @param list<string> $excluded_index_path_roots Roots which changes must not affect.
+ */
+function file_sync_index_path_may_change(
+    string $index_path,
+    array $included_index_path_roots,
+    array $excluded_index_path_roots
+): bool {
+    $is_included = false;
+    foreach ($included_index_path_roots as $included_index_path_root) {
+        if (
+            $included_index_path_root === ""
+            || path_is_same_as_or_descendant_of(
+                $index_path,
+                $included_index_path_root
+            )
+        ) {
+            $is_included = true;
+            break;
+        }
+    }
+    if (!$is_included) {
+        return false;
+    }
+
+    foreach ($excluded_index_path_roots as $excluded_index_path_root) {
+        if (
+            $excluded_index_path_root === ""
+            || path_is_same_as_or_descendant_of(
+                $index_path,
+                $excluded_index_path_root
+            )
+            || path_is_same_as_or_descendant_of(
+                $excluded_index_path_root,
+                $index_path
+            )
+        ) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Finds the shallowest missing path which the caller may delete.
+ *
+ * The missing path was present in the starting index and is absent from the
+ * result index. The adjacent result paths show whether each parent still has
+ * a result descendant. The callback keeps the result within the caller's path
+ * selection and mapping boundaries. The function returns null when no missing
+ * candidate may be deleted.
+ *
+ * A missing empty-directory entry needs no deletion when a result descendant
+ * now represents that directory.
+ *
+ * @param string                $missing_index_path                Path missing from the result index.
+ * @param string|null           $preceding_result_index_path       Adjacent result path before the missing path.
+ * @param string|null           $following_result_index_path       Adjacent result path after the missing path.
+ * @param callable(string):bool $candidate_index_path_may_change   Reports whether one missing candidate may be deleted.
+ * @param bool                  $missing_path_is_empty_directory   Whether the missing entry described an empty directory.
+ * @return string|null Shallowest missing path safe to delete, or null when no deletion is needed or allowed.
+ */
+function find_file_sync_deletion_root(
+    string $missing_index_path,
+    ?string $preceding_result_index_path,
+    ?string $following_result_index_path,
+    callable $candidate_index_path_may_change,
+    bool $missing_path_is_empty_directory = false
+): ?string {
+    if (
+        $missing_path_is_empty_directory
+        && file_sync_result_contains_path_or_descendant(
+            $missing_index_path,
+            $preceding_result_index_path,
+            $following_result_index_path
+        )
+    ) {
+        return null;
+    }
+
+    $deletion_root = $candidate_index_path_may_change($missing_index_path)
+        ? $missing_index_path
+        : null;
+    $missing_path_components = wp_unix_path_segments($missing_index_path);
+    $candidate_path_components = [];
+    $index_path_root = strpos($missing_index_path, "/") === 0 ? "/" : "";
+    for (
+        $component_index = 0,
+        $component_count = count($missing_path_components) - 1;
+        $component_index < $component_count;
+        ++$component_index
+    ) {
+        $candidate_path_components[] =
+            $missing_path_components[$component_index];
+        $candidate_index_path = wp_join_unix_paths(
+            $index_path_root,
+            ...$candidate_path_components
+        );
+        if (
+            !file_sync_result_contains_path_or_descendant(
+                $candidate_index_path,
+                $preceding_result_index_path,
+                $following_result_index_path
+            )
+            && $candidate_index_path_may_change($candidate_index_path)
+        ) {
+            return $candidate_index_path;
+        }
+    }
+    return $deletion_root;
+}
+
+/** Checks adjacent result entries for a path or its descendant. */
+function file_sync_result_contains_path_or_descendant(
+    string $index_path,
+    ?string $preceding_result_index_path,
+    ?string $following_result_index_path
+): bool {
+    // NUL cannot occur in an index path and cannot match either test.
+    $preceding_result_index_path = $preceding_result_index_path ?? "\0";
+    $following_result_index_path = $following_result_index_path ?? "\0";
+
+    return path_is_same_as_or_descendant_of(
+        $preceding_result_index_path,
+        $index_path
+    ) || path_is_same_as_or_descendant_of(
+        $following_result_index_path,
+        $index_path
+    );
+}

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -121,4 +121,40 @@ final class RemoteToLocalPathMapper
 
         return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
     }
+
+    /**
+     * Whether one remote path owns its mapped local subtree.
+     *
+     * A recursive local change at this path must not cross a remap used by a
+     * different remote subtree. This covers remap targets both below this path
+     * and above it.
+     */
+    public function remote_path_owns_mapped_local_subtree(
+        string $remote_absolute_path
+    ): bool
+    {
+        $local_absolute_path = $this->map_path($remote_absolute_path);
+        foreach ($this->resolved_path_mappings as $remote_root => $local_root) {
+            if (
+                !path_is_same_as_or_descendant_of(
+                    $remote_absolute_path,
+                    $remote_root
+                )
+                && (
+                    path_is_same_as_or_descendant_of(
+                        $local_absolute_path,
+                        $local_root
+                    )
+                    || path_is_same_as_or_descendant_of(
+                        $local_root,
+                        $local_absolute_path
+                    )
+                )
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/tests/Import/FileSyncPatchPlannerTest.php
+++ b/tests/Import/FileSyncPatchPlannerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
 
 use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\file_sync_index_path_may_change;
+use function Reprint\Importer\find_file_sync_deletion_root;
 
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php';
 
@@ -178,6 +180,92 @@ final class FileSyncPatchPlannerTest extends TestCase
             $this->collect_operations($planner)
         );
         $planner->close();
+    }
+
+    public function testFindsADeletionRootInsideANestedSelection(): void
+    {
+        $this->assertSame(
+            'outside/selected',
+            find_file_sync_deletion_root(
+                'outside/selected/child.txt',
+                null,
+                null,
+                static function (string $candidate_path): bool {
+                    return file_sync_index_path_may_change(
+                        $candidate_path,
+                        ['outside/selected'],
+                        []
+                    );
+                }
+            )
+        );
+    }
+
+    public function testDeletionRootDoesNotContainAnExcludedDescendant(): void
+    {
+        $this->assertSame(
+            'selected/delete',
+            find_file_sync_deletion_root(
+                'selected/delete/child.txt',
+                null,
+                null,
+                static function (string $candidate_path): bool {
+                    return file_sync_index_path_may_change(
+                        $candidate_path,
+                        ['selected'],
+                        ['selected/keep']
+                    );
+                }
+            )
+        );
+        $this->assertNull(
+            find_file_sync_deletion_root(
+                'selected/keep/child.txt',
+                null,
+                null,
+                static function (string $candidate_path): bool {
+                    return file_sync_index_path_may_change(
+                        $candidate_path,
+                        ['selected'],
+                        ['selected/keep']
+                    );
+                }
+            )
+        );
+    }
+
+    public function testDeletionRootPreservesAnAbsolutePathRoot(): void
+    {
+        $this->assertSame(
+            '/srv/site',
+            find_file_sync_deletion_root(
+                '/srv/site/child.txt',
+                null,
+                null,
+                static function (string $candidate_path): bool {
+                    return file_sync_index_path_may_change(
+                        $candidate_path,
+                        ['/srv/site'],
+                        []
+                    );
+                }
+            )
+        );
+    }
+
+    public function testEmptyDirectoryEntryIsKeptWhenAResultDescendantReplacesIt(): void
+    {
+        $this->assertNull(
+            find_file_sync_deletion_root(
+                'selected/directory',
+                null,
+                'selected/directory/child.txt',
+                static function (string $candidate_path): bool {
+                    return $candidate_path !== '';
+                },
+                true
+            )
+        );
     }
 
     public function testIncludedAndExcludedRootsLimitBothOperations(): void

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -498,7 +498,14 @@ final class FilesPullDiffCheckpointTest extends TestCase
                 'current_stage' => 'diff',
             ],
             'preflight' => [
-                'data' => ['ok' => true],
+                'data' => [
+                    'ok' => true,
+                    'wp_detect' => [
+                        'roots' => [[
+                            'path' => '/',
+                        ]],
+                    ],
+                ],
                 'http_code' => 200,
             ],
             'follow_symlinks' => false,

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -394,7 +394,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testPulledDeletionRemovesTheDerivedDirectoryRoot(): void
+    public function testPulledDeletionStopsAtNestedIncludedRoot(): void
     {
         $this->completeFilesPull();
         file_put_contents($this->localTree . '/folder/local-added.txt', 'local addition');
@@ -409,6 +409,10 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
         $this->assertDirectoryDoesNotExist($this->localTree . '/folder');
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
         $index = $this->readIndex($this->localIndexPath());
         $this->assertArrayNotHasKey(
             $this->localIndexEntryPath('folder'),
@@ -431,6 +435,197 @@ final class FilesPullLocalIndexTest extends TestCase
             'local_paths_to_push' => 0,
             'local_paths_to_delete' => 0,
         ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testPulledDeletionKeepsAnExcludedDescendant(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'folder/keep/child.txt' => 'excluded remote child',
+            ],
+        ]);
+        $this->completeFilesPull();
+        $excludedLocalPath = $this->localTree . '/folder/keep/child.txt';
+        $this->assertSame(
+            'excluded remote child',
+            file_get_contents($excludedLocalPath)
+        );
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'removed_paths' => ['folder/remote-deleted.txt'],
+        ]);
+        $pull = $this->runFilesPull([
+            '--include=/var/www/html/folder',
+            '--exclude=/var/www/html/folder/keep',
+        ]);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame(
+            'excluded remote child',
+            file_get_contents($excludedLocalPath)
+        );
+        $this->assertFileDoesNotExist(
+            $this->localTree . '/folder/remote-deleted.txt'
+        );
+        $index = $this->readIndex($this->localIndexPath());
+        $this->assertArrayHasKey(
+            $this->localIndexEntryPath('folder/keep/child.txt'),
+            $index
+        );
+        $this->assertArrayNotHasKey(
+            $this->localIndexEntryPath('folder/remote-deleted.txt'),
+            $index
+        );
+    }
+
+    public function testPulledDeletionRemovesAnEntireRemappedSelection(): void
+    {
+        $arguments = [
+            '--include=/var/www/html',
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/remapped',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertFileExists($this->rawFileRoot . '/remapped/unchanged.txt');
+        file_put_contents($this->rawFileRoot . '/outside.txt', 'outside selection');
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'removed_paths' => array_merge(
+                array_keys($this->remoteFiles),
+                [self::PULLED_PATH]
+            ),
+        ]);
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertDirectoryDoesNotExist($this->rawFileRoot . '/remapped');
+        $this->assertSame(
+            'outside selection',
+            file_get_contents($this->rawFileRoot . '/outside.txt')
+        );
+        $this->assertSame([], $this->readIndex($this->localIndexPath()));
+    }
+
+    public function testPulledDeletionKeepsAnotherRemapTargetBelowIt(): void
+    {
+        $arguments = [
+            '--remap',
+            '/var/www/html/folder',
+            ':fs-root:/shared',
+            '--remap',
+            '/var/www/html/unchanged.txt',
+            ':fs-root:/shared/kept.txt',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertSame(
+            'same',
+            file_get_contents($this->rawFileRoot . '/shared/kept.txt')
+        );
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'removed_paths' => ['folder/remote-deleted.txt'],
+        ]);
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertFileDoesNotExist(
+            $this->rawFileRoot . '/shared/remote-deleted.txt'
+        );
+        $this->assertSame(
+            'same',
+            file_get_contents($this->rawFileRoot . '/shared/kept.txt')
+        );
+    }
+
+    public function testPulledDeletionKeepsAnotherRemapTargetAboveIt(): void
+    {
+        $arguments = [
+            '--remap',
+            '/var/www/html/folder',
+            ':fs-root:/shared/inner',
+            '--remap',
+            '/var/www/html/other',
+            ':fs-root:/shared',
+        ];
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'other/inner/keep.txt' => 'keep',
+            ],
+        ]);
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertSame(
+            'keep',
+            file_get_contents($this->rawFileRoot . '/shared/inner/keep.txt')
+        );
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'other/inner/keep.txt' => 'keep',
+            ],
+            'removed_paths' => ['folder/remote-deleted.txt'],
+        ]);
+        $pull = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame(
+            'keep',
+            file_get_contents($this->rawFileRoot . '/shared/inner/keep.txt')
+        );
+    }
+
+    public function testRemoteEmptyDirectoryBecomingNonEmptyKeepsLocalChildren(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_directories' => ['folder/was-empty'],
+        ]);
+        $this->completeFilesPull();
+        file_put_contents(
+            $this->localTree . '/folder/was-empty/local.txt',
+            'local child'
+        );
+
+        $this->abortFilesPull();
+        $this->writeRemoteOverrides([
+            'added_files' => [
+                'folder/was-empty/remote.txt' => 'remote child',
+            ],
+        ]);
+        $pull = $this->runFilesPull([
+            '--include=/var/www/html/folder/was-empty',
+        ]);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame(
+            'local child',
+            file_get_contents(
+                $this->localTree . '/folder/was-empty/local.txt'
+            )
+        );
+        $this->assertSame(
+            'remote child',
+            file_get_contents(
+                $this->localTree . '/folder/was-empty/remote.txt'
+            )
+        );
+        $remoteIndex = $this->readIndex(
+            $this->pullStateDirectory . '/remote-index.jsonl'
+        );
+        $this->assertArrayNotHasKey(
+            '/var/www/html/folder/was-empty',
+            $remoteIndex
+        );
+        $this->assertArrayHasKey(
+            '/var/www/html/folder/was-empty/remote.txt',
+            $remoteIndex
+        );
     }
 
     public function testPulledDirectoryDeletionRemovesItsLocalIndexSubtree(): void

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -283,10 +283,11 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             ->getValue($client)
             ->apply_pending_records();
 
-        // The selected root, its matched contents, and its index entry survive…
+        // The selected root and its matched contents survive. The old empty
+        // directory entry is removed because the child now describes it.
         $this->assertDirectoryExists($this->filesystem_root . '/wp-content/themes');
         $this->assertFileExists($kept);
-        $this->assertContains('/wp-content/themes', $this->readRemoteIndexEntryPaths());
+        $this->assertNotContains('/wp-content/themes', $this->readRemoteIndexEntryPaths());
         // …while a genuine orphan inside it is still drained.
         $this->assertFileDoesNotExist($orphan);
         $this->assertNotContains('/wp-content/themes/old/orphan.css', $this->readRemoteIndexEntryPaths());

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -136,14 +136,14 @@ final class PullIndexWalTest extends TestCase
 
     public function testDeletedFileDerivesTheAbsentDirectoryRoot(): void
     {
-        $reflection = new \ReflectionClass(\ImportClient::class);
-        $remoteAbsolutePathToDelete = $reflection
-            ->getMethod('derive_remote_deletion_root_from_sparse_index')
-            ->invoke(
-                $this->client(),
+        $remoteAbsolutePathToDelete =
+            \Reprint\Importer\find_file_sync_deletion_root(
                 '/srv/site/gone/nested/file.txt',
                 '/srv/site/kept.txt',
-                null
+                null,
+                static function (): bool {
+                    return true;
+                }
             );
 
         $this->assertSame('/srv/site/gone', $remoteAbsolutePathToDelete);
@@ -151,14 +151,14 @@ final class PullIndexWalTest extends TestCase
 
     public function testDeletedFileKeepsAParentWithAnotherNextIndexEntry(): void
     {
-        $reflection = new \ReflectionClass(\ImportClient::class);
-        $remoteAbsolutePathToDelete = $reflection
-            ->getMethod('derive_remote_deletion_root_from_sparse_index')
-            ->invoke(
-                $this->client(),
+        $remoteAbsolutePathToDelete =
+            \Reprint\Importer\find_file_sync_deletion_root(
                 '/srv/site/kept/old.txt',
                 '/srv/site/kept/current.txt',
-                null
+                null,
+                static function (): bool {
+                    return true;
+                }
             );
 
         $this->assertSame('/srv/site/kept/old.txt', $remoteAbsolutePathToDelete);

--- a/tests/Import/RemoteToLocalPathMapperTest.php
+++ b/tests/Import/RemoteToLocalPathMapperTest.php
@@ -80,6 +80,38 @@ final class RemoteToLocalPathMapperTest extends TestCase
         );
     }
 
+    public function testRemotePathDoesNotOwnLocalSubtreeContainingAnotherRemapTarget(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a', '/b'],
+            [
+                '/a' => '/local/shared',
+                '/b' => '/local/shared/inner',
+            ]
+        );
+
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/a'));
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/b'));
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/a/file.txt'));
+    }
+
+    public function testRemotePathDoesNotOwnLocalSubtreeInsideAnotherRemapTarget(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a', '/b'],
+            [
+                '/a' => '/local/shared/inner',
+                '/b' => '/local/shared',
+            ]
+        );
+
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/a'));
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/b'));
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/b/file.txt'));
+    }
+
     public function testPathBytesDoNotNeedToBeValidUtf8(): void
     {
         $remote_root = "/srv/site-\xff";


### PR DESCRIPTION
Pulled remote deletions now stop at the active include, exclude, and remap boundaries.

For example, when `/var/www/html` is remapped to `site` and that whole remote tree disappears, the sparse index can identify `/var` as the first absent parent. Pull now stops at `/var/www/html` and removes `site` instead of mapping `/var` to an unrelated local path. An excluded descendant or a separate remap target also keeps a broader parent from being deleted.

`FileSyncPatchPlanner` and files-pull now use the same sparse-index deletion rule. When a former empty-directory entry is replaced by a descendant, pull removes the stale index entry without removing the directory.

## Testing

The focused tests cover nested includes, excluded descendants, complete remapped-tree deletion, overlapping local remap targets, and an empty directory becoming non-empty.