### PR TITLE
[PHP] Record remote sizes for pulled symlinks

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -9620,7 +9620,7 @@ class ImportClient
             $this->pull_index_journal->record_remote_upsert(
                 $path,
                 $ctime,
-                0,
+                strlen($target),
                 "link",
                 $local_absolute_path
             );

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -76,6 +76,40 @@ class PullSymlinkTest extends TestCase
         $this->assertEquals('target', readlink($symlinkPath), 'Symlink target should match');
     }
 
+    public function testSymlinkJournalRecordsTheRemoteTargetSize(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir,
+            $this->tempDir . '/fs-root'
+        );
+        $reflection = new \ReflectionClass($client);
+        $remoteTarget = '../target/file.php';
+
+        $reflection->getMethod('handle_symlink_chunk')->invoke($client, [
+            'headers' => [
+                'x-symlink-path' => base64_encode('/test/link'),
+                'x-symlink-target' => base64_encode($remoteTarget),
+                'x-symlink-ctime' => '1234567890',
+            ],
+        ]);
+
+        $journal = $reflection->getProperty('pull_index_journal')->getValue(
+            $client
+        );
+        $journal->flush();
+        $journal->close();
+        $walRecords = file(
+            $client->pull_state_directory . '/index.wal',
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($walRecords);
+        $this->assertCount(1, $walRecords);
+        $record = json_decode($walRecords[0], true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(strlen($remoteTarget), $record['remote_path_size']);
+    }
+
     public function testSymlinkTargetBesideVisitedRootRemainsQueued()
     {
         $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');


### PR DESCRIPTION
Pulled symlinks now retain the remote target's byte length in the remote index.

The next remote index gets a symlink's size from remote `lstat()`. Fetch later wrote size `0` into the pull index WAL, so applying that record changed the metadata of an otherwise unchanged symlink. This records `strlen($target)` from the decoded remote target. It deliberately does not use the rewritten local target, whose length may differ after path mapping.

## Testing

The symlink pull test checks the WAL record and the existing symlink cases continue to pass.
