### PR TITLE
[PHP] Refuse to resume interrupted stdout and MySQL database pulls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,9 @@ The `WpcloudHostAnalyzer` auto-detects WP Cloud production infrastructure that w
 
 Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic plugin deactivation: at the end of `db-apply`, while the target database connection is still open, the importer instantiates the host analyzer, extracts plugin directory names from `paths_to_remove`, and removes matching entries from the `active_plugins` option. This prevents "plugin file does not exist" warnings in wp-admin. The deactivation is derived from `paths_to_remove` — there is no separate manifest field for it. We skip WordPress's `deactivate_plugins()` because the plugin files will already be gone from disk by the time WordPress boots, so firing deactivation hooks into absent code is pointless.
 
-### SQL Streaming Crash Recovery
+### SQL Streaming Source Retries
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `<remote-state-directory>/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+When one SQL response ends in the middle of a statement, the importer keeps those bytes in memory and requests the next response in the same process. If that process stops while writing to stdout or MySQL, Reprint cannot tell how much SQL the destination received or kept. A new process refuses to continue until the destination is reset or restored and `db-pull --abort` is run.
 
 ### Progress Tracking
 

--- a/README.md
+++ b/README.md
@@ -367,12 +367,11 @@ The three modes:
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
 | `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
 
-All three modes recover from server crashes mid-stream (PHP fatal errors,
-OOM kills, `max_execution_time` expiry). When the server dies before sending
-a completion chunk, the importer detects the transport failure, saves its
-cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/sql-buffer`
-so the next run reloads it and continues.
+All three modes retry a source crash inside the same importer process. If the
+importer itself stops while writing to `stdout` or `mysql`, Reprint cannot tell
+how much SQL the receiving program or database got. It refuses to continue.
+Reset or restore that destination, abort the pull, download `db.sql`, and use
+`db-apply`.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -193,8 +193,7 @@ their parent directories.
         │   ├── fetch-list.jsonl
         │   ├── volatile-files.json
         │   ├── domains.json
-        │   ├── sql-stats.json
-        │   └── sql-buffer
+        │   └── sql-stats.json
         └── push/
 ```
 
@@ -214,7 +213,6 @@ Use these path names:
 | Volatile files file | `$volatile_files_file` |
 | Domains file | `$domains_file` |
 | SQL statistics file | `$sql_stats_file` |
-| SQL buffer file | `$sql_buffer_file` |
 | Audit log file | `$audit_log_file` |
 | Progress file | `$progress_file` |
 | Reprint process lock path | `$process_lock_path` |

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -173,6 +173,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const DATABASE_PULL_OUTPUT_STATUS_FILE = 'database-pull-output.json';
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -911,6 +912,64 @@ class ImportClient
         }
 
         $this->state = $this->load_state();
+
+        $output_status_file = wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_PULL_OUTPUT_STATUS_FILE,
+        );
+        $output_status = $this->read_json_file($output_status_file);
+        $has_unfinished_database_pull_output =
+            is_file($output_status_file)
+            && ( $output_status['status'] ?? null ) !== 'complete';
+        $saved_command = $this->get_state()->active_resumable_command;
+        $has_unfinished_sql_stage =
+            $saved_command->command_name === 'db-pull'
+            && $saved_command->current_stage === 'sql'
+            && in_array($saved_command->completion_state, ['in_progress', 'partial'], true);
+        $saved_output = $this->get_state()->sql_output;
+        if (
+            !$abort
+            && in_array($command, ['db-pull', 'pull', 'pull-db', 'db-apply'], true)
+            && $has_unfinished_sql_stage
+            && in_array($saved_output, ['stdout', 'mysql'], true)
+            && (
+                ( $output_status['status'] ?? null ) !== 'in_progress'
+                || ( $output_status['mode'] ?? null ) !== $saved_output
+            )
+        ) {
+            throw new RuntimeException(
+                'This db-pull did not finish, and Reprint cannot tell where to continue. ' .
+                'Run db-pull --abort, then start db-pull again.',
+            );
+        }
+        if (
+            !$abort
+            && in_array($command, ['db-pull', 'pull', 'pull-db'], true)
+            && $has_unfinished_database_pull_output
+        ) {
+            $saved_output = $output_status['mode'] ?? null;
+            if ($saved_output === 'stdout') {
+                throw new RuntimeException(
+                    'db-pull stopped while writing SQL to stdout. Reprint does not know how ' .
+                    'much SQL the receiving program or file got. Reset that program or file, ' .
+                    'then run db-pull --abort. Start again with --sql-output=file and apply ' .
+                    'db.sql with db-apply.',
+                );
+            }
+            if ($saved_output === 'mysql') {
+                throw new RuntimeException(
+                    'db-pull stopped while writing SQL to MySQL. Reprint does not know which ' .
+                    'database changes MySQL kept. Restore or reset the target database, then ' .
+                    'run db-pull --abort. Start again with --sql-output=file and apply db.sql ' .
+                    'with db-apply.',
+                );
+            }
+            throw new RuntimeException(
+                'db-pull did not finish, and its saved output setting is not valid. Reset ' .
+                'anything that may have received the SQL, then run db-pull --abort and start ' .
+                'db-pull again.',
+            );
+        }
 
         if ($command === "pull-metadata") {
             $this->run_pull_metadata();
@@ -2224,9 +2283,6 @@ class ImportClient
                     "RESTART | Clearing db-pull state",
                     true,
                 );
