### PR TITLE
[PHP] Read remote directory shape from index entries

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -25,11 +25,15 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
  *         "type"  => "file",
  *     ]
  *
+ * A directory entry may also contain `"empty" => true`. The next remote
+ * index records that result of the remote directory scan. The retained remote
+ * index rebuilt by PullIndexJournal may omit it, so callers must treat the
+ * field as optional.
+ *
  * Extra raw-record fields such as `target` and `intermediate` are deliberately
  * omitted from the returned entry. Callers which need those fields read the
- * raw symlink records instead. This reader also does not read
- * `local_index.jsonl`: that relative-path format has an optional `empty`
- * field and remains owned by PushPlan and the local-index merge helpers.
+ * raw symlink records instead. This reader does not read `local_index.jsonl`;
+ * that index uses local relative paths and locally observed metadata.
  *
  * ## Lifecycle and resume
  *
@@ -147,6 +151,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
+     *     @type bool   $empty Whether the directory was empty. Directory entries only.
      * }
      * @throws RuntimeException When the index cannot be read or a non-blank
      *                          line is not a decodable entry.
@@ -244,6 +249,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
+     *     @type bool   $empty Whether the directory was empty. Directory entries only.
      * }
      * @throws RuntimeException When the line or base64 path is malformed.
      * @throws InvalidArgumentException When the decoded path is not a valid
@@ -265,11 +271,27 @@ class RemoteIndexReader
             throw new RuntimeException("Invalid index path (base64 decode failed)");
         }
         assert_valid_path($path, "index path");
-        return [
+        $entry = [
             "path" => $path,
             "ctime" => (int) ( $data["ctime"] ?? 0 ),
             "size" => (int) ( $data["size"] ?? 0 ),
             "type" => (string) ( $data["type"] ?? "file" ),
         ];
+        if (array_key_exists("empty", $data)) {
+            if (!is_bool($data["empty"])) {
+                throw new RuntimeException(
+                    "Remote index empty value must be a boolean; got "
+                    . gettype($data["empty"])
+                    . "."
+                );
+            }
+            if ($entry["type"] !== "dir") {
+                throw new RuntimeException(
+                    "Remote index empty value belongs to a directory entry; got {$entry["type"]}."
+                );
+            }
+            $entry["empty"] = $data["empty"];
+        }
+        return $entry;
     }
 }

--- a/tests/Import/RemoteIndexReaderTest.php
+++ b/tests/Import/RemoteIndexReaderTest.php
@@ -173,6 +173,50 @@ final class RemoteIndexReaderTest extends TestCase
         }
     }
 
+    public function testDirectoryEmptyValueIsReturned(): void
+    {
+        $line = json_encode(
+            [
+                'path' => base64_encode('/site/empty'),
+                'ctime' => 10,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => true,
+            ],
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertTrue(
+            \RemoteIndexReader::decode_index_line($line)['empty'] ?? false
+        );
+    }
+
+    /** @dataProvider invalidEmptyValueProvider */
+    public function testRejectsInvalidDirectoryEmptyValue(
+        string $type,
+        mixed $directory_is_empty
+    ): void {
+        $line = json_encode(
+            [
+                'path' => base64_encode('/site/path'),
+                'type' => $type,
+                'empty' => $directory_is_empty,
+            ],
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->expectException(\RuntimeException::class);
+        \RemoteIndexReader::decode_index_line($line);
+    }
+
+    /** @return iterable<string,array{string,mixed}> */
+    public static function invalidEmptyValueProvider(): iterable
+    {
+        yield 'non-boolean' => ['dir', 1];
+        yield 'file' => ['file', true];
+        yield 'link' => ['link', false];
+    }
+
     private function indexLine(
         string $path,
         int $ctime,


### PR DESCRIPTION
`RemoteIndexReader` now returns the optional `empty` value recorded for remote directories.

The exporter writes this field when it has scanned an empty directory. Dropping it leaves downstream index consumers unable to distinguish an explicit empty directory from an ordinary directory whose descendants imply its presence. Retained remote indexes rebuilt by `PullIndexJournal` may omit the field, so it remains optional.

The decoder accepts a boolean `empty` value only on directory entries. Tests cover the returned value, non-boolean input, and file or link entries which incorrectly carry it.