### PR TITLE
[PHP] Add exact local cleanup to file sync patches

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
@@ -1,0 +1,744 @@
+<?php
+
+use function Reprint\Importer\append_file_sync_path_stack_entry;
+use function Reprint\Importer\file_sync_index_path_may_change;
+use function Reprint\Importer\read_file_sync_path_stack_entry;
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_relative_path;
+use function WordPress\Reprint\Exporter\read_file_index_entry_from_stat;
+use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
+use function WordPress\Reprint\Exporter\relative_path_under;
+use function WordPress\Reprint\Exporter\trim_right_slash;
+
+require_once __DIR__ . '/class-file-sync-patch-processor.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing streaming classes.
+
+/**
+ * Removes local paths which block a file-sync patch.
+ *
+ * This processor scans the local tree and asks FileSyncPatchProcessor for the
+ * patch from that tree to a supplied result index. It applies only `delete`
+ * and `replace` operations. A `copy` operation leaves the path for the caller
+ * to write after cleanup.
+ *
+ * Every removal names one exact path. Directories are removed with rmdir(),
+ * never by walking their children. An excluded, skipped, or newly created
+ * child therefore keeps its directory in place. Empty parents are pruned in
+ * separate steps after patch planning ends.
+ *
+ * A planned removal is stored in the cursor before it is applied. If a process
+ * stops after removing the path but before storing the next cursor, resume()
+ * repeats the same removal. A missing path counts as already removed.
+ *
+ *     $cleanup = FileSyncCleanupProcessor::start(
+ *         $work_directory,
+ *         $filesystem_root,
+ *         $patch_result_index,
+ *         $storage_path,
+ *         ['wp-content'],
+ *         ['wp-content/uploads/keep']
+ *     );
+ *     do {
+ *         $has_next_step = $cleanup->next_step();
+ *         $cleanup->flush_pending_output();
+ *         save_cursor($cleanup->get_cursor());
+ *     } while ($has_next_step);
+ *     $status = $cleanup->get_status();
+ *     $cleanup->close();
+ *     if ($status === 'restart') {
+ *         restart_file_sync();
+ *     }
+ *
+ * @phpstan-type PatchCursor array<string,mixed>
+ * @phpstan-type PlanningPosition array{phase:'planning',file_sync_patch_processor_cursor:PatchCursor}
+ * @phpstan-type ExpectedBase array{type:string,size:int,ctime:int}
+ * @phpstan-type RemovingPosition array{phase:'removing',path_b64:string,expected_base:ExpectedBase,file_sync_patch_processor_cursor:PatchCursor}
+ * @phpstan-type PruningPosition array{phase:'pruning'}
+ * @phpstan-type Position PlanningPosition|RemovingPosition|PruningPosition|array{phase:'complete'|'restart'}
+ * @phpstan-type Cursor array{filesystem_root_b64:string,empty_parent_paths_file_b64:string,empty_parent_paths_file_byte_offset:int,empty_parent_path_stack_top_byte_offset:int|null,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,position:Position}
+ * @phpstan-type EmptyParentPath array{path:string,previous_byte_offset:int|null,expected_ctime:int|null}
+ */
+final class FileSyncCleanupProcessor
+{
+    /** @var Cursor Cursor after the latest completed step. */
+    private array $cursor;
+
+    /** Canonical filesystem root decoded from the cursor. */
+    private string $filesystem_root;
+
+    /** @var list<string> Roots whose descendants may be removed. */
+    private array $included_index_path_roots;
+
+    /** @var list<string> Roots which cleanup must not affect. */
+    private array $excluded_index_path_roots;
+
+    /** Patch planning retained while the cursor is planning or removing. */
+    private FileSyncPatchProcessor $patch_processor;
+
+    /** @var resource|null Append-only stack of empty parent paths. */
+    private $empty_parent_paths_handle = null;
+
+    /** @var EmptyParentPath|null Top path on the empty-parent stack. */
+    private ?array $empty_parent_path = null;
+
+    /** Byte offset of the top path on the empty-parent stack. */
+    private ?int $empty_parent_path_byte_offset = null;
+
+    /** Whether close() released the retained handles. */
+    private bool $closed = false;
+
+    /**
+     * Starts cleanup before the first local-index step.
+     *
+     * The work directory must already exist. Its cleanup files are replaced.
+     * The patch result index describes the local paths which the caller wants
+     * to write after cleanup.
+     *
+     * @param string       $work_directory             Existing directory for cleanup state.
+     * @param string       $filesystem_root            Filesystem root scanned and changed by cleanup.
+     * @param string       $patch_result_index_file    Index which the later file sync must produce.
+     * @param string       $storage_path               Reprint storage path omitted from the local scan.
+     * @param list<string> $included_index_path_roots  Roots whose descendants cleanup may remove.
+     * @param list<string> $excluded_index_path_roots  Roots which cleanup must not affect.
+     * @param bool         $include_caches             Whether the local scan includes cache directories.
+     */
+    public static function start(
+        string $work_directory,
+        string $filesystem_root,
+        string $patch_result_index_file,
+        string $storage_path,
+        array $included_index_path_roots = [""],
+        array $excluded_index_path_roots = [],
+        bool $include_caches = false
+    ): self {
+        if (!is_dir($work_directory)) {
+            throw new LogicException(
+                "Cannot start file sync cleanup without its work directory: {$work_directory}"
+            );
+        }
+        $work_directory = trim_right_slash($work_directory);
+        $processor = new self();
+        $processor->patch_processor =
+            FileSyncPatchProcessor::start_from_fresh_local_tree(
+                $work_directory,
+                $filesystem_root,
+                $patch_result_index_file,
+                $storage_path,
+                $included_index_path_roots,
+                $excluded_index_path_roots,
+                $include_caches
+            );
+        $patch_cursor = $processor->patch_processor->get_cursor();
+        $canonical_filesystem_root = self::decode_cursor_path(
+            $patch_cursor["position"]["fresh_local_index_cursor"][
+                "filesystem_root_b64"
+            ],
+            "filesystem root"
+        );
+        $empty_parent_paths_file = wp_join_unix_paths(
+            $work_directory,
+            "empty_parent_paths_stack.jsonl"
+        );
+        $processor->empty_parent_paths_handle = fopen(
+            $empty_parent_paths_file,
+            "w+b"
+        );
+        if (!is_resource($processor->empty_parent_paths_handle)) {
+            $processor->patch_processor->close();
+            throw new RuntimeException(
+                "Failed to initialize the empty parent paths file: {$empty_parent_paths_file}"
+            );
+        }
+        $processor->filesystem_root = $canonical_filesystem_root;
+        $processor->included_index_path_roots = $included_index_path_roots;
+        $processor->excluded_index_path_roots = $excluded_index_path_roots;
+        $processor->cursor = [
+            "filesystem_root_b64" => base64_encode(
+                $canonical_filesystem_root
+            ),
+            "empty_parent_paths_file_b64" => base64_encode(
+                $empty_parent_paths_file
+            ),
+            "empty_parent_paths_file_byte_offset" => 0,
+            "empty_parent_path_stack_top_byte_offset" => null,
+            "included_index_path_roots_b64" => array_map(
+                "base64_encode",
+                $included_index_path_roots
+            ),
+            "excluded_index_path_roots_b64" => array_map(
+                "base64_encode",
+                $excluded_index_path_roots
+            ),
+            "position" => [
+                "phase" => "planning",
+                "file_sync_patch_processor_cursor" => $patch_cursor,
+            ],
+        ];
+        return $processor;
+    }
+
+    /**
+     * Reopens cleanup at a cursor returned by get_cursor().
+     *
+     * Bytes appended to the empty-parent stack after the saved byte offset are
+     * discarded. They came from a step whose cursor was not stored and will be
+     * appended again when that step is repeated.
+     *
+     * @param array $cursor {
+     *     Cursor returned by get_cursor().
+     *
+     *     @type string       $filesystem_root_b64                         Base64-encoded canonical filesystem root.
+     *     @type string       $empty_parent_paths_file_b64                 Base64-encoded path to the parent-path stack.
+     *     @type int          $empty_parent_paths_file_byte_offset         Confirmed byte offset in the parent-path stack.
+     *     @type int|null     $empty_parent_path_stack_top_byte_offset     Byte offset of the current stack entry.
+     *     @type list<string> $included_index_path_roots_b64               Base64-encoded roots whose contents may be removed.
+     *     @type list<string> $excluded_index_path_roots_b64               Base64-encoded roots cleanup must not affect.
+     *     @type array        $position                                    Current planning, removing, pruning, complete, or restart phase.
+     * }
+     * @phpstan-param Cursor $cursor
+     */
+    public static function resume(array $cursor): self
+    {
+        $processor = new self();
+        $processor->cursor = $cursor;
+        $processor->filesystem_root = self::decode_cursor_path(
+            $cursor["filesystem_root_b64"],
+            "filesystem root"
+        );
+        $resolved_filesystem_root = realpath($processor->filesystem_root);
+        if (
+            $resolved_filesystem_root === false
+            || $resolved_filesystem_root !== $processor->filesystem_root
+            || !is_dir($processor->filesystem_root)
+            || is_link($processor->filesystem_root)
+        ) {
+            throw new RuntimeException(
+                "The file sync cleanup filesystem root no longer resolves to its saved path."
+            );
+        }
+        $processor->included_index_path_roots = self::decode_path_roots(
+            $cursor["included_index_path_roots_b64"],
+            "included"
+        );
+        $processor->excluded_index_path_roots = self::decode_path_roots(
+            $cursor["excluded_index_path_roots_b64"],
+            "excluded"
+        );
+        $position = $cursor["position"];
+        if (
+            $position["phase"] === "complete"
+            || $position["phase"] === "restart"
+        ) {
+            return $processor;
+        }
+        $empty_parent_paths_file = self::decode_cursor_path(
+            $cursor["empty_parent_paths_file_b64"],
+            "empty parent paths file"
+        );
+        $processor->empty_parent_paths_handle = fopen(
+            $empty_parent_paths_file,
+            "r+b"
+        );
+        if (!is_resource($processor->empty_parent_paths_handle)) {
+            throw new RuntimeException(
+                "Failed to reopen the empty parent paths file: {$empty_parent_paths_file}"
+            );
+        }
+        try {
+            if (
+                !ftruncate(
+                    $processor->empty_parent_paths_handle,
+                    $cursor["empty_parent_paths_file_byte_offset"]
+                )
+                || fseek(
+                    $processor->empty_parent_paths_handle,
+                    $cursor["empty_parent_paths_file_byte_offset"]
+                ) !== 0
+            ) {
+                throw new RuntimeException(
+                    "Failed to truncate and seek the empty parent paths file to byte "
+                    . $cursor["empty_parent_paths_file_byte_offset"]
+                    . "."
+                );
+            }
+            if ($cursor["empty_parent_path_stack_top_byte_offset"] !== null) {
+                $processor->empty_parent_path_byte_offset =
+                    $cursor["empty_parent_path_stack_top_byte_offset"];
+                $saved_parent_path = read_file_sync_path_stack_entry(
+                    $processor->empty_parent_paths_handle,
+                    $cursor["empty_parent_path_stack_top_byte_offset"]
+                );
+                $processor->empty_parent_path = [
+                    "path" => $saved_parent_path["path"],
+                    "previous_byte_offset" =>
+                        $saved_parent_path["previous_byte_offset"],
+                    "expected_ctime" =>
+                        $saved_parent_path["expected_ctime"],
+                ];
+            }
+            if (
+                $position["phase"] === "planning"
+                || $position["phase"] === "removing"
+            ) {
+                $processor->patch_processor = FileSyncPatchProcessor::resume(
+                    $position["file_sync_patch_processor_cursor"]
+                );
+            }
+        } catch (Throwable $resume_failure) {
+            fclose($processor->empty_parent_paths_handle);
+            $processor->empty_parent_paths_handle = null;
+            throw $resume_failure;
+        }
+        return $processor;
+    }
+
+    /**
+     * Performs one patch-planning, exact-removal, or parent-pruning step.
+     *
+     * Planning stores a `delete` or `replace` operation as the next durable
+     * phase. A later step applies that operation. Pruning removes at most one
+     * empty directory. False is stable; get_status() then returns `complete`
+     * or `restart`.
+     */
+    public function next_step(): bool
+    {
+        $position = $this->cursor["position"];
+        if (
+            $position["phase"] === "complete"
+            || $position["phase"] === "restart"
+        ) {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException(
+                "Cannot take a file sync cleanup step after close()."
+            );
+        }
+
+        if ($position["phase"] === "planning") {
+            $has_next_patch_step = $this->patch_processor->next_step();
+            $patch_cursor = $this->patch_processor->get_cursor();
+            $operation = $this->patch_processor->get_operation();
+            // A selected root marks where traversal begins, not a result
+            // entry. Keep that boundary when its contents are empty.
+            if (
+                $operation !== null
+                && (
+                    $operation["action"] === "delete"
+                    || $operation["action"] === "replace"
+                )
+                && !in_array(
+                    $operation["path"],
+                    $this->included_index_path_roots,
+                    true
+                )
+            ) {
+                if (!isset($operation["expected_base"])) {
+                    throw new LogicException(
+                        "Exact file sync cleanup removal has no patch-base entry."
+                    );
+                }
+                $this->cursor["position"] = [
+                    "phase" => "removing",
+                    "path_b64" => base64_encode($operation["path"]),
+                    "expected_base" => $operation["expected_base"],
+                    "file_sync_patch_processor_cursor" => $patch_cursor,
+                ];
+                return true;
+            }
+            if (!$has_next_patch_step) {
+                $this->patch_processor->close();
+                $this->cursor["position"] = ["phase" => "pruning"];
+                if ($this->empty_parent_path === null) {
+                    $this->cursor["position"] = ["phase" => "complete"];
+                    return false;
+                }
+                return true;
+            }
+            $this->cursor["position"] = [
+                "phase" => "planning",
+                "file_sync_patch_processor_cursor" => $patch_cursor,
+            ];
+            return true;
+        }
+
+        if ($position["phase"] === "removing") {
+            $index_path = self::decode_cursor_path(
+                $position["path_b64"],
+                "pending cleanup path"
+            );
+            $absolute_path = $this->absolute_selected_path($index_path);
+            $path_stat = @lstat($absolute_path);
+            $path_removed = !is_array($path_stat);
+            if (is_array($path_stat)) {
+                $local_index_entry = read_file_index_entry_from_stat(
+                    $absolute_path,
+                    $path_stat
+                );
+                $path_type = $local_index_entry["type"];
+                if (
+                    $path_type !== $position["expected_base"]["type"]
+                    || $local_index_entry["size"]
+                        !== $position["expected_base"]["size"]
+                    || $local_index_entry["ctime"]
+                        !== $position["expected_base"]["ctime"]
+                ) {
+                    $this->patch_processor->close();
+                    $this->cursor["position"] = ["phase" => "restart"];
+                    return false;
+                }
+                if ($path_type === "dir") {
+                    $path_removed = @rmdir($absolute_path);
+                    if (!$path_removed) {
+                        clearstatcache(true, $absolute_path);
+                        $remaining_path_stat = @lstat($absolute_path);
+                        if (
+                            is_array($remaining_path_stat)
+                            && ( $remaining_path_stat["mode"] & 0170000 )
+                                === 0040000
+                        ) {
+                            if ($this->directory_has_children($absolute_path)) {
+                                $this->patch_processor->close();
+                                $this->cursor["position"] = [
+                                    "phase" => "restart",
+                                ];
+                                return false;
+                            }
+                            throw new RuntimeException(
+                                "Failed to remove the empty local directory selected for cleanup: "
+                                . base64_encode($index_path)
+                            );
+                        } elseif (is_array($remaining_path_stat)) {
+                            $this->patch_processor->close();
+                            $this->cursor["position"] = [
+                                "phase" => "restart",
+                            ];
+                            return false;
+                        } else {
+                            $path_removed = true;
+                        }
+                    }
+                } else {
+                    $path_removed = @unlink($absolute_path);
+                    if (!$path_removed) {
+                        clearstatcache(true, $absolute_path);
+                        $path_removed = !is_array(@lstat($absolute_path));
+                    }
+                    if (!$path_removed) {
+                        throw new RuntimeException(
+                            "Failed to remove the local path selected for cleanup: "
+                            . base64_encode($index_path)
+                        );
+                    }
+                }
+            }
+            if ($path_removed) {
+                $this->schedule_parent_path($index_path);
+            }
+            $patch_cursor = $position[
+                "file_sync_patch_processor_cursor"
+            ];
+            if ($patch_cursor["position"]["phase"] === "complete") {
+                $this->patch_processor->close();
+                if ($this->empty_parent_path === null) {
+                    $this->cursor["position"] = ["phase" => "complete"];
+                    return false;
+                }
+                $this->cursor["position"] = ["phase" => "pruning"];
+                return true;
+            }
+            $this->cursor["position"] = [
+                "phase" => "planning",
+                "file_sync_patch_processor_cursor" => $patch_cursor,
+            ];
+            return true;
+        }
+
+        if ($this->empty_parent_path === null) {
+            $this->cursor["position"] = ["phase" => "complete"];
+            return false;
+        }
+        $index_path = $this->empty_parent_path["path"];
+        $previous_byte_offset =
+            $this->empty_parent_path["previous_byte_offset"];
+        $absolute_path = $this->absolute_selected_path($index_path);
+        $path_stat = @lstat($absolute_path);
+        $removed = false;
+        // Parent pruning is optional cleanup after the exact removals. A
+        // changed parent belongs to a later fresh scan, so leave it in place.
+        $parent_is_unchanged_directory = is_array($path_stat)
+            && ( $path_stat["mode"] & 0170000 ) === 0040000
+            && $this->empty_parent_path["expected_ctime"] !== null
+            && (int) $path_stat["ctime"]
+                === $this->empty_parent_path["expected_ctime"];
+        if ($parent_is_unchanged_directory) {
+            $removed = @rmdir($absolute_path);
+            if (!$removed) {
+                clearstatcache(true, $absolute_path);
+                $remaining_path_stat = @lstat($absolute_path);
+                if (
+                    is_array($remaining_path_stat)
+                    && ( $remaining_path_stat["mode"] & 0170000 ) === 0040000
+                ) {
+                    if (!$this->directory_has_children($absolute_path)) {
+                        throw new RuntimeException(
+                            "Failed to prune an empty parent directory during cleanup: "
+                            . base64_encode($index_path)
+                        );
+                    }
+                }
+            }
+        }
+        $this->empty_parent_path_byte_offset = $previous_byte_offset;
+        $this->cursor["empty_parent_path_stack_top_byte_offset"] =
+            $previous_byte_offset;
+        if ($previous_byte_offset === null) {
+            $this->empty_parent_path = null;
+        } else {
+            $saved_parent_path = read_file_sync_path_stack_entry(
+                $this->empty_parent_paths_handle,
+                $previous_byte_offset
+            );
+            $this->empty_parent_path = [
+                "path" => $saved_parent_path["path"],
+                "previous_byte_offset" =>
+                    $saved_parent_path["previous_byte_offset"],
+                "expected_ctime" =>
+                    $saved_parent_path["expected_ctime"],
+            ];
+        }
+        if ($removed || !is_array($path_stat)) {
+            $this->schedule_parent_path($index_path);
+        }
+        if ($this->empty_parent_path === null) {
+            $this->cursor["position"] = ["phase" => "complete"];
+            return false;
+        }
+        $this->cursor["position"] = ["phase" => "pruning"];
+        return true;
+    }
+
+    /**
+     * Returns everything needed to resume after the latest completed step.
+     *
+     * @return array {
+     *     @type string       $filesystem_root_b64                         Base64-encoded canonical filesystem root.
+     *     @type string       $empty_parent_paths_file_b64                 Base64-encoded path to the parent-path stack.
+     *     @type int          $empty_parent_paths_file_byte_offset         Confirmed byte offset in the parent-path stack.
+     *     @type int|null     $empty_parent_path_stack_top_byte_offset     Byte offset of the current stack entry.
+     *     @type list<string> $included_index_path_roots_b64               Base64-encoded roots whose contents may be removed.
+     *     @type list<string> $excluded_index_path_roots_b64               Base64-encoded roots cleanup must not affect.
+     *     @type array        $position                                    Current planning, removing, pruning, complete, or restart phase.
+     * }
+     * @phpstan-return Cursor
+     */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Returns the current cleanup phase. */
+    public function get_phase(): string
+    {
+        if ($this->cursor["position"]["phase"] !== "planning") {
+            return $this->cursor["position"]["phase"];
+        }
+        return $this->patch_processor->get_phase();
+    }
+
+    /** Returns `complete` or `restart` after next_step() returns false. */
+    public function get_status(): ?string
+    {
+        $phase = $this->cursor["position"]["phase"];
+        return $phase === "complete" || $phase === "restart"
+            ? $phase
+            : null;
+    }
+
+    /** Flushes processor work files before the caller stores get_cursor(). */
+    public function flush_pending_output(): void
+    {
+        if (
+            isset($this->patch_processor)
+            && $this->cursor["position"]["phase"] !== "pruning"
+            && $this->cursor["position"]["phase"] !== "complete"
+            && $this->cursor["position"]["phase"] !== "restart"
+        ) {
+            $this->patch_processor->flush_pending_outputs();
+        }
+        if (
+            is_resource($this->empty_parent_paths_handle)
+            && !fflush($this->empty_parent_paths_handle)
+        ) {
+            throw new RuntimeException(
+                "Failed to flush the empty parent paths file."
+            );
+        }
+    }
+
+    /** Closes retained handles. Repeated calls do nothing. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        if (isset($this->patch_processor)) {
+            $this->patch_processor->close();
+        }
+        if (is_resource($this->empty_parent_paths_handle)) {
+            fclose($this->empty_parent_paths_handle);
+        }
+        $this->empty_parent_paths_handle = null;
+        $this->closed = true;
+    }
+
+    /** Returns one selected absolute path without following its final symlink. */
+    private function absolute_selected_path(string $index_path): string
+    {
+        assert_valid_relative_path($index_path, "File sync cleanup path");
+        if (
+            !file_sync_index_path_may_change(
+                $index_path,
+                $this->included_index_path_roots,
+                $this->excluded_index_path_roots
+            )
+        ) {
+            throw new RuntimeException(
+                "File sync cleanup cursor selected a path outside its allowed roots: "
+                . base64_encode($index_path)
+            );
+        }
+        $absolute_path = wp_join_unix_paths(
+            $this->filesystem_root,
+            $index_path
+        );
+        $parent = realpath_with_missing_tail(dirname($absolute_path));
+        if (
+            relative_path_under($parent, $this->filesystem_root) === null
+        ) {
+            throw new RuntimeException(
+                "A parent of the local cleanup path resolves outside the filesystem root: "
+                . base64_encode($index_path)
+            );
+        }
+        return $absolute_path;
+    }
+
+    /**
+     * Pushes a removable parent path after a child was removed.
+     *
+     * Repeated paths are useful. Two siblings may schedule the same parent;
+     * the first prune attempt can fail while the sibling still exists and the
+     * later attempt can remove the directory after both siblings are gone.
+     */
+    private function schedule_parent_path(string $index_path): void
+    {
+        $separator = strrpos($index_path, "/");
+        if ($separator === false) {
+            return;
+        }
+        $parent_path = substr($index_path, 0, $separator);
+        if (
+            in_array($parent_path, $this->included_index_path_roots, true)
+            || !file_sync_index_path_may_change(
+                $parent_path,
+                $this->included_index_path_roots,
+                $this->excluded_index_path_roots
+            )
+        ) {
+            return;
+        }
+        $parent_absolute_path = $this->absolute_selected_path($parent_path);
+        clearstatcache(true, $parent_absolute_path);
+        $parent_stat = @lstat($parent_absolute_path);
+        if (
+            is_array($parent_stat)
+            && ( $parent_stat["mode"] & 0170000 ) !== 0040000
+        ) {
+            return;
+        }
+        $expected_ctime = is_array($parent_stat)
+            ? (int) $parent_stat["ctime"]
+            : null;
+        $byte_offset = append_file_sync_path_stack_entry(
+            $this->empty_parent_paths_handle,
+            $parent_path,
+            $this->empty_parent_path_byte_offset,
+            $expected_ctime
+        );
+        $next_byte_offset = ftell($this->empty_parent_paths_handle);
+        if (!is_int($next_byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the empty parent paths byte offset."
+            );
+        }
+        $this->cursor["empty_parent_paths_file_byte_offset"] =
+            $next_byte_offset;
+        $previous_byte_offset = $this->empty_parent_path_byte_offset;
+        $this->empty_parent_path_byte_offset = $byte_offset;
+        $this->cursor["empty_parent_path_stack_top_byte_offset"] =
+            $byte_offset;
+        $this->empty_parent_path = [
+            "path" => $parent_path,
+            "previous_byte_offset" => $previous_byte_offset,
+            "expected_ctime" => $expected_ctime,
+        ];
+    }
+
+    /** Reports whether one directory contains an entry other than dot entries. */
+    private function directory_has_children(string $absolute_path): bool
+    {
+        $directory_handle = @opendir($absolute_path);
+        if (!is_resource($directory_handle)) {
+            throw new RuntimeException(
+                "Failed to inspect a local directory during file sync cleanup: "
+                . base64_encode($absolute_path)
+            );
+        }
+        try {
+            while (true) {
+                $entry = readdir($directory_handle);
+                if ($entry === false) {
+                    return false;
+                }
+                if ($entry !== "." && $entry !== "..") {
+                    return true;
+                }
+            }
+        } finally {
+            closedir($directory_handle);
+        }
+    }
+
+    /** Decodes arbitrary-byte path roots stored in the JSON cursor. */
+    private static function decode_path_roots(
+        array $path_roots_b64,
+        string $field_name
+    ): array {
+        $path_roots = [];
+        foreach ($path_roots_b64 as $path_root_b64) {
+            $path_roots[] = self::decode_cursor_path(
+                $path_root_b64,
+                $field_name . " path root"
+            );
+        }
+        return $path_roots;
+    }
+
+    /** Decodes one arbitrary-byte path stored in the JSON cursor. */
+    private static function decode_cursor_path(
+        string $encoded_path,
+        string $field_name
+    ): string {
+        $path = base64_decode($encoded_path, true);
+        if ($path === false) {
+            throw new InvalidArgumentException(
+                "File sync cleanup cursor contains an invalid base64 {$field_name}."
+            );
+        }
+        return $path;
+    }
+}

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -1,7 +1,9 @@
 <?php
 
