### PR TITLE
[PHP] Bind file-index cursors to canonical traversal selection

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -118,13 +118,14 @@ require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
  * The wire-protocol version this importer speaks.
  *
  * The export plugin and importer report this value during preflight so a
- * mismatched deployment fails before any content is transferred.
+ * mismatched deployment fails before a file-index request using this
+ * versioned format begins.
  *
  * Bump this whenever a change to the wire protocol (cursor encoding,
  * multipart structure, header names, endpoint parameters, response format)
  * would break an older export plugin.
  */
-define('PULL_PROTOCOL_VERSION', 1);
+define('PULL_PROTOCOL_VERSION', 2);
 
 register_shutdown_function(function () {
     $error = error_get_last();
@@ -2822,18 +2823,10 @@ class ImportClient
         }
 
         // 3. Protocol version
-        $remote_ver = $this->get_state()->remote_protocol_version ?? null;
-        if ($remote_ver === null) {
-            $proto_ok = false;
-            $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
-        } elseif ($remote_ver < PULL_PROTOCOL_VERSION) {
-            $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the export plugin.";
-        } elseif ($remote_ver > PULL_PROTOCOL_VERSION) {
-            $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the Reprint client.";
-        } else {
-            $proto_ok = true;
+        $remote_ver = $this->get_state()->remote_protocol_version;
+        $proto_detail = $this->remote_protocol_mismatch_message();
+        $proto_ok = $proto_detail === null;
+        if ($proto_ok) {
             $proto_detail = "remote v{$remote_ver}, client v" . PULL_PROTOCOL_VERSION;
         }
         $checks[] = [
@@ -3054,6 +3047,8 @@ class ImportClient
      */
     public function run_files_pull(): void
     {
+        $this->assert_file_index_protocol_version();
+
         $sender_state_path = wp_join_unix_paths(
             dirname($this->pull_state_directory),
             "push",
@@ -3397,6 +3392,8 @@ class ImportClient
      */
     private function run_files_index(): void
     {
+        $this->assert_file_index_protocol_version();
+
         $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
         $current_status =
             $state_command === "files-index"
@@ -3535,6 +3532,35 @@ class ImportClient
             "audit_log" => $this->audit_log_file,
             "message" => "files-index complete: {$next_remote_index_entry_count} entries indexed",
         ], true);
+    }
+
+    /** Refuse file-index work when preflight reported another protocol version. */
+    public function assert_file_index_protocol_version(): void
+    {
+        $protocol_mismatch = $this->remote_protocol_mismatch_message();
+        if ($protocol_mismatch !== null) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI protocol guidance is not HTML.
+            throw new RuntimeException($protocol_mismatch);
+        }
+    }
+
+    /** Return pointed upgrade guidance for a protocol mismatch. */
+    private function remote_protocol_mismatch_message(): ?string
+    {
+        $remote_protocol_version = $this->get_state()->remote_protocol_version;
+        if ($remote_protocol_version === null) {
+            return "Remote export plugin does not report a protocol version. " .
+                "Update the export plugin.";
+        }
+        if ($remote_protocol_version < PULL_PROTOCOL_VERSION) {
+            return "Remote protocol v{$remote_protocol_version} does not match client protocol v" .
+                PULL_PROTOCOL_VERSION . ". Update the export plugin.";
+        }
+        if ($remote_protocol_version > PULL_PROTOCOL_VERSION) {
+            return "Remote protocol v{$remote_protocol_version} does not match client protocol v" .
+                PULL_PROTOCOL_VERSION . ". Update the Reprint client.";
+        }
+        return null;
     }
 
     /**
@@ -11207,6 +11233,8 @@ class ImportClient
         $previous_state = $this->state;
         $this->state = new PullState();
         $this->state->set_preflight_record($previous_state->preflight_record());
+        $this->state->remote_protocol_version =
+            $previous_state->remote_protocol_version;
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -466,6 +466,12 @@ class Pull
 
             try {
                 $this->run_stage($stage, $options, $step, $total);
+                if (
+                    $stage === 'preflight'
+                    && in_array('files-pull', $stages, true)
+                ) {
+                    $this->client->assert_file_index_protocol_version();
+                }
             } catch (\Exception $e) {
                 $this->report_failure($command, $stage, $stages, $i, $e);
                 throw new PullFailureReportedException($e->getMessage(), 0, $e);

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -117,25 +117,10 @@ final class FileIndexProcessor {
         // Visit the requested directory first, followed by every other root in
         // stable byte order. Stable ordering makes a cursor independent of the
         // order in which configuration discovered the additional roots.
-        $ordered_directories = [$canonical_index_directory];
-        $extra_directories = [];
-        foreach ($directories as $directory) {
-            if ($directory !== $canonical_index_directory) {
-                $extra_directories[] = $directory;
-            }
-        }
-        sort($extra_directories, SORT_STRING);
-        foreach ($extra_directories as $directory) {
-            // Parent and child roots both remain scheduled. On wp.com Atomic,
-            // for example, the document root may be a parent of the primary
-            // WordPress root while also containing a separate wp-content.
-            // Dropping the parent would hide those plugins and themes. When
-            // traversal later reaches the scheduled child, the root check
-            // prevents entering it a second time.
-            if (!in_array($directory, $ordered_directories, true)) {
-                $ordered_directories[] = $directory;
-            }
-        }
+        $ordered_directories = self::ordered_index_roots(
+            $canonical_index_directory,
+            $directories
+        );
 
         // The last stack element is visited next, so reverse the desired order
         // while constructing the depth-first traversal stack.
@@ -194,8 +179,49 @@ final class FileIndexProcessor {
         if (!is_array($cursor)) {
             throw new InvalidArgumentException("Invalid index cursor format");
         }
-        if (!isset($cursor["stack"]) || !is_array($cursor["stack"])) {
-            throw new InvalidArgumentException("Index cursor missing stack");
+        if (
+            !isset(
+                $cursor["stack"],
+                $cursor["list_directory"],
+                $cursor["selection_fingerprint"]
+            )
+            || !is_array($cursor["stack"])
+            || array_values($cursor["stack"]) !== $cursor["stack"]
+            || !is_string($cursor["list_directory"])
+            || !is_string($cursor["selection_fingerprint"])
+        ) {
+            throw new InvalidArgumentException(
+                "Index cursor must contain its traversal stack, list directory, and selection fingerprint"
+            );
+        }
+        $index_directory = base64_decode($cursor["list_directory"], true);
+        if (
+            !is_string($index_directory)
+            || base64_encode($index_directory) !== $cursor["list_directory"]
+        ) {
+            throw new InvalidArgumentException(
+                "Index cursor list_directory contains invalid base64"
+            );
+        }
+        \WordPress\Reprint\Exporter\assert_valid_path(
+            $index_directory,
+            "index cursor list_directory path"
+        );
+        if (
+            !hash_equals(
+                self::selection_fingerprint(
+                    $index_directory,
+                    $directories,
+                    $follow_symlinks,
+                    $include_caches,
+                    $storage_path
+                ),
+                $cursor["selection_fingerprint"]
+            )
+        ) {
+            throw new InvalidArgumentException(
+                "The file-index selection changed while resuming the traversal"
+            );
         }
 
         // Paths are base64 text because filesystem names are arbitrary bytes
@@ -232,13 +258,6 @@ final class FileIndexProcessor {
                 "after" => $after,
             ];
         }
-
-        // During continuation, the active directory is the best description
-        // of what this request is indexing. A completed cursor has no active
-        // directory, so it falls back to the first configured root.
-        $index_directory = !empty($directory_stack)
-            ? $directory_stack[count($directory_stack) - 1]["dir"]
-            : ( isset($directories[0]) ? $directories[0] : "/" );
 
         return new self(
             $directories,
@@ -445,7 +464,9 @@ final class FileIndexProcessor {
      * @return array {
      *     File-index cursor.
      *
-     *     @type array[] $stack Active directories with base64-encoded path names.
+     *     @type array[] $stack                 Active directories with base64 path names.
+     *     @type string  $list_directory        Canonical list directory, stored as base64.
+     *     @type string  $selection_fingerprint SHA-256 of every traversal selection field.
      * }
      */
     public function get_cursor(): array
@@ -457,7 +478,17 @@ final class FileIndexProcessor {
                 "after" => $frame["after"] !== null ? base64_encode($frame["after"]) : null,
             ];
         }
-        return ["stack" => $encoded_stack];
+        return [
+            "stack" => $encoded_stack,
+            "list_directory" => base64_encode($this->index_directory),
+            "selection_fingerprint" => self::selection_fingerprint(
+                $this->index_directory,
+                $this->directories,
+                $this->follow_symlinks,
+                $this->include_caches,
+                $this->storage_path
+            ),
+        ];
     }
 
     /**
@@ -468,6 +499,15 @@ final class FileIndexProcessor {
     public function get_index_directory(): string
     {
         return $this->index_directory;
+    }
+
+    /** @return string[] Canonical roots scheduled by this traversal. */
+    public function get_index_roots(): array
+    {
+        return self::ordered_index_roots(
+            $this->index_directory,
+            $this->directories
+        );
     }
 
     /**
@@ -587,6 +627,64 @@ final class FileIndexProcessor {
         $this->directory_stack = $directory_stack;
         $this->index_directory = $index_directory;
         $this->initial_index_entries = $initial_index_entries;
+    }
+
+    /**
+     * Returns the stable roots scheduled for one traversal.
+     *
+     * Parent and child roots both remain scheduled. On wp.com Atomic, for
+     * example, the document root may be a parent of the primary WordPress root
+     * while also containing a separate wp-content. Dropping the parent would
+     * hide those plugins and themes. When traversal later reaches the scheduled
+     * child, the root check prevents entering it a second time.
+     *
+     * @param string   $index_directory Canonical directory visited first.
+     * @param string[] $directories     Canonical configured directories.
+     * @return string[] Stable scheduled roots.
+     */
+    private static function ordered_index_roots(
+        string $index_directory,
+        array $directories
+    ): array {
+        $ordered_directories = [$index_directory];
+        $extra_directories = [];
+        foreach ($directories as $directory) {
+            if ($directory !== $index_directory) {
+                $extra_directories[] = $directory;
+            }
+        }
+        sort($extra_directories, SORT_STRING);
+        foreach ($extra_directories as $directory) {
+            if (!in_array($directory, $ordered_directories, true)) {
+                $ordered_directories[] = $directory;
+            }
+        }
+        return $ordered_directories;
+    }
+
+    /** Returns a byte-safe digest of every selection affecting traversal. */
+    private static function selection_fingerprint(
+        string $index_directory,
+        array $directories,
+        bool $follow_symlinks,
+        bool $include_caches,
+        string $storage_path
+    ): string {
+        $canonical_directories = array_values(array_unique($directories));
+        sort($canonical_directories, SORT_STRING);
+        $selection_json = json_encode([
+            "list_directory_b64" => base64_encode($index_directory),
+            "directories_b64" => array_map("base64_encode", $canonical_directories),
+            "follow_symlinks" => $follow_symlinks,
+            "include_caches" => $include_caches,
+            "storage_path_b64" => base64_encode(
+                self::canonical_storage_path($storage_path)
+            ),
+        ], JSON_UNESCAPED_SLASHES);
+        if ($selection_json === false) {
+            throw new LogicException("Failed to encode the file-index selection");
+        }
+        return hash("sha256", $selection_json);
     }
 
     /**

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -24,14 +24,15 @@ if (!ob_get_level()) {
  * The wire-protocol version this export plugin speaks.
  *
  * The export plugin and importer report this value during preflight so a
- * mismatched deployment fails before any content is transferred.
+ * mismatched deployment fails before a file-index request using this
+ * versioned format begins.
  *
  * EXPORT_PROTOCOL_VERSION is sent to the importer in the preflight JSON
  * response as `protocol_version`.  Bump it whenever a change to the wire
  * protocol (cursor encoding, multipart structure, header names, endpoint
  * parameters, response format) would break an older importer.
  */
