### PR TITLE
[PHP] Support Unicode source hostnames in Cautious rewriters

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7,6 +7,93 @@
     "content-hash": "40247d2cff4fefbc84888dc43a867877",
     "packages": [
         {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-normalizer",
             "version": "v1.38.0",
             "source": {
@@ -453,6 +540,7 @@
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
+                "symfony/polyfill-intl-idn": "^1.31",
                 "symfony/polyfill-intl-normalizer": "^1.31",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -7,6 +7,91 @@
     "content-hash": "40247d2cff4fefbc84888dc43a867877",
     "packages": [
         {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
             "name": "wp-php-toolkit/bytestream",
             "version": "v0.8.1",
             "source": {
@@ -368,6 +453,7 @@
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
+                "symfony/polyfill-intl-normalizer": "^1.31",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0",
                 "wp-php-toolkit/reprint-server": "*@dev"

--- a/packages/reprint-client/composer.json
+++ b/packages/reprint-client/composer.json
@@ -10,6 +10,7 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
+        "symfony/polyfill-intl-idn": "^1.31",
         "symfony/polyfill-intl-normalizer": "^1.31",
         "wp-php-toolkit/data-liberation": "^0.8.0",
         "wp-php-toolkit/html": "^0.8.0",

--- a/packages/reprint-client/composer.json
+++ b/packages/reprint-client/composer.json
@@ -10,6 +10,7 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
+        "symfony/polyfill-intl-normalizer": "^1.31",
         "wp-php-toolkit/data-liberation": "^0.8.0",
         "wp-php-toolkit/html": "^0.8.0",
         "wp-php-toolkit/reprint-server": "*@dev"

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -33,16 +33,18 @@
  * Instead, the processor performs one narrow operation: find the configured
  * source base as bytes and replace that entire slice with a target domain and
  * optional path. It replaces the literal protocol separately when the mapping
- * changes it. It does not decode, normalize, or re-encode the input.
+ * changes it. Candidate Unicode path segments are normalized only for the
+ * comparison. The bytes outside the replaced slice remain unchanged.
  *
  * Supported sources:
  *
  * - ASCII or Unicode IDN source domains and IPv4 or IPv6 addresses, with
  *   an optional port. Unicode and Punycode spellings of the same IDN match.
  * - An optional initial path containing valid UTF-8 without whitespace or
- *   control characters. NFC and NFD spellings of the configured path match
- *   the same source base. That path is part of the source base and is removed
- *   with it. A root slash is the URL separator rather than a removable path,
+ *   control characters. Composed and decomposed characters may be mixed in
+ *   one path and still match the same source base. That path is part of the
+ *   source base and is removed with it. A root slash is the URL separator
+ *   rather than a removable path,
  *   so it remains after replacement. Mapping
  *   https://source.example/media to
  *   https://destination.example changes
@@ -115,6 +117,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -135,6 +138,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -256,6 +260,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -275,7 +280,10 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     {
         $next_match = null;
         foreach ($this->url_mappings as $mapping) {
-            if (!$mapping['source_host_uses_idn']) {
+            if (
+                !$mapping['source_host_uses_idn']
+                && $mapping['unicode_source_path_segments_in_nfd'] === []
+            ) {
                 $found = preg_match(
                     $mapping['pattern'],
                     $this->text,
@@ -293,19 +301,38 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                         PREG_OFFSET_CAPTURE,
                         $search_from
                     );
-                    if (
-                        $found !== 1
-                        || !isset($matches['unicode_host'])
-                        || $matches['unicode_host'][1] === -1
-                    ) {
+                    if ($found !== 1) {
                         break;
                     }
 
-                    $candidate_ascii_host =
-                        CautiousURLBaseRewriteMapping::to_ascii_idn_hostname(
-                            $matches['unicode_host'][0]
+                    $candidate_matches_mapping = true;
+                    if (
+                        isset($matches['unicode_host'])
+                        && $matches['unicode_host'][1] !== -1
+                    ) {
+                        $candidate_matches_mapping =
+                            CautiousURLBaseRewriteMapping::to_ascii_idn_hostname(
+                                $matches['unicode_host'][0]
+                            ) === $mapping['source_ascii_host'];
+                    }
+
+                    foreach (
+                        $mapping['unicode_source_path_segments_in_nfd']
+                        as $unicode_path_segment_index => $source_path_segment_in_nfd
+                    ) {
+                        $candidate_path_segment_in_nfd = Normalizer::normalize(
+                            $matches[
+                                'unicode_path_segment_' . $unicode_path_segment_index
+                            ][0],
+                            Normalizer::FORM_D
                         );
-                    if ($candidate_ascii_host === $mapping['source_ascii_host']) {
+                        if ($candidate_path_segment_in_nfd !== $source_path_segment_in_nfd) {
+                            $candidate_matches_mapping = false;
+                            break;
+                        }
+                    }
+
+                    if ($candidate_matches_mapping) {
                         break;
                     }
 

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -37,7 +37,8 @@
  *
  * Supported sources:
  *
- * - ASCII domains and IPv4 or IPv6 addresses, with an optional port.
+ * - ASCII or Unicode IDN source domains and IPv4 or IPv6 addresses, with
+ *   an optional port. Unicode and Punycode spellings of the same IDN match.
  * - An optional initial path containing valid UTF-8 without whitespace or
  *   control characters. NFC and NFD spellings of the configured path match
  *   the same source base. That path is part of the source base and is removed
@@ -70,14 +71,16 @@
  *   of the surrounding text.
  * - Target user information, queries, fragments, IPv4/IPv6 addresses, and
  *   Unicode domains are not supported. Punycode domains are supported.
- * - Unicode source domains are not supported.
  *
  * CSS hexadecimal escapes such as https\3a \2f \2f ... and percent-encoded
  * separators are not recognized. They need a parser for the enclosing format.
  * Complete PHP serializations, JSON documents, and block markup must likewise
  * be parsed first; pass only the resulting text leaves to this processor.
  *
- * The HTTP(S) scheme and authority are matched case-insensitively. A configured
+ * Ordinary ASCII authorities use a literal pattern and never run IDNA. A
+ * mapping with a Unicode or `xn--` source hostname also checks literal Unicode
+ * candidates through IDNA. The HTTP(S) scheme and authority are matched
+ * case-insensitively. A configured
  * source path remains case-sensitive because URL paths may name different
  * resources when their case differs. Canonically equivalent composed and
  * decomposed Unicode spellings match. A scheme may begin at the start of the
@@ -110,6 +113,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @var array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -128,6 +133,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @var array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -247,6 +254,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @return array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -266,13 +275,45 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     {
         $next_match = null;
         foreach ($this->url_mappings as $mapping) {
-            $found = preg_match(
-                $mapping['pattern'],
-                $this->text,
-                $matches,
-                PREG_OFFSET_CAPTURE,
-                $this->bytes_already_scanned
-            );
+            if (!$mapping['source_host_uses_idn']) {
+                $found = preg_match(
+                    $mapping['pattern'],
+                    $this->text,
+                    $matches,
+                    PREG_OFFSET_CAPTURE,
+                    $this->bytes_already_scanned
+                );
+            } else {
+                $search_from = $this->bytes_already_scanned;
+                while (true) {
+                    $found = preg_match(
+                        $mapping['pattern'],
+                        $this->text,
+                        $matches,
+                        PREG_OFFSET_CAPTURE,
+                        $search_from
+                    );
+                    if (
+                        $found !== 1
+                        || !isset($matches['unicode_host'])
+                        || $matches['unicode_host'][1] === -1
+                    ) {
+                        break;
+                    }
+
+                    $candidate_ascii_host =
+                        CautiousURLBaseRewriteMapping::to_ascii_idn_hostname(
+                            $matches['unicode_host'][0]
+                        );
+                    if ($candidate_ascii_host === $mapping['source_ascii_host']) {
+                        break;
+                    }
+
+                    $search_from =
+                        $matches['authority'][1]
+                        + strlen($matches['authority'][0]);
+                }
+            }
             if ($found !== 1) {
                 continue;
             }

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -38,10 +38,11 @@
  * Supported sources:
  *
  * - ASCII domains and IPv4 or IPv6 addresses, with an optional port.
- * - An optional initial path containing only bytes from `!` (0x21) through
- *   `~` (0x7E). Spaces and multibyte characters are rejected. That path is
- *   part of the source base and is removed with it. A root slash is the URL
- *   separator rather than a removable path, so it remains after replacement. Mapping
+ * - An optional initial path containing valid UTF-8 without whitespace or
+ *   control characters. NFC and NFD spellings of the configured path match
+ *   the same source base. That path is part of the source base and is removed
+ *   with it. A root slash is the URL separator rather than a removable path,
+ *   so it remains after replacement. Mapping
  *   https://source.example/media to
  *   https://destination.example changes
  *   https://source.example/media/logo.png to
@@ -69,7 +70,7 @@
  *   of the surrounding text.
  * - Target user information, queries, fragments, IPv4/IPv6 addresses, and
  *   Unicode domains are not supported. Punycode domains are supported.
- * - Unicode source domains and paths are not supported.
+ * - Unicode source domains are not supported.
  *
  * CSS hexadecimal escapes such as https\3a \2f \2f ... and percent-encoded
  * separators are not recognized. They need a parser for the enclosing format.
@@ -77,10 +78,11 @@
  * be parsed first; pass only the resulting text leaves to this processor.
  *
  * The HTTP(S) scheme and authority are matched case-insensitively. A configured
- * source path remains byte-for-byte and case-sensitive because URL paths may
- * name different resources when their case differs. A scheme may begin at the
- * start of the value or after a byte other than an ASCII letter, plus sign, or
- * hyphen. Scheme-less authorities use a stricter boundary so the scanner does
+ * source path remains case-sensitive because URL paths may name different
+ * resources when their case differs. Canonically equivalent composed and
+ * decomposed Unicode spellings match. A scheme may begin at the start of the
+ * value or after a byte other than an ASCII letter, plus sign, or hyphen.
+ * Scheme-less authorities use a stricter boundary so the scanner does
  * not mistake part of another URL or identifier for a match. A dot or colon
  * immediately after the configured base is rejected: it may continue the host
  * name or introduce a port which the mapping did not include.

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -15,6 +15,7 @@ class CautiousURLBaseRewriteMapping {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -68,6 +69,7 @@ class CautiousURLBaseRewriteMapping {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -87,6 +89,7 @@ class CautiousURLBaseRewriteMapping {
      *     source_authority: string,
      *     source_ascii_host: string,
      *     source_host_uses_idn: bool,
+     *     unicode_source_path_segments_in_nfd: array<int, string>,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -107,6 +110,26 @@ class CautiousURLBaseRewriteMapping {
         // A source URL ending at its authority uses / as the URL separator,
         // not as an initial path to remove. Leave its original spelling alone.
         $source_path = $source['path'] === '/' ? '' : $source['path'];
+        $unicode_source_path_segments_in_nfd = [];
+        foreach (explode('/', substr($source_path, 1)) as $source_path_segment) {
+            if (preg_match('/[\x80-\xFF]/', $source_path_segment) !== 1) {
+                continue;
+            }
+
+            // NFD writes é as e followed by a combining accent. Store every
+            // configured Unicode segment in NFD. The scanner converts each
+            // captured candidate segment to NFD before comparing the two.
+            $source_path_segment_in_nfd = Normalizer::normalize(
+                $source_path_segment,
+                Normalizer::FORM_D
+            );
+            if (!is_string($source_path_segment_in_nfd)) {
+                return null;
+            }
+            $unicode_source_path_segments_in_nfd[] =
+                $source_path_segment_in_nfd;
+        }
+
         $source_authority_pattern = '(?i:' . preg_quote($source['authority'], '~') . ')';
         if ($source['host_uses_idn']) {
             // This branch locates Unicode authority candidates. IDNA below
@@ -124,7 +147,9 @@ class CautiousURLBaseRewriteMapping {
             'source_authority'     => $source['authority'],
             'source_ascii_host'    => $source['ascii_host'],
             'source_host_uses_idn' => $source['host_uses_idn'],
-            'source_path'          => $source_path,
+            'unicode_source_path_segments_in_nfd' =>
+                $unicode_source_path_segments_in_nfd,
+            'source_path' => $source_path,
             'source_base'          => $source['authority'] . $source_path,
             'target_domain'        => $target['host'],
             'target_scheme'        => $target['scheme'],
@@ -157,36 +182,37 @@ class CautiousURLBaseRewriteMapping {
         $separator_escape = '\\\\{0,8}';
         $source_path_pattern = '';
         if ($source_path !== '') {
-            $source_path_spellings = [$source_path];
-            // NFC writes characters such as é as one code point. NFD writes
-            // the same character as e followed by a combining accent. Build
-            // both spellings because the mapping and input may use different
-            // forms for the same path.
-            foreach ([Normalizer::FORM_C, Normalizer::FORM_D] as $normalization_form) {
-                $normalized_source_path = Normalizer::normalize(
-                    $source_path,
-                    $normalization_form
-                );
-                if (
-                    is_string($normalized_source_path)
-                    && !in_array($normalized_source_path, $source_path_spellings, true)
-                ) {
-                    $source_path_spellings[] = $normalized_source_path;
+            $source_path_suffix_pattern = '';
+            $unicode_path_segment_index = 0;
+            foreach (
+                explode('/', substr($source_path, 1))
+                as $source_path_segment_index => $source_path_segment
+            ) {
+                if ($source_path_segment_index > 0) {
+                    $source_path_suffix_pattern .= $separator_escape . '/';
                 }
-            }
+                // Capture Unicode segments and compare them in NFD after
+                // matching. One regexp then handles any mixture of composed
+                // and decomposed characters without listing every combination.
+                if (preg_match('/[\x80-\xFF]/', $source_path_segment) !== 1) {
+                    $source_path_suffix_pattern .= preg_quote(
+                        $source_path_segment,
+                        '~'
+                    );
+                    continue;
+                }
 
-            $source_path_suffix_patterns = [];
-            foreach ($source_path_spellings as $source_path_spelling) {
-                $source_path_suffix_patterns[] = str_replace(
-                    '/',
-                    $separator_escape . '/',
-                    preg_quote(substr($source_path_spelling, 1), '~')
-                );
+                $source_path_suffix_pattern .=
+                    '(?<unicode_path_segment_' . $unicode_path_segment_index . '>'
+                    . '(?=[^/?#\x00-\x20\x7F]*[\x80-\xFF])'
+                    . '[^/?#\x00-\x20\x7F]+?'
+                    . ')';
+                ++$unicode_path_segment_index;
             }
 
             $source_path_pattern =
                 '(?<path_slash>' . $separator_escape . '/)'
-                . '(?:' . implode('|', $source_path_suffix_patterns) . ')';
+                . $source_path_suffix_pattern;
         }
         $candidate_boundary_pattern = '(?=
             $

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -13,6 +13,8 @@ class CautiousURLBaseRewriteMapping {
     /**
      * @var array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -64,6 +66,8 @@ class CautiousURLBaseRewriteMapping {
      *
      * @return array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -81,6 +85,8 @@ class CautiousURLBaseRewriteMapping {
     /**
      * @return array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -101,18 +107,32 @@ class CautiousURLBaseRewriteMapping {
         // A source URL ending at its authority uses / as the URL separator,
         // not as an initial path to remove. Leave its original spelling alone.
         $source_path = $source['path'] === '/' ? '' : $source['path'];
+        $source_authority_pattern = '(?i:' . preg_quote($source['authority'], '~') . ')';
+        if ($source['host_uses_idn']) {
+            // This branch locates Unicode authority candidates. IDNA below
+            // decides whether each candidate names the configured host.
+            $unicode_host_character = "[^\\s<>@/\\\\:?#,!;()\\[\\]{}>\"']";
+            $source_authority_pattern =
+                '(?:' . $source_authority_pattern
+                . '|(?<unicode_host>(?=' . $unicode_host_character . '*[\\x80-\\xFF])'
+                . $unicode_host_character . '+)'
+                . ( $source['port'] === null ? '' : ':' . $source['port'] )
+                . ')';
+        }
 
         return [
-            'source_authority' => $source['authority'],
-            'source_path'      => $source_path,
-            'source_base'      => $source['authority'] . $source_path,
-            'target_domain'    => $target['host'],
-            'target_scheme'    => $target['scheme'],
-            'target_path'      => $target['path'],
-            'target_port'      => $target['port'],
-            'pattern'          => $this->create_url_candidate_pattern(
+            'source_authority'     => $source['authority'],
+            'source_ascii_host'    => $source['ascii_host'],
+            'source_host_uses_idn' => $source['host_uses_idn'],
+            'source_path'          => $source_path,
+            'source_base'          => $source['authority'] . $source_path,
+            'target_domain'        => $target['host'],
+            'target_scheme'        => $target['scheme'],
+            'target_path'          => $target['path'],
+            'target_port'          => $target['port'],
+            'pattern'              => $this->create_url_candidate_pattern(
                 $source['scheme'],
-                $source['authority'],
+                $source_authority_pattern,
                 $source_path,
                 $target['path'] !== ''
             ),
@@ -129,7 +149,7 @@ class CautiousURLBaseRewriteMapping {
      */
     private function create_url_candidate_pattern(
         string $source_scheme,
-        string $source_authority,
+        string $source_authority_pattern,
         string $source_path,
         bool $requires_path_slash
     ): string
@@ -195,7 +215,7 @@ class CautiousURLBaseRewriteMapping {
                 (?:[^\s<>@/\\\\]+@)?
             )?
             (?<base>
-                (?<authority>(?i:' . preg_quote($source_authority, '~') . '))
+                (?<authority>' . $source_authority_pattern . ')
                 ' . $source_path_pattern . '
             )
             ' . $candidate_boundary_pattern . '
@@ -203,7 +223,15 @@ class CautiousURLBaseRewriteMapping {
     }
 
     /**
-     * @return array{scheme: string, host: string, authority: string, path: string, port: int|null}|null
+     * @return array{
+     *     scheme: string,
+     *     host: string,
+     *     ascii_host: string,
+     *     host_uses_idn: bool,
+     *     authority: string,
+     *     path: string,
+     *     port: int|null
+     * }|null
      */
     private function get_supported_url_parts(string $url, bool $is_source_url): ?array
     {
@@ -223,15 +251,62 @@ class CautiousURLBaseRewriteMapping {
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
         if ($is_source_url) {
             // parse_url() replaces control-valued bytes with underscores.
-            // Some UTF-8 continuation bytes fall in that range, so retain the
-            // source path directly from the configured URL.
+            // Some UTF-8 continuation bytes fall in that range. Read the
+            // source authority and path from the configured URL after
+            // parse_url() has checked its structure.
             $authority_separator_at = strpos($url, '://');
             if ($authority_separator_at === false) {
                 return null;
             }
-            $path_starts_at = strpos($url, '/', $authority_separator_at + 3);
+            $authority_starts_at = $authority_separator_at + 3;
+            $path_starts_at = strpos($url, '/', $authority_starts_at);
+            $source_authority = $path_starts_at === false
+                ? substr($url, $authority_starts_at)
+                : substr(
+                    $url,
+                    $authority_starts_at,
+                    $path_starts_at - $authority_starts_at
+                );
+            if (isset($parts['port'])) {
+                $port_suffix = ':' . $parts['port'];
+                if (substr($source_authority, -strlen($port_suffix)) !== $port_suffix) {
+                    return null;
+                }
+                $host = substr($source_authority, 0, -strlen($port_suffix));
+            } else {
+                $host = $source_authority;
+            }
             $path = $path_starts_at === false ? '' : substr($url, $path_starts_at);
         }
+
+        $host_is_ascii_domain = $this->is_alphanumeric_dot_hyphen_domain_name($host);
+        $host_is_ip_address =
+            $is_source_url
+            && !$host_is_ascii_domain
+            && $this->is_ip_address($host);
+        $host_contains_punycode_label =
+            $host_is_ascii_domain
+            && stripos('.' . $host, '.xn--') !== false;
+        $host_uses_idn =
+            $is_source_url
+            && (
+                $host_contains_punycode_label
+                || ( !$host_is_ascii_domain && !$host_is_ip_address )
+            );
+        $ascii_host = $host;
+        if ($host_uses_idn) {
+            if (
+                !$host_is_ascii_domain
+                && preg_match('/^[\p{L}\p{M}\p{N}.-]+$/u', $host) !== 1
+            ) {
+                return null;
+            }
+            $ascii_host = self::to_ascii_idn_hostname($host);
+            if ($ascii_host === null) {
+                return null;
+            }
+        }
+
         $has_unsupported_target_path =
             !$is_source_url
             && $path !== ''
@@ -239,20 +314,54 @@ class CautiousURLBaseRewriteMapping {
         $path_is_supported = $is_source_url
             ? preg_match('/^[^\p{Z}\p{C}]*$/u', $path) === 1
             : $this->contains_only_exclamation_mark_through_tilde_bytes($path);
+        $host_is_supported =
+            $host_is_ascii_domain
+            || $host_is_ip_address
+            || (
+                $host_uses_idn
+                && $this->is_alphanumeric_dot_hyphen_domain_name($ascii_host)
+            );
         if (( $scheme !== 'http' && $scheme !== 'https' )
             || ( !$is_source_url && $has_unsupported_target_path )
-            || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
+            || !$host_is_supported
             || !$path_is_supported) {
             return null;
         }
 
         return [
-            'scheme'    => $scheme,
-            'host'      => $host,
-            'authority' => $host . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ),
-            'path'      => $path,
-            'port'      => isset($parts['port']) ? (int) $parts['port'] : null,
+            'scheme'        => $scheme,
+            'host'          => $host,
+            'ascii_host'    => $ascii_host,
+            'host_uses_idn' => $host_uses_idn,
+            'authority'     => $ascii_host . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ),
+            'path'          => $path,
+            'port'          => isset($parts['port']) ? (int) $parts['port'] : null,
         ];
+    }
+
+    /**
+     * Converts a Unicode or Punycode hostname to its lowercase ASCII form.
+     *
+     * Returns null when IDNA rejects the hostname.
+     */
+    public static function to_ascii_idn_hostname(string $hostname): ?string
+    {
+        $idn_info = [];
+        $ascii_hostname = idn_to_ascii(
+            $hostname,
+            IDNA_NONTRANSITIONAL_TO_ASCII | IDNA_USE_STD3_RULES,
+            INTL_IDNA_VARIANT_UTS46,
+            $idn_info
+        );
+        if (
+            !is_string($ascii_hostname)
+            || $ascii_hostname === ''
+            || ( $idn_info['errors'] ?? 0 ) !== 0
+        ) {
+            return null;
+        }
+
+        return strtolower($ascii_hostname);
     }
 
     private function is_ip_address(string $host): bool

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -27,6 +27,16 @@ class CautiousURLBaseRewriteMapping {
     /**
      * Prepares source URL base => target URL pairs.
      *
+     * A source may include an initial valid UTF-8 path without whitespace or
+     * control characters. A target must be an HTTP(S) URL with a supported
+     * domain, optional port, and optional restricted path:
+     *
+     * ```
+     * [
+     *     'https://source.example/media' => 'https://destination.example/assets',
+     * ]
+     * ```
+     *
      * Invalid pairs are skipped as a whole. They cannot produce a partial
      * domain replacement.
      *
@@ -127,13 +137,36 @@ class CautiousURLBaseRewriteMapping {
         $separator_escape = '\\\\{0,8}';
         $source_path_pattern = '';
         if ($source_path !== '') {
-            $source_path_pattern =
-                '(?<path_slash>' . $separator_escape . '/)'
-                . str_replace(
+            $source_path_spellings = [$source_path];
+            // NFC writes characters such as é as one code point. NFD writes
+            // the same character as e followed by a combining accent. Build
+            // both spellings because the mapping and input may use different
+            // forms for the same path.
+            foreach ([Normalizer::FORM_C, Normalizer::FORM_D] as $normalization_form) {
+                $normalized_source_path = Normalizer::normalize(
+                    $source_path,
+                    $normalization_form
+                );
+                if (
+                    is_string($normalized_source_path)
+                    && !in_array($normalized_source_path, $source_path_spellings, true)
+                ) {
+                    $source_path_spellings[] = $normalized_source_path;
+                }
+            }
+
+            $source_path_suffix_patterns = [];
+            foreach ($source_path_spellings as $source_path_spelling) {
+                $source_path_suffix_patterns[] = str_replace(
                     '/',
                     $separator_escape . '/',
-                    preg_quote(substr($source_path, 1), '~')
+                    preg_quote(substr($source_path_spelling, 1), '~')
                 );
+            }
+
+            $source_path_pattern =
+                '(?<path_slash>' . $separator_escape . '/)'
+                . '(?:' . implode('|', $source_path_suffix_patterns) . ')';
         }
         $candidate_boundary_pattern = '(?=
             $
@@ -188,14 +221,28 @@ class CautiousURLBaseRewriteMapping {
         $scheme = strtolower( (string) $parts['scheme'] );
         $host = (string) $parts['host'];
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
+        if ($is_source_url) {
+            // parse_url() replaces control-valued bytes with underscores.
+            // Some UTF-8 continuation bytes fall in that range, so retain the
+            // source path directly from the configured URL.
+            $authority_separator_at = strpos($url, '://');
+            if ($authority_separator_at === false) {
+                return null;
+            }
+            $path_starts_at = strpos($url, '/', $authority_separator_at + 3);
+            $path = $path_starts_at === false ? '' : substr($url, $path_starts_at);
+        }
         $has_unsupported_target_path =
             !$is_source_url
             && $path !== ''
             && preg_match('#^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$#', $path) !== 1;
+        $path_is_supported = $is_source_url
+            ? preg_match('/^[^\p{Z}\p{C}]*$/u', $path) === 1
+            : $this->contains_only_exclamation_mark_through_tilde_bytes($path);
         if (( $scheme !== 'http' && $scheme !== 'https' )
             || ( !$is_source_url && $has_unsupported_target_path )
             || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
-            || !$this->contains_only_exclamation_mark_through_tilde_bytes($path)) {
+            || !$path_is_supported) {
             return null;
         }
 

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -329,6 +329,14 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                     'https://destination.example/assets',
                 ],
             ],
+            'mixed canonical forms within one source path segment' => [
+                'https:\\/\\/source.example\\/cafe' . "\u{0301}" . 'naïve\\/logo.png',
+                'https:\\/\\/destination.example\\/assets\\/logo.png',
+                [
+                    'https://source.example/cafénaïve' =>
+                    'https://destination.example/assets',
+                ],
+            ],
             'other Unicode source path matches its exact spelling' => [
                 'https://source.example/🚤/logo.png',
                 'https://destination.example/logo.png',
@@ -439,6 +447,14 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/' . "\u{FB01}" . '/logo.png',
                 'https://source.example/' . "\u{FB01}" . '/logo.png',
                 ['https://source.example/fi' => 'https://destination.example'],
+            ],
+            'canonically different Unicode source path stays distinct' => [
+                'https://source.example/cafe' . "\u{0301}" . 'naive/logo.png',
+                'https://source.example/cafe' . "\u{0301}" . 'naive/logo.png',
+                [
+                    'https://source.example/cafénaïve' =>
+                    'https://destination.example/assets',
+                ],
             ],
             'target path has a dot segment' => [
                 'https://source.example/media/logo.png',

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -278,6 +278,27 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://destination.example/assets-2026/_private/logo.png',
                 ['https://source.example/media' => 'https://destination.example/assets-2026/_private'],
             ],
+            'decomposed source path matches a composed mapping' => [
+                'https://source.example/cafe' . "\u{0301}" . '/logo.png',
+                'https://destination.example/assets/logo.png',
+                [
+                    'https://source.example/caf' . "\u{00E9}" =>
+                        'https://destination.example/assets',
+                ],
+            ],
+            'composed source path matches a decomposed mapping' => [
+                'https://source.example/caf' . "\u{00E9}" . '/logo.png',
+                'https://destination.example/assets/logo.png',
+                [
+                    'https://source.example/cafe' . "\u{0301}" =>
+                    'https://destination.example/assets',
+                ],
+            ],
+            'other Unicode source path matches its exact spelling' => [
+                'https://source.example/🚤/logo.png',
+                'https://destination.example/logo.png',
+                ['https://source.example/🚤' => 'https://destination.example'],
+            ],
             'escaped target path copies the protocol slash spelling' => [
                 'https:\\/\\/source.example\\/media\\/logo.png',
                 'https:\\/\\/destination.example\\/assets\\/logo.png',
@@ -379,6 +400,11 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://SOURCE.EXAMPLE/Media/logo.png',
                 ['https://source.example/media' => 'https://destination.example'],
             ],
+            'compatibility-equivalent source path stays distinct' => [
+                'https://source.example/' . "\u{FB01}" . '/logo.png',
+                'https://source.example/' . "\u{FB01}" . '/logo.png',
+                ['https://source.example/fi' => 'https://destination.example'],
+            ],
             'target path has a dot segment' => [
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
@@ -448,11 +474,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://bücher.example/media/logo.png',
                 'https://bücher.example/media/logo.png',
                 ['https://bücher.example/media' => 'https://destination.example'],
-            ],
-            'source path contains Unicode characters' => [
-                'https://source.example/über-uns/logo.png',
-                'https://source.example/über-uns/logo.png',
-                ['https://source.example/über-uns' => 'https://destination.example'],
             ],
             'source mapping has a username and password' => [
                 'https://user:password@source.example/media/logo.png',
@@ -543,11 +564,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://🚤.example/media/logo.png',
                 'https://🚤.example/media/logo.png',
                 ['https://🚤.example' => 'https://destination.example'],
-            ],
-            'configured source path contains an emoji' => [
-                'https://source.example/🚤/logo.png',
-                'https://source.example/🚤/logo.png',
-                ['https://source.example/🚤' => 'https://destination.example'],
             ],
             'configured source path contains a space byte' => [
                 'https://source.example/media archive/logo.png',

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -173,6 +173,41 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'url("https:\\/\\/xn--bcher-kva.example\\/media\\/logo.png");',
                 ['https://source.example' => 'https://xn--bcher-kva.example'],
             ],
+            'decomposed Unicode source host' => [
+                'https://mu' . "\u{0308}" . 'nich.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'all-Arabic Unicode source host' => [
+                'https://مثال.إختبار/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://مثال.إختبار' => 'https://destination.example'],
+            ],
+            'Unicode source host with a configured path' => [
+                'https://bücher.example/media/logo.png',
+                'https://destination.example/logo.png',
+                ['https://bücher.example/media' => 'https://destination.example'],
+            ],
+            'Punycode candidate for a Unicode source host' => [
+                'https://xn--mnich-kva.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'Unicode candidate for a Punycode source host' => [
+                'https://münich.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://xn--mnich-kva.example' => 'https://destination.example'],
+            ],
+            'escaped Unicode source host with a configured port' => [
+                'https:\\/\\/mu' . "\u{0308}" . 'nich.example:8443\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/media\\/logo.png',
+                ['https://münich.example:8443' => 'https://destination.example'],
+            ],
+            'configured Unicode host after a different Unicode host' => [
+                'https://zürich.example/media/a.png https://münich.example/media/b.png',
+                'https://zürich.example/media/a.png https://destination.example/media/b.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
             'complete literal source base' => [
                 'https://source.example/media/logo.png',
                 'https://destination.example/logo.png',
@@ -470,11 +505,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 ['https://source.example/media' => 'https://destination.example#part'],
             ],
-            'source domain contains Unicode characters' => [
-                'https://bücher.example/media/logo.png',
-                'https://bücher.example/media/logo.png',
-                ['https://bücher.example/media' => 'https://destination.example'],
-            ],
             'source mapping has a username and password' => [
                 'https://user:password@source.example/media/logo.png',
                 'https://user:password@source.example/media/logo.png',
@@ -559,6 +589,21 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
                 ['https://source.example' => 'https://🚤.example'],
+            ],
+            'Unicode target domain' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example' => 'https://bücher.example'],
+            ],
+            'Unicode candidate has an unconfigured port' => [
+                'https://münich.example:8443/media/logo.png',
+                'https://münich.example:8443/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'Unicode candidate is a subdomain of the configured host' => [
+                'https://cdn.münich.example/media/logo.png',
+                'https://cdn.münich.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
             ],
             'source domain contains an emoji' => [
                 'https://🚤.example/media/logo.png',


### PR DESCRIPTION
Matches Unicode source hostnames and canonically equivalent Unicode source paths.

For this mapping:

```text
https://münich.example/cafénaïve => https://destination.example/assets
```

this source URL also matches:

```text
https://xn--mnich-kva.example/cafénaïve/logo.png
```

Here, the hostname uses Punycode, `é` uses a combining accent, and `ï` remains composed. The result is:

```text
https://destination.example/assets/logo.png
```

The prepared mapping stores an IDN source hostname as lowercase ASCII. It also stores each Unicode source path segment in NFD. The regular expression captures a candidate Unicode segment, then the scanner converts that segment to NFD and compares it with the stored segment. This handles any mixture of composed and decomposed characters without building every possible path spelling.

Ordinary ASCII hostnames and path segments keep their literal patterns. Compatibility normalization remains out of scope, so `ﬁ` and `fi` stay distinct.

PHP’s `parse_url()` changes some control-valued bytes to underscores, including UTF-8 continuation bytes used by Arabic hostnames and decomposed paths. Source authorities and paths are therefore read from the configured URL after `parse_url()` checks its structure.

The Symfony IDN and normalizer polyfills provide the same operations when `ext-intl` is absent. Unicode target hostnames and Unicode target paths remain unsupported.

## Testing

The URL-rewriting suite passes with 376 tests and 2,515 assertions. The focused cases cover Unicode and Punycode hostname spellings, an all-Arabic hostname, ports, unrelated Unicode hosts, mixed composed and decomposed characters within one slash-escaped path segment, compatibility characters, invalid UTF-8, and the existing cautious URL boundaries. PHPStan, PHP 7.4 compatibility, and the coding-standard checks pass.