+use function Reprint\Importer\append_file_sync_path_stack_entry;
 use function Reprint\Importer\file_sync_index_path_may_change;
 use function Reprint\Importer\find_file_sync_deletion_root;
+use function Reprint\Importer\read_file_sync_path_stack_entry;
 use function WordPress\Reprint\Exporter\path_is_descendant_of;
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 
@@ -54,6 +56,11 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  * and `tree/child`, so each active root links to the preceding one instead of
  * assuming all descendants are adjacent.
  *
+ * create_with_exact_deletions() emits every removed base entry by its exact
+ * path. A new result entry above old descendants is copied without deleting
+ * the parent first. The old descendants appear as later delete operations.
+ * This lets a caller remove them without walking into unindexed children.
+ *
  * ## Selection
  *
  * Included and excluded roots use the same coordinates as the index paths. An
@@ -87,11 +94,11 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  * interruption. resume() ignores those bytes.
  *
  * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
- * @phpstan-type Cursor array{patch_base_index_file_b64:string,patch_result_index_file_b64:string,active_deletion_roots_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type Cursor array{patch_base_index_file_b64:string,patch_result_index_file_b64:string,active_deletion_roots_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
  * @phpstan-type ActiveDeletionRoot array{path:string,previous_byte_offset:int|null}
  * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
- * @phpstan-type DeleteOperation array{action:'delete',path:string}
- * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource}
+ * @phpstan-type DeleteOperation array{action:'delete',path:string,expected_base?:ExpectedSource}
+ * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource,expected_base?:ExpectedSource}
  * @phpstan-type SyncOperation DeleteOperation|CopyOperation
  */
 final class FileSyncPatchPlanner