-define('EXPORT_PROTOCOL_VERSION', 1);
+define('EXPORT_PROTOCOL_VERSION', 2);
 
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);
@@ -2605,9 +2606,15 @@ function endpoint_file_index(
     $abort_payload = null;
 
     try {
+        // Configured directories may be symlinks. Report the canonical roots
+        // used by the index so a later pull can match retained index paths.
         $metadata = [
             "filesystem_root" => base64_encode($filesystem_root),
             "list_dir" => base64_encode($list_directory),
+            "indexed_roots" => array_map(
+                "base64_encode",
+                $file_index->get_index_roots()
+            ),
         ];
         $metadata_json = json_encode_or_throw($metadata);
         $gz->write(

--- a/tests/FileIndexDedupTest.php
+++ b/tests/FileIndexDedupTest.php
@@ -75,11 +75,54 @@ final class FileIndexDedupTest extends TestCase
         );
     }
 
+    public function testFileIndexMetadataReportsCanonicalIndexedRoots(): void
+    {
+        $target = $this->tempDir . '/target';
+        $link = $this->tempDir . '/link';
+        mkdir($target, 0755, true);
+        symlink($target, $link);
+
+        $response = $this->runFileIndexResponse([$link], $link);
+        $matched = preg_match(
+            '/X-Chunk-Type: metadata\r\n(?:[^\r\n]+\r\n)*\r\n(\{[^\r\n]+\})\r\n/',
+            $response,
+            $matches
+        );
+        $this->assertSame(1, $matched, 'Expected file-index metadata part.');
+        $metadata = json_decode($matches[1], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($metadata);
+        $canonicalTarget = realpath($target);
+        $this->assertIsString($canonicalTarget);
+        $this->assertSame(
+            [base64_encode($canonicalTarget)],
+            $metadata['indexed_roots']
+        );
+        $this->assertSame(
+            base64_encode($canonicalTarget),
+            $metadata['list_dir']
+        );
+    }
+
     /**
      * @param string[] $directories
      * @return string[]
      */
     private function runFileIndex(array $directories, string $listDir): array
+    {
+        $decoded = $this->runFileIndexResponse($directories, $listDir);
+        preg_match_all('/"path":"([^"]+)"/', $decoded, $matches);
+
+        return array_map(
+            static fn(string $encodedPath): string => (string) base64_decode($encodedPath, true),
+            $matches[1],
+        );
+    }
+
+    /** @param string[] $directories */
+    private function runFileIndexResponse(
+        array $directories,
+        string $listDir
+    ): string
     {
         $configPath = $this->tempDir . '/config.json';
         file_put_contents(
@@ -129,13 +172,7 @@ PHP,
 
         $decoded = gzdecode($stdout);
         $this->assertNotFalse($decoded, 'Expected gzip-compressed multipart response');
-
-        preg_match_all('/"path":"([^"]+)"/', $decoded, $matches);
-
-        return array_map(
-            static fn(string $encodedPath): string => (string) base64_decode($encodedPath, true),
-            $matches[1],
-        );
+        return $decoded;
     }
 
     private function recursiveDelete(string $dir): void

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -225,6 +225,200 @@ final class FileIndexProcessorTest extends TestCase {
         $resumed->close();
     }
 
+    public function testCursorKeepsTheCanonicalRootsScheduledAtStart(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        $target = $this->tempDir . '/target';
+        $link = $docroot . '/link';
+        mkdir($docroot, 0755, true);
+        mkdir($target, 0755, true);
+        symlink($target, $link);
+        $canonicalDocroot = (string) realpath($docroot);
+        $canonicalTarget = (string) realpath($target);
+
+        $processor = FileIndexProcessor::start(
+            [$canonicalDocroot],
+            $link,
+            true,
+            true,
+            ''
+        );
+        $this->assertSame(
+            [$canonicalTarget, $canonicalDocroot],
+            $processor->get_index_roots()
+        );
+        $this->assertTrue($processor->next_index_step());
+        $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+        $processor->close();
+
+        $resumed = FileIndexProcessor::resume(
+            [$canonicalDocroot],
+            $cursor,
+            true,
+            true,
+            ''
+        );
+        $this->assertSame(
+            [$canonicalTarget, $canonicalDocroot],
+            $resumed->get_index_roots()
+        );
+        $this->assertSame($canonicalTarget, $resumed->get_index_directory());
+        $resumed->close();
+    }
+
+    public function testResumeRejectsChangedCanonicalDirectories(): void
+    {
+        $first = $this->tempDir . '/first';
+        $second = $this->tempDir . '/second';
+        mkdir($first, 0755, true);
+        mkdir($second, 0755, true);
+        $first = (string) realpath($first);
+        $second = (string) realpath($second);
+
+        $processor = FileIndexProcessor::start(
+            [$first],
+            $first,
+            true,
+            true,
+            ''
+        );
+        $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+        $processor->close();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The file-index selection changed while resuming the traversal'
+        );
+        FileIndexProcessor::resume(
+            [$second],
+            $cursor,
+            true,
+            true,
+            ''
+        );
+    }
+
+    public function testResumeAcceptsTheSameCanonicalDirectoriesInAnotherOrder(): void
+    {
+        $first = $this->tempDir . '/first';
+        $second = $this->tempDir . '/second';
+        mkdir($first, 0755, true);
+        mkdir($second, 0755, true);
+        $first = (string) realpath($first);
+        $second = (string) realpath($second);
+
+        $processor = FileIndexProcessor::start(
+            [$first, $second],
+            $first,
+            true,
+            true,
+            ''
+        );
+        $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+        $processor->close();
+
+        $resumed = FileIndexProcessor::resume(
+            [$second, $first, $second],
+            $cursor,
+            true,
+            true,
+            ''
+        );
+        $this->assertSame([$first, $second], $resumed->get_index_roots());
+        $resumed->close();
+    }
+
+    public function testResumeRejectsCursorWithoutTraversalRoots(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot, 0755, true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Index cursor must contain its traversal stack, list directory, and selection fingerprint'
+        );
+        FileIndexProcessor::resume(
+            [ (string) realpath( $docroot ) ],
+            json_encode(['stack' => []], JSON_THROW_ON_ERROR),
+            false,
+            true,
+            ''
+        );
+    }
+
+    public function testResumeRejectsTamperedSelectionFingerprint(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        mkdir($docroot, 0755, true);
+        $canonical_docroot = (string) realpath($docroot);
+
+        $processor = FileIndexProcessor::start(
+            [$canonical_docroot],
+            $canonical_docroot,
+            true,
+            false,
+            ''
+        );
+        $cursor = $processor->get_cursor();
+        $processor->close();
+        $cursor['selection_fingerprint'] = str_repeat('0', 64);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The file-index selection changed while resuming the traversal'
+        );
+        FileIndexProcessor::resume(
+            [$canonical_docroot],
+            json_encode($cursor, JSON_THROW_ON_ERROR),
+            true,
+            false,
+            ''
+        );
+    }
+
+    public function testResumeRejectsChangedTraversalSettings(): void
+    {
+        $docroot = $this->tempDir . '/site';
+        $storage = $this->tempDir . '/storage';
+        mkdir($docroot, 0755, true);
+        mkdir($storage, 0755, true);
+        $canonical_docroot = (string) realpath($docroot);
+
+        $processor = FileIndexProcessor::start(
+            [$canonical_docroot],
+            $canonical_docroot,
+            true,
+            true,
+            $storage
+        );
+        $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
+        $processor->close();
+
+        foreach (
+            [
+                [false, true, $storage],
+                [true, false, $storage],
+                [true, true, ''],
+            ] as [$follow_symlinks, $include_caches, $next_storage]
+        ) {
+            try {
+                FileIndexProcessor::resume(
+                    [$canonical_docroot],
+                    $cursor,
+                    $follow_symlinks,
+                    $include_caches,
+                    $next_storage
+                );
+                $this->fail('Expected changed traversal settings to be rejected.');
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString(
+                    'file-index selection changed',
+                    $exception->getMessage()
+                );
+            }
+        }
+    }
+
     public function testStepAfterCloseIsRejected(): void
     {
         $docroot = $this->tempDir . '/site';

--- a/tests/Import/FileIndexProtocolVersionTest.php
+++ b/tests/Import/FileIndexProtocolVersionTest.php
@@ -1,0 +1,335 @@
+<?php
+
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The generated router needs literal filesystem paths.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the next line.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+/** Exercises file-index protocol rejection through the CLI and a real HTTP endpoint. */
+final class FileIndexProtocolVersionTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $filesystemRoot;
+    private $remoteSite;
+    private $requestLog;
+    private $protocolVersionFile;
+    private $remoteUrl;
+    private $serverProcess;
+    private $serverPipes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/file-index-protocol-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->filesystemRoot = $this->tempDir . '/local';
+        $this->remoteSite = $this->tempDir . '/remote-site';
+        $this->requestLog = $this->tempDir . '/requests.jsonl';
+        $this->protocolVersionFile = $this->tempDir . '/protocol-version';
+        foreach ([$this->stateDir, $this->filesystemRoot, $this->remoteSite] as $directory) {
+            mkdir($directory, 0755, true);
+        }
+        file_put_contents($this->remoteSite . '/index.php', '<?php');
+        file_put_contents($this->protocolVersionFile, '1');
+        $this->remoteUrl = $this->startExporter();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopExporter();
+        $this->removeTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testDirectFileIndexCommandsRejectProtocolV1BeforeAFileIndexRequest(): void
+    {
+        $this->runPreflight();
+
+        foreach (['files-index', 'files-pull'] as $command) {
+            $result = $this->runCli([$command]);
+            $this->assertSame(1, $result['exit'], $result['output']);
+            $this->assertStringContainsString(
+                'Remote protocol v1 does not match client protocol v2',
+                $result['output']
+            );
+            $this->assertStringContainsString(
+                'Update the export plugin',
+                $result['output']
+            );
+            $this->assertSame([], $this->fileIndexRequests());
+        }
+        $this->assertNull(
+            $this->readSavedState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testPullFilesRetriesPreflightAfterProtocolV1IsUpgraded(): void
+    {
+        $result = $this->runCli([
+            'pull-files',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $this->assertStringContainsString(
+            'Remote protocol v1 does not match client protocol v2',
+            $result['output']
+        );
+        $this->assertStringContainsString(
+            'Update the export plugin',
+            $result['output']
+        );
+        $this->assertSame([], $this->fileIndexRequests());
+        $savedState = $this->readSavedState();
+        $this->assertSame(1, $savedState['remote_protocol_version']);
+        $this->assertNull($savedState['pull_pipeline']['last_completed_stage']);
+        $this->assertNull(
+            $savedState['active_resumable_command']['completion_state']
+        );
+
+        file_put_contents($this->protocolVersionFile, '2');
+        $result = $this->runCli([
+            'pull-files',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertStringNotContainsString(
+            'does not match client protocol',
+            $result['output']
+        );
+        $this->assertNotSame([], $this->fileIndexRequests());
+        $this->assertCount(2, $this->requestsForEndpoint('preflight'));
+    }
+
+    public function testProtocolV1DoesNotPreventLocalFileIndexAbort(): void
+    {
+        $this->runPreflight();
+        $this->stopExporter();
+
+        foreach (['files-pull', 'files-index'] as $command) {
+            $result = $this->runCli([$command, '--abort']);
+            $this->assertSame(0, $result['exit'], $result['output']);
+            $this->assertStringContainsString(
+                '"status":"aborted"',
+                $result['output']
+            );
+        }
+
+        $this->assertSame(
+            1,
+            $this->readSavedState()['remote_protocol_version']
+        );
+        $this->assertSame([], $this->fileIndexRequests());
+    }
+
+    private function runPreflight(): void
+    {
+        $result = $this->runCli(['preflight']);
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame(1, $this->readSavedState()['remote_protocol_version']);
+    }
+
+    /** @return array{exit:int,output:string} */
+    private function runCli(array $arguments): array
+    {
+        $command = array_merge(
+            [
+                PHP_BINARY,
+                __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
+                $arguments[0],
+                $this->remoteUrl,
+            ],
+            array_slice($arguments, 1),
+            [
+                '--state-dir=' . $this->stateDir,
+                '--fs-root=' . $this->filesystemRoot,
+            ]
+        );
+        $process = proc_open(
+            $command,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes,
+            $this->tempDir
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        $this->assertIsString($stdout);
+        $this->assertIsString($stderr);
+        return [
+            'exit' => $exit,
+            'output' => $stdout . $stderr,
+        ];
+    }
+
+    private function readSavedState(): array
+    {
+        return json_decode(
+            (string) file_get_contents(
+                $this->stateDir
+                    . '/remotes/'
+                    . md5(rtrim($this->remoteUrl, '?&'))
+                    . '/pull/state.json'
+            ),
+            true
+        );
+    }
+
+    private function startExporter(): string
+    {
+        $router = $this->tempDir . '/router.php';
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $serverClass = realpath(
+            __DIR__ . '/../../packages/reprint-server/src/class-http-server.php'
+        );
+        $this->assertIsString($autoload);
+        $this->assertIsString($serverClass);
+        file_put_contents(
+            $router,
+            sprintf(
+                <<<'PHP'
+<?php
+file_put_contents(
+    %s,
+    json_encode(['endpoint' => $_GET['endpoint'] ?? null]) . "\n",
+    FILE_APPEND
+);
+if (($_GET['endpoint'] ?? null) === 'preflight') {
+    header('Content-Type: application/json');
+    echo json_encode([
+        'ok' => true,
+        'protocol_version' => (int) file_get_contents(%s),
+        'runtime' => [
+            'document_root' => %s,
+            'ini_get_all' => [],
+        ],
+        'filesystem' => ['ok' => true],
+        'wp_detect' => [
+            'roots' => [['path' => %s]],
+        ],
+        'database' => [
+            'wp' => [
+                'paths_urls' => [
+                    'content_dir' => %s,
+                ],
+            ],
+        ],
+    ]);
+    return;
+}
+require_once %s;
+require_once %s;
+Site_Export_HTTP_Server::serve(['default_directory' => %s]);
+PHP,
+                var_export($this->requestLog, true),
+                var_export($this->protocolVersionFile, true),
+                var_export($this->remoteSite, true),
+                var_export($this->remoteSite, true),
+                var_export($this->remoteSite, true),
+                var_export($autoload, true),
+                var_export($serverClass, true),
+                var_export($this->remoteSite, true)
+            )
+        );
+
+        $socket = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $errorNumber,
+            $errorMessage
+        );
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->serverPipes,
+            $this->tempDir
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen(
+                '127.0.0.1',
+                $port,
+                $errorNumber,
+                $errorMessage,
+                0.1
+            );
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port
+                    . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Exporter did not start.');
+    }
+
+    private function stopExporter(): void
+    {
+        if (!is_resource($this->serverProcess)) {
+            return;
+        }
+        proc_terminate($this->serverProcess, 9);
+        foreach ($this->serverPipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+        proc_close($this->serverProcess);
+        $this->serverProcess = null;
+        $this->serverPipes = [];
+    }
+
+    private function fileIndexRequests(): array
+    {
+        return $this->requestsForEndpoint('file_index');
+    }
+
+    private function requestsForEndpoint(string $expectedEndpoint): array
+    {
+        $lines = is_file($this->requestLog)
+            ? file($this->requestLog, FILE_IGNORE_NEW_LINES)
+            : [];
+        $requests = [];
+        foreach ($lines ?: [] as $line) {
+            $request = json_decode($line, true);
+            $endpoint = $request['endpoint'] ?? null;
+            if ($endpoint === $expectedEndpoint) {
+                $requests[] = $request;
+            }
+        }
+        return $requests;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -508,6 +508,7 @@ final class FilesPullDiffCheckpointTest extends TestCase
                 ],
                 'http_code' => 200,
             ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
             'fs_root_nonempty_behavior' => 'preserve-local',
             'files_pull_path_selection_fingerprint' => hash(

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -868,6 +868,7 @@ final class FilesPullLocalIndexTest extends TestCase
     {
         mkdir($this->pullStateDirectory, 0700, true);
         $state = new \PullState();
+        $state->remote_protocol_version = PULL_PROTOCOL_VERSION;
         $state->set_preflight_record([
             'http_code' => 200,
             'data' => [
@@ -993,6 +994,7 @@ if ($endpoint === 'preflight') {
     header('Content-Type: application/json');
     echo json_encode(array(
         'ok' => true,
+        'protocol_version' => %d,
         'runtime' => array(
             'document_root' => '/var/www/html',
             'ini_get_all' => array(),
@@ -1126,7 +1128,8 @@ echo "--{$boundary}--\r\n";
 PHP,
             base64_encode( (string) json_encode($remoteFiles)),
             base64_encode(self::PULLED_PATH),
-            base64_encode($this->root . '/remote-overrides.json')
+            base64_encode($this->root . '/remote-overrides.json'),
+            PULL_PROTOCOL_VERSION
         ));
 
         $socket = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -73,6 +73,7 @@ class FilesPullStateTest extends TestCase
     {
         \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "remote_protocol_version" => PULL_PROTOCOL_VERSION,
             "follow_symlinks" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
         ], $state));

--- a/tests/Import/IndexLifecycleOwnershipTest.php
+++ b/tests/Import/IndexLifecycleOwnershipTest.php
@@ -89,6 +89,7 @@ final class IndexLifecycleOwnershipTest extends TestCase
             $this->stateDirectory,
             $this->filesystemRoot
         );
+        $client->get_state()->remote_protocol_version = PULL_PROTOCOL_VERSION;
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -186,6 +186,7 @@ PHP, var_export($requestsLog, true)));
                     'data' => $data,
                     'http_code' => 200,
                 ),
+                'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             )
         );
     }

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -129,6 +129,7 @@ class OnlyFilesPathPrefixTest extends TestCase
                 ),
                 'http_code' => 200,
             ),
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
             'fs_root_nonempty_behavior' => 'preserve-local',
             'filter' => 'none',

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -90,6 +90,7 @@ class PullFilterFakeClient extends \ImportClient
                 ],
             ],
         ]);
+        $state->remote_protocol_version = PULL_PROTOCOL_VERSION;
         $state->active_resumable_command->completion_state = "complete";
         $this->save_state();
     }


### PR DESCRIPTION
File-index cursors now reject traversal-selection changes, and the exporter reports the canonical roots covered by a completed traversal.

The cursor binds the canonical list directory, sorted directory selection, symlink and cache settings, and storage path. The client requires protocol v2 before starting versioned file-index work; a local abort remains available with stale preflight state. High-level pulls reject an old exporter before checkpointing preflight, so rerunning after an exporter upgrade performs preflight again.

## Testing

Resume cursors with reordered equivalent directories and reject changed traversal settings. Run a v1 endpoint, confirm no file-index request is sent or preflight checkpointed, switch the same endpoint to v2, and confirm the rerun reaches file indexing.
