### PR TITLE
[PHP] Retain file-index selection across interrupted commands

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -917,25 +917,134 @@ class ImportClient
 
         $this->state = $this->load_state();
 
+        if (
+            ( !$abort && in_array($command, ["pull", "pull-files", "pull-db"], true) )
+            || in_array($command, ["files-pull", "files-index"], true)
+        ) {
+            $this->pull->assert_command_owns_resume_state($command, $options);
+        }
+
         if ($command === "pull-metadata") {
             $this->run_pull_metadata();
             return;
         }
 
-        // Persist follow_symlinks in state so it survives across invocations.
-        // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
-        if (isset($options["follow_symlinks"])) {
-            $this->get_state()->follow_symlinks = $this->follow_symlinks;
-            $this->save_state();
-        } elseif (isset($this->get_state()->follow_symlinks)) {
-            $this->follow_symlinks = $this->get_state()->follow_symlinks;
+        $file_index_lifecycle_command = null;
+        if (in_array($command, ["pull", "pull-files", "files-pull"], true)) {
+            $file_index_lifecycle_command = "files-pull";
+        } elseif ($command === "files-index") {
+            $file_index_lifecycle_command = "files-index";
         }
 
-        if (isset($options["local_followed_symlinks_root"])) {
-            $this->local_followed_symlinks_root = $this->resolve_local_followed_symlinks_root($options["local_followed_symlinks_root"]);
-            $this->follow_symlinks = true;
-            $this->get_state()->follow_symlinks = true;
+        if ($file_index_lifecycle_command !== null) {
+            // Persist the traversal selection across invocations. Explicit
+            // values are validated before the lifecycle checkpoint changes;
+            // omitted values restore an active lifecycle's saved selection.
+            $active_command = $this->get_state()->active_resumable_command;
+            $is_resuming_file_index_lifecycle =
+                $active_command->command_name === $file_index_lifecycle_command
+                && $active_command->completion_state !== null
+                && $active_command->completion_state !== "complete";
+            if (in_array($command, ["pull", "pull-files"], true)) {
+                $pull_pipeline = $this->get_state()->pull_pipeline;
+                $stage_sequence = $pull_pipeline->stage_sequence;
+                $last_stage = $stage_sequence !== []
+                    ? $stage_sequence[count($stage_sequence) - 1]
+                    : null;
+                $pipeline_is_complete =
+                    $last_stage !== null
+                    && $pull_pipeline->last_completed_stage === $last_stage;
+                $is_resuming_file_index_lifecycle =
+                    $is_resuming_file_index_lifecycle
+                    || (
+                        $pull_pipeline->started_by_command === $command
+                        && $stage_sequence !== []
+                        && !$pipeline_is_complete
+                    );
+            }
+
+            if (
+                array_key_exists("extra_directory", $options)
+                && !is_string($this->extra_directory)
+                && $this->extra_directory !== null
+            ) {
+                throw new InvalidArgumentException(
+                    "Invalid --extra-directory value: expected a path string."
+                );
+            }
+
+            $follow_symlinks_was_explicit =
+                array_key_exists("follow_symlinks", $options)
+                || array_key_exists("local_followed_symlinks_root", $options);
+            if (isset($options["local_followed_symlinks_root"])) {
+                $this->local_followed_symlinks_root =
+                    $this->resolve_local_followed_symlinks_root(
+                        $options["local_followed_symlinks_root"]
+                    );
+                $this->follow_symlinks = true;
+            }
+
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option values and command names are not HTML.
+            if (
+                $follow_symlinks_was_explicit
+                && $is_resuming_file_index_lifecycle
+                && !$abort
+                && $this->get_state()->follow_symlinks !== $this->follow_symlinks
+            ) {
+                throw new RuntimeException(
+                    "Cannot change --follow-symlinks while resuming " .
+                        "{$file_index_lifecycle_command}. Use the original setting, " .
+                        "or use --abort to start a new {$file_index_lifecycle_command}."
+                );
+            }
+            if (!$follow_symlinks_was_explicit) {
+                // This setting predates the file-index selection checkpoint and
+                // remains a caller preference between completed lifecycles.
+                $this->follow_symlinks = $this->get_state()->follow_symlinks;
+            }
+
+            if (array_key_exists("include_caches", $options)) {
+                if (
+                    $is_resuming_file_index_lifecycle
+                    && !$abort
+                    && $this->get_state()->include_caches !== $this->include_caches
+                ) {
+                    throw new RuntimeException(
+                        "Cannot change --include-caches while resuming " .
+                            "{$file_index_lifecycle_command}. Use the original setting, " .
+                            "or use --abort to start a new {$file_index_lifecycle_command}."
+                    );
+                }
+            } elseif ($is_resuming_file_index_lifecycle && !$abort) {
+                $this->include_caches = $this->get_state()->include_caches;
+            }
+
+            if (array_key_exists("extra_directory", $options)) {
+                if (
+                    $is_resuming_file_index_lifecycle
+                    && !$abort
+                    && $this->get_state()->extra_directory !== $this->extra_directory
+                ) {
+                    throw new RuntimeException(
+                        "Cannot change --extra-directory while resuming " .
+                            "{$file_index_lifecycle_command}. Use the original directory, " .
+                            "or use --abort to start a new {$file_index_lifecycle_command}."
+                    );
+                }
+            } elseif ($is_resuming_file_index_lifecycle && !$abort) {
+                $this->extra_directory = $this->get_state()->extra_directory;
+            }
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+            $options["follow_symlinks"] = $this->follow_symlinks;
+            $options["include_caches"] = $this->include_caches;
+            $options["extra_directory"] = $this->extra_directory;
+        } elseif (isset($options["follow_symlinks"])) {
+            // Persist follow_symlinks in state so it survives across invocations.
+            $this->get_state()->follow_symlinks = $this->follow_symlinks;
             $this->save_state();
+        } else {
+            $this->follow_symlinks = $this->get_state()->follow_symlinks;
         }
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
@@ -2213,15 +2322,22 @@ class ImportClient
                     "RESTART | Clearing files-index state",
                     true,
                 );
-                $this->get_state()->active_resumable_command->command_name = "files-index";
-                $this->get_state()->active_resumable_command->completion_state = null;
-                $this->get_state()->active_resumable_command->current_stage = null;
-                $this->get_state()->index = new RemoteFileIndexCursorState();
+                reprint_update_and_save_state_without_signal_interruption(
+                    function (): void {
+                        $state = $this->get_state();
+                        $state->active_resumable_command->command_name = "files-index";
+                        $state->active_resumable_command->completion_state = null;
+                        $state->active_resumable_command->current_stage = null;
+                        $state->include_caches = false;
+                        $state->extra_directory = null;
+                        $state->index = new RemoteFileIndexCursorState();
+                    },
+                    [$this, 'save_state']
+                );
                 if (file_exists($this->next_remote_index_file)) {
                     @unlink($this->next_remote_index_file);
                     $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
                 }
-                $this->save_state();
                 break;
 
             case "db-pull":
@@ -2300,6 +2416,8 @@ class ImportClient
             true,
         );
         $this->reset_state();