@@ -107,6 +114,9 @@ final class FileSyncPatchPlanner
 
     /** @var list<string> Index path roots which no planned operation may affect. */
     private array $excluded_index_path_roots;
+
+    /** Whether removed index entries collapse into one directory deletion. */
+    private string $deletion_policy;
 
     /** @var ActiveDeletionRoot|null Top active deleted-directory root. */
     private ?array $active_deletion_root = null;
@@ -146,6 +156,55 @@ final class FileSyncPatchPlanner
         array $included_index_path_roots = [""],
         array $excluded_index_path_roots = []
     ): self {
+        return self::create_with_deletion_policy(
+            $patch_base_index_file,
+            $patch_result_index_file,
+            $active_deletion_roots_file,
+            $included_index_path_roots,
+            $excluded_index_path_roots,
+            "collapsed"
+        );
+    }
+
+    /**
+     * Creates a plan whose deletions name only indexed paths.
+     *
+     * This form is used before a pull writes new paths into the local tree.
+     * A recursive deletion at a shared directory could remove an excluded or
+     * unindexed child. Exact deletions leave those children in place.
+     *
+     * @param string       $patch_base_index_file          Tree state before the patch, or a missing path for an empty tree.
+     * @param string       $patch_result_index_file        Tree state described by the patch.
+     * @param string       $active_deletion_roots_file     Work file retained for the common cursor format.
+     * @param list<string> $included_index_path_roots      Roots within which changes may be planned.
+     * @param list<string> $excluded_index_path_roots      Roots which changes must not affect.
+     * @return self Open planner positioned before the first path.
+     */
+    public static function create_with_exact_deletions(
+        string $patch_base_index_file,
+        string $patch_result_index_file,
+        string $active_deletion_roots_file,
+        array $included_index_path_roots = [""],
+        array $excluded_index_path_roots = []
+    ): self {
+        return self::create_with_deletion_policy(
+            $patch_base_index_file,
+            $patch_result_index_file,
+            $active_deletion_roots_file,
+            $included_index_path_roots,
+            $excluded_index_path_roots,
+            "exact"
+        );
+    }
+
+    private static function create_with_deletion_policy(
+        string $patch_base_index_file,
+        string $patch_result_index_file,
+        string $active_deletion_roots_file,
+        array $included_index_path_roots,
+        array $excluded_index_path_roots,
+        string $deletion_policy
+    ): self {
         if (file_put_contents($active_deletion_roots_file, "") !== 0) {
             throw new RuntimeException(
                 "Failed to initialize the active deletion roots file: {$active_deletion_roots_file}"
@@ -170,6 +229,7 @@ final class FileSyncPatchPlanner
                     "base64_encode",
                     $excluded_index_path_roots
                 ),
+                "deletion_policy" => $deletion_policy,
                 "index_diff_cursor" => [
                     "old_index_byte_offset" => 0,
                     "new_index_byte_offset" => 0,
@@ -183,7 +243,8 @@ final class FileSyncPatchPlanner
     /**
      * Reopens a planner at its last stored cursor.
      *
-     * Both index files must still contain the same snapshots used by create().
+     * Both index files must still contain the same snapshots used by the
+     * create method which made the cursor.
      * The active deletion roots file must still belong to this plan.
      *
      * @param array $cursor {
@@ -194,6 +255,7 @@ final class FileSyncPatchPlanner
      *     @type string       $active_deletion_roots_file_b64           Base64-encoded path to the active directory-deletion state.
      *     @type list<string> $included_index_path_roots_b64            Base64-encoded roots within which changes may be planned.
      *     @type list<string> $excluded_index_path_roots_b64            Base64-encoded roots which changes must not affect.
+     *     @type string       $deletion_policy                          `collapsed` or `exact` deletion planning.
      *     @type array        $index_diff_cursor                        File-index diff cursor.
      *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
      * }
@@ -224,6 +286,16 @@ final class FileSyncPatchPlanner
             [self::class, "decode_index_path_root"],
             $cursor["excluded_index_path_roots_b64"]
         );
+        if (
+            $cursor["deletion_policy"] !== "collapsed"
+            && $cursor["deletion_policy"] !== "exact"
+        ) {
+            throw new InvalidArgumentException(
+                "File sync patch planner cursor has an invalid deletion policy: "
+                . $cursor["deletion_policy"]
+            );
+        }
+        $planner->deletion_policy = $cursor["deletion_policy"];
         $planner->index_diff = FileIndexDiffProcessor::resume(
             $patch_base_index_file,
             $patch_result_index_file,
@@ -241,9 +313,12 @@ final class FileSyncPatchPlanner
             );
         }
         $planner->active_deletion_root =
-            $planner->read_active_deletion_root(
-                $cursor["active_deletion_root_byte_offset"]
-            );
+            $cursor["active_deletion_root_byte_offset"] === null
+                ? null
+                : read_file_sync_path_stack_entry(
+                    $planner->active_deletion_roots_handle,
+                    $cursor["active_deletion_root_byte_offset"]
+                );
         return $planner;
     }
 
@@ -286,7 +361,8 @@ final class FileSyncPatchPlanner
             $this->cursor["active_deletion_root_byte_offset"];
 
         if (
-            $patch_base_path_type !== null
+            $this->deletion_policy === "collapsed"
+            && $patch_base_path_type !== null
             && $this->active_deletion_root !== null
         ) {
             // Byte sorting can place `a-other` before `a/child`. Keep the
@@ -303,9 +379,12 @@ final class FileSyncPatchPlanner
                 $active_deletion_root_byte_offset =
                     $this->active_deletion_root["previous_byte_offset"];
                 $this->active_deletion_root =
-                    $this->read_active_deletion_root(
-                        $active_deletion_root_byte_offset
-                    );
+                    $active_deletion_root_byte_offset === null
+                        ? null
+                        : read_file_sync_path_stack_entry(
+                            $this->active_deletion_roots_handle,
+                            $active_deletion_root_byte_offset
+                        );
             }
         }
 
@@ -319,7 +398,8 @@ final class FileSyncPatchPlanner
                     $index_path
                 );
             if (
-                $patch_result_entry_replaces_patch_base_subtree
+                $this->deletion_policy === "collapsed"
+                && $patch_result_entry_replaces_patch_base_subtree
                 && file_sync_index_path_may_change(
                     $index_path,
                     $this->included_index_path_roots,
@@ -328,11 +408,19 @@ final class FileSyncPatchPlanner
                 && !$this->active_deletion_root_covers_path($index_path)
             ) {
                 $path_to_delete = $index_path;
+                $previous_active_deletion_root_byte_offset =
+                    $active_deletion_root_byte_offset;
                 $active_deletion_root_byte_offset =
-                    $this->append_active_deletion_root(
+                    append_file_sync_path_stack_entry(
+                        $this->active_deletion_roots_handle,
                         $index_path,
                         $active_deletion_root_byte_offset
                     );
+                $this->active_deletion_root = [
+                    "path" => $index_path,
+                    "previous_byte_offset" =>
+                        $previous_active_deletion_root_byte_offset,
+                ];
             }
             if (
                 file_sync_index_path_may_change(
@@ -344,30 +432,55 @@ final class FileSyncPatchPlanner
                 $path_to_copy = $index_path;
             }
         } elseif ($path_transition === "deleted") {
-            $candidate_path_to_delete = find_file_sync_deletion_root(
-                $index_path,
-                $this->index_diff->get_preceding_path_in_new_index(),
-                $this->index_diff->get_following_path_in_new_index(),
-                function (string $candidate_path): bool {
-                    return file_sync_index_path_may_change(
-                        $candidate_path,
+            if ($this->deletion_policy === "exact") {
+                $candidate_path_to_delete =
+                    file_sync_index_path_may_change(
+                        $index_path,
                         $this->included_index_path_roots,
                         $this->excluded_index_path_roots
-                    );
-                },
-                $patch_base_entry_shape === "empty_directory"
-            );
+                    )
+                        ? $index_path
+                        : null;
+            } else {
+                $candidate_path_to_delete = find_file_sync_deletion_root(
+                    $index_path,
+                    $this->index_diff->get_preceding_path_in_new_index(),
+                    $this->index_diff->get_following_path_in_new_index(),
+                    function (string $candidate_path): bool {
+                        return file_sync_index_path_may_change(
+                            $candidate_path,
+                            $this->included_index_path_roots,
+                            $this->excluded_index_path_roots
+                        );
+                    },
+                    $patch_base_entry_shape === "empty_directory"
+                );
+            }
             if (
                 $candidate_path_to_delete !== null
-                && !$this->active_deletion_root_covers_path($index_path)
+                && (
+                    $this->deletion_policy === "exact"
+                    || !$this->active_deletion_root_covers_path($index_path)
+                )
             ) {
                 $path_to_delete = $candidate_path_to_delete;
-                if ($candidate_path_to_delete !== $index_path) {
+                if (
+                    $this->deletion_policy === "collapsed"
+                    && $candidate_path_to_delete !== $index_path
+                ) {
+                    $previous_active_deletion_root_byte_offset =
+                        $active_deletion_root_byte_offset;
                     $active_deletion_root_byte_offset =
-                        $this->append_active_deletion_root(
+                        append_file_sync_path_stack_entry(
+                            $this->active_deletion_roots_handle,
                             $candidate_path_to_delete,
                             $active_deletion_root_byte_offset
                         );
+                    $this->active_deletion_root = [
+                        "path" => $candidate_path_to_delete,
+                        "previous_byte_offset" =>
+                            $previous_active_deletion_root_byte_offset,
+                    ];
                 }
             }
         } else {
@@ -385,9 +498,10 @@ final class FileSyncPatchPlanner
                 && $path_transition === "modified";
             // The diff defines modification by type, size, and ctime. Only a
             // modified file or symlink needs its result value copied.
-            $needs_delete =
-                $patch_result_entry_is_file_or_symlink
-                !== $patch_base_entry_is_file_or_symlink;
+            $needs_delete = $this->deletion_policy === "exact"
+                ? $patch_result_path_type !== $patch_base_path_type
+                : $patch_result_entry_is_file_or_symlink
+                    !== $patch_base_entry_is_file_or_symlink;
             $path_may_change = file_sync_index_path_may_change(
                 $index_path,
                 $this->included_index_path_roots,
@@ -397,7 +511,10 @@ final class FileSyncPatchPlanner
             if (
                 $needs_delete
                 && $path_may_change
-                && !$this->active_deletion_root_covers_path($index_path)
+                && (
+                    $this->deletion_policy === "exact"
+                    || !$this->active_deletion_root_covers_path($index_path)
+                )
             ) {
                 $path_to_delete = $index_path;
             }
@@ -426,6 +543,17 @@ final class FileSyncPatchPlanner
                 "path" => $path_to_delete,
             ];
         }
+        if (
+            $this->deletion_policy === "exact"
+            && $path_to_delete === $index_path
+            && $patch_base_path_type !== null
+        ) {
+            $this->operation["expected_base"] = [
+                "type" => $patch_base_path_type,
+                "size" => $this->index_diff->get_size_in_old_index(),
+                "ctime" => $this->index_diff->get_ctime_in_old_index(),
+            ];
+        }
 
         $this->complete = !$this->index_diff->next_path();
         $this->index_diff_path_selected = !$this->complete;
@@ -448,10 +576,10 @@ final class FileSyncPatchPlanner
     /**
      * Returns the operation selected for the current path.
      *
-     * Null means the current path needs no operation. A `delete` operation has
-     * only an action and path. A `copy` or `replace` operation also records the
-     * source state expected when the operation is performed. `replace` means
-     * delete the path before copying the patch-result entry there.
+     * Null means the current path needs no operation. A `copy` or `replace`
+     * operation records the patch-result entry which must be copied. An exact
+     * `delete` or `replace` also records the patch-base entry which may be
+     * removed. A collapsed directory deletion has only an action and path.
      *
      * @return array|null {
      *     Current sync operation, or null.
@@ -460,6 +588,14 @@ final class FileSyncPatchPlanner
      *     @type string $path            Path on which to operate.
      *     @type array  $expected_source {
      *         Source state required by `copy` and `replace`. Absent for `delete`.
+     *
+     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type int    $size  Expected size.
+     *         @type int    $ctime Expected inode change time.
+     *     }
+     *     @type array  $expected_base {
+     *         Base state which an exact `delete` or `replace` removes. Absent
+     *         from copy operations and collapsed directory deletions.
      *
      *         @type string $type  Expected `file`, `link`, or `dir` type.
      *         @type int    $size  Expected size.
@@ -485,6 +621,7 @@ final class FileSyncPatchPlanner
      *     @type string       $active_deletion_roots_file_b64           Base64-encoded path to the active directory-deletion state.
      *     @type list<string> $included_index_path_roots_b64            Base64-encoded roots within which changes may be planned.
      *     @type list<string> $excluded_index_path_roots_b64            Base64-encoded roots which changes must not affect.
+     *     @type string       $deletion_policy                          `collapsed` or `exact` deletion planning.
      *     @type array        $index_diff_cursor                        File-index diff cursor.
      *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
      * }
@@ -528,89 +665,6 @@ final class FileSyncPatchPlanner
             return "symlink";
         }
         return "empty_directory";
-    }
-
-    /** Adds one active deletion root and returns its byte offset. */
-    private function append_active_deletion_root(
-        string $index_path,
-        ?int $previous_byte_offset
-    ): int {
-        if (fseek($this->active_deletion_roots_handle, 0, SEEK_END) !== 0) {
-            throw new RuntimeException(
-                "Failed to seek to the end of the active deletion roots file."
-            );
-        }
-        $byte_offset = ftell($this->active_deletion_roots_handle);
-        if (!is_int($byte_offset)) {
-            throw new RuntimeException(
-                "Failed to determine the active deletion roots byte offset."
-            );
-        }
-        $line = json_encode(
-            [
-                "path_b64" => base64_encode($index_path),
-                "previous_byte_offset" => $previous_byte_offset,
-            ],
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (
-            fwrite($this->active_deletion_roots_handle, $line)
-            !== strlen($line)
-        ) {
-            throw new RuntimeException(
-                "Failed to append to the active deletion roots file."
-            );
-        }
-        $this->active_deletion_root = [
-            "path" => $index_path,
-            "previous_byte_offset" => $previous_byte_offset,
-        ];
-        return $byte_offset;
-    }
-
-    /** Returns one active deletion root addressed by its byte offset. */
-    private function read_active_deletion_root(
-        ?int $byte_offset
-    ): ?array {
-        if ($byte_offset === null) {
-            return null;
-        }
-        if (
-            fseek(
-                $this->active_deletion_roots_handle,
-                $byte_offset
-            ) !== 0
-        ) {
-            throw new RuntimeException(
-                "Failed to seek in the active deletion roots file."
-            );
-        }
-        $line = fgets($this->active_deletion_roots_handle);
-        if (!is_string($line)) {
-            throw new RuntimeException(
-                "Failed to read the active deletion root at byte {$byte_offset}."
-            );
-        }
-        try {
-            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $exception) {
-            throw new RuntimeException(
-                "Failed to decode the active deletion root at byte {$byte_offset}.",
-                0,
-                $exception
-            );
-        }
-        /** @var array{path_b64:string,previous_byte_offset:int|null} $entry */
-        $index_path = base64_decode($entry["path_b64"], true);
-        if ($index_path === false) {
-            throw new RuntimeException(
-                "Failed to decode the deleted-directory path at byte {$byte_offset}."
-            );
-        }
-        return [
-            "path" => $index_path,
-            "previous_byte_offset" => $entry["previous_byte_offset"],
-        ];
     }
 
     /** Reports whether the active deletion root contains the index path. */

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
@@ -49,11 +49,11 @@ require_once __DIR__ . '/class-fresh-local-index-processor.php';
  * @phpstan-type FreshIndexPosition array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}|array{phase:'sorting'}|array{phase:'complete'}
  * @phpstan-type FreshIndexCursor array{fresh_local_index_file_b64:string,filesystem_root_b64:string,storage_path_b64:string,include_caches:bool,position:FreshIndexPosition}
  * @phpstan-type PlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
- * @phpstan-type PlannerCursor array{patch_base_index_file_b64:string,patch_result_index_file_b64:string,active_deletion_roots_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,index_diff_cursor:PlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
- * @phpstan-type FreshTreePosition array{phase:'indexing'|'sorting'|'starting_patch',patch_base_index_file_b64:string,patch_result_index_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,fresh_local_index_cursor:FreshIndexCursor}
+ * @phpstan-type PlannerCursor array{patch_base_index_file_b64:string,patch_result_index_file_b64:string,active_deletion_roots_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',index_diff_cursor:PlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type FreshTreePosition array{phase:'indexing'|'sorting'|'starting_patch',patch_base_index_file_b64:string,patch_result_index_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',fresh_local_index_cursor:FreshIndexCursor}
  * @phpstan-type Position FreshTreePosition|array{phase:'planning',file_sync_patch_planner_cursor:PlannerCursor}|array{phase:'complete'}
  * @phpstan-type Cursor array{fresh_local_index_file_b64:string,position:Position}
- * @phpstan-type SyncOperation array{action:'copy'|'delete'|'replace',path:string,expected_source?:array{type:string,size:int,ctime:int}}
+ * @phpstan-type SyncOperation array{action:'copy'|'delete'|'replace',path:string,expected_source?:array{type:string,size:int,ctime:int},expected_base?:array{type:string,size:int,ctime:int}}
  */
 final class FileSyncPatchProcessor {
     /** @var Cursor */
@@ -100,7 +100,8 @@ final class FileSyncPatchProcessor {
             $storage_path,
             $included_index_path_roots,
             $excluded_index_path_roots,
-            $include_caches
+            $include_caches,
+            "collapsed"
         );
     }
 
@@ -108,7 +109,9 @@ final class FileSyncPatchProcessor {
      * Plans the patch which changes the current local tree into a saved index.
      *
      * Copy and replace operations read their expected source state from the
-     * supplied patch-result index.
+     * supplied patch-result index. Deleted local entries keep their exact
+     * paths. A caller can remove them with unlink() or rmdir() without walking
+     * through skipped or excluded children.
      *
      * @param string       $work_directory             Existing directory for the fresh index and planner state.
      * @param string       $filesystem_root            Filesystem root scanned for the fresh index.
@@ -136,7 +139,8 @@ final class FileSyncPatchProcessor {
             $storage_path,
             $included_index_path_roots,
             $excluded_index_path_roots,
-            $include_caches
+            $include_caches,
+            "exact"
         );
     }
 
@@ -241,22 +245,41 @@ final class FileSyncPatchProcessor {
                 }
                 $excluded_index_path_roots[] = $excluded_index_path_root;
             }
-            $this->patch_planner = FileSyncPatchPlanner::create(
-                self::decode_cursor_path(
-                    $position["patch_base_index_file_b64"],
-                    "patch base index file"
-                ),
-                self::decode_cursor_path(
-                    $position["patch_result_index_file_b64"],
-                    "patch result index file"
-                ),
-                wp_join_unix_paths(
-                    dirname($this->fresh_local_index_file),
-                    "deleted_directories_stack.jsonl"
-                ),
-                $included_index_path_roots,
-                $excluded_index_path_roots
+            $patch_base_index_file = self::decode_cursor_path(
+                $position["patch_base_index_file_b64"],
+                "patch base index file"
             );
+            $patch_result_index_file = self::decode_cursor_path(
+                $position["patch_result_index_file_b64"],
+                "patch result index file"
+            );
+            $active_deletion_roots_file = wp_join_unix_paths(
+                dirname($this->fresh_local_index_file),
+                "deleted_directories_stack.jsonl"
+            );
+            if ($position["deletion_policy"] === "exact") {
+                $this->patch_planner =
+                    FileSyncPatchPlanner::create_with_exact_deletions(
+                        $patch_base_index_file,
+                        $patch_result_index_file,
+                        $active_deletion_roots_file,
+                        $included_index_path_roots,
+                        $excluded_index_path_roots
+                    );
+            } elseif ($position["deletion_policy"] === "collapsed") {
+                $this->patch_planner = FileSyncPatchPlanner::create(
+                    $patch_base_index_file,
+                    $patch_result_index_file,
+                    $active_deletion_roots_file,
+                    $included_index_path_roots,
+                    $excluded_index_path_roots
+                );
+            } else {
+                throw new InvalidArgumentException(
+                    "File sync patch processor cursor has an invalid deletion policy: "
+                    . $position["deletion_policy"]
+                );
+            }
             $this->cursor["position"] = [
                 "phase" => "planning",
                 "file_sync_patch_planner_cursor" =>
@@ -285,15 +308,23 @@ final class FileSyncPatchProcessor {
     /**
      * Returns the operation selected by the latest planning step.
      *
-     * Delete operations contain only `action` and `path`. Copy and replace
-     * operations also contain the result index entry which must be copied.
-     * Non-planning steps and processed paths which need no change return null.
+     * Copy and replace operations contain the result index entry which must
+     * be copied. Exact delete and replace operations also contain the base
+     * entry which will be removed. Non-planning steps and processed paths
+     * which need no change return null.
      *
      * @return array|null {
      *     @type string $action          `copy`, `delete`, or `replace`.
      *     @type string $path            Local relative path selected by the patch.
      *     @type array  $expected_source {
      *         Result index entry required by `copy` and `replace`.
+     *
+     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type int    $size  Expected size.
+     *         @type int    $ctime Expected inode change time.
+     *     }
+     *     @type array  $expected_base {
+     *         Base index entry removed by an exact `delete` or `replace`.
      *
      *         @type string $type  Expected `file`, `link`, or `dir` type.
      *         @type int    $size  Expected size.
@@ -416,7 +447,8 @@ final class FileSyncPatchProcessor {
         string $storage_path,
         array $included_index_path_roots,
         array $excluded_index_path_roots,
-        bool $include_caches
+        bool $include_caches,
+        string $deletion_policy
     ): self {
         if (!is_dir($work_directory)) {
             throw new LogicException(
@@ -456,6 +488,7 @@ final class FileSyncPatchProcessor {
                     "base64_encode",
                     $excluded_index_path_roots
                 ),
+                "deletion_policy" => $deletion_policy,
                 "fresh_local_index_cursor" =>
                     $processor->fresh_local_index_processor->get_cursor(),
             ],

--- a/packages/reprint-client/src/lib/index/file-sync-path-functions.php
+++ b/packages/reprint-client/src/lib/index/file-sync-path-functions.php
@@ -2,6 +2,8 @@
 
 namespace Reprint\Importer;
 
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and byte offsets are CLI values, never HTML output.
+
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
@@ -143,4 +145,97 @@ function file_sync_result_contains_path_or_descendant(
         $following_result_index_path,
         $index_path
     );
+}
+
+/**
+ * Appends one path to a linked stack stored in a file.
+ *
+ * Each entry points to the preceding stack entry by byte offset. Entries from
+ * an interrupted step can remain at the end of the file without joining the
+ * saved stack. A caller which needs to reclaim those bytes may truncate the
+ * file to its separately stored output byte offset before appending again.
+ *
+ * @param resource $stack_handle        Open file used by this stack.
+ * @param string   $path                Arbitrary-byte path to push.
+ * @param int|null $previous_byte_offset Byte offset of the preceding entry.
+ * @param int|null $expected_ctime       Expected directory ctime, when the
+ *                                       caller will remove this path later.
+ * @return int Byte offset of the appended entry.
+ */
+function append_file_sync_path_stack_entry(
+    $stack_handle,
+    string $path,
+    ?int $previous_byte_offset,
+    ?int $expected_ctime = null
+): int {
+    if (fseek($stack_handle, 0, SEEK_END) !== 0) {
+        throw new \RuntimeException(
+            "Failed to seek to the end of the file sync path stack."
+        );
+    }
+    $byte_offset = ftell($stack_handle);
+    if (!is_int($byte_offset)) {
+        throw new \RuntimeException(
+            "Failed to determine the file sync path stack byte offset."
+        );
+    }
+    $entry = [
+        "path_b64" => base64_encode($path),
+        "previous_byte_offset" => $previous_byte_offset,
+        "expected_ctime" => $expected_ctime,
+    ];
+    $line = json_encode(
+        $entry,
+        JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+    ) . "\n";
+    if (fwrite($stack_handle, $line) !== strlen($line)) {
+        throw new \RuntimeException(
+            "Failed to append to the file sync path stack."
+        );
+    }
+    return $byte_offset;
+}
+
+/**
+ * Reads one linked path-stack entry at its byte offset.
+ *
+ * @param resource $stack_handle Open file used by this stack.
+ * @return array{path:string,previous_byte_offset:int|null,expected_ctime:int|null} Decoded stack entry.
+ */
+function read_file_sync_path_stack_entry(
+    $stack_handle,
+    int $byte_offset
+): array {
+    if (fseek($stack_handle, $byte_offset) !== 0) {
+        throw new \RuntimeException(
+            "Failed to seek to file sync path stack byte {$byte_offset}."
+        );
+    }
+    $line = fgets($stack_handle);
+    if (!is_string($line)) {
+        throw new \RuntimeException(
+            "Failed to read the file sync path stack at byte {$byte_offset}."
+        );
+    }
+    try {
+        $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $exception) {
+        throw new \RuntimeException(
+            "Failed to decode the file sync path stack at byte {$byte_offset}.",
+            0,
+            $exception
+        );
+    }
+    /** @var array{path_b64:string,previous_byte_offset:int|null,expected_ctime:int|null} $entry */
+    $path = base64_decode($entry["path_b64"], true);
+    if ($path === false) {
+        throw new \RuntimeException(
+            "Failed to decode the file sync path at byte {$byte_offset}."
+        );
+    }
+    return [
+        "path" => $path,
+        "previous_byte_offset" => $entry["previous_byte_offset"],
+        "expected_ctime" => $entry["expected_ctime"],
+    ];
 }

--- a/tests/Import/FileSyncCleanupProcessorTest.php
+++ b/tests/Import/FileSyncCleanupProcessorTest.php
@@ -1,0 +1,807 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-server/src/utils.php';
+require_once __DIR__ . '/../../packages/reprint-server/src/class-file-index-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php';
+
+final class FileSyncCleanupProcessorTest extends TestCase {
+    private string $temporary_directory;
+    private string $filesystem_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporary_directory = sys_get_temp_dir()
+            . '/file-sync-cleanup-processor-'
+            . bin2hex(random_bytes(6));
+        $this->filesystem_root =
+            $this->temporary_directory . '/filesystem-root';
+        mkdir($this->filesystem_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_path($this->temporary_directory);
+        parent::tearDown();
+    }
+
+    public function testRemovesIndexedPathsAndPrunesEmptyParents(): void
+    {
+        mkdir($this->filesystem_root . '/selected/gone/nested', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/gone/child.txt',
+            'child'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/gone/nested/leaf.txt',
+            'leaf'
+        );
+        $work_directory = $this->work_directory('remove-tree');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('empty.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+
+        $phases = $this->run_to_completion($processor);
+
+        $this->assertDirectoryExists($this->filesystem_root . '/selected');
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/gone'
+        );
+        $this->assertContains('removing', $phases);
+        $this->assertContains('pruning', $phases);
+        $this->assertSame('complete', $processor->get_status());
+    }
+
+    public function testKeepsUnindexedCacheAndStorageChildren(): void
+    {
+        mkdir($this->filesystem_root . '/selected/tree/node_modules', 0755, true);
+        mkdir($this->filesystem_root . '/selected/tree/.git');
+        file_put_contents(
+            $this->filesystem_root . '/selected/tree/delete.txt',
+            'delete'
+        );
+        file_put_contents(
+            $this->filesystem_root
+                . '/selected/tree/node_modules/package.js',
+            'package'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/tree/.git/config',
+            'config'
+        );
+        $storage_path =
+            $this->filesystem_root . '/selected/tree/.reprint';
+        mkdir($storage_path);
+        file_put_contents($storage_path . '/keep.txt', 'state');
+        $work_directory = $this->work_directory('keep-skipped');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('keep-skipped-result.jsonl', []),
+            $storage_path,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/tree/delete.txt'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root
+                . '/selected/tree/node_modules/package.js'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root . '/selected/tree/.git/config'
+        );
+        $this->assertFileExists($storage_path . '/keep.txt');
+    }
+
+    public function testKeepsAnExplicitlyExcludedChild(): void
+    {
+        mkdir($this->filesystem_root . '/selected/tree/keep', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/tree/delete.txt',
+            'delete'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/tree/keep/child.txt',
+            'keep'
+        );
+        $work_directory = $this->work_directory('keep-excluded');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('keep-excluded-result.jsonl', []),
+            $work_directory,
+            ['selected'],
+            ['selected/tree/keep']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/tree/delete.txt'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root . '/selected/tree/keep/child.txt'
+        );
+    }
+
+    public function testKeepsAnEmptyIncludedRoot(): void
+    {
+        mkdir($this->filesystem_root . '/selected');
+        $work_directory = $this->work_directory('keep-included-root');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('keep-included-root-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected'
+        );
+    }
+
+    /** @dataProvider exactPathTypes */
+    public function testRemovesAnExactPathBeforeItsTypeChanges(
+        string $local_type,
+        string $result_type
+    ): void {
+        $path = $this->filesystem_root . '/selected/entry';
+        mkdir(dirname($path), 0755, true);
+        if ($local_type === 'dir') {
+            mkdir($path);
+        } elseif ($local_type === 'link') {
+            symlink('missing-target', $path);
+        } else {
+            file_put_contents($path, 'local');
+        }
+        $work_directory = $this->work_directory(
+            'replace-' . $local_type . '-' . $result_type
+        );
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('replace-result.jsonl', [
+                $this->entry('selected/entry', $result_type),
+            ]),
+            $work_directory,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFalse(file_exists($path));
+        $this->assertFalse(is_link($path));
+        $this->assertDirectoryExists($this->filesystem_root . '/selected');
+    }
+
+    /** @return list<array{string,string}> */
+    public static function exactPathTypes(): array
+    {
+        return [
+            ['dir', 'file'],
+            ['file', 'dir'],
+            ['link', 'file'],
+            ['file', 'link'],
+        ];
+    }
+
+    public function testAResultParentDoesNotRemoveAnUnindexedChild(): void
+    {
+        mkdir(
+            $this->filesystem_root . '/selected/tree/node_modules',
+            0755,
+            true
+        );
+        file_put_contents(
+            $this->filesystem_root
+                . '/selected/tree/node_modules/package.js',
+            'package'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/tree/indexed.txt',
+            'indexed'
+        );
+        $work_directory = $this->work_directory('result-parent');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('result-parent.jsonl', [
+                $this->entry('selected/tree', 'file'),
+            ]),
+            $work_directory,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/tree/indexed.txt'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root
+                . '/selected/tree/node_modules/package.js'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/tree'
+        );
+    }
+
+    public function testResumeRepeatsAPendingRemovalSafely(): void
+    {
+        file_put_contents($this->filesystem_root . '/delete.txt', 'delete');
+        $work_directory = $this->work_directory('pending-removal');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('pending-result.jsonl', []),
+            $work_directory
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->flush_pending_output();
+        $pending_cursor = $this->stored_cursor($processor->get_cursor());
+        $this->assertArrayNotHasKey('action', $pending_cursor['position']);
+        $this->assertSame(
+            'file',
+            $pending_cursor['position']['expected_base']['type']
+        );
+
+        $processor->next_step();
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/delete.txt'
+        );
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume($pending_cursor);
+        $this->run_to_completion($resumed);
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/delete.txt'
+        );
+    }
+
+    public function testCopyLeavesThePathForTheCallerToWrite(): void
+    {
+        $work_directory = $this->work_directory('copy-restart');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('copy-restart-result.jsonl', [
+                $this->entry('remote.txt', 'file'),
+            ]),
+            $work_directory
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertSame('complete', $processor->get_status());
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/remote.txt'
+        );
+    }
+
+    public function testChangedPendingRemovalRestartsWithoutDeletingTheNewPath(): void
+    {
+        $path = $this->filesystem_root . '/delete.txt';
+        file_put_contents($path, 'old');
+        $work_directory = $this->work_directory('changed-removal');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('changed-removal-result.jsonl', []),
+            $work_directory
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->flush_pending_output();
+        $removing_cursor = $this->stored_cursor($processor->get_cursor());
+        $processor->close();
+
+        $processor = FileSyncCleanupProcessor::resume($removing_cursor);
+
+        file_put_contents($path, 'new version');
+        clearstatcache(true, $path);
+
+        $this->assertFalse($processor->next_step());
+        $this->assertSame('restart', $processor->get_status());
+        $this->assertSame('new version', file_get_contents($path));
+        $restart_cursor = $this->stored_cursor($processor->get_cursor());
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume($restart_cursor);
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('restart', $resumed->get_status());
+        $this->assertSame('new version', file_get_contents($path));
+        $resumed->close();
+    }
+
+    public function testChangedPendingReplacementRestartsWithoutDeletingTheNewPath(): void
+    {
+        $path = $this->filesystem_root . '/entry';
+        file_put_contents($path, 'old');
+        $work_directory = $this->work_directory('changed-replacement');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('changed-replacement-result.jsonl', [
+                $this->entry('entry', 'dir'),
+            ]),
+            $work_directory
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+
+        file_put_contents($path, 'new version');
+        clearstatcache(true, $path);
+
+        $this->assertFalse($processor->next_step());
+        $this->assertSame('restart', $processor->get_status());
+        $this->assertSame('new version', file_get_contents($path));
+    }
+
+    public function testPendingEmptyDirectoryWhichGainsAChildRequiresRestart(): void
+    {
+        $path = $this->filesystem_root . '/entry';
+        mkdir($path);
+        $work_directory = $this->work_directory('changed-empty-directory');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('changed-empty-directory-result.jsonl', [
+                $this->entry('entry', 'file'),
+            ]),
+            $work_directory
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+
+        file_put_contents($path . '/new.txt', 'new');
+        clearstatcache(true, $path);
+
+        $this->assertFalse($processor->next_step());
+        $this->assertSame('restart', $processor->get_status());
+        $this->assertSame('new', file_get_contents($path . '/new.txt'));
+    }
+
+    public function testPendingRemovalRejectsAParentMovedOutsideTheRoot(): void
+    {
+        mkdir($this->filesystem_root . '/selected/directory', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/directory/delete.txt',
+            'local'
+        );
+        $outside_directory = $this->temporary_directory . '/outside';
+        mkdir($outside_directory);
+        file_put_contents($outside_directory . '/delete.txt', 'outside');
+        $work_directory = $this->work_directory('moved-parent');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('moved-parent-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $this->assertSame(
+            base64_encode('selected/directory/delete.txt'),
+            $processor->get_cursor()['position']['path_b64']
+        );
+
+        rename(
+            $this->filesystem_root . '/selected/directory',
+            $this->filesystem_root . '/saved-directory'
+        );
+        symlink(
+            $outside_directory,
+            $this->filesystem_root . '/selected/directory'
+        );
+
+        try {
+            $processor->next_step();
+            $this->fail('Expected the moved parent path to be rejected.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'resolves outside the filesystem root',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            'outside',
+            file_get_contents($outside_directory . '/delete.txt')
+        );
+        $processor->close();
+    }
+
+    public function testResumeKeepsTheEmptyParentStack(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/delete.txt',
+            'delete'
+        );
+        $work_directory = $this->work_directory('parent-stack');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('parent-stack-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+            $processor->flush_pending_output();
+        } while ($processor->get_phase() !== 'pruning');
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $this->assertNotNull(
+            $cursor['empty_parent_path_stack_top_byte_offset']
+        );
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume($cursor);
+        $this->run_to_completion($resumed);
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a'
+        );
+        $this->assertDirectoryExists($this->filesystem_root . '/selected');
+    }
+
+    public function testResumeDiscardsAnUnstoredParentStackEntry(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/first.txt',
+            'first'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/second.txt',
+            'second'
+        );
+        $work_directory = $this->work_directory('discard-stack-tail');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('discard-stack-tail-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->flush_pending_output();
+        $processor->next_step();
+        $processor->flush_pending_output();
+        $stored_after_first_removal = $this->stored_cursor(
+            $processor->get_cursor()
+        );
+
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->next_step();
+        $this->assertGreaterThan(
+            $stored_after_first_removal[
+                'empty_parent_paths_file_byte_offset'
+            ],
+            $processor->get_cursor()[
+                'empty_parent_paths_file_byte_offset'
+            ]
+        );
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume(
+            $stored_after_first_removal
+        );
+        $this->run_to_completion($resumed);
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a'
+        );
+    }
+
+    public function testCorruptParentStackDoesNotLeaveItsFileOpen(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/delete.txt',
+            'delete'
+        );
+        $work_directory = $this->work_directory('corrupt-parent-stack');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('corrupt-parent-stack-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+            $processor->flush_pending_output();
+        } while ($processor->get_phase() !== 'pruning');
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $processor->close();
+
+        $parent_stack_file = base64_decode(
+            $cursor['empty_parent_paths_file_b64'],
+            true
+        );
+        $this->assertIsString($parent_stack_file);
+        file_put_contents($parent_stack_file, "not-json\n");
+        $this->assertSame(
+            0,
+            $this->count_open_streams_for_path($parent_stack_file)
+        );
+
+        try {
+            FileSyncCleanupProcessor::resume($cursor);
+            $this->fail('Expected the corrupt parent stack to be rejected.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Failed to decode the file sync path stack',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            0,
+            $this->count_open_streams_for_path($parent_stack_file)
+        );
+    }
+
+    public function testResumeAfterAnUnstoredPruneStillSchedulesItsParent(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/delete.txt',
+            'delete'
+        );
+        $work_directory = $this->work_directory('repeat-prune');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('repeat-prune-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+            $processor->flush_pending_output();
+        } while ($processor->get_phase() !== 'pruning');
+        $pruning_cursor = $this->stored_cursor($processor->get_cursor());
+
+        $processor->next_step();
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a/b'
+        );
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume($pruning_cursor);
+        $this->run_to_completion($resumed);
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a'
+        );
+        $this->assertDirectoryExists($this->filesystem_root . '/selected');
+    }
+
+    public function testChangedScheduledParentIsLeftForTheNextFreshScan(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/delete.txt',
+            'delete'
+        );
+        $work_directory = $this->work_directory('changed-parent');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('changed-parent-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+        do {
+            $processor->next_step();
+            $processor->flush_pending_output();
+        } while ($processor->get_phase() !== 'pruning');
+
+        rmdir($this->filesystem_root . '/selected/a/b');
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b',
+            'new path'
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertSame(
+            'new path',
+            file_get_contents($this->filesystem_root . '/selected/a/b')
+        );
+        $this->assertSame('complete', $processor->get_status());
+    }
+
+    public function testCursorStoresArbitraryBytePathsAsBase64(): void
+    {
+        $included_root = "selected-\xff";
+        $path = $included_root . "/delete-\xfe.txt";
+        if (!@mkdir($this->filesystem_root . '/' . $included_root)) {
+            $this->markTestSkipped(
+                'This filesystem does not accept non-UTF-8 path components.'
+            );
+        }
+        file_put_contents($this->filesystem_root . '/' . $path, 'delete');
+        $work_directory = $this->work_directory("arbitrary-\xfd");
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('arbitrary-result.jsonl', []),
+            $work_directory,
+            [$included_root]
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $this->assertSame(
+            base64_encode($path),
+            $cursor['position']['path_b64']
+        );
+        $this->assertSame(
+            [base64_encode($included_root)],
+            $cursor['included_index_path_roots_b64']
+        );
+        $processor->flush_pending_output();
+        $processor->close();
+
+        $resumed = FileSyncCleanupProcessor::resume($cursor);
+        $this->run_to_completion($resumed);
+        $this->assertFileDoesNotExist($this->filesystem_root . '/' . $path);
+    }
+
+    public function testCompleteAndCloseAreStable(): void
+    {
+        $work_directory = $this->work_directory('complete');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('complete-result.jsonl', []),
+            $work_directory
+        );
+        $this->run_to_completion($processor);
+        $cursor = $this->stored_cursor($processor->get_cursor());
+
+        $this->assertSame('complete', $processor->get_status());
+        $this->assertFalse($processor->next_step());
+        $processor->close();
+        $processor->close();
+        $this->assertFalse($processor->next_step());
+
+        $resumed = FileSyncCleanupProcessor::resume($cursor);
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('complete', $resumed->get_status());
+        $resumed->close();
+    }
+
+    /** @return list<string> */
+    private function run_to_completion(
+        FileSyncCleanupProcessor $processor
+    ): array {
+        $phases = [];
+        for ($step = 0; $step < 300; ++$step) {
+            $phases[] = $processor->get_phase();
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            if (!$has_next_step) {
+                return $phases;
+            }
+        }
+        $this->fail('File sync cleanup did not complete in 300 steps.');
+    }
+
+    /** @return array<string,mixed> */
+    private function stored_cursor(array $cursor): array
+    {
+        $stored_cursor = json_decode(
+            json_encode($cursor, JSON_THROW_ON_ERROR),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertIsArray($stored_cursor);
+        return $stored_cursor;
+    }
+
+    /**
+     * @param list<array{path:string,ctime:int,size:int,type:string,empty?:bool}> $entries
+     */
+    private function write_index(string $filename, array $entries): string
+    {
+        usort(
+            $entries,
+            static fn (array $left, array $right): int =>
+                strcmp($left['path'], $right['path'])
+        );
+        $lines = [];
+        foreach ($entries as $entry) {
+            $entry['path'] = base64_encode($entry['path']);
+            $lines[] = json_encode(
+                $entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+        $path = $this->temporary_directory . '/' . $filename;
+        file_put_contents(
+            $path,
+            $lines === [] ? '' : implode("\n", $lines) . "\n"
+        );
+        return $path;
+    }
+
+    /** @return array{path:string,ctime:int,size:int,type:string,empty?:bool} */
+    private function entry(string $path, string $type): array
+    {
+        $entry = [
+            'path' => $path,
+            'ctime' => 1,
+            'size' => $type === 'dir' ? 0 : 1,
+            'type' => $type,
+        ];
+        if ($type === 'dir') {
+            $entry['empty'] = true;
+        }
+        return $entry;
+    }
+
+    private function work_directory(string $name): string
+    {
+        $path = $this->temporary_directory . '/' . $name;
+        mkdir($path, 0755, true);
+        return $path;
+    }
+
+    private function count_open_streams_for_path(string $path): int
+    {
+        $count = 0;
+        foreach (get_resources('stream') as $stream) {
+            $metadata = stream_get_meta_data($stream);
+            $stream_path = $metadata['uri'] ?? null;
+            if ($stream_path === $path) {
+                ++$count;
+            }
+        }
+        return $count;
+    }
+
+    private function remove_path(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $child) {
+            if ($child !== '.' && $child !== '..') {
+                $this->remove_path($path . '/' . $child);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Import/FileSyncPatchPlannerTest.php
+++ b/tests/Import/FileSyncPatchPlannerTest.php
@@ -132,6 +132,99 @@ final class FileSyncPatchPlannerTest extends TestCase
         $planner->close();
     }
 
+    public function testExactDeletionsKeepEveryIndexedPath(): void
+    {
+        $patch_base_index = $this->write_index('exact-base.jsonl', [
+            'gone/child.txt' => $this->entry('gone/child.txt'),
+            'gone/nested/leaf.txt' => $this->entry('gone/nested/leaf.txt'),
+            'stays.txt' => $this->entry('stays.txt'),
+        ]);
+        $patch_result_index = $this->write_index('exact-result.jsonl', [
+            'stays.txt' => $this->entry('stays.txt'),
+        ]);
+        $planner = FileSyncPatchPlanner::create_with_exact_deletions(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertSame(
+            [
+                $this->exact_delete_operation('gone/child.txt'),
+                $this->exact_delete_operation('gone/nested/leaf.txt'),
+                null,
+            ],
+            $this->collect_operations($planner)
+        );
+        $planner->close();
+    }
+
+    public function testExactDeletionsDoNotReplaceAParentBeforeItsChildren(): void
+    {
+        $patch_base_index = $this->write_index('exact-parent-base.jsonl', [
+            'tree/child.txt' => $this->entry('tree/child.txt'),
+            'tree/nested/leaf.txt' => $this->entry('tree/nested/leaf.txt'),
+        ]);
+        $patch_result_index = $this->write_index('exact-parent-result.jsonl', [
+            'tree' => $this->entry('tree', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create_with_exact_deletions(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('copy', 'tree', 'file', 1, 2),
+            $planner->get_operation()
+        );
+        $planner->flush_pending_outputs();
+        $cursor = $planner->get_cursor();
+        $this->assertSame('exact', $cursor['deletion_policy']);
+        $planner->close();
+
+        $resumed = FileSyncPatchPlanner::resume($cursor);
+        $this->assertSame(
+            [
+                $this->exact_delete_operation('tree/child.txt'),
+                $this->exact_delete_operation('tree/nested/leaf.txt'),
+            ],
+            $this->collect_operations($resumed)
+        );
+        $resumed->close();
+    }
+
+    public function testExactDeletionsReplaceATypeChangeAtTheSamePath(): void
+    {
+        $patch_base_index = $this->write_index('exact-type-base.jsonl', [
+            'entry' => $this->entry('entry', 1, 1, 'link'),
+        ]);
+        $patch_result_index = $this->write_index('exact-type-result.jsonl', [
+            'entry' => $this->entry('entry', 2, 1, 'file'),
+        ]);
+        $planner = FileSyncPatchPlanner::create_with_exact_deletions(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertSame(
+            [
+                $this->copy_operation(
+                    'replace',
+                    'entry',
+                    'file',
+                    1,
+                    2,
+                    ['type' => 'link', 'size' => 1, 'ctime' => 1]
+                ),
+            ],
+            $this->collect_operations($planner)
+        );
+        $planner->close();
+    }
+
     public function testCollapsesADeletedSubtreeAtANestedIncludedRoot(): void
     {
         $patch_base_index = $this->write_index('base.jsonl', [
@@ -343,6 +436,7 @@ final class FileSyncPatchPlannerTest extends TestCase
             base64_encode($active_deletion_roots_file),
             $cursor['active_deletion_roots_file_b64']
         );
+        $this->assertSame('collapsed', $cursor['deletion_policy']);
         $planner->close();
 
         $resumed = FileSyncPatchPlanner::resume($cursor);
@@ -409,6 +503,7 @@ final class FileSyncPatchPlannerTest extends TestCase
 
     /**
      * @param 'copy'|'replace' $action Whether the source entry replaces a conflicting path.
+     * @param array{type:string,size:int,ctime:int}|null $expected_base Base entry removed by replace.
      * @return SyncOperation
      */
     private function copy_operation(
@@ -416,9 +511,10 @@ final class FileSyncPatchPlannerTest extends TestCase
         string $path,
         string $type,
         int $size,
-        int $ctime
+        int $ctime,
+        ?array $expected_base = null
     ): array {
-        return [
+        $operation = [
             'action' => $action,
             'path' => $path,
             'expected_source' => [
@@ -427,6 +523,10 @@ final class FileSyncPatchPlannerTest extends TestCase
                 'ctime' => $ctime,
             ],
         ];
+        if ($expected_base !== null) {
+            $operation['expected_base'] = $expected_base;
+        }
+        return $operation;
     }
 
     /** @return SyncOperation */
@@ -435,6 +535,18 @@ final class FileSyncPatchPlannerTest extends TestCase
         return [
             'action' => 'delete',
             'path' => $path,
+        ];
+    }
+
+    /** @return SyncOperation */
+    private function exact_delete_operation(string $path): array
+    {
+        return $this->delete_operation($path) + [
+            'expected_base' => [
+                'type' => 'file',
+                'size' => 1,
+                'ctime' => 1,
+            ],
         ];
     }
 

--- a/tests/Import/FileSyncPatchProcessorTest.php
+++ b/tests/Import/FileSyncPatchProcessorTest.php
@@ -52,6 +52,8 @@ final class FileSyncPatchProcessorTest extends TestCase {
         );
 
         $from_fresh_work_directory = $this->work_directory('from-fresh');
+        $current_stat = lstat($this->filesystem_root . '/current.txt');
+        $this->assertIsArray($current_stat);
         $from_fresh = FileSyncPatchProcessor::start_from_fresh_local_tree(
             $from_fresh_work_directory,
             $this->filesystem_root,
@@ -63,6 +65,11 @@ final class FileSyncPatchProcessorTest extends TestCase {
                 [
                     'action' => 'delete',
                     'path' => 'current.txt',
+                    'expected_base' => [
+                        'type' => 'file',
+                        'size' => 7,
+                        'ctime' => (int) $current_stat['ctime'],
+                    ],
                 ],
                 [
                     'action' => 'copy',
@@ -75,6 +82,53 @@ final class FileSyncPatchProcessorTest extends TestCase {
                 ],
             ],
             $this->run_to_completion($from_fresh)
+        );
+    }
+
+    public function testFromFreshUsesExactDeletionPlanning(): void
+    {
+        mkdir($this->filesystem_root . '/tree');
+        file_put_contents(
+            $this->filesystem_root . '/tree/child.txt',
+            'child'
+        );
+        $patch_result_index = $this->write_index('parent-result.jsonl', [
+            $this->entry('tree', 4),
+        ]);
+        $work_directory = $this->work_directory('exact-from-fresh');
+        $child_stat = lstat(
+            $this->filesystem_root . '/tree/child.txt'
+        );
+        $this->assertIsArray($child_stat);
+        $processor = FileSyncPatchProcessor::start_from_fresh_local_tree(
+            $work_directory,
+            $this->filesystem_root,
+            $patch_result_index,
+            $work_directory
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'action' => 'copy',
+                    'path' => 'tree',
+                    'expected_source' => [
+                        'type' => 'file',
+                        'size' => 4,
+                        'ctime' => 1,
+                    ],
+                ],
+                [
+                    'action' => 'delete',
+                    'path' => 'tree/child.txt',
+                    'expected_base' => [
+                        'type' => 'file',
+                        'size' => 5,
+                        'ctime' => (int) $child_stat['ctime'],
+                    ],
+                ],
+            ],
+            $this->run_to_completion($processor)
         );
     }
 
@@ -237,6 +291,7 @@ final class FileSyncPatchProcessorTest extends TestCase {
                 'patch_result_index_file_b64',
                 'included_index_path_roots_b64',
                 'excluded_index_path_roots_b64',
+                'deletion_policy',
                 'fresh_local_index_cursor',
             ],
             array_keys($cursor['position'])
@@ -248,6 +303,10 @@ final class FileSyncPatchProcessorTest extends TestCase {
         $this->assertSame(
             [base64_encode($excluded_root)],
             $cursor['position']['excluded_index_path_roots_b64']
+        );
+        $this->assertSame(
+            'collapsed',
+            $cursor['position']['deletion_policy']
         );
         $this->assertSame(
             base64_encode($storage_path),

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -631,6 +631,7 @@ final class PushPlanTest extends TestCase
             'active_deletion_roots_file_b64',
             'included_index_path_roots_b64',
             'excluded_index_path_roots_b64',
+            'deletion_policy',
             'index_diff_cursor',
             'active_deletion_root_byte_offset',
         ], array_keys($cursor['position']['file_sync_patch_processor_cursor']['position']['file_sync_patch_planner_cursor']));


### PR DESCRIPTION
File sync cleanup can now remove selected indexed paths without removing skipped or excluded children.

`FileSyncPatchProcessor::start_from_fresh_local_tree()` plans exact deletions. The push direction keeps collapsing deleted subtrees to one root.

`FileSyncCleanupProcessor` removes one exact file, link, or empty directory per step. It uses `unlink()` and `rmdir()` and never walks a directory recursively. If a cache, storage, excluded, or newly created child remains, its parent remains too. After the exact removals, cleanup prunes one unchanged empty parent per step.

The cursor stores a pending removal and the local type, size, and ctime seen by the fresh scan. Cleanup checks those fields before removing the path. If they changed, it returns `restart` and leaves the new path alone.

```php
$cleanup = FileSyncCleanupProcessor::start(
    $work_directory,
    $filesystem_root,
    $patch_result_index,
    $storage_path,
    ["wp-content"],
    ["wp-content/uploads/keep"]
);

do {
    $has_next_step = $cleanup->next_step();
    $cleanup->flush_pending_output();
    save_cursor($cleanup->get_cursor());
} while ($has_next_step);

$status = $cleanup->get_status();
$cleanup->close();

if ($status === "restart") {
    restart_file_sync();
}
```
