### PR TITLE
[PHP] Build local-coordinate indexes for file pulls

### DIFF
--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -69,6 +69,17 @@ local relative path to a document-root-relative path.
 - A **file sync patch processor** builds a fresh local index, then runs a file
   sync patch planner in the direction selected by its start method. Its cursor
   owns both phases, so a caller can store it unchanged.
+- A **pull local index processor** (`PullLocalIndexProcessor`) maps the next
+  remote index into local relative paths and merges those paths with the
+  retained local index. It owns the patch-result index or next local index
+  through completion or restart.
+- A **patch-result index** is temporary pre-fetch planning input. Its paths use
+  local coordinates and its selected entries retain remote type, size, ctime,
+  and empty-directory state. Use `$patch_result_index_file`.
+- A **next local index** is the candidate retained local index built after
+  fetch. Its selected entries use metadata from the WAL-applied local index.
+  It replaces the local index only after a final fresh scan finds no selected
+  difference. Use `$next_local_index_file`.
 - The **pull index WAL** records completed pull mutations awaiting application
   to the remote and local indexes.
 - A **pull plan** lists remote absolute paths still scheduled for download or

--- a/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
+++ b/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
@@ -1,0 +1,1089 @@
+<?php
+
+use function Reprint\Importer\file_sync_index_path_may_change;
+use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\sort_index_file_preserving_duplicate_paths;
+use function Reprint\Importer\write_local_index_entry;
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\read_file_index_directory_is_empty;
+use function WordPress\Reprint\Exporter\read_file_index_entry_from_stat;
+use function WordPress\Reprint\Exporter\relative_path_under;
+
+require_once __DIR__ . '/../local-index-update-functions.php';
+require_once __DIR__ . '/../sort-index-file.php';
+require_once __DIR__ . '/../pull/class-remote-index-reader.php';
+require_once __DIR__ . '/../pull/class-remote-to-local-path-mapper.php';
+require_once __DIR__ . '/class-file-index-diff-processor.php';
+require_once __DIR__ . '/class-file-sync-patch-processor.php';
+require_once __DIR__ . '/file-sync-path-functions.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing streaming classes.
+
+/**
+ * Builds a local-coordinate index for the next remote tree.
+ *
+ * A pull mapping can change path order. The processor maps one selected remote
+ * entry per step, sorts the mapped entries by local relative path, then merges
+ * them with the retained local index. It replaces retained entries inside the
+ * selected roots and keeps entries outside them or across an excluded root.
+ *
+ * start_patch_result() copies remote type, size, ctime, and directory emptiness
+ * into local coordinates. FileSyncPatchProcessor can use that index to plan
+ * pre-fetch cleanup. The patch-result file is temporary planning input. Its
+ * mapped entries' ctime values belong to the remote machine.
+ *
+ * start_next_local_index() requires the selected paths in the remote index and
+ * next remote index to match in presence, type, size, and ctime. Candidate
+ * entries use the WAL-applied retained local metadata recorded after fetch. A
+ * remote empty-directory row is written only when the local directory is
+ * physically empty. A child omitted from the pull therefore keeps its parent
+ * directory implicit instead of recording that parent as empty.
+ *
+ * The completed candidate is checked by FileSyncPatchProcessor against one
+ * final fresh local index. Any selected difference means local state changed
+ * after the pull work was confirmed, so the processor returns `restart`. A
+ * candidate with no selected difference returns `complete` and can replace the
+ * retained local index.
+ *
+ * One next_step() maps and confirms one remote entry, sorts one work file,
+ * starts the merge, scans one implied-parent record, merges one local path, or
+ * performs one final verification step. Flush pending output before storing
+ * get_cursor(). Resume truncates output to its saved byte offset.
+ *
+ *     $processor = PullLocalIndexProcessor::start_next_local_index(
+ *         $work_directory,
+ *         $next_remote_index_file,
+ *         $remote_index_file,
+ *         $local_index_file,
+ *         $path_mapper,
+ *         $storage_path,
+ *         false
+ *     );
+ *     do {
+ *         $has_next_step = $processor->next_step();
+ *         $processor->flush_pending_output();
+ *         save_cursor($processor->get_cursor());
+ *     } while ($has_next_step);
+ *     if ($processor->get_status() === 'complete') {
+ *         replace_local_index($processor->get_index_path());
+ *     }
+ *     $processor->close();
+ *
+ * @phpstan-type MapperConfig array{filesystem_root_b64:string,original_remote_roots_b64:list<string>,resolved_path_mappings:list<array{remote_prefix_b64:string,local_prefix_b64:string}>,local_followed_symlinks_root_b64:string|null}
+ * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
+ * @phpstan-type Position array{phase:'mapping',remote_index_byte_offset?:int,remote_index_diff_cursor?:IndexDiffCursor,mapped_index_byte_offset:int,mapped_index_parents_byte_offset:int}|array{phase:'sorting'|'sorting_parents'|'starting_merge'}|array{phase:'merging',index_diff_cursor:IndexDiffCursor,mapped_index_parent_cursor:IndexDiffCursor,index_byte_offset:int}|array{phase:'verifying',file_sync_patch_processor_cursor:array}|array{phase:'complete'|'restart'}
+ * @phpstan-type Cursor array{metadata_source:'remote_recorded'|'locally_observed',next_remote_index_file_b64:string,remote_index_file_b64:string|null,remote_index_exists:bool,retained_local_index_file_b64:string,retained_local_index_exists:bool,mapped_index_file_b64:string,mapped_index_parents_file_b64:string,index_file_b64:string,path_mapper_config:MapperConfig,included_local_index_path_roots_b64:list<string>,excluded_local_index_path_roots_b64:list<string>,verification_storage_path_b64:string,verification_include_caches:bool,position:Position}
+ */
+final class PullLocalIndexProcessor
+{
+    /** @var Cursor Cursor after the latest completed step. */
+    private array $cursor;
+
+    private string $next_remote_index_file;
+    private string $retained_local_index_file;
+    private string $mapped_index_file;
+    private string $mapped_index_parents_file;
+    private string $index_file;
+    private RemoteToLocalPathMapper $path_mapper;
+
+    /** @var list<string> */
+    private array $included_local_index_path_roots;
+
+    /** @var list<string> */
+    private array $excluded_local_index_path_roots;
+
+    private ?RemoteIndexReader $remote_index_reader = null;
+    private ?FileIndexDiffProcessor $remote_index_diff = null;
+    private bool $remote_index_path_selected = false;
+
+    /** @var resource|null Mapped entries written before sorting. */
+    private $mapped_index_handle = null;
+
+    /** @var resource|null Implied-parent records written while mapping. */
+    private $mapped_index_parents_handle = null;
+
+    private ?FileIndexDiffProcessor $index_diff = null;
+    private bool $index_diff_path_selected = false;
+    private ?FileIndexDiffProcessor $mapped_index_parent_reader = null;
+    private bool $mapped_index_parent_path_selected = false;
+
+    /** @var resource|null */
+    private $index_handle = null;
+
+    private ?FileSyncPatchProcessor $verification_processor = null;
+
+    private bool $closed = false;
+
+    /**
+     * Starts a local-coordinate patch-result index using remote metadata.
+     *
+     * @param string                  $work_directory            Existing directory for processor work files.
+     * @param string                  $next_remote_index_file Immutable next remote index.
+     * @param string                  $retained_local_index_file Retained local index, or a missing path on the first pull.
+     * @param RemoteToLocalPathMapper $path_mapper               Path mapping used by this pull.
+     * @param list<string> $included_local_index_path_roots Local roots which the pull may change.
+     * @param list<string> $excluded_local_index_path_roots Local roots which the pull must not affect.
+     */
+    public static function start_patch_result(
+        string $work_directory,
+        string $next_remote_index_file,
+        string $retained_local_index_file,
+        RemoteToLocalPathMapper $path_mapper,
+        array $included_local_index_path_roots = [""],
+        array $excluded_local_index_path_roots = []
+    ): self {
+        return self::start(
+            "remote_recorded", $work_directory,
+            $next_remote_index_file,
+            null,
+            $retained_local_index_file,
+            $path_mapper,
+            $included_local_index_path_roots,
+            $excluded_local_index_path_roots,
+            "",
+            false
+        );
+    }
+
+    /**
+     * Starts the next local index using local metadata recorded after fetch.
+     *
+     * @param string                  $work_directory            Existing directory for processor work files.
+     * @param string                  $next_remote_index_file Immutable next remote index.
+     * @param string                  $remote_index_file WAL-applied remote index containing confirmed fetch records, or a missing path for an empty index.
+     * @param string                  $retained_local_index_file WAL-applied local index containing confirmed local metadata.
+     * @param RemoteToLocalPathMapper $path_mapper               Path mapping used by this pull.
+     * @param string       $storage_path                    Reprint storage path omitted from final verification.
+     * @param bool         $include_caches                  Whether final verification includes cache paths.
+     * @param list<string> $included_local_index_path_roots Local roots which the pull may change.
+     * @param list<string> $excluded_local_index_path_roots Local roots which the pull must not affect.
+     */
+    public static function start_next_local_index(
+        string $work_directory,
+        string $next_remote_index_file,
+        string $remote_index_file,
+        string $retained_local_index_file,
+        RemoteToLocalPathMapper $path_mapper,
+        string $storage_path,
+        bool $include_caches,
+        array $included_local_index_path_roots = [""],
+        array $excluded_local_index_path_roots = []
+    ): self {
+        return self::start(
+            "locally_observed", $work_directory,
+            $next_remote_index_file,
+            $remote_index_file,
+            $retained_local_index_file,
+            $path_mapper,
+            $included_local_index_path_roots,
+            $excluded_local_index_path_roots,
+            $storage_path,
+            $include_caches
+        );
+    }
+
+    /**
+     * Resumes from a cursor returned by get_cursor().
+     *
+     * Mapping and merging outputs are truncated to the stored byte offsets.
+     * The work files required by the saved phase must still exist. During
+     * mapping, the remote index must retain its starting presence; a saved
+     * missing path remains an empty index. A complete cursor also requires its
+     * completed output index.
+     *
+     * @phpstan-param Cursor $cursor
+     */
+    public static function resume(array $cursor): self
+    {
+        $processor = new self();
+        $processor->cursor = $cursor;
+        if (
+            $cursor["metadata_source"] !== "remote_recorded"
+            && $cursor["metadata_source"] !== "locally_observed"
+        ) {
+            throw new InvalidArgumentException("Pull local index cursor contains an invalid metadata source.");
+        }
+        $processor->next_remote_index_file = self::decode_cursor_path($cursor["next_remote_index_file_b64"]);
+        $processor->retained_local_index_file = self::decode_cursor_path($cursor["retained_local_index_file_b64"]);
+        $processor->mapped_index_file = self::decode_cursor_path($cursor["mapped_index_file_b64"]);
+        $processor->mapped_index_parents_file = self::decode_cursor_path(
+            $cursor["mapped_index_parents_file_b64"]
+        );
+        $processor->index_file = self::decode_cursor_path($cursor["index_file_b64"]);
+        $processor->path_mapper = RemoteToLocalPathMapper::from_config($cursor["path_mapper_config"]);
+        $decode_path = [self::class, "decode_cursor_path"];
+        $processor->included_local_index_path_roots = array_map(
+            $decode_path, $cursor["included_local_index_path_roots_b64"]
+        );
+        $processor->excluded_local_index_path_roots = array_map(
+            $decode_path, $cursor["excluded_local_index_path_roots_b64"]
+        );
+        $position = $cursor["position"];
+        self::require_file($processor->index_file, "output index");
+        if (
+            $position["phase"] === "complete"
+            || $position["phase"] === "restart"
+        ) {
+            return $processor;
+        }
+        if ($position["phase"] === "verifying") {
+            $processor->verification_processor =
+                FileSyncPatchProcessor::resume(
+                    $position["file_sync_patch_processor_cursor"]
+                );
+            return $processor;
+        }
+        self::require_file($processor->mapped_index_file, "mapped index");
+        self::require_file(
+            $processor->mapped_index_parents_file,
+            "mapped index parents"
+        );
+
+        if ($position["phase"] === "mapping") {
+            self::require_file($processor->next_remote_index_file, "next remote index");
+            try {
+                if ($cursor["metadata_source"] === "locally_observed") {
+                    if ($cursor["remote_index_file_b64"] === null) {
+                        throw new InvalidArgumentException(
+                            "Pull local index cursor is missing its remote index."
+                        );
+                    }
+                    $remote_index_file = self::decode_cursor_path(
+                        $cursor["remote_index_file_b64"]
+                    );
+                    $remote_index_exists = self::optional_file_exists(
+                        $remote_index_file,
+                        "remote index"
+                    );
+                    if (
+                        $remote_index_exists
+                            !== $cursor["remote_index_exists"]
+                    ) {
+                        throw new RuntimeException(
+                            "The remote index presence changed during pull local indexing."
+                        );
+                    }
+                    $processor->remote_index_diff =
+                        FileIndexDiffProcessor::resume(
+                            $remote_index_file,
+                            $processor->next_remote_index_file,
+                            $position[
+                                "remote_index_diff_cursor"
+                            ],
+                            [RemoteIndexReader::class, "decode_index_line"]
+                        );
+                } else {
+                    $processor->remote_index_reader = new RemoteIndexReader(
+                        $processor->next_remote_index_file
+                    );
+                    $processor->remote_index_reader->open();
+                    $processor->remote_index_reader->seek_to_byte_offset(
+                        $position["remote_index_byte_offset"]
+                    );
+                }
+                $processor->mapped_index_handle =
+                    self::open_and_truncate_to_saved_byte_offset(
+                        $processor->mapped_index_file,
+                        $position["mapped_index_byte_offset"],
+                        "mapped pull index"
+                    );
+                $processor->mapped_index_parents_handle =
+                    self::open_and_truncate_to_saved_byte_offset(
+                        $processor->mapped_index_parents_file,
+                        $position["mapped_index_parents_byte_offset"],
+                        "mapped pull index parents"
+                    );
+            } catch (Throwable $throwable) {
+                $processor->close();
+                throw $throwable;
+            }
+            return $processor;
+        }
+
+        if (
+            $position["phase"] === "sorting"
+            || $position["phase"] === "sorting_parents"
+        ) {
+            return $processor;
+        }
+        $processor->assert_retained_local_index_state();
+        if ($position["phase"] === "starting_merge") {
+            return $processor;
+        }
+        if ($position["phase"] !== "merging") {
+            throw new InvalidArgumentException("Pull local index cursor contains an invalid phase.");
+        }
+
+        try {
+            $processor->index_diff = FileIndexDiffProcessor::resume(
+                $processor->retained_local_index_file,
+                $processor->mapped_index_file,
+                $position["index_diff_cursor"]
+            );
+            $processor->mapped_index_parent_reader =
+                FileIndexDiffProcessor::resume(
+                    "",
+                    $processor->mapped_index_parents_file,
+                    $position["mapped_index_parent_cursor"]
+                );
+            $processor->index_handle =
+                self::open_and_truncate_to_saved_byte_offset(
+                    $processor->index_file,
+                    $position["index_byte_offset"],
+                    "pull local index"
+                );
+        } catch (Throwable $throwable) {
+            $processor->close();
+            throw $throwable;
+        }
+        return $processor;
+    }
+
+    /**
+     * Maps one remote entry, sorts the mapped index, or merges one local path.
+     *
+     * True means another step may be attempted. False is stable; get_status()
+     * then returns `complete` or `restart`.
+     */
+    public function next_step(): bool
+    {
+        $position = $this->cursor["position"];
+        if (
+            $position["phase"] === "complete"
+            || $position["phase"] === "restart"
+        ) {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException("Cannot take a pull local index step after close().");
+        }
+
+        if ($position["phase"] === "mapping") {
+            $remote_index_entry = null;
+            $local_absolute_path = null;
+            $local_relative_path = null;
+            $path_may_change = null;
+            if ($this->cursor["metadata_source"] === "locally_observed") {
+                if (
+                    !$this->remote_index_path_selected
+                    && !$this->remote_index_diff->next_path()
+                ) {
+                    $this->remote_index_diff->close();
+                    $this->remote_index_diff = null;
+                } else {
+                    $this->remote_index_path_selected = true;
+                    $remote_absolute_path =
+                        $this->remote_index_diff->get_path();
+                    $local_absolute_path = $this->path_mapper->map_path(
+                        $remote_absolute_path
+                    );
+                    $local_relative_path = relative_path_under(
+                        $local_absolute_path,
+                        $this->path_mapper->get_filesystem_root()
+                    );
+                    if ($local_relative_path === null) {
+                        throw new RuntimeException(
+                            "Remote path maps outside the writable local tree: "
+                            . base64_encode($remote_absolute_path)
+                            . "."
+                        );
+                    }
+                    $path_may_change = file_sync_index_path_may_change(
+                        $local_relative_path,
+                        $this->included_local_index_path_roots,
+                        $this->excluded_local_index_path_roots
+                    );
+                    if (
+                        $path_may_change
+                        && $this->remote_index_diff
+                            ->get_path_transition() !== "unchanged"
+                    ) {
+                        return $this->restart();
+                    }
+                    $next_remote_path_type =
+                        $this->remote_index_diff
+                            ->get_path_type_in_new_index();
+                    if ($next_remote_path_type !== null) {
+                        $remote_index_entry = [
+                            "path" => $remote_absolute_path,
+                            "ctime" => $this->remote_index_diff
+                                ->get_ctime_in_new_index(),
+                            "size" => $this->remote_index_diff
+                                ->get_size_in_new_index(),
+                            "type" => $next_remote_path_type,
+                        ];
+                        $directory_is_empty =
+                            $this->remote_index_diff
+                                ->get_directory_is_empty_in_new_index();
+                        if ($directory_is_empty !== null) {
+                            $remote_index_entry["empty"] =
+                                $directory_is_empty;
+                        }
+                    }
+                }
+            } else {
+                $remote_index_entry = $this->remote_index_reader->next_entry();
+                if ($remote_index_entry === null) {
+                    $this->remote_index_reader->close();
+                    $this->remote_index_reader = null;
+                }
+            }
+
+            if (
+                $remote_index_entry === null
+                && !$this->remote_index_path_selected
+            ) {
+                $this->flush_pending_output();
+                fclose($this->mapped_index_handle);
+                $this->mapped_index_handle = null;
+                fclose($this->mapped_index_parents_handle);
+                $this->mapped_index_parents_handle = null;
+                $this->cursor["position"] = ["phase" => "sorting"];
+                return true;
+            }
+            if ($remote_index_entry === null) {
+                $this->remote_index_path_selected =
+                    $this->remote_index_diff->next_path();
+                $this->cursor["position"] = [
+                    "phase" => "mapping",
+                    "remote_index_diff_cursor" =>
+                        $this->remote_index_diff->get_cursor(),
+                    "mapped_index_byte_offset" =>
+                        $position["mapped_index_byte_offset"],
+                    "mapped_index_parents_byte_offset" =>
+                        $position["mapped_index_parents_byte_offset"],
+                ];
+                return true;
+            }
+
+            if ($local_absolute_path === null) {
+                $local_absolute_path = $this->path_mapper->map_path(
+                    $remote_index_entry["path"]
+                );
+                $local_relative_path = relative_path_under(
+                    $local_absolute_path,
+                    $this->path_mapper->get_filesystem_root()
+                );
+                if ($local_relative_path === null) {
+                    throw new RuntimeException(
+                        "Remote path maps outside the writable local tree: "
+                        . base64_encode($remote_index_entry["path"])
+                        . "."
+                    );
+                }
+                $path_may_change = file_sync_index_path_may_change(
+                    $local_relative_path,
+                    $this->included_local_index_path_roots,
+                    $this->excluded_local_index_path_roots
+                );
+            }
+            if ($path_may_change && $local_relative_path !== "") {
+                if (
+                    $remote_index_entry["type"] === "dir"
+                    && ( $remote_index_entry["empty"] ?? null ) !== true
+                ) {
+                    throw new RuntimeException(
+                        "Remote directory was not confirmed empty during indexing: "
+                        . base64_encode($remote_index_entry["path"])
+                        . "."
+                    );
+                }
+                $mapped_index_entry = [
+                    "path" => $local_relative_path,
+                    "ctime" => $remote_index_entry["ctime"],
+                    "size" => $remote_index_entry["size"],
+                    "type" => $remote_index_entry["type"],
+                ];
+                if (array_key_exists("empty", $remote_index_entry)) {
+                    $mapped_index_entry["empty"] = $remote_index_entry["empty"];
+                }
+
+                if (
+                    $this->cursor["metadata_source"] === "locally_observed"
+                    && $remote_index_entry["type"] === "dir"
+                ) {
+                    clearstatcache(true, $local_absolute_path);
+                    $local_path_stat = @lstat($local_absolute_path);
+                    if ($local_path_stat === false) {
+                        return $this->restart();
+                    }
+                    $local_index_path = read_file_index_entry_from_stat(
+                        $local_absolute_path,
+                        $local_path_stat
+                    );
+                    if ($local_index_path["type"] !== "dir") {
+                        return $this->restart();
+                    }
+                    if (read_file_index_directory_is_empty(
+                        $local_absolute_path
+                    ) !== true) {
+                        $mapped_index_entry = null;
+                    } else {
+                        $mapped_index_entry["empty"] = true;
+                    }
+                }
+
+                if ($mapped_index_entry !== null) {
+                    write_local_index_entry(
+                        $this->mapped_index_handle,
+                        $mapped_index_entry
+                    );
+                }
+                // The selected path makes each ancestor non-empty even when
+                // the path's own directory row stays sparse.
+                $mapped_index_parent_path = $local_relative_path;
+                while (true) {
+                    $last_separator = strrpos(
+                        $mapped_index_parent_path,
+                        "/"
+                    );
+                    if ($last_separator === false) {
+                        break;
+                    }
+                    $mapped_index_parent_path = substr(
+                        $mapped_index_parent_path,
+                        0,
+                        $last_separator
+                    );
+                    if ($mapped_index_parent_path === "") {
+                        break;
+                    }
+                    write_local_index_entry(
+                        $this->mapped_index_parents_handle,
+                        [
+                            "path" => $mapped_index_parent_path,
+                            "ctime" => 0,
+                            "size" => 0,
+                            "type" => "dir",
+                        ]
+                    );
+                }
+            }
+
+            $mapped_index_byte_offset = ftell($this->mapped_index_handle);
+            if (!is_int($mapped_index_byte_offset)) {
+                throw new RuntimeException(
+                    "Failed to read the mapped pull index byte offset."
+                );
+            }
+            $mapped_index_parents_byte_offset = ftell(
+                $this->mapped_index_parents_handle
+            );
+            if (!is_int($mapped_index_parents_byte_offset)) {
+                throw new RuntimeException(
+                    "Failed to read the mapped pull index parents byte offset."
+                );
+            }
+            $mapping_position = [
+                "phase" => "mapping",
+                "mapped_index_byte_offset" => $mapped_index_byte_offset,
+                "mapped_index_parents_byte_offset" =>
+                    $mapped_index_parents_byte_offset,
+            ];
+            if ($this->cursor["metadata_source"] === "locally_observed") {
+                $this->remote_index_path_selected =
+                    $this->remote_index_diff->next_path();
+                $mapping_position[
+                    "remote_index_diff_cursor"
+                ] = $this->remote_index_diff->get_cursor();
+            } else {
+                $mapping_position["remote_index_byte_offset"] =
+                    $this->remote_index_reader->byte_offset();
+            }
+            $this->cursor["position"] = $mapping_position;
+            return true;
+        }
+
+        if ($position["phase"] === "verifying") {
+            $has_next_verification_step =
+                $this->verification_processor->next_step();
+            if ($this->verification_processor->get_operation() !== null) {
+                return $this->restart();
+            }
+            if (!$has_next_verification_step) {
+                $this->cursor["position"] = ["phase" => "complete"];
+                $this->close();
+                return false;
+            }
+            $this->cursor["position"] = [
+                "phase" => "verifying",
+                "file_sync_patch_processor_cursor" =>
+                    $this->verification_processor->get_cursor(),
+            ];
+            return true;
+        }
+
+        if ($position["phase"] === "sorting") {
+            if (
+                !sort_index_file_preserving_duplicate_paths(
+                    $this->mapped_index_file
+                )
+            ) {
+                throw new RuntimeException("Failed to sort the mapped pull index.");
+            }
+            $this->cursor["position"] = ["phase" => "sorting_parents"];
+            return true;
+        }
+
+        if ($position["phase"] === "sorting_parents") {
+            if (!sort_index_file($this->mapped_index_parents_file)) {
+                throw new RuntimeException(
+                    "Failed to sort the mapped pull index parents."
+                );
+            }
+            $this->cursor["position"] = ["phase" => "starting_merge"];
+            return true;
+        }
+
+        if ($position["phase"] === "starting_merge") {
+            $this->assert_retained_local_index_state();
+            $this->index_handle = fopen($this->index_file, "w+b");
+            if (!is_resource($this->index_handle)) {
+                throw new RuntimeException("Failed to open the pull local index.");
+            }
+            try {
+                $this->index_diff = FileIndexDiffProcessor::create(
+                    $this->retained_local_index_file,
+                    $this->mapped_index_file
+                );
+                $this->mapped_index_parent_reader =
+                    FileIndexDiffProcessor::create(
+                        "",
+                        $this->mapped_index_parents_file
+                    );
+            } catch (Throwable $throwable) {
+                $this->close();
+                throw $throwable;
+            }
+            $this->cursor["position"] = [
+                "phase" => "merging",
+                "index_diff_cursor" => $this->index_diff->get_cursor(),
+                "mapped_index_parent_cursor" =>
+                    $this->mapped_index_parent_reader->get_cursor(),
+                "index_byte_offset" => 0,
+            ];
+            return true;
+        }
+
+        if (!$this->index_diff_path_selected && !$this->index_diff->next_path()) {
+            return $this->finish_merge();
+        }
+        $this->index_diff_path_selected = true;
+        $new_path_type = $this->index_diff->get_path_type_in_new_index();
+        $old_path_type = $this->index_diff->get_path_type_in_old_index();
+        if (
+            $new_path_type !== null
+            && $this->index_diff->get_preceding_path_in_new_index()
+                === $this->index_diff->get_path()
+        ) {
+            throw new RuntimeException(
+                "Two remote paths map to the same local relative path: "
+                . base64_encode($this->index_diff->get_path())
+                . "."
+            );
+        }
+
+        $write_new_entry = $new_path_type !== null;
+        $write_old_entry = $new_path_type === null
+            && $old_path_type !== null
+            && !file_sync_index_path_may_change(
+                $this->index_diff->get_path(),
+                $this->included_local_index_path_roots,
+                $this->excluded_local_index_path_roots
+            );
+        $has_mapped_descendant = false;
+        if ($write_new_entry || $write_old_entry) {
+            if (!$this->mapped_index_parent_path_selected) {
+                $this->mapped_index_parent_path_selected =
+                    $this->mapped_index_parent_reader->next_path();
+            }
+            if (
+                $this->mapped_index_parent_path_selected
+                && strcmp(
+                    $this->mapped_index_parent_reader->get_path(),
+                    $this->index_diff->get_path()
+                ) < 0
+            ) {
+                $this->mapped_index_parent_path_selected =
+                    $this->mapped_index_parent_reader->next_path();
+                $this->cursor["position"]["mapped_index_parent_cursor"] =
+                    $this->mapped_index_parent_reader->get_cursor();
+                return true;
+            }
+            $has_mapped_descendant =
+                $this->mapped_index_parent_path_selected
+                && $this->mapped_index_parent_reader->get_path()
+                    === $this->index_diff->get_path();
+        }
+        if ($has_mapped_descendant) {
+            // Descendants imply their directory ancestors in a sparse index.
+            if ($write_new_entry && $new_path_type === "dir") {
+                $write_new_entry = false;
+            } elseif ($write_new_entry) {
+                throw new RuntimeException(
+                    "Mapped local index path "
+                    . base64_encode($this->index_diff->get_path())
+                    . " has type {$new_path_type} and has a mapped descendant."
+                );
+            } elseif ($old_path_type === "dir") {
+                $write_old_entry = false;
+            } else {
+                throw new RuntimeException(
+                    "Retained local index path "
+                    . base64_encode($this->index_diff->get_path())
+                    . " has type {$old_path_type} and has a selected mapped descendant."
+                );
+            }
+        }
+        $write_retained_local_metadata =
+            $this->cursor["metadata_source"] === "locally_observed"
+            && $write_new_entry;
+        if (
+            $write_retained_local_metadata
+            && $old_path_type !== $new_path_type
+        ) {
+            return $this->restart();
+        }
+        if ($write_new_entry || $write_old_entry) {
+            $index_entry = [
+                "path" => $this->index_diff->get_path(),
+                "ctime" => $write_new_entry
+                    ? ( $write_retained_local_metadata
+                        ? $this->index_diff->get_ctime_in_old_index()
+                        : $this->index_diff->get_ctime_in_new_index() )
+                    : $this->index_diff->get_ctime_in_old_index(),
+                "size" => $write_new_entry
+                    ? ( $write_retained_local_metadata
+                        ? $this->index_diff->get_size_in_old_index()
+                        : $this->index_diff->get_size_in_new_index() )
+                    : $this->index_diff->get_size_in_old_index(),
+                "type" => $write_new_entry ? $new_path_type : $old_path_type,
+            ];
+            $directory_is_empty = $write_new_entry
+                ? $this->index_diff->get_directory_is_empty_in_new_index()
+                : $this->index_diff->get_directory_is_empty_in_old_index();
+            if ($directory_is_empty !== null) {
+                $index_entry["empty"] = $directory_is_empty;
+            }
+            write_local_index_entry($this->index_handle, $index_entry);
+        }
+
+        $this->index_diff_path_selected = $this->index_diff->next_path();
+        $index_byte_offset = ftell($this->index_handle);
+        if (!is_int($index_byte_offset)) {
+            throw new RuntimeException("Failed to read the pull local index byte offset.");
+        }
+        if (!$this->index_diff_path_selected) {
+            return $this->finish_merge();
+        }
+        $this->cursor["position"] = [
+            "phase" => "merging",
+            "index_diff_cursor" => $this->index_diff->get_cursor(),
+            "mapped_index_parent_cursor" =>
+                $this->mapped_index_parent_reader->get_cursor(),
+            "index_byte_offset" => $index_byte_offset,
+        ];
+        return true;
+    }
+
+    /** @phpstan-return Cursor Cursor after the latest completed step. */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Returns the current durable phase. */
+    public function get_phase(): string
+    {
+        return $this->cursor["position"]["phase"];
+    }
+
+    /** Returns `complete` or `restart` after next_step() returns false. */
+    public function get_status(): ?string
+    {
+        $phase = $this->cursor["position"]["phase"];
+        return $phase === "complete" || $phase === "restart"
+            ? $phase
+            : null;
+    }
+
+    /** Returns the processor-owned patch-result or next-local-index path. */
+    public function get_index_path(): string
+    {
+        return $this->index_file;
+    }
+
+    /** Flushes append-only output before the caller stores get_cursor(). */
+    public function flush_pending_output(): void
+    {
+        if (is_resource($this->mapped_index_handle) && !fflush($this->mapped_index_handle)) {
+            throw new RuntimeException("Failed to flush the mapped pull index.");
+        }
+        if (
+            is_resource($this->mapped_index_parents_handle)
+            && !fflush($this->mapped_index_parents_handle)
+        ) {
+            throw new RuntimeException(
+                "Failed to flush the mapped pull index parents."
+            );
+        }
+        if (is_resource($this->index_handle) && !fflush($this->index_handle)) {
+            throw new RuntimeException("Failed to flush the pull local index.");
+        }
+        if ($this->verification_processor !== null) {
+            $this->verification_processor->flush_pending_outputs();
+        }
+    }
+
+    /** Closes retained handles. Repeated calls do nothing. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        if ($this->remote_index_reader !== null) {
+            $this->remote_index_reader->close();
+            $this->remote_index_reader = null;
+        }
+        if ($this->remote_index_diff !== null) {
+            $this->remote_index_diff->close();
+            $this->remote_index_diff = null;
+        }
+        if (is_resource($this->mapped_index_handle)) {
+            fclose($this->mapped_index_handle);
+            $this->mapped_index_handle = null;
+        }
+        if (is_resource($this->mapped_index_parents_handle)) {
+            fclose($this->mapped_index_parents_handle);
+            $this->mapped_index_parents_handle = null;
+        }
+        if ($this->index_diff !== null) {
+            $this->index_diff->close();
+            $this->index_diff = null;
+        }
+        if ($this->mapped_index_parent_reader !== null) {
+            $this->mapped_index_parent_reader->close();
+            $this->mapped_index_parent_reader = null;
+        }
+        if (is_resource($this->index_handle)) {
+            fclose($this->index_handle);
+            $this->index_handle = null;
+        }
+        if ($this->verification_processor !== null) {
+            $this->verification_processor->close();
+            $this->verification_processor = null;
+        }
+        $this->closed = true;
+    }
+
+    private static function start(
+        string $metadata_source,
+        string $work_directory,
+        string $next_remote_index_file,
+        ?string $remote_index_file,
+        string $retained_local_index_file,
+        RemoteToLocalPathMapper $path_mapper,
+        array $included_local_index_path_roots,
+        array $excluded_local_index_path_roots,
+        string $verification_storage_path,
+        bool $verification_include_caches
+    ): self {
+        if (!is_dir($work_directory)) {
+            throw new LogicException("Cannot start pull local indexing without its work directory: {$work_directory}.");
+        }
+        self::require_file($next_remote_index_file, "next remote index");
+        $remote_index_exists = false;
+        if ($metadata_source === "locally_observed") {
+            if ($remote_index_file === null) {
+                throw new LogicException(
+                    "Cannot build the next local index without its remote index."
+                );
+            }
+            $remote_index_exists = self::optional_file_exists(
+                $remote_index_file,
+                "remote index"
+            );
+        }
+        if (file_exists($retained_local_index_file) && !is_file($retained_local_index_file)) {
+            throw new LogicException("The retained local index path is not a file: {$retained_local_index_file}.");
+        }
+
+        $mapped_index_file = wp_join_unix_paths(
+            $work_directory, "mapped_remote_index.jsonl"
+        );
+        $mapped_index_parents_file = wp_join_unix_paths(
+            $work_directory,
+            "mapped_remote_index_parents.jsonl"
+        );
+        $index_file = wp_join_unix_paths(
+            $work_directory,
+            $metadata_source === "remote_recorded"
+                ? "pull_patch_result_index.jsonl"
+                : "next_local_index.jsonl"
+        );
+        if (file_put_contents($mapped_index_file, "") !== 0) {
+            throw new RuntimeException("Failed to open the mapped pull index.");
+        }
+        if (file_put_contents($mapped_index_parents_file, "") !== 0) {
+            throw new RuntimeException(
+                "Failed to open the mapped pull index parents."
+            );
+        }
+        if (file_put_contents($index_file, "") !== 0) {
+            throw new RuntimeException("Failed to initialize the pull local index.");
+        }
+        if ($metadata_source === "locally_observed") {
+            $position = [
+                "phase" => "mapping",
+                "remote_index_diff_cursor" => [
+                    "old_index_byte_offset" => 0,
+                    "new_index_byte_offset" => 0,
+                    "preceding_new_index_entry_path_b64" => null,
+                ],
+                "mapped_index_byte_offset" => 0,
+                "mapped_index_parents_byte_offset" => 0,
+            ];
+        } else {
+            $position = [
+                "phase" => "mapping",
+                "remote_index_byte_offset" => 0,
+                "mapped_index_byte_offset" => 0,
+                "mapped_index_parents_byte_offset" => 0,
+            ];
+        }
+        return self::resume([
+            "metadata_source" => $metadata_source,
+            "next_remote_index_file_b64" => base64_encode($next_remote_index_file),
+            "remote_index_file_b64" =>
+                $remote_index_file === null
+                    ? null
+                    : base64_encode($remote_index_file),
+            "remote_index_exists" => $remote_index_exists,
+            "retained_local_index_file_b64" => base64_encode($retained_local_index_file),
+            "retained_local_index_exists" => is_file($retained_local_index_file),
+            "mapped_index_file_b64" => base64_encode($mapped_index_file),
+            "mapped_index_parents_file_b64" =>
+                base64_encode($mapped_index_parents_file),
+            "index_file_b64" => base64_encode($index_file),
+            "path_mapper_config" => $path_mapper->get_config(),
+            "included_local_index_path_roots_b64" => array_map("base64_encode", $included_local_index_path_roots),
+            "excluded_local_index_path_roots_b64" => array_map("base64_encode", $excluded_local_index_path_roots),
+            "verification_storage_path_b64" =>
+                base64_encode($verification_storage_path),
+            "verification_include_caches" => $verification_include_caches,
+            "position" => $position,
+        ]);
+    }
+
+    /** Finishes the patch result or starts final next-index verification. */
+    private function finish_merge(): bool
+    {
+        $this->flush_pending_output();
+        $this->index_diff->close();
+        $this->index_diff = null;
+        $this->mapped_index_parent_reader->close();
+        $this->mapped_index_parent_reader = null;
+        fclose($this->index_handle);
+        $this->index_handle = null;
+        if ($this->cursor["metadata_source"] === "remote_recorded") {
+            $this->cursor["position"] = ["phase" => "complete"];
+            $this->close();
+            return false;
+        }
+
+        $this->verification_processor =
+            FileSyncPatchProcessor::start_from_fresh_local_tree(
+                dirname($this->index_file),
+                $this->path_mapper->get_filesystem_root(),
+                $this->index_file,
+                self::decode_cursor_path(
+                    $this->cursor["verification_storage_path_b64"]
+                ),
+                $this->included_local_index_path_roots,
+                $this->excluded_local_index_path_roots,
+                $this->cursor["verification_include_caches"]
+            );
+        $this->cursor["position"] = [
+            "phase" => "verifying",
+            "file_sync_patch_processor_cursor" =>
+                $this->verification_processor->get_cursor(),
+        ];
+        return true;
+    }
+
+    /** Stores stable restart and closes retained handles. */
+    private function restart(): bool
+    {
+        $this->cursor["position"] = ["phase" => "restart"];
+        $this->close();
+        return false;
+    }
+
+    /** Confirms that the retained index still has its starting presence. */
+    private function assert_retained_local_index_state(): void
+    {
+        if (is_file($this->retained_local_index_file) !== $this->cursor["retained_local_index_exists"]) {
+            throw new RuntimeException("The retained local index presence changed during pull local indexing.");
+        }
+    }
+
+    /** Decodes one arbitrary-byte path stored in the JSON cursor. */
+    private static function decode_cursor_path(string $encoded_path): string
+    {
+        $path = base64_decode($encoded_path, true);
+        if ($path === false) {
+            throw new InvalidArgumentException("Pull local index cursor contains an invalid base64 path.");
+        }
+        return $path;
+    }
+
+    /** Requires one regular file before a phase uses it. */
+    private static function require_file(string $path, string $name): void
+    {
+        if (!is_file($path)) {
+            throw new RuntimeException("Pull local index {$name} is missing: {$path}.");
+        }
+    }
+
+    /** Returns whether an optional regular file is present. */
+    private static function optional_file_exists(
+        string $path,
+        string $name
+    ): bool {
+        if (is_file($path)) {
+            return true;
+        }
+        if (file_exists($path) || is_link($path)) {
+            throw new RuntimeException(
+                "The {$name} path is not a file: {$path}."
+            );
+        }
+        return false;
+    }
+
+    /**
+     * Opens an append-only output at its last saved byte offset.
+     *
+     * @return resource Open output handle.
+     */
+    private static function open_and_truncate_to_saved_byte_offset(
+        string $path,
+        int $byte_offset,
+        string $name
+    ) {
+        $handle = fopen($path, "r+b");
+        if (
+            !is_resource($handle)
+            || !ftruncate($handle, $byte_offset)
+            || fseek($handle, $byte_offset) !== 0
+        ) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            throw new RuntimeException("Failed to restore the {$name} to byte offset {$byte_offset}.");
+        }
+        return $handle;
+    }
+}

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -356,20 +356,11 @@ final class FileIndexProcessor {
             // exclusions. A cache or Reprint-storage child still makes its
             // parent non-empty; calling that parent empty could turn an
             // intentionally omitted descendant into destructive push work.
-            $directory_handle = @opendir($path);
-            if ($directory_handle !== false) {
-                $item["empty"] = true;
-                while (true) {
-                    $directory_entry = readdir($directory_handle);
-                    if ($directory_entry === false) {
-                        break;
-                    }
-                    if ($directory_entry !== "." && $directory_entry !== "..") {
-                        $item["empty"] = false;
-                        break;
-                    }
-                }
-                closedir($directory_handle);
+            $directory_is_empty = \WordPress\Reprint\Exporter\read_file_index_directory_is_empty(
+                $path
+            );
+            if ($directory_is_empty !== null) {
+                $item["empty"] = $directory_is_empty;
             }
             // When the directory cannot be inspected, leave "empty" absent.
             // Pull reports the later directory-open failure. A push index

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -542,6 +542,31 @@ function read_file_index_entry_from_stat(string $path, array $path_stat): array
 }
 
 /**
+ * Reads whether a physical directory has any children.
+ *
+ * @return bool|null True for an empty directory, false for a non-empty
+ *                   directory, or null when the directory cannot be opened.
+ */
+function read_file_index_directory_is_empty(string $path): ?bool
+{
+    $directory_handle = @opendir($path);
+    if ($directory_handle === false) {
+        return null;
+    }
+    while (true) {
+        $directory_entry = readdir($directory_handle);
+        if ($directory_entry === false) {
+            closedir($directory_handle);
+            return true;
+        }
+        if ($directory_entry !== "." && $directory_entry !== "..") {
+            closedir($directory_handle);
+            return false;
+        }
+    }
+}
+
+/**
  * Validates that a path is a non-empty absolute string without NUL bytes
  * or dot-segments (. or ..).
  *

--- a/tests/Import/PullLocalIndexProcessorTest.php
+++ b/tests/Import/PullLocalIndexProcessorTest.php
@@ -1,0 +1,1416 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use function Reprint\Importer\decode_local_index_entry;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-pull-local-index-processor.php';
+
+final class PullLocalIndexProcessorTest extends TestCase {
+    private string $temporary_directory;
+    private string $filesystem_root;
+    private string $work_directory;
+    private string $next_remote_index_file;
+    private string $remote_index_file;
+    private string $retained_local_index_file;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporary_directory = sys_get_temp_dir()
+            . '/pull-local-index-processor-test-'
+            . bin2hex(random_bytes(6));
+        $this->filesystem_root =
+            $this->temporary_directory . '/filesystem-root';
+        $this->work_directory = $this->temporary_directory . '/work';
+        $this->next_remote_index_file =
+            $this->temporary_directory . '/next-remote-index.jsonl';
+        $this->remote_index_file =
+            $this->temporary_directory . '/remote-index.jsonl';
+        $this->retained_local_index_file =
+            $this->temporary_directory . '/retained-local-index.jsonl';
+        mkdir($this->filesystem_root, 0700, true);
+        mkdir($this->work_directory, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_path($this->temporary_directory);
+        parent::tearDown();
+    }
+
+    public function testSortsMappedPathsAfterRemapsChangeTheirOrder(): void
+    {
+        $this->write_file('a-local.txt', 'a-local');
+        $this->write_file('z-local.txt', 'z-local');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/a.txt', 'file', 900, 900),
+            $this->remote_entry('/remote/z.txt', 'file', 901, 901),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('a-local.txt'),
+            $this->local_entry_from_path('z-local.txt'),
+        ]);
+        $mapper = new RemoteToLocalPathMapper(
+            $this->filesystem_root,
+            ['/remote'],
+            [
+                '/remote/a.txt' => $this->filesystem_root . '/z-local.txt',
+                '/remote/z.txt' => $this->filesystem_root . '/a-local.txt',
+            ]
+        );
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $mapper,
+                $this->temporary_directory . '/storage',
+                false
+            )
+        );
+
+        $this->assertSame(
+            ['a-local.txt', 'z-local.txt'],
+            array_column($entries, 'path')
+        );
+        $a_stat = lstat($this->filesystem_root . '/a-local.txt');
+        $z_stat = lstat($this->filesystem_root . '/z-local.txt');
+        $this->assertIsArray($a_stat);
+        $this->assertIsArray($z_stat);
+        $this->assertSame( (int) $a_stat['ctime'], $entries[0]['ctime']);
+        $this->assertSame( (int) $a_stat['size'], $entries[0]['size']);
+        $this->assertSame( (int) $z_stat['ctime'], $entries[1]['ctime']);
+        $this->assertSame( (int) $z_stat['size'], $entries[1]['size']);
+    }
+
+    public function testPatchResultKeepsRemoteMetadataAndEmptyDirectory(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/empty', 'dir', 0, 456, true),
+            $this->remote_entry('/remote/file.txt', 'file', 123, 789),
+        ]);
+        $this->write_local_index([]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                )
+            )
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'path' => 'empty',
+                    'ctime' => 456,
+                    'size' => 0,
+                    'type' => 'dir',
+                    'empty' => true,
+                ],
+                [
+                    'path' => 'file.txt',
+                    'ctime' => 789,
+                    'size' => 123,
+                    'type' => 'file',
+                ],
+            ],
+            $entries
+        );
+    }
+
+    public function testFilesystemRootIsATraversalBoundaryNotAnIndexEntry(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote', 'dir', 0, 10, true),
+        ]);
+        $this->write_local_index([]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                )
+            )
+        );
+
+        $this->assertSame([], $entries);
+    }
+
+    public function testRejectsSelectedRemoteDirectoryWithoutAnEmptyScan(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/unreadable', 'dir'),
+        ]);
+        $this->write_local_index([]);
+        $processor = PullLocalIndexProcessor::start_patch_result(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                ['/remote' => $this->filesystem_root]
+            )
+        );
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Remote directory was not confirmed empty during indexing: '
+                    . base64_encode('/remote/unreadable')
+                    . '.'
+            );
+            $processor->next_step();
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testDropsSelectedRetainedPathsMissingFromTheRemoteTree(): void
+    {
+        $this->write_file('kept.txt', 'remote value');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/kept.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('kept.txt'),
+            $this->local_entry('local-stale.txt', 2, 2),
+            $this->local_entry('pushed-after-pull.txt', 3, 3),
+        ]);
+
+        $entries = $this->run_to_completion($this->start_processor());
+
+        $this->assertSame(['kept.txt'], array_column($entries, 'path'));
+    }
+
+    public function testRetainsPathsOutsideSelectionAndUnderExclusions(): void
+    {
+        $this->write_file('selected/current.txt', 'current');
+        $this->write_file('selected/excluded/remote.txt', 'excluded remote');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/selected/current.txt', 'file'),
+            $this->remote_entry('/remote/selected/excluded/remote.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry('outside.txt', 10, 10),
+            $this->local_entry('selected/excluded/retained.txt', 11, 11),
+            $this->local_entry('selected/stale.txt', 12, 12),
+            $this->local_entry_from_path('selected/current.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(
+                ['selected'],
+                ['selected/excluded']
+            )
+        );
+
+        $this->assertSame(
+            [
+                'outside.txt',
+                'selected/current.txt',
+                'selected/excluded/retained.txt',
+            ],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testDropsRetainedEmptyDirectoryImpliedBySelectedDescendant(): void
+    {
+        $this->write_file('parent/child.txt', 'child');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/parent/child.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            [
+                'path' => 'parent',
+                'ctime' => 10,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => true,
+            ],
+            $this->local_entry_from_path('parent/child.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(['parent/child.txt'])
+        );
+
+        $this->assertSame(
+            ['parent/child.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testDropsRetainedEmptyDirectoryAcrossInterleavingNewPath(): void
+    {
+        $this->write_file('parent-name.txt', 'unrelated');
+        $this->write_file('parent/child.txt', 'child');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/parent-name.txt', 'file'),
+            $this->remote_entry('/remote/parent/child.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            [
+                'path' => 'parent',
+                'ctime' => 10,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => true,
+            ],
+            $this->local_entry_from_path('parent-name.txt'),
+            $this->local_entry_from_path('parent/child.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(
+                ['parent-name.txt', 'parent/child.txt']
+            )
+        );
+
+        $this->assertSame(
+            ['parent-name.txt', 'parent/child.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testDropsMappedEmptyDirectoryImpliedByOverlappingRemapDescendant(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/empty', 'dir', 0, 10, true),
+            $this->remote_entry('/remote/interleaving.txt', 'file', 11, 11),
+            $this->remote_entry('/remote/leaf.txt', 'file', 12, 12),
+        ]);
+        $this->write_local_index([]);
+        $processor = PullLocalIndexProcessor::start_patch_result(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                [
+                    '/remote/empty' => $this->filesystem_root . '/parent',
+                    '/remote/interleaving.txt' =>
+                        $this->filesystem_root . '/parent-name.txt',
+                    '/remote/leaf.txt' =>
+                        $this->filesystem_root . '/parent/child.txt',
+                ]
+            )
+        );
+
+        $entries = $this->run_to_completion($processor);
+
+        $this->assertSame(
+            ['parent-name.txt', 'parent/child.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    /** @dataProvider mappedLeafAncestorTypeProvider */
+    public function testRejectsMappedLeafAncestorOfMappedDescendant(
+        string $ancestor_type
+    ): void {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/ancestor', $ancestor_type),
+            $this->remote_entry('/remote/leaf.txt', 'file'),
+        ]);
+        $this->write_local_index([]);
+        $processor = PullLocalIndexProcessor::start_patch_result(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                [
+                    '/remote/ancestor' => $this->filesystem_root . '/parent',
+                    '/remote/leaf.txt' =>
+                        $this->filesystem_root . '/parent/child.txt',
+                ]
+            )
+        );
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Mapped local index path '
+                    . base64_encode('parent')
+                    . " has type {$ancestor_type} and has a mapped descendant."
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function mappedLeafAncestorTypeProvider(): iterable
+    {
+        yield 'file' => ['file'];
+        yield 'link' => ['link'];
+    }
+
+    public function testRejectsRetainedFileOutsideNarrowSelectionWithMappedDescendant(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/parent-name.txt', 'file'),
+            $this->remote_entry('/remote/parent/child.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry('parent', 10, 10),
+        ]);
+        $processor = PullLocalIndexProcessor::start_patch_result(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                ['/remote' => $this->filesystem_root]
+            ),
+            ['parent-name.txt', 'parent/child.txt']
+        );
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Retained local index path '
+                    . base64_encode('parent')
+                    . ' has type file and has a selected mapped descendant.'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testResumeBetweenParentMembershipLookupsWithInterleavingPath(): void
+    {
+        $this->write_file('parent-name.txt', 'unrelated');
+        $this->write_file('parent/child.txt', 'child');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/parent-name.txt', 'file'),
+            $this->remote_entry('/remote/parent/child.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            [
+                'path' => 'parent',
+                'ctime' => 10,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => true,
+            ],
+            $this->local_entry_from_path('parent-name.txt'),
+            $this->local_entry_from_path('parent/child.txt'),
+        ]);
+        $processor = $this->start_processor(
+            ['parent-name.txt', 'parent/child.txt']
+        );
+        while ($processor->get_phase() !== 'merging') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $cursor_before_parent_lookup_advance = $processor->get_cursor();
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $cursor = $processor->get_cursor();
+        $this->assertSame(
+            $cursor_before_parent_lookup_advance['position'][
+                'index_diff_cursor'
+            ],
+            $cursor['position']['index_diff_cursor']
+        );
+        $this->assertGreaterThan(
+            0,
+            $cursor['position']['mapped_index_parent_cursor'][
+                'new_index_byte_offset'
+            ]
+        );
+        $this->assertIsString(json_encode($cursor, JSON_THROW_ON_ERROR));
+        $processor->close();
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($cursor)
+        );
+        $this->assertSame(
+            ['parent-name.txt', 'parent/child.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testFirstPullDoesNotAddAnExcludedRemoteEntry(): void
+    {
+        $this->write_file('selected/keep.txt', 'keep');
+        $this->write_file('selected/excluded.txt', 'excluded');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/selected/excluded.txt', 'file'),
+            $this->remote_entry('/remote/selected/keep.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('selected/keep.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(
+                ['selected'],
+                ['selected/excluded.txt']
+            )
+        );
+
+        $this->assertSame(['selected/keep.txt'], array_column($entries, 'path'));
+    }
+
+    public function testSkipsARemoteParentWhichContainsAnExcludedRoot(): void
+    {
+        mkdir($this->filesystem_root . '/selected/parent/protected', 0700, true);
+        $this->write_file(
+            'selected/parent/protected/keep.txt',
+            'protected'
+        );
+        $this->write_remote_index([
+            $this->remote_entry(
+                '/remote/selected/parent',
+                'dir',
+                0,
+                1,
+                true
+            ),
+        ]);
+        $this->write_local_index([
+            $this->local_entry(
+                'selected/parent/protected/keep.txt',
+                10,
+                9
+            ),
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(
+                ['selected'],
+                ['selected/parent/protected']
+            )
+        );
+
+        $this->assertSame(
+            ['selected/parent/protected/keep.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testKeepsAnEmptyDirectorySparseWhenItHasAnUnmanagedChild(): void
+    {
+        mkdir($this->filesystem_root . '/parent', 0700, true);
+        $this->write_file('parent/node_modules/package.js', 'unmanaged');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/parent', 'dir', 0, 1, true),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('parent'),
+        ]);
+
+        $entries = $this->run_to_completion($this->start_processor());
+
+        $this->assertSame([], $entries);
+    }
+
+    public function testDropsRetainedEmptyAncestorWhenSelectedDirectoryHasAnUnmanagedChild(): void
+    {
+        $this->write_file(
+            'parent/child/node_modules/package.js',
+            'unmanaged'
+        );
+        $this->write_remote_index([
+            $this->remote_entry(
+                '/remote/parent/child',
+                'dir',
+                0,
+                1,
+                true
+            ),
+        ]);
+        $this->write_local_index([
+            [
+                'path' => 'parent',
+                'ctime' => 10,
+                'size' => 0,
+                'type' => 'dir',
+                'empty' => true,
+            ],
+        ]);
+
+        $entries = $this->run_to_completion(
+            $this->start_processor(['parent/child'])
+        );
+
+        $this->assertSame([], $entries);
+    }
+
+    public function testWritesALocallyEmptyRemoteDirectory(): void
+    {
+        mkdir($this->filesystem_root . '/empty', 0700, true);
+        $this->write_remote_index([
+            $this->remote_entry('/remote/empty', 'dir', 0, 10, true),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('empty'),
+        ]);
+
+        $entries = $this->run_to_completion($this->start_processor());
+
+        $this->assertCount(1, $entries);
+        $this->assertSame('empty', $entries[0]['path']);
+        $this->assertSame('dir', $entries[0]['type']);
+        $this->assertTrue($entries[0]['empty']);
+        $local_stat = lstat($this->filesystem_root . '/empty');
+        $this->assertIsArray($local_stat);
+        $this->assertSame(
+            (int) $local_stat['ctime'],
+            $entries[0]['ctime']
+        );
+    }
+
+    public function testRejectsRemotePathsWhichMapToTheSameLocalPath(): void
+    {
+        $this->write_file('collision.txt', 'collision');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/a.txt', 'file'),
+            $this->remote_entry('/remote/b.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('collision.txt'),
+        ]);
+        $local_path = $this->filesystem_root . '/collision.txt';
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                [
+                    '/remote/a.txt' => $local_path,
+                    '/remote/b.txt' => $local_path,
+                ]
+            ),
+            $this->temporary_directory . '/storage',
+            false
+        );
+
+        try {
+            for ($step = 0; $step < 30; ++$step) {
+                $processor->next_step();
+            }
+            $this->fail('Expected the local mapping collision to throw.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame(
+                'Two remote paths map to the same local relative path: '
+                    . base64_encode('collision.txt') . '.',
+                $exception->getMessage()
+            );
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testMissingMappedPathReturnsStableRestart(): void
+    {
+        $this->write_file('missing.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/missing.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('missing.txt'),
+        ]);
+        unlink($this->filesystem_root . '/missing.txt');
+        $processor = $this->start_processor();
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $this->assertFalse($processor->next_step());
+        $cursor = json_decode(
+            json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $processor->close();
+        $resumed = PullLocalIndexProcessor::resume($cursor);
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('restart', $resumed->get_status());
+        $resumed->close();
+    }
+
+    public function testMappedPathTypeChangeReturnsRestart(): void
+    {
+        $this->write_file('value', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value'),
+        ]);
+        unlink($this->filesystem_root . '/value');
+        mkdir($this->filesystem_root . '/value', 0700, true);
+        $processor = $this->start_processor();
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testFileChangedBeforeCandidateMappingReturnsRestart(): void
+    {
+        $this->write_file('value.txt', 'old');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file', 3, 10),
+        ]);
+        $retained_entry = $this->local_entry_from_path('value.txt');
+        $this->write_local_index([$retained_entry]);
+        $this->write_file('value.txt', 'changed after fetch');
+
+        $processor = $this->start_processor();
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $candidate_entries = $this->read_local_index(
+            $processor->get_index_path()
+        );
+        $this->assertSame($retained_entry['size'], $candidate_entries[0]['size']);
+        $this->assertSame(
+            $retained_entry['ctime'],
+            $candidate_entries[0]['ctime']
+        );
+        $processor->close();
+    }
+
+    public function testLocalOnlyAdditionDuringFinalVerificationReturnsRestart(): void
+    {
+        $this->write_file('value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file', 7, 10),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value.txt'),
+        ]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+
+        $this->write_file('local-only.txt', 'new local value');
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testNextRemoteEntryMissingFromRemoteIndexReturnsRestart(): void
+    {
+        $this->write_file('value.txt', 'fetched');
+        $target_entry = $this->remote_entry(
+            '/remote/value.txt',
+            'file',
+            7,
+            10
+        );
+        $this->write_remote_index([$target_entry]);
+        $this->write_remote_index_file($this->remote_index_file, []);
+        $this->write_local_index([
+            $this->local_entry_from_path('value.txt'),
+        ]);
+        $processor = $this->start_processor();
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testSelectedRemoteIndexEntryMissingFromNextRemoteIndexReturnsRestart(): void
+    {
+        $stale_entry = $this->remote_entry(
+            '/remote/stale.txt',
+            'file',
+            7,
+            10
+        );
+        $this->write_remote_index([]);
+        $this->write_remote_index_file(
+            $this->remote_index_file,
+            [$stale_entry]
+        );
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testNonzeroNextRemoteSymlinkSizeMustMatchRemoteIndex(): void
+    {
+        $link_path = $this->filesystem_root . '/link';
+        $this->assertTrue(symlink('abcdefghij', $link_path));
+        $next_remote_entry = $this->remote_entry(
+            '/remote/link',
+            'link',
+            10,
+            20
+        );
+        $remote_entry = $this->remote_entry(
+            '/remote/link',
+            'link',
+            9,
+            20
+        );
+        $this->write_remote_index([$next_remote_entry]);
+        $this->write_remote_index_file(
+            $this->remote_index_file,
+            [$remote_entry]
+        );
+        $this->write_local_index([
+            $this->local_entry_from_path('link'),
+        ]);
+        $processor = $this->start_processor();
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    /** @dataProvider verificationPhaseProvider */
+    public function testResumeFromEachFinalVerificationPhase(
+        string $verification_phase
+    ): void {
+        $this->write_file('value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file', 7, 10),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value.txt'),
+        ]);
+        $processor = $this->start_processor();
+        while (true) {
+            $cursor = $processor->get_cursor();
+            if (
+                $processor->get_phase() === 'verifying'
+                && $cursor['position']['file_sync_patch_processor_cursor']
+                    ['position']['phase'] === $verification_phase
+            ) {
+                break;
+            }
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $cursor = json_decode(
+            json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $processor->close();
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($cursor)
+        );
+
+        $this->assertSame(['value.txt'], array_column($entries, 'path'));
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function verificationPhaseProvider(): iterable
+    {
+        yield 'indexing' => ['indexing'];
+        yield 'sorting' => ['sorting'];
+        yield 'starting patch' => ['starting_patch'];
+        yield 'planning' => ['planning'];
+    }
+
+    public function testCursorAndIndexesSupportArbitraryPathBytes(): void
+    {
+        $remote_root = "/remote-\xfd";
+        $local_root = $this->filesystem_root . '/selected';
+        $local_path = $local_root . '/file.txt';
+        mkdir($local_root, 0700, true);
+        file_put_contents($local_path, 'bytes');
+        $this->write_remote_index([
+            $this->remote_entry(
+                $remote_root . "/file-\xff.txt",
+                'file'
+            ),
+        ]);
+        $this->write_local_index([
+            $this->local_entry("outside-\xfa.txt", 10, 10),
+            $this->local_entry_from_path('selected/file.txt'),
+        ]);
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                [$remote_root],
+                [$remote_root . "/file-\xff.txt" => $local_path]
+            ),
+            $this->temporary_directory . '/storage',
+            false,
+            ['selected'],
+            ["selected/excluded-\xfc"]
+        );
+        $cursor = $processor->get_cursor();
+        $this->assertIsString(json_encode($cursor, JSON_THROW_ON_ERROR));
+        $processor->close();
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($cursor)
+        );
+
+        $this->assertSame(
+            ["outside-\xfa.txt", 'selected/file.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testResumeTruncatesUnstoredMappedEntries(): void
+    {
+        $this->write_file('a/one.txt', 'a');
+        $this->write_file('b/two.txt', 'b');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/a/one.txt', 'file'),
+            $this->remote_entry('/remote/b/two.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('a/one.txt'),
+            $this->local_entry_from_path('b/two.txt'),
+        ]);
+        $processor = $this->start_processor();
+
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $saved_cursor = $processor->get_cursor();
+        $saved_offset = $saved_cursor['position'][
+            'mapped_index_byte_offset'
+        ];
+        $saved_parents_offset = $saved_cursor['position'][
+            'mapped_index_parents_byte_offset'
+        ];
+        $this->assertGreaterThan(0, $saved_offset);
+        $this->assertGreaterThan(0, $saved_parents_offset);
+
+        $this->assertTrue($processor->next_step());
+        $processor->close();
+        $mapped_local_index_file = base64_decode(
+            $saved_cursor['mapped_index_file_b64'],
+            true
+        );
+        $this->assertIsString($mapped_local_index_file);
+        $mapped_index_parents_file = base64_decode(
+            $saved_cursor['mapped_index_parents_file_b64'],
+            true
+        );
+        $this->assertIsString($mapped_index_parents_file);
+        clearstatcache(true, $mapped_local_index_file);
+        clearstatcache(true, $mapped_index_parents_file);
+        $this->assertGreaterThan(
+            $saved_offset,
+            filesize($mapped_local_index_file)
+        );
+        $this->assertGreaterThan(
+            $saved_parents_offset,
+            filesize($mapped_index_parents_file)
+        );
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($saved_cursor)
+        );
+        $this->assertSame(
+            ['a/one.txt', 'b/two.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    /** @dataProvider phaseCursorProvider */
+    public function testResumeContinuesFromEachDurablePhase(
+        string $phase
+    ): void {
+        $this->write_file('value.txt', 'value');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value.txt'),
+        ]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== $phase) {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $cursor = $processor->get_cursor();
+        $this->assertIsString(json_encode($cursor, JSON_THROW_ON_ERROR));
+        $processor->close();
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($cursor)
+        );
+
+        $this->assertSame(['value.txt'], array_column($entries, 'path'));
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function phaseCursorProvider(): iterable
+    {
+        yield 'sorting' => ['sorting'];
+        yield 'sorting parents' => ['sorting_parents'];
+        yield 'starting merge' => ['starting_merge'];
+        yield 'merging' => ['merging'];
+    }
+
+    public function testCompleteAndCloseAreStable(): void
+    {
+        $this->write_remote_index([]);
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $this->run_to_completion_without_closing($processor);
+        $complete_cursor = json_decode(
+            json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertFalse($processor->next_step());
+        $processor->close();
+        $processor->close();
+        $this->assertFalse($processor->next_step());
+        $this->assertSame($complete_cursor, $processor->get_cursor());
+
+        $resumed = PullLocalIndexProcessor::resume($complete_cursor);
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('complete', $resumed->get_phase());
+        $resumed->close();
+    }
+
+    public function testMissingRemoteIndexRepresentsAnEmptyConfirmationIndex(): void
+    {
+        $this->write_remote_index([]);
+        unlink($this->remote_index_file);
+        $this->write_local_index([]);
+
+        $entries = $this->run_to_completion($this->start_processor());
+
+        $this->assertSame([], $entries);
+    }
+
+    public function testCompleteResumeRejectsADeletedOutput(): void
+    {
+        $this->write_remote_index([]);
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $this->run_to_completion_without_closing($processor);
+        $cursor = $processor->get_cursor();
+        $output = $processor->get_index_path();
+        $processor->close();
+        unlink($output);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('output index is missing');
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    public function testMappingResumeRejectsADeletedNextRemoteIndex(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file'),
+        ]);
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $cursor = $processor->get_cursor();
+        $processor->close();
+        unlink($this->next_remote_index_file);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('next remote index is missing');
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    /** @dataProvider remoteIndexStartingPresenceProvider */
+    public function testMappingResumeRejectsRemoteIndexPresenceDrift(
+        bool $starts_present
+    ): void
+    {
+        $this->write_remote_index([]);
+        if (!$starts_present) {
+            unlink($this->remote_index_file);
+        }
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $cursor = $processor->get_cursor();
+        $processor->close();
+        if ($starts_present) {
+            unlink($this->remote_index_file);
+        } else {
+            file_put_contents($this->remote_index_file, '');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'remote index presence changed during pull local indexing'
+        );
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    /** @return iterable<string,array{bool}> */
+    public static function remoteIndexStartingPresenceProvider(): iterable
+    {
+        yield 'present then missing' => [true];
+        yield 'missing then present' => [false];
+    }
+
+    public function testSortingResumeRejectsADeletedMappedIndex(): void
+    {
+        $this->write_remote_index([]);
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $this->assertTrue($processor->next_step());
+        $cursor = $processor->get_cursor();
+        $mapped_index = base64_decode(
+            $cursor['mapped_index_file_b64'],
+            true
+        );
+        $this->assertIsString($mapped_index);
+        $processor->close();
+        unlink($mapped_index);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('mapped index is missing');
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    public function testSortingParentsResumeRejectsADeletedParentIndex(): void
+    {
+        $this->write_remote_index([]);
+        $this->write_local_index([]);
+        $processor = $this->start_processor();
+        $this->assertTrue($processor->next_step());
+        $this->assertTrue($processor->next_step());
+        $cursor = $processor->get_cursor();
+        $mapped_index_parents = base64_decode(
+            $cursor['mapped_index_parents_file_b64'],
+            true
+        );
+        $this->assertIsString($mapped_index_parents);
+        $processor->close();
+        unlink($mapped_index_parents);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('mapped index parents is missing');
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    public function testStartingMergeResumeRejectsADeletedRetainedIndex(): void
+    {
+        $this->write_remote_index([]);
+        $this->write_local_index([
+            $this->local_entry('retained.txt', 1, 1),
+        ]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== 'starting_merge') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $cursor = $processor->get_cursor();
+        $processor->close();
+        unlink($this->retained_local_index_file);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('retained local index presence changed');
+        PullLocalIndexProcessor::resume($cursor);
+    }
+
+    public function testResumeTruncatesUnstoredDesiredEntries(): void
+    {
+        $this->write_file('a.txt', 'a');
+        $this->write_file('b.txt', 'b');
+        $this->write_file('c.txt', 'c');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/a.txt', 'file'),
+            $this->remote_entry('/remote/b.txt', 'file'),
+            $this->remote_entry('/remote/c.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('a.txt'),
+            $this->local_entry_from_path('b.txt'),
+            $this->local_entry_from_path('c.txt'),
+        ]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== 'merging') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+
+        do {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        } while (
+            $processor->get_cursor()['position']['index_byte_offset'] === 0
+        );
+        $saved_cursor = $processor->get_cursor();
+        $saved_offset = $saved_cursor['position'][
+            'index_byte_offset'
+        ];
+        $this->assertGreaterThan(0, $saved_offset);
+
+        do {
+            $this->assertTrue($processor->next_step());
+        } while (
+            $processor->get_cursor()['position']['index_byte_offset']
+                === $saved_offset
+        );
+        $processor->close();
+        $desired_local_index_file = base64_decode(
+            $saved_cursor['index_file_b64'],
+            true
+        );
+        $this->assertIsString($desired_local_index_file);
+        clearstatcache(true, $desired_local_index_file);
+        $this->assertGreaterThan(
+            $saved_offset,
+            filesize($desired_local_index_file)
+        );
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::resume($saved_cursor)
+        );
+        $this->assertSame(
+            ['a.txt', 'b.txt', 'c.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    /**
+     * @param list<string> $included_local_index_path_roots
+     * @param list<string> $excluded_local_index_path_roots
+     */
+    private function start_processor(
+        array $included_local_index_path_roots = [""],
+        array $excluded_local_index_path_roots = []
+    ): PullLocalIndexProcessor
+    {
+        return PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                ['/remote'],
+                ['/remote' => $this->filesystem_root]
+            ),
+            $this->temporary_directory . '/storage',
+            false,
+            $included_local_index_path_roots,
+            $excluded_local_index_path_roots
+        );
+    }
+
+    /** @return list<array{path:string,ctime:int,size:int,type:string,empty?:bool}> */
+    private function run_to_completion(
+        PullLocalIndexProcessor $processor
+    ): array {
+        $this->run_to_completion_without_closing($processor);
+        $this->assertSame('complete', $processor->get_status());
+        $desired_local_index_path =
+            $processor->get_index_path();
+        $processor->close();
+        return $this->read_local_index($desired_local_index_path);
+    }
+
+    private function run_to_completion_without_closing(
+        PullLocalIndexProcessor $processor
+    ): void {
+        for ($step = 0; $step < 300; ++$step) {
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            if (!$has_next_step) {
+                return;
+            }
+        }
+        $processor->close();
+        $this->fail(
+            'Pull local indexing did not complete within 300 steps.'
+        );
+    }
+
+    /** @param list<array<string,mixed>> $entries */
+    private function write_remote_index(array $entries): void
+    {
+        $this->write_remote_index_file(
+            $this->next_remote_index_file,
+            $entries
+        );
+        $this->write_remote_index_file($this->remote_index_file, $entries);
+    }
+
+    /** @param list<array<string,mixed>> $entries */
+    private function write_remote_index_file(
+        string $path,
+        array $entries
+    ): void
+    {
+        usort(
+            $entries,
+            static fn (array $left, array $right): int =>
+                strcmp($left['path'], $right['path'])
+        );
+        $lines = [];
+        foreach ($entries as $entry) {
+            $entry['path'] = base64_encode($entry['path']);
+            $lines[] = json_encode(
+                $entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+        file_put_contents(
+            $path,
+            $lines === [] ? '' : implode("\n", $lines) . "\n"
+        );
+    }
+
+    /** @param list<array<string,mixed>> $entries */
+    private function write_local_index(array $entries): void
+    {
+        usort(
+            $entries,
+            static fn (array $left, array $right): int =>
+                strcmp($left['path'], $right['path'])
+        );
+        $lines = [];
+        foreach ($entries as $entry) {
+            $entry['path'] = base64_encode($entry['path']);
+            $lines[] = json_encode(
+                $entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+        file_put_contents(
+            $this->retained_local_index_file,
+            $lines === [] ? '' : implode("\n", $lines) . "\n"
+        );
+    }
+
+    /**
+     * @return array{path:string,ctime:int,size:int,type:string,empty?:bool}
+     */
+    private function remote_entry(
+        string $path,
+        string $type,
+        int $size = 1,
+        int $ctime = 1,
+        ?bool $directory_is_empty = null
+    ): array {
+        $entry = [
+            'path' => $path,
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => $type,
+        ];
+        if ($directory_is_empty !== null) {
+            $entry['empty'] = $directory_is_empty;
+        }
+        return $entry;
+    }
+
+    /** @return array{path:string,ctime:int,size:int,type:string} */
+    private function local_entry(
+        string $path,
+        int $ctime,
+        int $size
+    ): array {
+        return [
+            'path' => $path,
+            'ctime' => $ctime,
+            'size' => $size,
+            'type' => 'file',
+        ];
+    }
+
+    /** @return array{path:string,ctime:int,size:int,type:string} */
+    private function local_entry_from_path(string $relative_path): array
+    {
+        $absolute_path = $this->filesystem_root . '/' . $relative_path;
+        $path_stat = lstat($absolute_path);
+        $this->assertIsArray($path_stat);
+        $entry = \WordPress\Reprint\Exporter\read_file_index_entry_from_stat(
+            $absolute_path,
+            $path_stat
+        );
+        $entry['path'] = $relative_path;
+        $this->assertNotSame('other', $entry['type']);
+        return $entry;
+    }
+
+    /** @return list<array{path:string,ctime:int,size:int,type:string,empty?:bool}> */
+    private function read_local_index(string $path): array
+    {
+        $lines = file(
+            $path,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        return array_map(
+            static fn (string $line): array => decode_local_index_entry($line),
+            $lines
+        );
+    }
+
+    private function write_file(string $relative_path, string $contents): void
+    {
+        $path = $this->filesystem_root . '/' . $relative_path;
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0700, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    private function remove_path(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $child) {
+            if ($child !== '.' && $child !== '..') {
+                $this->remove_path($path . '/' . $child);
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
Adds `PullLocalIndexProcessor`, a resumable processor which maps a remote index into local coordinates, sorts mapped entries, and merges them with the retained local index.

The processor builds a patch-result index from remote metadata for pre-fetch cleanup. After fetch, it builds a next local index from target-confirmed local metadata and checks it against one fresh local scan. A changed local tree returns `restart`; a matching tree returns `complete`.

Mapping collisions and file-or-link ancestors are rejected. Empty directories remain sparse when a selected or omitted child makes them nonempty. Each processor step advances one mapping, sort, merge, or verification boundary, and its JSON-safe cursor resumes without accepting unconfirmed output bytes.

## Testing

The processor suite covers remap reordering, overlapping mappings, sparse directories, scoped retention, fetch confirmation, restart after local changes, arbitrary path bytes, output truncation, and resume at each phase.

Stacked on #598.