+        $this->get_state()->include_caches = false;
+        $this->get_state()->extra_directory = null;
 
         if (file_exists($this->next_remote_index_file)) {
             @unlink($this->next_remote_index_file);
@@ -3051,16 +3169,26 @@ class ImportClient
             // The empty WAL blocks files-diff and files-push before the first
             // pull checkpoint can make this lifecycle resumable.
             $this->pull_index_journal->open();
-            $this->get_state()->active_resumable_command->command_name = "files-pull";
-            $this->get_state()->active_resumable_command->completion_state = "in_progress";
-            $this->get_state()->active_resumable_command->current_stage = "index";
-            $this->get_state()->files_pull_path_selection_fingerprint =
+            $path_selection_fingerprint =
                 $this->files_pull_path_selection_fingerprint();
-            $this->get_state()->diff = new FileDiffProgressState();
-            $this->get_state()->index = new RemoteFileIndexCursorState();
-            $this->get_state()->fetch = new FetchListProgressState();
-            $this->get_state()->files_pull_summary = new FilesPullSummaryState();
-            $this->save_state();
+            reprint_update_and_save_state_without_signal_interruption(
+                function () use ($path_selection_fingerprint): void {
+                    $state = $this->get_state();
+                    $state->active_resumable_command->command_name = "files-pull";
+                    $state->active_resumable_command->completion_state = "in_progress";
+                    $state->active_resumable_command->current_stage = "index";
+                    $state->follow_symlinks = $this->follow_symlinks;
+                    $state->include_caches = $this->include_caches;
+                    $state->extra_directory = $this->extra_directory;
+                    $state->files_pull_path_selection_fingerprint =
+                        $path_selection_fingerprint;
+                    $state->diff = new FileDiffProgressState();
+                    $state->index = new RemoteFileIndexCursorState();
+                    $state->fetch = new FetchListProgressState();
+                    $state->files_pull_summary = new FilesPullSummaryState();
+                },
+                [$this, 'save_state']
+            );
 
             if ($is_delta) {
                 $this->files_pulled = 0;
@@ -3273,10 +3401,19 @@ class ImportClient
         }
 
         if ($current_status === null) {
-            $this->get_state()->active_resumable_command->command_name = "files-index";
-            $this->get_state()->active_resumable_command->completion_state = "in_progress";
-            $this->get_state()->active_resumable_command->current_stage = "index";
-            $this->save_state();
+            reprint_update_and_save_state_without_signal_interruption(
+                function (): void {
+                    $state = $this->get_state();
+                    $state->active_resumable_command->command_name = "files-index";
+                    $state->active_resumable_command->completion_state = "in_progress";
+                    $state->active_resumable_command->current_stage = "index";
+                    $state->follow_symlinks = $this->follow_symlinks;
+                    $state->include_caches = $this->include_caches;
+                    $state->extra_directory = $this->extra_directory;
+                    $state->index = new RemoteFileIndexCursorState();
+                },
+                [$this, 'save_state']
+            );
             $this->audit_log("START files-index", true);
             $this->progress->show_lifecycle_line("Starting files-index\n");
             $this->output_progress([
@@ -8591,8 +8728,10 @@ class ImportClient
 
         if ($previous !== $fingerprint) {
             throw new RuntimeException(
-                "Cannot change --include or --exclude while resuming files-pull. " .
-                    "Use the original path selections, or use --abort to start a new files-pull.",
+                "Cannot change --include or --exclude while resuming files-pull; " .
+                    "--extra-directory, --follow-symlinks, and --include-caches " .
+                    "must remain unchanged too. Use the original file-index selection, " .
+                    "or use --abort to start a new files-pull.",
             );
         }
     }
@@ -8613,8 +8752,19 @@ class ImportClient
             "sha256",
             json_encode(
                 [
-                    "only_path_prefixes" => $this->pull_only_files_with_path_prefixes,
-                    "excluded_path_prefixes" => $excluded_path_prefixes,
+                    "only_path_prefixes_b64" => array_map(
+                        "base64_encode",
+                        $this->pull_only_files_with_path_prefixes
+                    ),
+                    "excluded_path_prefixes_b64" => array_map(
+                        "base64_encode",
+                        $excluded_path_prefixes
+                    ),
+                    "extra_directory_b64" => $this->extra_directory === null
+                        ? null
+                        : base64_encode($this->extra_directory),
+                    "follow_symlinks" => $this->follow_symlinks,
+                    "include_caches" => $this->include_caches,
                 ],
                 JSON_UNESCAPED_SLASHES
             ),
@@ -10788,6 +10938,8 @@ class ImportClient
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;
+        $this->state->include_caches = $previous_state->include_caches;
+        $this->state->extra_directory = $previous_state->extra_directory;
         $this->state->fs_root_nonempty_behavior = $previous_state->fs_root_nonempty_behavior;
         $this->state->max_allowed_packet = $previous_state->max_allowed_packet;
         $this->state->resolved_path_mappings_fingerprint = $previous_state->resolved_path_mappings_fingerprint;
@@ -10810,6 +10962,9 @@ class ImportClient
         );
         $state["current_file"] = $this->encode_state_path_value(
             $state["current_file"] ?? null,
+        );
+        $state["extra_directory"] = $this->encode_state_path_value(
+            $state["extra_directory"] ?? null,
         );
         $state["db_index"]["file"] = $this->encode_state_path_value(
             $state["db_index"]["file"] ?? null,
@@ -10839,6 +10994,9 @@ class ImportClient
         );
         $state["current_file"] = $this->decode_state_path_value(
             $state["current_file"] ?? null,
+        );
+        $state["extra_directory"] = $this->decode_state_path_value(
+            $state["extra_directory"] ?? null,
         );
         $state["db_index"]["file"] = $this->decode_state_path_value(
             $state["db_index"]["file"] ?? null,

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -200,6 +200,91 @@ class Pull
     }
 
     /**
+     * Refuse to let one command overwrite another command's resume state.
+     *
+     * @param array $options {
+     *     Options which determine the pull pipeline's stage sequence.
+     *
+     *     @type string $target_db          Target database DSN.
+     *     @type string $target_engine      Target database engine.
+     *     @type string $target_sqlite_path Target SQLite path.
+     *     @type string $target_user        Target database user.
+     *     @type string $flatten_to         Flattened document-root path.
+     *     @type string $runtime            Runtime to generate.
+     *     @type string $start_runtime      Runtime to start.
+     * }
+     */
+    public function assert_command_owns_resume_state(string $command, array $options): void
+    {
+        switch ($command) {
+            case 'pull':
+                $stages = $this->stages($options);
+                break;
+            case 'pull-files':
+                $stages = ['preflight', 'files-pull'];
+                break;
+            case 'pull-db':
+                $stages = ['preflight', 'db-pull', 'db-apply'];
+                break;
+            case 'files-pull':
+            case 'files-index':
+                $stages = [$command];
+                break;
+            default:
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI command name, never HTML.
+                throw new InvalidArgumentException("Unknown pull command: {$command}");
+        }
+
+        $state = $this->client->get_state();
+        $pull_pipeline = $state->pull_pipeline->started_by_command;
+        $saved_stage_sequence = $state->pull_pipeline->stage_sequence;
+        $pipeline_final_stage = $saved_stage_sequence[
+            count($saved_stage_sequence) - 1
+        ] ?? null;
+        $pipeline_is_complete =
+            $pipeline_final_stage !== null
+            && $state->pull_pipeline->last_completed_stage === $pipeline_final_stage;
+        $state_command = $state->active_resumable_command->command_name;
+        $state_status = $state->active_resumable_command->completion_state;
+        $pipeline_has_resume_state =
+            $pull_pipeline !== null
+            && !$pipeline_is_complete
+            && (
+                $saved_stage_sequence !== []
+                || $state->pull_pipeline->last_completed_stage !== null
+                || $state_command !== null
+                || $state_status !== null
+            );
+
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI command names are not HTML.
+        if ($pipeline_has_resume_state && $pull_pipeline !== $command) {
+            throw new RuntimeException(
+                "Another command is already in progress: {$pull_pipeline}. " .
+                "Rerun {$pull_pipeline} to resume it. Only use --abort if you want to discard " .
+                "that pipeline's resume state before running {$command}."
+            );
+        }
+
+        if (
+            $state_status !== null
+            && $state_status !== 'complete'
+            && in_array(
+                $state_command,
+                ['files-pull', 'files-index', 'db-pull', 'db-apply'],
+                true
+            )
+            && !in_array($state_command, $stages, true)
+        ) {
+            throw new RuntimeException(
+                "Another command is already in progress: {$state_command}. " .
+                "Rerun {$state_command} to resume it. Only use --abort if you want to discard " .
+                "that command's resume state before running {$command}."
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+    }
+
+    /**
      * Runs a named pull pipeline from the first unfinished stage.
      *
      * PullState::$pull_pipeline records orchestration progress: which
@@ -235,11 +320,20 @@ class Pull
             $pull_stage !== null &&
             $pipeline_final_stage !== null &&
             $pull_stage === $pipeline_final_stage;
+        $file_selection_checkpoint_saved = false;
 
         if ($completed_pipeline) {
-            $this->prepare_repull($command);
+            $this->prepare_repull(
+                $command,
+                $stages,
+                !empty($options['follow_symlinks']),
+                !empty($options['include_caches']),
+                $options['extra_directory'] ?? null
+            );
+            $file_selection_checkpoint_saved =
+                $command === 'pull' || $command === 'pull-files';
             $completed_stage = null;
-            $pull_pipeline = null;
+            $pull_pipeline = $command;
             $pull_stage = null;
             $state_command = null;
             $state_status = null;
@@ -253,28 +347,7 @@ class Pull
                 $state_status !== null
             );
 
-        if ($pipeline_has_resume_state && $pull_pipeline !== $command) {
-            throw new RuntimeException(
-                "Another command is already in progress: {$pull_pipeline}. " .
-                "Rerun {$pull_pipeline} to resume it. Only use --abort if you want to discard " .
-                "that pipeline's resume state before running {$command}."
-            );
-        }
-
         $has_direct_command_state = !$pipeline_has_resume_state && $state_status !== null;
-        if (
-            $has_direct_command_state &&
-            $state_status !== 'complete' &&
-            in_array($state_command, ['files-pull', 'db-pull', 'db-apply'], true) &&
-            !in_array($state_command, $stages, true)
-        ) {
-            throw new RuntimeException(
-                "Another command is already in progress: {$state_command}. " .
-                "Rerun {$state_command} to resume it. Only use --abort if you want to discard " .
-                "that command's resume state before running {$command}."
-            );
-        }
-
         if ($has_direct_command_state && $state_status === 'complete') {
             // Users can run lower-level commands directly, e.g.
             // `reprint files-pull` or `reprint db-pull`, without going through
@@ -332,6 +405,25 @@ class Pull
                     }
                 }
             }
+        }
+
+        if (
+            !$file_selection_checkpoint_saved
+            && in_array($command, ['pull', 'pull-files'], true)
+        ) {
+            // Save the file-index selection before preflight starts. A process
+            // may stop after that request but before its stage checkpoint.
+            reprint_update_and_save_state_without_signal_interruption(
+                function () use ($command, $options, $stages): void {
+                    $state = $this->client->get_state();
+                    $state->follow_symlinks = !empty($options['follow_symlinks']);
+                    $state->include_caches = !empty($options['include_caches']);
+                    $state->extra_directory = $options['extra_directory'] ?? null;
+                    $state->pull_pipeline->started_by_command = $command;
+                    $state->pull_pipeline->stage_sequence = $stages;
+                },
+                [$this->client, 'save_state']
+            );
         }
 
         $total = count($stages);
@@ -765,8 +857,20 @@ class Pull
      * owned by the high-level command being restarted. Keeping that ownership
      * map here prevents callers from having to know which file/database state
      * belongs to which pipeline.
+     *
+     * @param string      $command         High-level command whose state is reset.
+     * @param string[]    $stage_sequence  Fresh lifecycle stages, or an empty list for abort.
+     * @param bool|null   $follow_symlinks Fresh lifecycle link selection, or null to retain it.
+     * @param bool        $include_caches  Fresh lifecycle cache selection.
+     * @param string|null $extra_directory Fresh lifecycle additional remote directory.
      */
-    private function prepare_repull(string $command): void
+    private function prepare_repull(
+        string $command,
+        array $stage_sequence = [],
+        ?bool $follow_symlinks = null,
+        bool $include_caches = false,
+        ?string $extra_directory = null
+    ): void
     {
         $state_dir = $this->client->state_dir;
         $pull_state_directory = $this->client->pull_state_directory;
@@ -792,36 +896,55 @@ class Pull
             default:
                 throw new InvalidArgumentException("Unknown pull command: {$command}");
         }
-
-
-        $state = $this->client->get_state();
-        $state->pull_pipeline->started_by_command = $command;
-        $state->pull_pipeline->stage_sequence = [];
-        $state->pull_pipeline->last_completed_stage = null;
-        $state->pull_pipeline->has_completed_once = true;
-        $state->active_resumable_command->command_name = null;
-        $state->active_resumable_command->completion_state = null;
-        $state->active_resumable_command->remote_cursor = null;
-        $state->active_resumable_command->current_stage = null;
-        $state->consecutive_interrupted_responses = 0;
-        if ($reset_file_transfer_state) {
-            $state->current_file = null;
-            $state->current_file_bytes = null;
-            $state->diff = new FileDiffProgressState();
-            $state->fetch = new FetchListProgressState();
-            $state->files_pull_summary = new FilesPullSummaryState();
-        }
-        if ($reset_file_selection_state) {
-            $state->index = new RemoteFileIndexCursorState();
-            $state->files_pull_path_selection_fingerprint = null;
-        }
-        if ($reset_db_state) {
-            $state->sql_bytes = null;
-            $state->db_index = new DatabaseTableIndexState();
-            $state->apply = new DatabaseApplyCommandState();
-            $state->sql_output = null;
-        }
-        $this->client->save_state();
+        reprint_update_and_save_state_without_signal_interruption(
+            function () use (
+                $command,
+                $stage_sequence,
+                $follow_symlinks,
+                $include_caches,
+                $extra_directory,
+                $reset_file_transfer_state,
+                $reset_file_selection_state,
+                $reset_db_state
+            ): void {
+                $state = $this->client->get_state();
+                $state->pull_pipeline->started_by_command =
+                    $stage_sequence === [] ? null : $command;
+                $state->pull_pipeline->stage_sequence = $stage_sequence;
+                $state->pull_pipeline->last_completed_stage = null;
+                $state->pull_pipeline->has_completed_once = true;
+                $state->active_resumable_command->command_name = null;
+                $state->active_resumable_command->completion_state = null;
+                $state->active_resumable_command->remote_cursor = null;
+                $state->active_resumable_command->current_stage = null;
+                $state->consecutive_interrupted_responses = 0;
+                if ($command === 'pull' || $command === 'pull-files') {
+                    if ($follow_symlinks !== null) {
+                        $state->follow_symlinks = $follow_symlinks;
+                    }
+                    $state->include_caches = $include_caches;
+                    $state->extra_directory = $extra_directory;
+                }
+                if ($reset_file_transfer_state) {
+                    $state->current_file = null;
+                    $state->current_file_bytes = null;
+                    $state->diff = new FileDiffProgressState();
+                    $state->fetch = new FetchListProgressState();
+                    $state->files_pull_summary = new FilesPullSummaryState();
+                }
+                if ($reset_file_selection_state) {
+                    $state->index = new RemoteFileIndexCursorState();
+                    $state->files_pull_path_selection_fingerprint = null;
+                }
+                if ($reset_db_state) {
+                    $state->sql_bytes = null;
+                    $state->db_index = new DatabaseTableIndexState();
+                    $state->apply = new DatabaseApplyCommandState();
+                    $state->sql_output = null;
+                }
+            },
+            [$this->client, 'save_state']
+        );
 
         $paths = [];
         if ($reset_file_transfer_state) {

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -49,6 +49,10 @@ class PullState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
+    /** Whether remote and local file indexes include cache and development paths. */
+    public bool $include_caches = false;
+    /** @var string|null Additional remote directory included in the file index. */
+    public ?string $extra_directory = null;
     /** @var string|null Fingerprint of the local followed symlinks root; guards resume. */
     public ?string $local_followed_symlinks_root_fingerprint = null;
     public string $fs_root_nonempty_behavior = 'error';
@@ -118,6 +122,18 @@ class PullState
         $state->version = $data['version'];
         $state->webhost = $data['webhost'];
         $state->follow_symlinks = $data['follow_symlinks'];
+        if (!is_bool($data['include_caches'])) {
+            throw new UnexpectedValueException(
+                'PullState include_caches must be a boolean.'
+            );
+        }
+        $state->include_caches = $data['include_caches'];
+        if (!is_string($data['extra_directory']) && $data['extra_directory'] !== null) {
+            throw new UnexpectedValueException(
+                'PullState extra_directory must be a string or null.'
+            );
+        }
+        $state->extra_directory = $data['extra_directory'];
         $state->local_followed_symlinks_root_fingerprint = $data['local_followed_symlinks_root_fingerprint'];
         $state->fs_root_nonempty_behavior = $data['fs_root_nonempty_behavior'];
         $state->filter = $data['filter'];
@@ -222,6 +238,8 @@ class PullState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
+            'include_caches' => $this->include_caches,
+            'extra_directory' => $this->extra_directory,
             'local_followed_symlinks_root_fingerprint' => $this->local_followed_symlinks_root_fingerprint,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,

--- a/packages/reprint-client/src/lib/state/load.php
+++ b/packages/reprint-client/src/lib/state/load.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * on-disk schema.
  */
 
+require_once __DIR__ . '/state-functions.php';
 require_once __DIR__ . '/class-resumable-command-checkpoint-state.php';
 require_once __DIR__ . '/class-database-table-index-state.php';
 require_once __DIR__ . '/class-file-diff-progress-state.php';

--- a/packages/reprint-client/src/lib/state/state-functions.php
+++ b/packages/reprint-client/src/lib/state/state-functions.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Applies related state changes and saves them as one shutdown boundary.
+ *
+ * An async signal handler may save the current in-memory state before it
+ * stops the process. Deferring that handler keeps it from saving only the
+ * first half of a related state transition.
+ *
+ * @param callable():void $update Related in-memory state changes.
+ * @param callable():void $save   Persist the updated state.
+ */
+function reprint_update_and_save_state_without_signal_interruption(
+    callable $update,
+    callable $save
+): void {
+    $async_signals_were_enabled =
+        function_exists('pcntl_async_signals')
+        && pcntl_async_signals();
+    if ($async_signals_were_enabled) {
+        pcntl_async_signals(false);
+    }
+    try {
+        $update();
+        $save();
+    } finally {
+        if ($async_signals_were_enabled) {
+            pcntl_async_signals(true);
+        }
+    }
+}

--- a/tests/Import/FileIndexSelectionLifecycleTest.php
+++ b/tests/Import/FileIndexSelectionLifecycleTest.php
@@ -1,0 +1,354 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the next line.
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generated child and router scripts require literal PHP values.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/** Exercises file-index selection checkpoints at a real preflight request. */
+final class FileIndexSelectionLifecycleTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $filesystemRoot;
+    private $remoteSite;
+    private $extraDirectory;
+    private $controlFile;
+    private $preflightReadyFile;
+    private $remoteUrl;
+    private $serverProcess;
+    private $serverPipes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/file-index-selection-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->filesystemRoot = $this->tempDir . '/local';
+        $this->remoteSite = $this->tempDir . '/remote-site';
+        $this->extraDirectory = $this->tempDir . '/remote-extra';
+        $this->controlFile = $this->tempDir . '/control.json';
+        $this->preflightReadyFile = $this->tempDir . '/preflight-ready.log';
+        foreach (
+            [
+                $this->stateDir,
+                $this->filesystemRoot,
+                $this->remoteSite,
+                $this->extraDirectory,
+            ] as $directory
+        ) {
+            mkdir($directory, 0755, true);
+        }
+        $this->writeControl([]);
+        $this->remoteUrl = $this->startExporter();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess, 9);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testPullFilesCheckpointsSelectionBeforeInterruptedPreflight(): void
+    {
+        $this->writeControl(['block_preflight' => true]);
+        [$firstProcess, $firstPipes] = $this->startPullFilesProcess(
+            true,
+            $this->extraDirectory
+        );
+        $this->waitForPreflightReadyCount(1, $firstProcess, $firstPipes);
+
+        $state = $this->readState();
+        $this->assertTrue($state['include_caches']);
+        $this->assertSame(
+            'base64:' . base64_encode($this->extraDirectory),
+            $state['extra_directory']
+        );
+        $this->assertSame(
+            ['preflight', 'files-pull'],
+            $state['pull_pipeline']['stage_sequence']
+        );
+        $this->assertNull($state['pull_pipeline']['last_completed_stage']);
+        $this->stopPullFilesProcess($firstProcess, $firstPipes);
+
+        $this->writeControl(['block_preflight' => true]);
+        [$secondProcess, $secondPipes] = $this->startPullFilesProcess(null);
+        $this->waitForPreflightReadyCount(2, $secondProcess, $secondPipes);
+        $state = $this->readState();
+        $this->assertTrue($state['include_caches']);
+        $this->assertSame(
+            'base64:' . base64_encode($this->extraDirectory),
+            $state['extra_directory']
+        );
+        $this->stopPullFilesProcess($secondProcess, $secondPipes);
+    }
+
+    public function testPullFilesAdoptsDirectFilesPullSelectionBeforePreflight(): void
+    {
+        \write_current_pull_state(
+            new \ImportClient(
+                $this->remoteUrl,
+                $this->stateDir,
+                $this->filesystemRoot
+            ),
+            [
+                'active_resumable_command' => [
+                    'command_name' => 'files-pull',
+                    'completion_state' => 'in_progress',
+                    'current_stage' => 'index',
+                    'remote_cursor' => null,
+                ],
+                'include_caches' => true,
+                'extra_directory' => $this->extraDirectory,
+            ]
+        );
+        $this->writeControl(['block_preflight' => true]);
+
+        [$process, $pipes] = $this->startPullFilesProcess(null);
+        $this->waitForPreflightReadyCount(1, $process, $pipes);
+        $state = $this->readState();
+        $this->assertTrue($state['include_caches']);
+        $this->assertSame(
+            'base64:' . base64_encode($this->extraDirectory),
+            $state['extra_directory']
+        );
+        $this->assertSame(
+            'pull-files',
+            $state['pull_pipeline']['started_by_command']
+        );
+        $this->stopPullFilesProcess($process, $pipes);
+    }
+
+    /** @return array{0:resource,1:array<int,resource>} */
+    private function startPullFilesProcess(
+        ?bool $includeCaches,
+        ?string $extraDirectory = null
+    ): array {
+        $script = $this->tempDir . '/pull-files-' . uniqid() . '.php';
+        $importer = realpath(
+            __DIR__ . '/../../packages/reprint-client/src/import.php'
+        );
+        $this->assertIsString($importer);
+        $options = [
+            'command' => 'pull-files',
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'progress' => 'jsonl',
+        ];
+        if ($includeCaches !== null) {
+            $options['include_caches'] = $includeCaches;
+        }
+        if ($extraDirectory !== null) {
+            $options['extra_directory'] = $extraDirectory;
+        }
+        file_put_contents(
+            $script,
+            sprintf(
+                <<<'PHP'
+<?php
+require_once %s;
+$client = new ImportClient(%s, %s, %s, 'pull-files');
+$client->run(%s);
+PHP,
+                var_export($importer, true),
+                var_export($this->remoteUrl, true),
+                var_export($this->stateDir, true),
+                var_export($this->filesystemRoot, true),
+                var_export($options, true)
+            )
+        );
+        $process = proc_open(
+            [PHP_BINARY, $script],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            $this->tempDir
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        unset($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /**
+     * @param resource            $process Child process.
+     * @param array<int,resource> $pipes   Child output pipes.
+     */
+    private function stopPullFilesProcess($process, array $pipes): void
+    {
+        proc_terminate($process, 9);
+        $this->writeControl([]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        proc_close($process);
+        usleep(100000);
+    }
+
+    /**
+     * @param resource            $process Child process.
+     * @param array<int,resource> $pipes   Child output pipes.
+     */
+    private function waitForPreflightReadyCount(
+        int $expectedCount,
+        $process,
+        array $pipes
+    ): void {
+        for ($attempt = 0; $attempt < 100; ++$attempt) {
+            $lines = is_file($this->preflightReadyFile)
+                ? file($this->preflightReadyFile, FILE_IGNORE_NEW_LINES)
+                : [];
+            if (count($lines ?: []) >= $expectedCount) {
+                return;
+            }
+            usleep(50000);
+        }
+        $status = proc_get_status($process);
+        foreach ($pipes as $pipe) {
+            stream_set_blocking($pipe, false);
+        }
+        $this->fail(
+            'The preflight request did not reach its blocking boundary. '
+            . 'Process running: ' . ( !empty($status['running']) ? 'yes' : 'no' )
+            . '; stdout: ' . stream_get_contents($pipes[1])
+            . '; stderr: ' . stream_get_contents($pipes[2])
+        );
+    }
+
+    private function startExporter(): string
+    {
+        $router = $this->tempDir . '/router.php';
+        $serverClass = realpath(
+            __DIR__ . '/../../packages/reprint-server/src/class-http-server.php'
+        );
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $this->assertIsString($serverClass);
+        $this->assertIsString($autoload);
+        file_put_contents(
+            $router,
+            sprintf(
+                <<<'PHP'
+<?php
+$control = json_decode((string) file_get_contents(%s), true);
+if (
+    ($_GET['endpoint'] ?? null) === 'preflight'
+    && !empty($control['block_preflight'])
+) {
+    file_put_contents(%s, "ready\n", FILE_APPEND);
+    do {
+        usleep(20000);
+        clearstatcache(true, %s);
+        $control = json_decode((string) file_get_contents(%s), true);
+    } while (!empty($control['block_preflight']));
+}
+require_once %s;
+require_once %s;
+Site_Export_HTTP_Server::serve(['default_directory' => %s]);
+PHP,
+                var_export($this->controlFile, true),
+                var_export($this->preflightReadyFile, true),
+                var_export($this->controlFile, true),
+                var_export($this->controlFile, true),
+                var_export($autoload, true),
+                var_export($serverClass, true),
+                var_export($this->remoteSite, true)
+            )
+        );
+
+        $socket = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $errorNumber,
+            $errorMessage
+        );
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+        $environment = getenv();
+        $environment = is_array($environment) ? $environment : [];
+        $environment['SITE_EXPORT_TEST_MODE'] = '1';
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->serverPipes,
+            $this->tempDir,
+            $environment
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen(
+                '127.0.0.1',
+                $port,
+                $errorNumber,
+                $errorMessage,
+                0.1
+            );
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port
+                    . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Exporter did not start.');
+    }
+
+    private function readState(): array
+    {
+        return json_decode(
+            file_get_contents($this->pullStateDirectory() . '/state.json'),
+            true
+        );
+    }
+
+    private function pullStateDirectory(): string
+    {
+        return $this->stateDir . '/remotes/'
+            . md5(rtrim($this->remoteUrl, '?&'))
+            . '/pull';
+    }
+
+    private function writeControl(array $control): void
+    {
+        file_put_contents($this->controlFile, json_encode($control));
+        clearstatcache(true, $this->controlFile);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -513,8 +513,11 @@ final class FilesPullDiffCheckpointTest extends TestCase
             'files_pull_path_selection_fingerprint' => hash(
                 'sha256',
                 json_encode([
-                    'only_path_prefixes' => [],
-                    'excluded_path_prefixes' => [],
+                    'only_path_prefixes_b64' => [],
+                    'excluded_path_prefixes_b64' => [],
+                    'extra_directory_b64' => null,
+                    'follow_symlinks' => true,
+                    'include_caches' => false,
                 ], JSON_UNESCAPED_SLASHES)
             ),
         ]);

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -84,12 +84,23 @@ class OnlyFilesPathPrefixTest extends TestCase
         return $this->client(array('database' => array('wp' => array('paths_urls' => $pathsUrls))));
     }
 
-    private function pathSelectionFingerprint(array $included, array $excluded = array()): string
+    private function pathSelectionFingerprint(
+        array $included,
+        array $excluded = array(),
+        bool $followSymlinks = false,
+        bool $includeCaches = false,
+        ?string $extraDirectory = null
+    ): string
     {
         sort($excluded, SORT_STRING);
         return hash('sha256', json_encode(array(
-            'only_path_prefixes' => $included,
-            'excluded_path_prefixes' => $excluded,
+            'only_path_prefixes_b64' => array_map('base64_encode', $included),
+            'excluded_path_prefixes_b64' => array_map('base64_encode', $excluded),
+            'extra_directory_b64' => $extraDirectory === null
+                ? null
+                : base64_encode($extraDirectory),
+            'follow_symlinks' => $followSymlinks,
+            'include_caches' => $includeCaches,
         ), JSON_UNESCAPED_SLASHES));
     }
 
@@ -129,7 +140,12 @@ class OnlyFilesPathPrefixTest extends TestCase
         );
     }
 
-    private function runFilesPull(array $fileSelectionOptions): void
+    private function runFilesPull(array $fileSelectionOptions): \ImportClient
+    {
+        return $this->runCommand('files-pull', $fileSelectionOptions);
+    }
+
+    private function runCommand(string $command, array $options): \ImportClient
     {
         $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
         $output = fopen('php://temp', 'w');
@@ -140,12 +156,13 @@ class OnlyFilesPathPrefixTest extends TestCase
 
         try {
             $c->run(array_merge(
-                array('command' => 'files-pull'),
-                $fileSelectionOptions
+                array('command' => $command),
+                $options
             ));
         } finally {
             fclose($output);
         }
+        return $c;
     }
 
     private function readState(): array
@@ -338,6 +355,308 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->assertSame(
             $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
             $state['files_pull_path_selection_fingerprint'] ?? null
+        );
+    }
+
+    public function testRunRestoresIncludeCachesWhileFilesPullIsInProgress(): void
+    {
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+        $this->writeFilesPullState(array(
+            'include_caches' => true,
+            'files_pull_path_selection_fingerprint' =>
+                $this->pathSelectionFingerprint(array(), array(), false, true),
+        ));
+
+        $this->runFilesPull(array());
+
+        $state = $this->readState();
+        $this->assertTrue($state['include_caches']);
+        $this->assertSame(
+            'complete',
+            $state['active_resumable_command']['completion_state'] ?? null
+        );
+    }
+
+    public function testRunRejectsChangingIncludeCachesWithoutChangingState(): void
+    {
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+        $this->writeFilesPullState(array(
+            'include_caches' => false,
+            'files_pull_path_selection_fingerprint' =>
+                $this->pathSelectionFingerprint(array()),
+        ));
+
+        try {
+            $this->runFilesPull(array('include_caches' => true));
+            $this->fail('Expected an active files-pull to reject a cache-selection change.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --include-caches while resuming files-pull',
+                $exception->getMessage()
+            );
+        }
+        $this->assertFalse($this->readState()['include_caches']);
+    }
+
+    public function testOmittedIncludeCachesDoesNotReuseCompletedPullValue(): void
+    {
+        $this->writeFilesPullState(array(
+            'active_resumable_command' => array(
+                'completion_state' => 'complete',
+                'current_stage' => null,
+            ),
+            'include_caches' => true,
+        ));
+
+        $client = $this->runFilesPull(array());
+
+        $include_caches = ( new \ReflectionClass( $client ) )
+            ->getProperty('include_caches')
+            ->getValue($client);
+        $this->assertFalse($include_caches);
+        $this->assertTrue($this->readState()['include_caches']);
+    }
+
+    public function testAbortClearsIncludeCachesBeforeTheNextPull(): void
+    {
+        $this->writeFilesPullState(array('include_caches' => true));
+
+        $this->runFilesPull(array('abort' => true));
+
+        $this->assertFalse($this->readState()['include_caches']);
+    }
+
+    public function testRunRestoresByteSafeExtraDirectoryWhileFilesPullIsInProgress(): void
+    {
+        $extraDirectory = "/srv/extra-\x80";
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+        $this->writeFilesPullState(array(
+            'extra_directory' => $extraDirectory,
+            'files_pull_path_selection_fingerprint' =>
+                $this->pathSelectionFingerprint(
+                    array(),
+                    array(),
+                    false,
+                    false,
+                    $extraDirectory
+                ),
+        ));
+
+        $client = $this->runFilesPull(array());
+
+        $savedState = $this->readState();
+        $this->assertSame(
+            'base64:' . base64_encode($extraDirectory),
+            $savedState['extra_directory']
+        );
+        $this->assertSame(
+            $extraDirectory,
+            ( new \ReflectionClass( $client ) )
+                ->getProperty('extra_directory')
+                ->getValue($client)
+        );
+    }
+
+    public function testRunRejectsChangingExtraDirectoryWithoutChangingState(): void
+    {
+        $extraDirectory = '/srv/original-extra';
+        $this->writeFilesPullState(array(
+            'extra_directory' => $extraDirectory,
+            'files_pull_path_selection_fingerprint' =>
+                $this->pathSelectionFingerprint(
+                    array(),
+                    array(),
+                    false,
+                    false,
+                    $extraDirectory
+                ),
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runFilesPull(array('extra_directory' => '/srv/different-extra'));
+            $this->fail('Expected an active files-pull to reject an extra-directory change.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --extra-directory while resuming files-pull',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    public function testConflictingPipelineCommandLeavesStateBytesUnchanged(): void
+    {
+        $this->writeFilesPullState(array(
+            'pull_pipeline' => array(
+                'started_by_command' => 'pull-files',
+                'stage_sequence' => array('preflight', 'files-pull'),
+                'last_completed_stage' => null,
+                'has_completed_once' => false,
+            ),
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runCommand('pull', array(
+                'follow_symlinks' => true,
+                'include_caches' => true,
+                'extra_directory' => '/srv/different-extra',
+                'fs_root_nonempty_behavior' => 'error',
+            ));
+            $this->fail('Expected pull to reject the active pull-files pipeline.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another command is already in progress: pull-files',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    /**
+     * @dataProvider directFileIndexCommandProvider
+     */
+    public function testDirectFileIndexCommandRejectsHighLevelOwnerWithoutChangingState(
+        string $command
+    ): void {
+        $this->writeFilesPullState(array(
+            'pull_pipeline' => array(
+                'started_by_command' => 'pull-files',
+                'stage_sequence' => array('preflight', 'files-pull'),
+                'last_completed_stage' => 'preflight',
+                'has_completed_once' => false,
+            ),
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runCommand($command, array(
+                'follow_symlinks' => true,
+                'include_caches' => true,
+                'extra_directory' => '/srv/different-extra',
+            ));
+            $this->fail("Expected {$command} to reject the active pull-files pipeline.");
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another command is already in progress: pull-files',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    /** @return array<string,array{string}> */
+    public static function directFileIndexCommandProvider(): array
+    {
+        return array(
+            'files-pull' => array('files-pull'),
+            'files-index' => array('files-index'),
+        );
+    }
+
+    public function testHighLevelPullRejectsActiveDirectFilesIndexWithoutChangingState(): void
+    {
+        $this->writeFilesPullState(array(
+            'active_resumable_command' => array(
+                'command_name' => 'files-index',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'index',
+                'remote_cursor' => null,
+            ),
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runCommand('pull-files', array(
+                'follow_symlinks' => true,
+                'include_caches' => true,
+                'extra_directory' => '/srv/different-extra',
+            ));
+            $this->fail('Expected pull-files to reject the active files-index command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another command is already in progress: files-index',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    public function testHighLevelOwnerRejectsIncompatibleActiveCommandWithoutChangingState(): void
+    {
+        $this->writeFilesPullState(array(
+            'active_resumable_command' => array(
+                'command_name' => 'files-index',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'index',
+                'remote_cursor' => null,
+            ),
+            'pull_pipeline' => array(
+                'started_by_command' => 'pull-files',
+                'stage_sequence' => array('preflight', 'files-pull'),
+                'last_completed_stage' => 'preflight',
+                'has_completed_once' => false,
+            ),
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runCommand('pull-files', array(
+                'follow_symlinks' => true,
+                'include_caches' => true,
+                'extra_directory' => '/srv/different-extra',
+            ));
+            $this->fail('Expected pull-files to reject its incompatible active command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Another command is already in progress: files-index',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    public function testFilesIndexRejectsChangingCacheSelectionWithoutChangingState(): void
+    {
+        $this->writeFilesPullState(array(
+            'active_resumable_command' => array(
+                'command_name' => 'files-index',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'index',
+                'remote_cursor' => null,
+            ),
+            'include_caches' => true,
+        ));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runCommand('files-index', array('include_caches' => false));
+            $this->fail('Expected files-index to reject a cache-selection change.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --include-caches while resuming files-index',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
         );
     }
 

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -558,6 +558,55 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('files-pull', $state["pull_pipeline"]["last_completed_stage"]);
     }
 
+    public function testPullFilesAbortAllowsANewFileIndexSelection(): void
+    {
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "partial",
+                "current_stage" => "index",
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull-files",
+                "stage_sequence" => ["preflight", "files-pull"],
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            "include_caches" => true,
+            "extra_directory" => "/srv/original-extra",
+        ]);
+
+        $client = $this->makeClient();
+
+        ob_start();
+        $client->run([
+            "command" => "pull-files",
+            "abort" => true,
+        ]);
+        $abortedState = $this->readState();
+        $this->assertNull($abortedState["pull_pipeline"]["started_by_command"]);
+        $this->assertSame([], $abortedState["pull_pipeline"]["stage_sequence"]);
+
+        $client->run([
+            "command" => "pull-files",
+            "include_caches" => false,
+            "extra_directory" => "/srv/new-extra",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertFalse($state["include_caches"]);
+        $this->assertSame(
+            'base64:' . base64_encode('/srv/new-extra'),
+            $state["extra_directory"]
+        );
+        $this->assertSame(
+            ["preflight", "files-pull"],
+            $state["pull_pipeline"]["stage_sequence"]
+        );
+        $this->assertSame(1, $client->files_pull_runs);
+    }
+
     public function testPullAfterFilesPullCompletedBeforePipelineStageWasMarkedDoesNotStealIt(): void
     {
         $this->writeState([

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -133,6 +133,30 @@ class PullStateTest extends TestCase
         \PullState::from_array($data);
     }
 
+    public function testStateRejectsNonStringExtraDirectory(): void
+    {
+        $data = ( new \PullState() )->to_array();
+        $data['extra_directory'] = ['not', 'a', 'path'];
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'extra_directory must be a string or null'
+        );
+
+        \PullState::from_array($data);
+    }
+
+    public function testStateRejectsNonBooleanIncludeCaches(): void
+    {
+        $data = ( new \PullState() )->to_array();
+        $data['include_caches'] = 1;
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('include_caches must be a boolean');
+
+        \PullState::from_array($data);
+    }
+
     public function testStateRejectsDiffFieldsFromThePreviousSchema(): void
     {
         $data = (new \PullState())->to_array();

--- a/tests/Import/StateFunctionsTest.php
+++ b/tests/Import/StateFunctionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/state/state-functions.php';
+
+final class StateFunctionsTest extends TestCase {
+    public function testRelatedStateChangesReachAsyncSignalHandlerTogether(): void
+    {
+        if (
+            !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_signal')
+            || !function_exists('pcntl_signal_get_handler')
+            || !function_exists('posix_getpid')
+            || !function_exists('posix_kill')
+            || !defined('SIGUSR1')
+        ) {
+            $this->markTestSkipped('This test requires async signal support.');
+        }
+
+        $state = ['cursor' => 'old-cursor', 'byte_offset' => 10];
+        $saved_state = null;
+        $signal_observed_state = null;
+        $previous_async_signals = pcntl_async_signals();
+        $previous_signal_handler = pcntl_signal_get_handler(SIGUSR1);
+        pcntl_signal(
+            SIGUSR1,
+            static function () use (&$signal_observed_state, &$saved_state): void {
+                $signal_observed_state = $saved_state;
+            }
+        );
+        pcntl_async_signals(true);
+
+        try {
+            \reprint_update_and_save_state_without_signal_interruption(
+                function () use (&$state, &$signal_observed_state): void {
+                    $state['cursor'] = null;
+                    posix_kill(posix_getpid(), SIGUSR1);
+                    $this->assertNull($signal_observed_state);
+                    $state['byte_offset'] = 20;
+                },
+                static function () use (&$state, &$saved_state): void {
+                    $saved_state = $state;
+                }
+            );
+            pcntl_signal_dispatch();
+            $this->assertSame(
+                ['cursor' => null, 'byte_offset' => 20],
+                $signal_observed_state
+            );
+        } finally {
+            pcntl_signal(SIGUSR1, $previous_signal_handler);
+            pcntl_async_signals($previous_async_signals);
+        }
+    }
+}


### PR DESCRIPTION
Files-index and files-pull now retain their traversal selection across interrupted commands.

Before this change, omitting `--include-caches` or `--extra-directory` on resume could continue an index with a different selection. A conflicting direct or high-level pull command could also overwrite unfinished lifecycle state before command ownership was checked.

This checkpoints symlink following, cache inclusion, and the extra directory at the first durable boundary. Omitted options resume the saved selection. Explicit changes require `--abort`, and incompatible commands are rejected before state changes.

## Testing

Run the focused selection lifecycle, pull option, state, and real endpoint tests.