-                $this->reset_state();
-                $this->save_state();
-
                 if ($this->sql_output_mode === "file") {
                     $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
                     if (file_exists($sql_file)) {
@@ -2250,6 +2306,9 @@ class ImportClient
                         "FILE DELETE | {$domains_file} | abort db-pull",
                     );
                 }
+                $this->clear_database_pull_records();
+                $this->reset_state();
+                $this->save_state();
                 break;
 
             case "db-index":
@@ -3731,7 +3790,7 @@ class ImportClient
      * Command: db-pull
      *
      * Rules:
-     * - Stream next portion of SQL from last saved cursor
+     * - File output continues from a saved cursor; direct output retries only in this process
      * - If already completed and db.sql exists: require --abort flag
      * - If db.sql missing but state says complete: warn and require --abort flag
      * - Otherwise: error
@@ -3798,6 +3857,7 @@ class ImportClient
             $this->get_state()->active_resumable_command->current_stage = "db-index";
             $this->get_state()->diff = new FileDiffProgressState();
             $this->get_state()->db_index = new DatabaseTableIndexState();
+            $this->get_state()->sql_output = $this->sql_output_mode;
             $this->save_state();
 
             $this->audit_log("START db-pull", true);
@@ -3838,6 +3898,18 @@ class ImportClient
             // Transition to sql stage
             $this->get_state()->active_resumable_command->current_stage = "sql";
             $this->get_state()->active_resumable_command->remote_cursor = null;
+            if (in_array($this->sql_output_mode, ['stdout', 'mysql'], true)) {
+                $this->write_json_file(
+                    wp_join_unix_paths(
+                        $this->pull_state_directory,
+                        self::DATABASE_PULL_OUTPUT_STATUS_FILE,
+                    ),
+                    [
+                        'mode' => $this->sql_output_mode,
+                        'status' => 'in_progress',
+                    ],
+                );
+            }
             $this->save_state();
         }
 
@@ -3858,6 +3930,18 @@ class ImportClient
         // Mark as complete
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->save_state();
+        if (in_array($this->sql_output_mode, ['stdout', 'mysql'], true)) {
+            $this->write_json_file(
+                wp_join_unix_paths(
+                    $this->pull_state_directory,
+                    self::DATABASE_PULL_OUTPUT_STATUS_FILE,
+                ),
+                [
+                    'mode' => $this->sql_output_mode,
+                    'status' => 'complete',
+                ],
+            );
+        }
 
         $this->audit_log("db-pull complete", true);
 
@@ -7531,7 +7615,6 @@ class ImportClient
 
         $sql_handle = null;
         $mysql_conn = null;
-        $sql_buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
 
@@ -7603,25 +7686,6 @@ class ImportClient
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
                 true,
             );
-
-            // Open a persistent buffer file so partial queries survive crashes.
-            // Each SQL chunk is appended to this file as it arrives; when the
-            // query completes and executes, the file is truncated. If the process
-            // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-            if (file_exists($sql_buffer_file)) {
-                $sql_buffer = file_get_contents($sql_buffer_file);
-                $this->audit_log(
-                    sprintf("CRASH RECOVERY | Restored %d bytes from pull/sql-buffer", strlen($sql_buffer)),
-                    true,
-                );
-            }
-            // Open in write mode (truncate) if we loaded nothing, append if we
-            // have a partial query to continue accumulating into.
-            $sql_buffer_handle = fopen($sql_buffer_file, $sql_buffer !== "" ? "a" : "w");
-            if (!$sql_buffer_handle) {
-                throw new RuntimeException("Cannot open SQL buffer file: {$sql_buffer_file}");
-            }
         }
 
         // Domain discovery and statement counting: scan SQL for URLs during download
@@ -7684,7 +7748,6 @@ class ImportClient
                     &$complete,
                     &$sql_handle,
                     $mysql_conn,
-                    &$sql_buffer_handle,
                     &$sql_buffer,
                     &$sql_bytes_written,
                     $context,
@@ -7706,13 +7769,12 @@ class ImportClient
 
                     $cursor = $chunk["headers"]["x-cursor"] ?? $cursor;
 
