### PR TITLE
[PHP] Share file-index path inspection

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -3,6 +3,7 @@
 use function Reprint\Importer\merge_local_index_mutations;
 use function Reprint\Importer\sort_index_file;
 use function Reprint\Importer\write_local_index_update;
+use function WordPress\Reprint\Exporter\read_file_index_entry_from_stat;
 use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI filesystem paths, never HTML output.
@@ -310,23 +311,22 @@ class PullIndexJournal
                     "Failed to inspect the pulled local absolute path: {$local_absolute_path}."
                 );
             }
-            $local_file_type_bits = $local_path_stat["mode"] & 0170000;
-            if ($local_file_type_bits === 0120000) {
-                $local_path_type = "link";
-            } elseif ($local_file_type_bits === 0040000) {
-                $local_path_type = "dir";
-            } elseif ($local_file_type_bits === 0100000) {
-                $local_path_type = "file";
-            } else {
+            $local_index_entry = read_file_index_entry_from_stat(
+                $local_absolute_path,
+                $local_path_stat
+            );
+            $local_path_type = $local_index_entry["type"];
+            if ($local_path_type === "other") {
                 throw new RuntimeException(
                     "The pulled local absolute path has an unsupported type: {$local_absolute_path}."
                 );
             }
             $pull_index_wal_record["local_relative_path_b64"] =
                 base64_encode($local_relative_path);
-            $pull_index_wal_record["local_path_ctime"] = (int) $local_path_stat["ctime"];
+            $pull_index_wal_record["local_path_ctime"] =
+                $local_index_entry["ctime"];
             $pull_index_wal_record["local_path_size"] =
-                $local_path_type === "dir" ? 0 : (int) $local_path_stat["size"];
+                $local_index_entry["size"];
             $pull_index_wal_record["local_path_type"] = $local_path_type;
         }
         $this->write_record($pull_index_wal_record);

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -35,11 +35,6 @@ final class FileIndexProcessor {
     const STATUS_DIRECTORY_COMPLETE = "directory_complete";
     const STATUS_DIRECTORY_ERROR = "directory_error";
 
-    const STAT_TYPE_MASK = 0170000;
-    const STAT_TYPE_LINK = 0120000;
-    const STAT_TYPE_FILE = 0100000;
-    const STAT_TYPE_DIR = 0040000;
-
     /** @var string[] Canonical directories allowed during traversal. */
     private $directories;
 
@@ -336,35 +331,23 @@ final class FileIndexProcessor {
             return true;
         }
 
-        // Translate platform mode bits into the four types understood by the
-        // file index. A directory link may also reveal intermediate links that
+        // Build the index entry from the one successful lstat() call. A
+        // directory link may also reveal intermediate links which
         // canonicalization would otherwise hide.
-        $mode = $stat["mode"] & self::STAT_TYPE_MASK;
-        $type = "file";
+        $item = \WordPress\Reprint\Exporter\read_file_index_entry_from_stat(
+            $path,
+            $stat
+        );
+        $type = $item["type"];
         $link_target = null;
         $intermediate_symlinks = [];
-        if ($mode === self::STAT_TYPE_LINK) {
-            $type = "link";
+        if ($type === "link") {
             $resolved_symlink = self::resolve_symlink_target($path);
             $link_target = $resolved_symlink["target"];
             if ($this->follow_symlinks) {
                 $intermediate_symlinks = $resolved_symlink["intermediates"];
             }
-        } elseif ($mode === self::STAT_TYPE_DIR) {
-            $type = "dir";
-        } elseif ($mode !== self::STAT_TYPE_FILE) {
-            $type = "other";
         }
-
-        // Build the index entry from the one successful lstat() call. File and
-        // link sizes participate in push change detection; directory size does
-        // not describe its descendants and is normalized to zero.
-        $item = [
-            "path" => $path,
-            "ctime" => (int) ( isset($stat["ctime"]) ? $stat["ctime"] : 0 ),
-            "size" => $type === "file" || $type === "link" ? (int) ( isset($stat["size"]) ? $stat["size"] : 0 ) : 0,
-            "type" => $type,
-        ];
         if ($link_target !== null) {
             $item["target"] = $link_target;
         }

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -497,6 +497,51 @@ function relative_path_under(string $path, string $root): ?string
 }
 
 /**
+ * Builds one file-index entry from a completed lstat() call.
+ *
+ * File and link sizes participate in change detection. A directory's stat
+ * size does not describe its descendants, so directory size is always zero.
+ * Symlink targets and directory contents are left to callers because neither
+ * comes from the stat record.
+ *
+ * @param string $path      Absolute path inspected by lstat().
+ * @param array  $path_stat Value returned by lstat().
+ * @return array {
+ *     File-index entry.
+ *
+ *     @type string $path  Absolute path.
+ *     @type int    $ctime Local ctime.
+ *     @type int    $size  File or link size. Other types use zero.
+ *     @type string $type  `file`, `dir`, `link`, or `other`.
+ * }
+ * @phpstan-param array{mode:int,ctime?:int,size?:int} $path_stat
+ * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'dir'|'link'|'other'}
+ */
+function read_file_index_entry_from_stat(string $path, array $path_stat): array
+{
+    $path_type_bits = $path_stat["mode"] & 0170000;
+    if ($path_type_bits === 0120000) {
+        $path_type = "link";
+    } elseif ($path_type_bits === 0040000) {
+        $path_type = "dir";
+    } elseif ($path_type_bits === 0100000) {
+        $path_type = "file";
+    } else {
+        $path_type = "other";
+    }
+
+    $entry = [
+        "path" => $path,
+        "ctime" => (int) ( $path_stat["ctime"] ?? 0 ),
+        "size" => $path_type === "file" || $path_type === "link"
+            ? (int) ( $path_stat["size"] ?? 0 )
+            : 0,
+        "type" => $path_type,
+    ];
+    return $entry;
+}
+
+/**
  * Validates that a path is a non-empty absolute string without NUL bytes
  * or dot-segments (. or ..).
  *


### PR DESCRIPTION
File indexing and files-pull journal updates now derive path type, size, and ctime from one stat-record decoder.

Both paths were decoding the same Unix mode bits. There is no reason to maintain two answers for whether a path is a file, directory, link, or unsupported type. `read_file_index_entry_from_stat()` now owns that translation and the size normalization used by file indexes.

`FileIndexProcessor` still owns symlink targets and physical directory emptiness. `PullIndexJournal` still writes only the fields carried by its WAL. This changes no index format or pull behavior.

Tested with `FileIndexProcessorTest`, `PullIndexWalTest`, and `FreshLocalIndexProcessorTest`, plus the PHP 7.2 server and PHP 7.4 client compatibility scans.