### PR TITLE
[PHP] Resume remote-index sorting without another request

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3050,7 +3050,7 @@ class ImportClient
      * - Prior completed files-pull → delta mode (re-index, diff, fetch changes)
      * - In-progress files-pull → resume from saved state
      *
-     * Both modes share the same pipeline: index → diff → fetch.
+     * Both modes share the same pipeline: index → sort → diff → fetch.
      */
     public function run_files_pull(): void
     {
@@ -3250,6 +3250,15 @@ class ImportClient
                     return;
                 }
             }
+            // Sorting replaces the index atomically. Save its phase first so
+            // interruption after the replacement reruns the idempotent sort
+            // instead of requesting the remote index again.
+            $this->get_state()->active_resumable_command->current_stage = "sort";
+            $this->save_state();
+            $stage = "sort";
+        }
+
+        if ($stage === "sort") {
             $this->sort_next_remote_index_file();
             $this->get_state()->active_resumable_command->current_stage = "diff";
             $this->get_state()->diff = new FileDiffProgressState();
@@ -3443,47 +3452,59 @@ class ImportClient
         $this->get_state()->active_resumable_command->command_name = "files-index";
         $this->save_state();
 
-        $attempts = 0;
-        $last_cursor = $this->get_state()->index->cursor ?? null;
-        while (true) {
-            $complete = $this->fetch_next_remote_index();
-            if ($complete) {
-                break;
+        $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
+        if ($stage === "index") {
+            $attempts = 0;
+            $last_cursor = $this->get_state()->index->cursor ?? null;
+            while (true) {
+                $complete = $this->fetch_next_remote_index();
+                if ($complete) {
+                    break;
+                }
+
+                if ($this->shutdown_requested) {
+                    $this->get_state()->active_resumable_command->completion_state = "partial";
+                    $this->save_state();
+                    return;
+                }
+
+                $current_cursor = $this->get_state()->index->cursor ?? null;
+                if ($current_cursor === $last_cursor) {
+                    throw new RuntimeException(
+                        "files-index made no progress (cursor unchanged)",
+                    );
+                }
+                $last_cursor = $current_cursor;
+
+                $attempts++;
+                if ($attempts > 100000) {
+                    throw new RuntimeException(
+                        "files-index exceeded maximum attempts",
+                    );
+                }
             }
 
-            if ($this->shutdown_requested) {
-                $this->get_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state();
-                return;
+            // Follow symlinks: discover symlink targets outside known roots and
+            // index them as additional directories.  Repeats until no new targets
+            // are found, with cycle detection via realpath.
+            if ($this->follow_symlinks) {
+                $this->discover_symlink_targets();
             }
 
-            $current_cursor = $this->get_state()->index->cursor ?? null;
-            if ($current_cursor === $last_cursor) {
-                throw new RuntimeException(
-                    "files-index made no progress (cursor unchanged)",
-                );
-            }
-            $last_cursor = $current_cursor;
-
-            $attempts++;
-            if ($attempts > 100000) {
-                throw new RuntimeException(
-                    "files-index exceeded maximum attempts",
-                );
-            }
+            // Sorting replaces the index atomically. Save its phase first so
+            // interruption after the replacement reruns the idempotent sort
+            // instead of requesting the remote index again.
+            $this->get_state()->active_resumable_command->current_stage = "sort";
+            $this->save_state();
+            $stage = "sort";
         }
 
-        // Follow symlinks: discover symlink targets outside known roots and
-        // index them as additional directories.  Repeats until no new targets
-        // are found, with cycle detection via realpath.
-        if ($this->follow_symlinks) {
-            $this->discover_symlink_targets();
+        if ($stage === "sort") {
+            $this->sort_next_remote_index_file();
+            $this->get_state()->active_resumable_command->completion_state = "complete";
+            $this->get_state()->active_resumable_command->current_stage = null;
+            $this->save_state();
         }
-
-        $this->sort_next_remote_index_file();
-        $this->get_state()->active_resumable_command->completion_state = "complete";
-        $this->get_state()->active_resumable_command->current_stage = null;
-        $this->save_state();
 
         $next_remote_index_entry_count = 0;
         if (file_exists($this->next_remote_index_file)) {

--- a/tests/Import/RemoteIndexSortResumeTest.php
+++ b/tests/Import/RemoteIndexSortResumeTest.php
@@ -1,0 +1,367 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the next line.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Boundary clients live with the lifecycle tests which use them.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The generated local router needs literal PHP values.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/** Exercises the durable remote-index sort phase through the real exporter. */
+final class RemoteIndexSortResumeTest extends TestCase
+{
+    private $tempDirectory;
+    private $stateDirectory;
+    private $filesystemRoot;
+    private $remoteSiteDirectory;
+    private $requestLog;
+    private $remoteUrl;
+    private $serverProcess;
+    private $serverPipes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDirectory = sys_get_temp_dir()
+            . '/remote-index-sort-' . uniqid();
+        $this->stateDirectory = $this->tempDirectory . '/state';
+        $this->filesystemRoot = $this->tempDirectory . '/local';
+        $this->remoteSiteDirectory = $this->tempDirectory . '/remote-site';
+        $this->requestLog = $this->tempDirectory . '/requests.jsonl';
+        foreach (
+            [
+                $this->stateDirectory,
+                $this->filesystemRoot,
+                $this->remoteSiteDirectory,
+            ] as $directory
+        ) {
+            mkdir($directory, 0755, true);
+        }
+        file_put_contents($this->remoteSiteDirectory . '/z-last.txt', 'z');
+        file_put_contents($this->remoteSiteDirectory . '/a-first.txt', 'a');
+        $this->remoteUrl = $this->startRealExporter();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess, 9);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->tempDirectory);
+        parent::tearDown();
+    }
+
+    public function testFilesIndexResumesSortWithoutAnotherIndexRequest(): void
+    {
+        $this->writePreflightState();
+
+        try {
+            $this->runClient(
+                $this->newClient(StopAfterFilesIndexSortClient::class),
+                'files-index'
+            );
+            $this->fail('Expected the post-sort state save to stop files-index.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop after sorting the files-index output.',
+                $exception->getMessage()
+            );
+        }
+
+        $stateAfterSort = $this->readState();
+        $indexAfterSort = file_get_contents($this->nextRemoteIndexPath());
+        $requestsAfterSort = $this->fileIndexRequestCount();
+        $this->assertSame(
+            'sort',
+            $stateAfterSort['active_resumable_command']['current_stage']
+        );
+        $this->assertGreaterThan(0, $requestsAfterSort);
+        $this->assertIsString($indexAfterSort);
+
+        $this->runClient($this->newClient(), 'files-index');
+
+        $this->assertSame($requestsAfterSort, $this->fileIndexRequestCount());
+        $this->assertSame($indexAfterSort, file_get_contents($this->nextRemoteIndexPath()));
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testFilesPullResumesSortWithoutAnotherIndexRequest(): void
+    {
+        $this->writePreflightState();
+
+        $stoppedAfterSort = false;
+        for ($attempt = 0; $attempt < 20; ++$attempt) {
+            try {
+                $this->runClient(
+                    $this->newClient(StopAfterFilesPullSortClient::class),
+                    'files-pull'
+                );
+            } catch (\RuntimeException $exception) {
+                $this->assertSame(
+                    'Stop after sorting the files-pull index.',
+                    $exception->getMessage()
+                );
+                $stoppedAfterSort = true;
+                break;
+            }
+        }
+        $this->assertTrue(
+            $stoppedAfterSort,
+            'Expected the post-sort state save to stop files-pull.'
+        );
+
+        $stateAfterSort = $this->readState();
+        $requestsAfterSort = $this->fileIndexRequestCount();
+        $this->assertSame(
+            'sort',
+            $stateAfterSort['active_resumable_command']['current_stage']
+        );
+        $this->assertGreaterThan(0, $requestsAfterSort);
+
+        $this->runClient($this->newClient(), 'files-pull');
+
+        $this->assertSame($requestsAfterSort, $this->fileIndexRequestCount());
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    /** @param class-string<\ImportClient> $clientClass */
+    private function newClient(string $clientClass = \ImportClient::class): \ImportClient
+    {
+        $client = new $clientClass(
+            $this->remoteUrl,
+            $this->stateDirectory,
+            $this->filesystemRoot
+        );
+        $output = fopen('php://temp', 'w+');
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('progress_fd')->setValue($client, $output);
+        $progress = $reflection->getProperty('progress')->getValue($client);
+        ( new \ReflectionClass($progress) )->getProperty('progress_fd')->setValue(
+            $progress,
+            $output
+        );
+        return $client;
+    }
+
+    private function runClient(\ImportClient $client, string $command): void
+    {
+        $client->run([
+            'command' => $command,
+            'follow_symlinks' => false,
+            'progress' => 'jsonl',
+        ]);
+    }
+
+    private function writePreflightState(): void
+    {
+        \write_current_pull_state($this->newClient(), [
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'runtime' => [
+                        'document_root' => $this->remoteSiteDirectory,
+                    ],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => $this->remoteSiteDirectory],
+                        ],
+                    ],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+        ]);
+    }
+
+    private function readState(): array
+    {
+        $state = json_decode(
+            file_get_contents($this->pullStateDirectory() . '/state.json'),
+            true
+        );
+        $this->assertIsArray($state);
+        return $state;
+    }
+
+    private function fileIndexRequestCount(): int
+    {
+        $requests = is_file($this->requestLog)
+            ? file($this->requestLog, FILE_IGNORE_NEW_LINES)
+            : [];
+        $count = 0;
+        foreach ($requests ?: [] as $requestJson) {
+            $request = json_decode($requestJson, true);
+            if (is_array($request) && ( $request['endpoint'] ?? null ) === 'file_index') {
+                ++$count;
+            }
+        }
+        return $count;
+    }
+
+    private function pullStateDirectory(): string
+    {
+        return $this->stateDirectory . '/remotes/'
+            . md5(rtrim($this->remoteUrl, '?&')) . '/pull';
+    }
+
+    private function nextRemoteIndexPath(): string
+    {
+        return $this->pullStateDirectory() . '/remote-index.next.jsonl';
+    }
+
+    private function startRealExporter(): string
+    {
+        $router = $this->tempDirectory . '/router.php';
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $serverClass = realpath(
+            __DIR__ . '/../../packages/reprint-server/src/class-http-server.php'
+        );
+        $this->assertIsString($autoload);
+        $this->assertIsString($serverClass);
+        file_put_contents(
+            $router,
+            sprintf(
+                <<<'PHP'
+<?php
+file_put_contents(
+    %s,
+    json_encode(['endpoint' => $_GET['endpoint'] ?? null]) . "\n",
+    FILE_APPEND
+);
+require_once %s;
+require_once %s;
+Site_Export_HTTP_Server::serve(['default_directory' => %s]);
+PHP,
+                var_export($this->requestLog, true),
+                var_export($autoload, true),
+                var_export($serverClass, true),
+                var_export($this->remoteSiteDirectory, true)
+            )
+        );
+
+        $socket = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $errorNumber,
+            $errorMessage
+        );
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+        $environment = getenv();
+        if (!is_array($environment)) {
+            $environment = [];
+        }
+        $environment['SITE_EXPORT_TEST_MODE'] = '1';
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->serverPipes,
+            $this->tempDirectory,
+            $environment
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen(
+                '127.0.0.1',
+                $port,
+                $errorNumber,
+                $errorMessage,
+                0.1
+            );
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port
+                    . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('The real exporter did not start.');
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}
+
+/** Stops files-index after the atomic sort and before its completion save. */
+final class StopAfterFilesIndexSortClient extends \ImportClient
+{
+    private $stopped = false;
+
+    public function save_state(): void
+    {
+        $command = $this->get_state()->active_resumable_command;
+        if (
+            !$this->stopped
+            && $command->command_name === 'files-index'
+            && $command->completion_state === 'complete'
+            && $command->current_stage === null
+        ) {
+            $this->stopped = true;
+            throw new \RuntimeException(
+                'Stop after sorting the files-index output.'
+            );
+        }
+        parent::save_state();
+    }
+}
+
+/** Stops files-pull after the atomic sort and before its diff-phase save. */
+final class StopAfterFilesPullSortClient extends \ImportClient
+{
+    private $stopped = false;
+
+    public function save_state(): void
+    {
+        $command = $this->get_state()->active_resumable_command;
+        if (
+            !$this->stopped
+            && $command->command_name === 'files-pull'
+            && $command->current_stage === 'diff'
+        ) {
+            $this->stopped = true;
+            throw new \RuntimeException(
+                'Stop after sorting the files-pull index.'
+            );
+        }
+        parent::save_state();
+    }
+}


### PR DESCRIPTION
Remote-index sorting now has its own durable stage.

Sorting replaces the index atomically. If the process stops after that replacement but before the following state save, the saved lifecycle used to return to indexing and request the remote tree again. Resume now repeats the idempotent sort and proceeds without another file-index request.

## Testing

Interrupt files-index and files-pull after the sorted index replaces the unsorted file, then resume and confirm no additional file-index request is sent.