-                    // Save cursor periodically (every 50 chunks).
-                    // Skip saving when there's buffered SQL waiting for a
-                    // complete statement — crash recovery would replay the
-                    // cursor but miss the buffered bytes.
+                    // File output saves both the SQL bytes and their source cursor.
+                    // stdout and MySQL keep the cursor only for retries in this process.
                     $chunks_since_save++;
                     if (
-                        $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS
+                        $mode === 'file'
+                        && $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS
                         && $sql_buffer === ""
                     ) {
                         if ($sql_handle) {
@@ -7759,23 +7821,23 @@ class ImportClient
 
                             case "stdout":
                                 $bytes = @fwrite(STDOUT, $data);
-                                if ($bytes === false) {
-                                    // Broken pipe — save state and exit cleanly so the
-                                    // pipe reader (e.g. `mysql`) can finish on its own.
-                                    $this->save_state();
-                                    exit(0);
+                                if ($bytes === false || $bytes !== strlen($data)) {
+                                    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI stream byte counts are not HTML.
+                                    throw new RuntimeException(
+                                        'SQL stdout write failed after ' .
+                                        ( $bytes === false ? '0' : $bytes ) . '/' . strlen($data) .
+                                        ' bytes. The program reading stdout may have received only part ' .
+                                        'of the SQL. Reset it before trying again.',
+                                    );
+                                    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
                                 }
                                 $sql_bytes_written += $bytes;
                                 break;
 
                             case "mysql":
-                                // Append to disk immediately so the buffer survives
-                                // even if the process is killed mid-chunk.
-                                if ($sql_buffer_handle) {
-                                    fwrite($sql_buffer_handle, $data);
-                                    fflush($sql_buffer_handle);
-                                }
-
+                                // The incomplete statement stays in memory while source
+                                // responses retry inside this process. A new process is
+                                // rejected because it cannot align this buffer with the target.
                                 $sql_buffer .= $data;
                                 $sql_bytes_written += strlen($data);
 
@@ -7785,18 +7847,20 @@ class ImportClient
                                     }
                                     // Drain all result sets from multi_query before sending the
                                     // next chunk — mysqli requires this.
-                                    do {
+                                    while (true) {
                                         $result = $mysql_conn->store_result();
                                         if ($result) { $result->free(); }
                                         if ($mysql_conn->errno) {
                                             throw new RuntimeException("MySQL statement error: " . $mysql_conn->error);
                                         }
-                                    } while ($mysql_conn->more_results() && $mysql_conn->next_result());
-
-                                    // Query executed — truncate the buffer file and reset.
-                                    if ($sql_buffer_handle) {
-                                        ftruncate($sql_buffer_handle, 0);
-                                        rewind($sql_buffer_handle);
+                                        if (!$mysql_conn->more_results()) {
+                                            break;
+                                        }
+                                        if (!$mysql_conn->next_result()) {
+                                            throw new RuntimeException(
+                                                "MySQL statement error: " . $mysql_conn->error,
+                                            );
+                                        }
                                     }
                                     $sql_buffer = "";
                                 }
@@ -7902,15 +7966,13 @@ class ImportClient
                     $context->response_stats ?? [],
                 );
 
-                // Save cursor for resumption (keep it even when complete for reference)
                 if ($sql_handle) {
                     fflush($sql_handle);
+                    $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                    // Clear sql_bytes when complete, otherwise save current position.
+                    $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
+                    $this->save_state();
                 }
-
-                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
-                // Clear sql_bytes when complete, otherwise save current position
-                $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
-                $this->save_state();
             }
 
             // Drain any remaining statements after download completes
@@ -7960,26 +8022,16 @@ class ImportClient
             if ($sql_handle) {
                 fclose($sql_handle);
             }
