### PR TITLE
[PHP] Report remote index read failures

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -148,8 +148,8 @@ class RemoteIndexReader
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
      * }
-     * @throws RuntimeException When a non-blank line is not a decodable index
-     *                          entry.
+     * @throws RuntimeException When the index cannot be read or a non-blank
+     *                          line is not a decodable entry.
      * @throws InvalidArgumentException When the decoded path is not a valid
      *                                  remote absolute path.
      */
@@ -163,6 +163,11 @@ class RemoteIndexReader
                 continue;
             }
             return self::decode_index_line($remote_index_json_line);
+        }
+        if (!feof($this->remote_index_file_handle)) {
+            throw new RuntimeException(
+                "Failed to read the remote index file: {$this->remote_index_path}"
+            );
         }
         return null;
     }

--- a/tests/Import/RemoteIndexReadFailureStream.php
+++ b/tests/Import/RemoteIndexReadFailureStream.php
@@ -1,0 +1,47 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
+
+namespace ImportTests;
+
+/** Stream wrapper whose reads fail before EOF. */
+final class RemoteIndexReadFailureStream
+{
+    /** @var resource|null Stream context supplied by PHP. */
+    public $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$opened_path
+    ): bool {
+        unset($path, $mode, $options, $opened_path);
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        unset($count);
+        return '';
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    /** @return array{mode:int,size:int} */
+    public function stream_stat(): array
+    {
+        return ['mode' => 0100644, 'size' => 1];
+    }
+
+    /** @return array{mode:int,size:int} */
+    public function url_stat(string $path, int $flags): array
+    {
+        unset($path, $flags);
+        return ['mode' => 0100644, 'size' => 1];
+    }
+}

--- a/tests/Import/RemoteIndexReaderTest.php
+++ b/tests/Import/RemoteIndexReaderTest.php
@@ -8,6 +8,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/RemoteIndexReadFailureStream.php';
 
 final class RemoteIndexReaderTest extends TestCase
 {
@@ -145,6 +146,31 @@ final class RemoteIndexReaderTest extends TestCase
         $this->expectExceptionMessage('Invalid index line format');
 
         \RemoteIndexReader::decode_index_line("\n");
+    }
+
+    public function testReadFailureDoesNotLookLikeEndOfFile(): void
+    {
+        $scheme = 'failingremoteindex';
+        $this->assertTrue(
+            stream_wrapper_register(
+                $scheme,
+                RemoteIndexReadFailureStream::class
+            )
+        );
+        $reader = new \RemoteIndexReader($scheme . '://index');
+        try {
+            $reader->open();
+            $reader->next_entry();
+            $this->fail('Expected the remote index read failure to throw.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Failed to read the remote index file',
+                $exception->getMessage()
+            );
+        } finally {
+            $reader->close();
+            stream_wrapper_unregister($scheme);
+        }
     }
 
     private function indexLine(


### PR DESCRIPTION
`RemoteIndexReader` now distinguishes a failed read from the end of an index.

`fgets()` returns `false` for both cases. Returning `null` without checking `feof()` lets a caller accept a partial index as complete. The reader now returns `null` only at EOF and throws a pointed exception when the stream failed before EOF.

The test uses a stream wrapper whose read fails while `stream_eof()` remains false. The existing file-backed reader tests continue to cover normal completion and resume.