-            if ($sql_buffer_handle) {
-                fclose($sql_buffer_handle);
-                $sql_buffer_handle = null;
-            }
             if ($mysql_conn) {
                 $pending = $sql_buffer;
                 $mysql_conn->close();
                 $mysql_conn = null;
-                // Clean up buffer file — if we got here with an empty buffer,
-                // all queries were executed successfully.
-                $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-                if ($pending === "" && file_exists($sql_buffer_file)) {
-                    unlink($sql_buffer_file);
-                }
                 if ($pending !== "") {
                     if ($caught_exception !== null) {
                         // An exception is already in flight (e.g. curl error,
-                        // MySQL error). Don't mask it by throwing about the
-                        // buffer — the buffer data is safely persisted in
-                        // pull/sql-buffer and will be recovered on the next run.
+                        // MySQL error). Do not mask it with the discarded
+                        // in-memory tail. The saved output status makes a later
+                        // process stop instead of sending more SQL to this target.
                         $this->audit_log(
                             "BUFFER NOT FLUSHED | " . strlen($pending) .
                             " bytes in SQL buffer during exception unwind" .
@@ -10160,13 +10212,13 @@ class ImportClient
      * Track consecutive interrupted responses and decide whether to resume.
      *
      * Compares the cursor before and after the request. A cursor advance means
-     * the request produced another durable part, so the counter resets. If the
+     * the request handler accepted another complete part, so the counter resets. If the
      * cursor did not move, the counter increments. After
      * MAX_CONSECUTIVE_INTERRUPTED_RESPONSES with no progress, the runner stops.
      *
      * @param string                           $phase         Human-readable phase name.
      * @param ?string                          $cursor_before Cursor at request start.
-     * @param ?string                          $cursor_after  Last durable cursor.
+     * @param ?string                          $cursor_after  Last accepted cursor in this process.
      * @param TransientInterruptionException   $exception     Response failure.
      */
     protected function assert_can_resume_after_interrupted_response(
@@ -10862,6 +10914,67 @@ class ImportClient
         $this->state->pull_pipeline = $previous_state->pull_pipeline;
     }
 
+    /** Removes the files that describe a database pull. */
+    public function clear_database_pull_records(): void
+    {
+        $path = wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_PULL_OUTPUT_STATUS_FILE,
+        );
+        if (file_exists($path) && !unlink($path)) {
+            throw new RuntimeException('Cannot delete the saved database output status.');
+        }
+    }
+
+    /**
+     * Reads a JSON object, returning an empty array when it is absent or invalid.
+     *
+     * @return array<string,mixed> Decoded JSON object.
+     */
+    private function read_json_file(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return [];
+        }
+        $value = json_decode($contents, true);
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * Writes a JSON object without exposing a partly written file.
+     *
+     * @param array<string,mixed> $value JSON object fields.
+     */
+    private function write_json_file(string $path, array $value): void
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These CLI errors name the state file and its directory.
+        $json = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new RuntimeException(
+                'Reprint could not encode ' . basename($path) . ' as JSON: ' . json_last_error_msg(),
+            );
+        }
+        $contents = $json . "\n";
+        $temporary_path = $path . '.tmp';
+        if (file_put_contents($temporary_path, $contents) !== strlen($contents)) {
+            throw new RuntimeException(
+                'Reprint could not save ' . basename($path) . '. Check that ' . dirname($path) .
+                ' is writable and has free space.',
+            );
+        }
+        if (!rename($temporary_path, $path)) {
+            throw new RuntimeException(
+                'Reprint could not finish saving ' . basename($path) .
+                '. Check the state directory permissions.',
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+    }
+
     /** Return the in-process pull state. */
     public function get_state(): PullState
     {
@@ -11146,19 +11259,7 @@ class ImportClient
         }
         $state = $this->encode_state_paths($state);
 
-        // Write to temp file first, then atomic rename
-        $json = json_encode($state, JSON_PRETTY_PRINT);
-        if ($json === false) {
-            throw new RuntimeException("Failed to encode state: " . json_last_error_msg());
-        }
-        $tmp_file = $this->pull_state_file . '.tmp';
-        $bytes = file_put_contents($tmp_file, $json);
-        if ($bytes === false) {
-            throw new RuntimeException("Failed to write state file: $tmp_file (disk full?)");
-        }
-        if (!rename($tmp_file, $this->pull_state_file)) {
-            throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->pull_state_file}");
-        }
+        $this->write_json_file($this->pull_state_file, $state);
 
         $remote_index_entry_count = $this->remote_index_entry_count();
         $files_pulled = $this->files_pulled; // Completed in this run
@@ -12506,7 +12607,9 @@ if (
             "description" =>
                 "Indexes remote tables, then streams the full SQL dump into\n" .
                 "--state-dir/db.sql (default), to stdout, or directly into a\n" .
-                "MySQL connection. Resumes from the last cursor if interrupted.\n" .
+                "MySQL connection. Source interruptions retry within this process.\n" .
+                "If that process stops, Reprint cannot tell how much SQL reached stdout or MySQL.\n" .
+                "Reset or restore the destination, then abort and restart as file output.\n" .
                 "Discovered domains are cached for later use by db-apply.\n",
             "extra" =>
                 "Output modes:\n" .

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -321,7 +321,6 @@ class Pull
                 $state->consecutive_interrupted_responses = 0;
                 $state->sql_bytes = null;
                 $state->db_index = new DatabaseTableIndexState();
-                $this->client->save_state();
                 foreach ([
                     "{$state_dir}/db.sql",
                     "{$state_dir}/db-tables.jsonl",
@@ -331,6 +330,8 @@ class Pull
                         @unlink($path);
                     }
                 }
+                $this->client->clear_database_pull_records();
+                $this->client->save_state();
             }
         }
 
@@ -821,8 +822,6 @@ class Pull
             $state->apply = new DatabaseApplyCommandState();
             $state->sql_output = null;
         }
-        $this->client->save_state();
-
         $paths = [];
         if ($reset_file_transfer_state) {
             $paths[] = wp_join_unix_paths($pull_state_directory, 'remote-index.next.jsonl');
@@ -839,6 +838,10 @@ class Pull
                 @unlink($path);
             }
         }
+        if ($reset_db_state) {
+            $this->client->clear_database_pull_records();
+        }
+        $this->client->save_state();
 
         $this->client->audit_log(strtoupper($command) . " | prepared for delta re-pull", true);
     }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -139,6 +139,12 @@
     },
     "db-index-interruption": {
       "port": 8125
+    },
+    "stdout-db-pull-process-death": {
+      "port": 8127
+    },
+    "direct-mysql-db-pull-safety": {
+      "port": 8131
     }
   }
 }

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -1,29 +1,27 @@
 /**
- * Test 36: MySQL Mode Crash Recovery
+ * Test 36: MySQL Mode Source Interruption
  *
  * When using --sql-output=mysql with short execution times, the server
  * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to pull/sql-buffer on disk as each
- * chunk arrives. If the process dies at any point, the next run reloads
- * whatever was accumulated.
+ * partial SQL in memory while it requests the next response in the same
+ * process. A different importer process cannot align that buffer and cursor
+ * with the target database.
  *
- * This test forces many resume cycles with --max-exec=1, verifies the
- * database is correct after completion, and confirms pull/sql-buffer is
- * cleaned up.
+ * This test forces many source-response cycles with --max-exec=1 and verifies
+ * same-process completion.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    readAuditLog, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
+describe('Import: MySQL Mode Source Interruption', { timeout: 120000 }, () => {
     const site = 'basic';
 
     beforeAll(async () => {
@@ -42,7 +40,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         '--mysql-password=e2e_password',
     ];
 
-    describe('resume with short --max-exec completes correctly', () => {
+    describe('same-process source retries with short --max-exec', () => {
         let tempDir;
         const importDb = 'e2e_basic_import_36_resume';
 
@@ -61,9 +59,9 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
             await conn.end();
         });
 
-        it('completes via multiple resume cycles and database matches source', async () => {
+        it('completes and matches the source database', async () => {
             // Use --max-exec=1 to force the server to pause frequently,
-            // creating many resume cycles. auto-resume handles exit code 2.
+            // creating many source responses within one importer process.
             const result = runImporter(importUrl(), tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
@@ -79,65 +77,10 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer')),
-                'Expected pull/sql-buffer to be cleaned up after successful completion');
-        });
-
         it('no db.sql on disk', () => {
             assert.ok(!existsSync(join(tempDir, 'db.sql')),
                 'Expected no db.sql file when using --sql-output=mysql');
         });
     });
 
-    describe('pre-seeded pull/sql-buffer is loaded on resume', () => {
-        let tempDir;
-        const importDb = 'e2e_basic_import_36_seeded';
-
-        beforeAll(async () => {
-            tempDir = createTempDir('e2e-mysql-seeded-buffer');
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.query(`CREATE DATABASE \`${importDb}\``);
-            await conn.end();
-        });
-
-        afterAll(async () => {
-            cleanupTempDir(tempDir);
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.end();
-        });
-
-        it('loads pull/sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
-            // Run preflight so db-pull can proceed
-            runImporter(importUrl(), tempDir, 'preflight', {
-                secret: getSiteSecret(site),
-            });
-
-            // Seed a pull/sql-buffer file before running db-pull.
-            // The content is a harmless SQL comment that won't affect execution
-            // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer');
-            writeFileSync(bufferFile, '-- pre-seeded buffer\n');
-
-            // Run a fresh db-pull — the importer should detect the buffer file
-            const result = runImporter(importUrl(), tempDir, 'db-pull', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                skipPreflight: true,
-            });
-            assert.equal(result.exitCode, 0,
-                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
-
-            // Verify recovery was logged
-            const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('pull/sql-buffer'),
-                'Expected audit log to mention pull/sql-buffer crash recovery');
-
-            // Buffer should be cleaned up
-            assert.ok(!existsSync(bufferFile),
-                'Expected pull/sql-buffer to be removed after completion');
-        });
-    });
 });

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -195,11 +195,6 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(
-                    pullStateDirectory(tempDir, importUrl()),
-                    'sql-buffer',
-                )),
-                    'Expected pull/sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);
                 if (mode === 'mysql') {

--- a/tests/e2e/tests/import-57-non-file-db-pull-process-death.test.js
+++ b/tests/e2e/tests/import-57-non-file-db-pull-process-death.test.js
@@ -1,0 +1,246 @@
+/**
+ * A db-pull writing to stdout has no local SQL file to resume. Stop its
+ * process after SQL reaches stdout, then verify that a later file-mode run
+ * refuses to write only the unconsumed suffix of the dump.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, fsRootDir,
+    writeTestHooks, removeTestHooks,
+    readHookState, clearHookState, pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: stdout db-pull process death', { timeout: 180000 }, () => {
+    const site = 'stdout-db-pull-process-death';
+    const earlyTable = 'aa_stdout_process_death_early';
+    const lateTable = 'zz_stdout_process_death_late';
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                const tables = [
+                    earlyTable,
+                    ...Array.from(
+                        { length: 40 },
+                        (_, index) => `mm_stdout_process_death_${String(index).padStart(2, '0')}`,
+                    ),
+                    lateTable,
+                ];
+                for (const [index, table] of tables.entries()) {
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `stdout-process-death-${index + 1}`],
+                    );
+                }
+            },
+        });
+        tempDir = createTempDir('e2e-stdout-db-pull-process-death');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = file_exists($state_file)',
+            '        ? json_decode(file_get_contents($state_file), true)',
+            '        : [];',
+            "    $state['sql_batches'] = ($state['sql_batches'] ?? 0) + 1;",
+            "    if ($state['sql_batches'] === 61) {",
+            "        $state['pause_started'] = true;",
+            '        file_put_contents($state_file, json_encode($state));',
+            '        usleep(3000000);',
+            "        $state['pause_finished'] = true;",
+            '    }',
+            '    file_put_contents($state_file, json_encode($state));',
+            '}',
+        ].join('\n'));
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    it('refuses a new file pull after a stdout process stops', async () => {
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+
+        const output = { stdout: '', stderr: '' };
+        const firstProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            '--sql-output=stdout',
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        firstProcess.stdout.setEncoding('utf8');
+        firstProcess.stderr.setEncoding('utf8');
+        firstProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        firstProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const firstExit = new Promise(resolve => {
+            firstProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+
+        const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+        const pauseDeadline = Date.now() + 60000;
+        let interruptedState = null;
+        while (Date.now() < pauseDeadline) {
+            if (firstProcess.exitCode !== null || firstProcess.signalCode !== null) {
+                const result = await firstExit;
+                assert.fail(
+                    `db-pull exited before the SQL pause (${result.code}/${result.signal}):\n`
+                    + output.stderr + output.stdout,
+                );
+            }
+
+            const hookState = readHookState(site);
+            if (hookState?.pause_started && existsSync(statePath)) {
+                const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                const command = state.active_resumable_command;
+                const databasePullOutputStatus = join(
+                    pullStateDirectory(tempDir, importUrl()),
+                    'database-pull-output.json',
+                );
+                if (command?.current_stage === 'sql' && existsSync(databasePullOutputStatus)) {
+                    interruptedState = state;
+                    break;
+                }
+            }
+            await sleep(20);
+        }
+
+        assert.ok(interruptedState, 'db-pull did not record direct output before the pause');
+        assert.equal(interruptedState.sql_output, 'stdout');
+        assert.equal(existsSync(join(tempDir, 'db.sql')), false);
+
+        assert.equal(firstProcess.kill('SIGKILL'), true);
+        const killed = await firstExit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        const serverDeadline = Date.now() + 10000;
+        while (!readHookState(site)?.pause_finished && Date.now() < serverDeadline) {
+            await sleep(20);
+        }
+        assert.equal(
+            readHookState(site)?.pause_finished,
+            true,
+            'source did not leave the pause after the client process stopped',
+        );
+
+        const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--sql-output=file',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+        });
+
+        const sqlFile = join(tempDir, 'db.sql');
+        if (resumed.exitCode === 0) {
+            const sql = existsSync(sqlFile) ? readFileSync(sqlFile, 'utf8') : '';
+            assert.fail(
+                'db-pull silently continued the stdout cursor into db.sql; '
+                + `early_table=${sql.includes(earlyTable)}, late_table=${sql.includes(lateTable)}`,
+            );
+        }
+        assert.equal(
+            resumed.exitCode,
+            1,
+            `Expected file-mode continuation to fail closed:\n${resumed.stderr}\n${resumed.stdout}`,
+        );
+        assert.equal(existsSync(sqlFile), false, 'db-pull created a suffix-only db.sql');
+        const resumeError = `${resumed.stderr}\n${resumed.stdout}`;
+        assert.match(resumeError, /db-pull stopped while writing SQL to stdout\./);
+        assert.match(
+            resumeError,
+            /Reprint does not know how much SQL the receiving program or file got\./,
+        );
+        assert.match(
+            resumeError,
+            /Reset that program or file, then run db-pull --abort\./,
+        );
+        assert.match(
+            resumeError,
+            /Start again with --sql-output=file and apply db\.sql with db-apply\./,
+        );
+
+        const aborted = runImporter(importUrl(), tempDir, 'pull-db', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--abort',
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${join(tempDir, 'unused.sqlite')}`,
+                '--target-db=wordpress',
+            ],
+        });
+        assert.equal(
+            aborted.exitCode,
+            0,
+            `pull-db --abort failed:\n${aborted.stderr}\n${aborted.stdout}`,
+        );
+
+        const restarted = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--sql-output=file',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+        });
+        assert.equal(
+            restarted.exitCode,
+            0,
+            `fresh file db-pull failed after wrapper abort:\n`
+            + restarted.stderr + restarted.stdout,
+        );
+        const restartedSql = readFileSync(sqlFile, 'utf8');
+        assert.match(restartedSql, new RegExp(earlyTable));
+        assert.match(restartedSql, new RegExp(lateTable));
+    });
+});

--- a/tests/e2e/tests/import-60-direct-mysql-db-pull-safety.test.js
+++ b/tests/e2e/tests/import-60-direct-mysql-db-pull-safety.test.js
@@ -1,0 +1,381 @@
+/**
+ * Direct MySQL output saves source progress separately from MySQL changes. If
+ * the process stops, a later process must refuse to send more SQL even when
+ * another command has replaced the normal pull checkpoint.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, fsRootDir, pullStateDirectory,
+    writeTestHooks, removeTestHooks, readHookState, clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: direct MySQL db-pull safety', { timeout: 300000 }, () => {
+    const site = 'direct-mysql-db-pull-safety';
+    const guardTable = 'aa_direct_mysql_guard';
+    const laterErrorTable = 'zz_direct_mysql_later_error';
+    const targetDatabases = [
+        `${getDbName(site)}_guard_target`,
+        `${getDbName(site)}_later_error_target`,
+    ];
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const importerSourcePath = join(projectRoot, 'packages', 'reprint-client', 'src', 'import.php');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlOutputArguments(targetDatabase) {
+        return [
+            '--sql-output=mysql',
+            `--mysql-database=${targetDatabase}`,
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_databaseName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${guardTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${guardTable}\` (id, value) VALUES (1, 'source-value')`
+                );
+
+                for (let index = 0; index < 40; index++) {
+                    const table = `mm_direct_mysql_guard_${String(index).padStart(2, '0')}`;
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `checkpoint-${index + 1}`],
+                    );
+                }
+
+                await connection.query(
+                    `CREATE TABLE \`${laterErrorTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${laterErrorTable}\` (id, value) VALUES (1, 'source-value')`
+                );
+            },
+        });
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        const connection = await createMysqlConnection();
+        try {
+            for (const targetDatabase of targetDatabases) {
+                await connection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            }
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('rejects new target SQL after another command replaces the stopped pull checkpoint', async () => {
+        const tempDir = createTempDir('e2e-direct-mysql-db-pull-guard');
+        const targetDatabase = targetDatabases[0];
+        const adminConnection = await createMysqlConnection();
+        let firstProcess;
+        let firstExit;
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDatabase}\``);
+
+            const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+                autoResume: false,
+            });
+            assert.equal(
+                preflight.exitCode,
+                0,
+                `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+            );
+
+            clearHookState(site);
+            writeTestHooks(site, [
+                'function test_hook_before_sql_batch(&$sql, $cursor) {',
+                `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+                '    $state = file_exists($state_file)',
+                '        ? json_decode(file_get_contents($state_file), true)',
+                '        : [];',
+                "    $state['sql_batches'] = ($state['sql_batches'] ?? 0) + 1;",
+                "    if ($state['sql_batches'] === 61) {",
+                "        $state['pause_started'] = true;",
+                '        file_put_contents($state_file, json_encode($state));',
+                '        usleep(3000000);',
+                "        $state['pause_finished'] = true;",
+                '    }',
+                '    file_put_contents($state_file, json_encode($state));',
+                '}',
+            ].join('\n'));
+
+            const output = { stdout: '', stderr: '' };
+            firstProcess = spawn(phpBinary, [
+                importerPath,
+                'db-pull',
+                importUrl(),
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
+                `--secret=${getSiteSecret(site)}`,
+                ...mysqlOutputArguments(targetDatabase),
+            ], {
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            firstProcess.stdout.setEncoding('utf8');
+            firstProcess.stderr.setEncoding('utf8');
+            firstProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+            firstProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+            firstExit = new Promise(resolve => {
+                firstProcess.once('exit', (code, signal) => resolve({ code, signal }));
+            });
+
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+            const pauseDeadline = Date.now() + 60000;
+            let targetReceivedSql = false;
+            while (Date.now() < pauseDeadline) {
+                if (firstProcess.exitCode !== null || firstProcess.signalCode !== null) {
+                    const result = await firstExit;
+                    assert.fail(
+                        `db-pull exited before the SQL pause (${result.code}/${result.signal}):\n`
+                        + output.stderr + output.stdout,
+                    );
+                }
+
+                if (readHookState(site)?.pause_started) {
+                    try {
+                        const [[row]] = await adminConnection.query(
+                            'SELECT COUNT(*) AS matching_rows FROM '
+                            + `\`${targetDatabase}\`.\`${guardTable}\` `
+                            + "WHERE id = 1 AND value = 'source-value'"
+                        );
+                        if (Number(row.matching_rows) === 1) {
+                            targetReceivedSql = true;
+                            break;
+                        }
+                    } catch (error) {
+                        if (error.code !== 'ER_NO_SUCH_TABLE') {
+                            throw error;
+                        }
+                    }
+                }
+                await sleep(20);
+            }
+
+            assert.equal(
+                targetReceivedSql,
+                true,
+                'db-pull did not execute target SQL before the source pause',
+            );
+            const stoppedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(stoppedState.sql_output, 'mysql');
+            assert.equal(firstProcess.kill('SIGKILL'), true);
+            const killed = await firstExit;
+            assert.equal(killed.code, null);
+            assert.equal(killed.signal, 'SIGKILL');
+            firstProcess = null;
+
+            const serverDeadline = Date.now() + 10000;
+            while (!readHookState(site)?.pause_finished && Date.now() < serverDeadline) {
+                await sleep(20);
+            }
+            assert.equal(
+                readHookState(site)?.pause_finished,
+                true,
+                'source did not leave the pause after the client process stopped',
+            );
+
+            const targetConnection = await createMysqlConnection(targetDatabase);
+            try {
+                await targetConnection.query(
+                    `INSERT INTO \`${guardTable}\` (id, value) VALUES (1, 'target-only-after-death') `
+                    + 'ON DUPLICATE KEY UPDATE value = VALUES(value)'
+                );
+            } finally {
+                await targetConnection.end();
+            }
+
+            // This is an ordinary public command, not out-of-band state editing.
+            // It currently replaces active_resumable_command with db-index.
+            const indexResult = runImporter(importUrl(), tempDir, 'db-index', {
+                secret: getSiteSecret(site),
+                autoResume: false,
+            });
+            assert.equal(
+                indexResult.exitCode,
+                0,
+                `db-index failed:\n${indexResult.stderr}\n${indexResult.stdout}`,
+            );
+            const overwrittenState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(overwrittenState.active_resumable_command.command_name, 'db-index');
+            assert.equal(overwrittenState.active_resumable_command.completion_state, 'complete');
+
+            const restarted = runImporter(importUrl(), tempDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlOutputArguments(targetDatabase),
+                autoResume: false,
+                timeout: 180000,
+            });
+
+            const checkConnection = await createMysqlConnection(targetDatabase);
+            let targetValue;
+            try {
+                const [[row]] = await checkConnection.query(
+                    `SELECT value FROM \`${guardTable}\` WHERE id = 1`
+                );
+                targetValue = row?.value;
+            } finally {
+                await checkConnection.end();
+            }
+
+            assert.equal(
+                targetValue,
+                'target-only-after-death',
+                'a new db-pull changed the target after db-index replaced the normal checkpoint; '
+                + `exit=${restarted.exitCode}\n${restarted.stderr}\n${restarted.stdout}`,
+            );
+            assert.equal(
+                restarted.exitCode,
+                1,
+                `Expected the unfinished direct output to reject a new process:\n`
+                + restarted.stderr + restarted.stdout,
+            );
+            const restartError = `${restarted.stderr}\n${restarted.stdout}`;
+            assert.match(restartError, /db-pull stopped while writing SQL to MySQL\./);
+            assert.match(
+                restartError,
+                /Reprint does not know which database changes MySQL kept\./,
+            );
+            assert.match(
+                restartError,
+                /Restore or reset the target database, then run db-pull --abort\./,
+            );
+        } finally {
+            if (
+                firstProcess
+                && firstProcess.exitCode === null
+                && firstProcess.signalCode === null
+            ) {
+                firstProcess.kill('SIGKILL');
+                await firstExit;
+            }
+            removeTestHooks(site);
+            clearHookState(site);
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.end();
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    it('exits nonzero when a later statement in one multi_query group fails', async () => {
+        const tempDir = createTempDir('e2e-direct-mysql-later-statement-error');
+        const targetDatabase = targetDatabases[1];
+        const adminConnection = await createMysqlConnection();
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDatabase}\``);
+
+            const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+                autoResume: false,
+            });
+            assert.equal(
+                preflight.exitCode,
+                0,
+                `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+            );
+
+            clearHookState(site);
+            writeTestHooks(site, [
+                'function test_hook_before_sql_batch(&$sql, $cursor) {',
+                "    if (strpos($sql, 'INSERT INTO `" + laterErrorTable + "`') === false) { return; }",
+                '    $sql = "INSERT INTO `' + laterErrorTable + '` (id, value) "',
+                '        . "VALUES (2, \'first statement reached target\');\\n"',
+                '        . "THIS IS NOT VALID MYSQL;\\n";',
+                `    file_put_contents('/srv/e2e-sites/.e2e-hook-state-${site}', json_encode([`,
+                "        'later_statement_error_injected' => true,",
+                '    ]));',
+                '}',
+            ].join('\n'));
+
+            // PHP 7.4 and 8.0 default to MYSQLI_REPORT_OFF. Force that supported
+            // runtime behavior when the E2E runner uses a newer PHP whose strict
+            // default would throw before the importer's explicit errno check.
+            const wrapperPath = join(tempDir, 'mysqli-report-off-importer.php');
+            const escapedImporterSourcePath = importerSourcePath
+                .replaceAll('\\', '\\\\')
+                .replaceAll("'", "\\'");
+            writeFileSync(
+                wrapperPath,
+                '<?php\n'
+                + 'mysqli_report(MYSQLI_REPORT_OFF);\n'
+                + "define('IMPORTER_WRAPPER_ENTRY', true);\n"
+                + `require '${escapedImporterSourcePath}';\n`,
+            );
+
+            const result = spawnSync(phpBinary, [
+                wrapperPath,
+                'db-pull',
+                importUrl(),
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
+                `--secret=${getSiteSecret(site)}`,
+                ...mysqlOutputArguments(targetDatabase),
+            ], {
+                env: { ...process.env },
+                encoding: 'utf8',
+                timeout: 180000,
+                maxBuffer: 50 * 1024 * 1024,
+            });
+
+            assert.equal(
+                readHookState(site)?.later_statement_error_injected,
+                true,
+                `source did not emit the two-statement failure group:\n${result.stderr}\n${result.stdout}`,
+            );
+            assert.notEqual(
+                result.status,
+                0,
+                'db-pull reported success after MySQL rejected the later statement in a group; '
+                + `stderr=${result.stderr}\nstdout=${result.stdout}`,
+            );
+        } finally {
+            removeTestHooks(site);
+            clearHookState(site);
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.end();
+            cleanupTempDir(tempDir);
+        }
+    });
+});


### PR DESCRIPTION
A new `db-pull` process now refuses to continue stdout or direct MySQL output after the earlier importer stops.

## Background

The old process could save a source position without knowing what reached stdout or what MySQL kept. A later process could therefore skip SQL, send it twice, or append the rest of a dump to a different output.

## This change

`database-pull-output.json` is written before the first stdout or MySQL write. If the process stops, the next command explains what may have happened and tells the user to reset the receiving program, file, or database before running `db-pull --abort`.

Source failures still retry inside the same importer process, where the connection and unfinished SQL remain in memory. The command also rejects short stdout writes and checks every result returned by `mysqli::multi_query()`.

This is PR 1 of 5: #590 → #591 → #595 → #582 → #607.

## Testing

The focused E2E tests stop real stdout and MySQL pulls, replace normal command state with `db-index`, and check that a later process does not send more SQL. They also cover a failure in the second statement of one MySQL group.
