### PR TITLE
[PHP] Replay completed remote-index traversals from durable ranges

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -113,6 +113,7 @@ require_once __DIR__ . '/lib/pull/class-pull.php';
 require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
 require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
+require_once __DIR__ . '/lib/pull/class-remote-index-traversal-journal.php';
 
 /**
  * The wire-protocol version this importer speaks.
@@ -249,6 +250,9 @@ class ImportClient
      * directory `empty` fields when available.
      */
     private $next_remote_index_file;
+
+    /** @var string Durable traversal boundaries for pull/remote-index.next.jsonl. */
+    private $next_remote_index_traversal_journal_file;
 
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by comparing the next remote index with the remote index. */
     private $fetch_list_file;
@@ -494,6 +498,11 @@ class ImportClient
             wp_join_unix_paths($this->pull_state_directory, "index.wal");
         $this->next_remote_index_file =
             wp_join_unix_paths($this->pull_state_directory, "remote-index.next.jsonl");
+        $this->next_remote_index_traversal_journal_file =
+            wp_join_unix_paths(
+                $this->pull_state_directory,
+                "remote-index-traversals.next.jsonl"
+            );
         $this->fetch_list_file =
             wp_join_unix_paths($this->pull_state_directory, "fetch-list.jsonl");
         $this->audit_log_file = wp_join_unix_paths($this->state_dir, "audit.log");
@@ -2339,6 +2348,12 @@ class ImportClient
                     @unlink($this->next_remote_index_file);
                     $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
                 }
+                if (file_exists($this->next_remote_index_traversal_journal_file)) {
+                    @unlink($this->next_remote_index_traversal_journal_file);
+                    $this->audit_log(
+                        "FILE DELETE | {$this->next_remote_index_traversal_journal_file}"
+                    );
+                }
                 break;
 
             case "db-pull":
@@ -2423,6 +2438,12 @@ class ImportClient
         if (file_exists($this->next_remote_index_file)) {
             @unlink($this->next_remote_index_file);
             $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
+        }
+        if (file_exists($this->next_remote_index_traversal_journal_file)) {
+            @unlink($this->next_remote_index_traversal_journal_file);
+            $this->audit_log(
+                "FILE DELETE | {$this->next_remote_index_traversal_journal_file}"
+            );
         }
         if (file_exists($this->fetch_list_file)) {
             @unlink($this->fetch_list_file);
@@ -3231,19 +3252,44 @@ class ImportClient
         }
 
         if ($stage === "index") {
-            $complete = $this->fetch_next_remote_index();
-            if (!$complete) {
-                $this->get_state()->active_resumable_command->completion_state = "partial";
-                $this->save_state();
-                return;
-            }
-            if ($this->follow_symlinks) {
-                $this->discover_symlink_targets();
-                if ($this->shutdown_requested) {
-                    $this->get_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state();
-                    return;
+            $traversal_journal = new RemoteIndexTraversalJournal(
+                $this->next_remote_index_traversal_journal_file
+            );
+            $traversal_journal->open_and_truncate_to_saved_byte_offset(
+                $this->get_state()->index->traversal_journal_byte_offset
+            );
+            try {
+                if (
+                    $this->get_state()->index
+                        ->discovery_next_remote_index_byte_offset === null
+                ) {
+                    $complete = $this->fetch_next_remote_index_with_journal(
+                        $traversal_journal,
+                        null,
+                        0
+                    );
+                    if (!$complete) {
+                        $this->get_state()->active_resumable_command->completion_state = "partial";
+                        $this->save_state();
+                        return;
+                    }
                 }
+                if ($this->follow_symlinks) {
+                    $this->discover_symlink_targets($traversal_journal);
+                    if (
+                        $this->get_state()->active_resumable_command
+                            ->completion_state === "partial"
+                    ) {
+                        return;
+                    }
+                    if ($this->shutdown_requested) {
+                        $this->get_state()->active_resumable_command->completion_state = "partial";
+                        $this->save_state();
+                        return;
+                    }
+                }
+            } finally {
+                $traversal_journal->close();
             }
             // Sorting replaces the index atomically. Save its phase first so
             // interruption after the replacement reruns the idempotent sort
@@ -3447,45 +3493,86 @@ class ImportClient
         }
 
         $this->get_state()->active_resumable_command->command_name = "files-index";
+        $this->get_state()->active_resumable_command->completion_state = "in_progress";
         $this->save_state();
 
         $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
         if ($stage === "index") {
-            $attempts = 0;
-            $last_cursor = $this->get_state()->index->cursor ?? null;
-            while (true) {
-                $complete = $this->fetch_next_remote_index();
-                if ($complete) {
-                    break;
+            $traversal_journal = new RemoteIndexTraversalJournal(
+                $this->next_remote_index_traversal_journal_file
+            );
+            $traversal_journal->open_and_truncate_to_saved_byte_offset(
+                $this->get_state()->index->traversal_journal_byte_offset
+            );
+            try {
+                if (
+                    $this->get_state()->index
+                        ->discovery_next_remote_index_byte_offset === null
+                ) {
+                    $attempts = 0;
+                    $last_cursor = $this->get_state()->index->cursor ?? null;
+                    while (true) {
+                        $complete = $this->fetch_next_remote_index_with_journal(
+                            $traversal_journal,
+                            null,
+                            0
+                        );
+                        if ($complete) {
+                            break;
+                        }
+
+                        // A request failure ends the current run. A normal
+                        // protocol partial response keeps the lifecycle in
+                        // progress and may continue in this invocation.
+                        if (
+                            $this->get_state()->active_resumable_command
+                                ->completion_state === "partial"
+                        ) {
+                            return;
+                        }
+                        if ($this->shutdown_requested) {
+                            $this->get_state()->active_resumable_command->completion_state = "partial";
+                            $this->save_state();
+                            return;
+                        }
+
+                        $current_cursor = $this->get_state()->index->cursor ?? null;
+                        if ($current_cursor === $last_cursor) {
+                            throw new RuntimeException(
+                                "files-index made no progress (cursor unchanged)",
+                            );
+                        }
+                        $last_cursor = $current_cursor;
+
+                        $attempts++;
+                        if ($attempts > 100000) {
+                            throw new RuntimeException(
+                                "files-index exceeded maximum attempts",
+                            );
+                        }
+                    }
                 }
 
-                if ($this->shutdown_requested) {
-                    $this->get_state()->active_resumable_command->completion_state = "partial";
-                    $this->save_state();
-                    return;
+                // Follow symlinks: discover symlink targets outside known roots and
+                // index them as additional directories. Repeats until no new targets
+                // are found, with cycle detection through durable root markers.
+                if ($this->follow_symlinks) {
+                    $this->discover_symlink_targets($traversal_journal);
+                    if (
+                        $this->get_state()->active_resumable_command
+                            ->completion_state === "partial"
+                    ) {
+                        return;
+                    }
+                    if ($this->shutdown_requested) {
+                        $this->get_state()->active_resumable_command
+                            ->completion_state = "partial";
+                        $this->save_state();
+                        return;
+                    }
                 }
-
-                $current_cursor = $this->get_state()->index->cursor ?? null;
-                if ($current_cursor === $last_cursor) {
-                    throw new RuntimeException(
-                        "files-index made no progress (cursor unchanged)",
-                    );
-                }
-                $last_cursor = $current_cursor;
-
-                $attempts++;
-                if ($attempts > 100000) {
-                    throw new RuntimeException(
-                        "files-index exceeded maximum attempts",
-                    );
-                }
-            }
-
-            // Follow symlinks: discover symlink targets outside known roots and
-            // index them as additional directories.  Repeats until no new targets
-            // are found, with cycle detection via realpath.
-            if ($this->follow_symlinks) {
-                $this->discover_symlink_targets();
+            } finally {
+                $traversal_journal->close();
             }
 
             // Sorting replaces the index atomically. Save its phase first so
@@ -3567,196 +3654,213 @@ class ImportClient
      * Recursively discover directories that need indexing beyond the primary
      * export roots.
      *
-     * Scans the next remote index for symlink entries with a "target" field,
-     * resolves relative targets to absolute paths, and indexes each target
-     * directory. Repeats until the queue is drained, with cycle detection.
+     * Reads the growing next index once. A followed traversal appends entries
+     * behind the retained handle, so nested targets join the same forward pass.
+     * Disk-backed canonical-root markers provide bounded cycle detection.
      */
-    private function discover_symlink_targets(): void
+    private function discover_symlink_targets(
+        RemoteIndexTraversalJournal $traversal_journal
+    ): void
     {
-        // Seed "already covered" from the dirs actually enumerated this run (the
-        // --include prefixes when scoped), not the full preflight roots — otherwise a
-        // narrow --include skips a target under a root but outside its scope.
-        $roots = $this->get_export_directories();
+        $durable_next_remote_index_byte_offset = $this->get_state()->index
+            ->next_remote_index_byte_offset;
+        $discovery_byte_offset = $this->get_state()->index
+            ->discovery_next_remote_index_byte_offset;
+        // Truncate before opening the retained reader. Opening it first may
+        // buffer bytes past the durable boundary while a nested resumed
+        // traversal replaces that tail.
+        $next_remote_index_truncation_handle = fopen(
+            $this->next_remote_index_file,
+            "r+b"
+        );
+        $next_remote_index_stat = is_resource(
+            $next_remote_index_truncation_handle
+        )
+            ? fstat($next_remote_index_truncation_handle)
+            : false;
+        if (
+            !is_resource($next_remote_index_truncation_handle)
+            || !is_int($discovery_byte_offset)
+            || $next_remote_index_stat === false
+            || $discovery_byte_offset
+                > $durable_next_remote_index_byte_offset
+            || $durable_next_remote_index_byte_offset
+                > $next_remote_index_stat["size"]
+            || !ftruncate(
+                $next_remote_index_truncation_handle,
+                $durable_next_remote_index_byte_offset
+            )
+        ) {
+            if (is_resource($next_remote_index_truncation_handle)) {
+                fclose($next_remote_index_truncation_handle);
+            }
+            throw new RuntimeException(
+                "Cannot resume followed-target discovery at its saved byte offset."
+            );
+        }
+        fclose($next_remote_index_truncation_handle);
 
-        // Collect all indexed directory real paths for containment checks
-        $visited = [];
-        foreach ($roots as $root) {
-            $visited[$root] = true;
+        $next_remote_index_file_handle = fopen(
+            $this->next_remote_index_file,
+            "r"
+        );
+        if (
+            !is_resource($next_remote_index_file_handle)
+            || fseek($next_remote_index_file_handle, $discovery_byte_offset) !== 0
+        ) {
+            if (is_resource($next_remote_index_file_handle)) {
+                fclose($next_remote_index_file_handle);
+            }
+            throw new RuntimeException(
+                "Cannot resume followed-target discovery at its saved byte offset."
+            );
         }
 
-        $queue = $this->extract_symlink_directories_from_next_remote_index($visited);
-
-        while (!empty($queue)) {
-            $dir = array_shift($queue);
-            if (isset($visited[$dir])) {
-                continue;
-            }
-            // Skip if this directory is a subdirectory of an already-visited path,
-            // since those files were already included in the parent's index.
-            if (path_is_same_as_or_descendant_of($dir, array_keys($visited))) {
-                $this->audit_log(
-                    "FOLLOW SYMLINK SKIP | {$dir} already covered by a visited parent",
-                    true,
-                );
-                continue;
-            }
-            $visited[$dir] = true;
-
-            $this->audit_log(
-                "FOLLOW SYMLINK | indexing remote directory: {$dir}",
-                true,
-            );
-            $this->progress->show_lifecycle_line("Following symlink target: {$dir}\n");
-            $this->output_progress([
-                "type" => "symlink_follow",
-                "directory" => $dir,
-                "message" => "Following symlink target: {$dir}",
-            ], true);
-
-            // Reset the index cursor so fetch_next_remote_index starts fresh
-            // for this directory, but appends to the existing index file.
-            // Note we are not losing the previous cursor position. This code
-            // runs only after the previous directory was fully indexed so
-            // we won't need any prior cursor information again.
-            $this->get_state()->index->cursor = null;
-            $this->save_state();
-
-            $attempts = 0;
-            $last_cursor = null;
+        try {
+            $bytes_since_discovery_checkpoint = 0;
             while (true) {
-                try {
-                $complete = $this->fetch_next_remote_index($dir);
-                } catch (RuntimeException $e) {
-                    // We won't be able to follow every symlink. If
-                    // the response seems like the remote server rejecting
-                    // our attempt to index this directory, log a warning
-                    // and skip to the next directory instead of crashing.
-                    $msg = $e->getMessage();
-                    if (
-                        strpos($msg, "HTTP error 4") !== false ||
-                        strpos($msg, "dir_outside_root") !== false ||
-                        strpos($msg, "outside of allowed roots") !== false
-                    ) {
-                        $this->audit_log(
-                            "FOLLOW SYMLINK SKIP | server rejected {$dir}: " .
-                                substr($msg, 0, 200),
-                            true,
-                        );
-                        $this->progress->show_lifecycle_line("  Skipped (server rejected): {$dir}\n");
-                        $this->output_progress([
-                            "type" => "symlink_follow_rejected",
-                            "directory" => $dir,
-                            "message" => "Skipped (server rejected): {$dir}",
-                        ], true);
-                        // Deliberately abandon the rejected target's saved
-                        // traversal before trying the next queued target. Keep
-                        // the byte offset confirmed by earlier traversals so
-                        // the next target appends after their durable entries.
-                        reprint_update_and_save_state_without_signal_interruption(
-                            function (): void {
-                                $this->get_state()->index->cursor = null;
-                                $this->get_state()->index->active_traversal = null;
-                            },
-                            [$this, 'save_state']
-                        );
-                        continue 2;
-                    }
-
-                    // Still throw all the other errors.
-                    throw $e;
-                }
-                if ($complete) {
+                $next_remote_index_json_line = fgets(
+                    $next_remote_index_file_handle
+                );
+                if ($next_remote_index_json_line === false) {
                     break;
                 }
-
-                if ($this->shutdown_requested) {
-                    return;
-                }
-
-                $current_cursor = $this->get_state()->index->cursor ?? null;
-                if ($current_cursor === $last_cursor) {
+                $next_entry_byte_offset = ftell(
+                    $next_remote_index_file_handle
+                );
+                if (!is_int($next_entry_byte_offset)) {
                     throw new RuntimeException(
-                        "files-index (symlink follow) made no progress (cursor unchanged)",
+                        "Failed to read the followed-target discovery byte offset."
                     );
                 }
-                $last_cursor = $current_cursor;
-
-                $attempts++;
-                if ($attempts > 10_000) {
-                    // @TODO: Consider a configurable maximum attempts for really large sites that
-                    //        require more than 10,000 requests to index.
-                    throw new RuntimeException(
-                        "files-index (symlink follow) exceeded maximum attempts",
+                $next_remote_index_entry = json_decode(
+                    $next_remote_index_json_line,
+                    true
+                );
+                $dir = null;
+                // Intermediate links describe path components which the pull
+                // recreates locally. Only ordinary link targets start another
+                // remote-index traversal.
+                if (
+                    is_array($next_remote_index_entry)
+                    && ($next_remote_index_entry["type"] ?? "") === "link"
+                    && empty($next_remote_index_entry["intermediate"])
+                ) {
+                    $symlink_target_encoded =
+                        $next_remote_index_entry["target"] ?? null;
+                    if (
+                        is_string($symlink_target_encoded)
+                        && $symlink_target_encoded !== ""
+                    ) {
+                        $dir = RemoteIndexTraversalJournal::decode_canonical_path(
+                            $symlink_target_encoded,
+                            "remote-index symlink target"
+                        );
+                    }
+                }
+                if (
+                    $dir !== null
+                    && !$traversal_journal->covers_canonical_path(
+                        $dir,
+                        $this->get_state()->index
+                            ->traversal_journal_byte_offset
+                    )
+                ) {
+                    $this->audit_log(
+                        "FOLLOW SYMLINK | indexing remote directory: {$dir}",
+                        true,
                     );
+                    $this->progress->show_lifecycle_line("Following symlink target: {$dir}\n");
+                    $this->output_progress([
+                        "type" => "symlink_follow",
+                        "directory" => $dir,
+                        "message" => "Following symlink target: {$dir}",
+                    ], true);
+
+                    $attempts = 0;
+                    $last_cursor = $this->get_state()->index->cursor;
+                    while (true) {
+                        $complete =
+                            $this->fetch_next_remote_index_with_journal(
+                                $traversal_journal,
+                                $dir,
+                                $next_entry_byte_offset
+                            );
+                        if ($complete) {
+                            break;
+                        }
+
+                        // A request failure ends the current run. A normal
+                        // protocol partial response keeps the lifecycle in
+                        // progress and may continue in this invocation.
+                        if (
+                            $this->get_state()->active_resumable_command
+                                ->completion_state === "partial"
+                        ) {
+                            return;
+                        }
+                        if ($this->shutdown_requested) {
+                            return;
+                        }
+
+                        $current_cursor = $this->get_state()->index->cursor;
+                        if ($current_cursor === $last_cursor) {
+                            throw new RuntimeException(
+                                "files-index (symlink follow) made no progress (cursor unchanged)",
+                            );
+                        }
+                        $last_cursor = $current_cursor;
+
+                        $attempts++;
+                        if ($attempts > 10_000) {
+                            // @TODO: Consider a configurable maximum attempts for really large sites that
+                            //        require more than 10,000 requests to index.
+                            throw new RuntimeException(
+                                "files-index (symlink follow) exceeded maximum attempts",
+                            );
+                        }
+                    }
+                    $bytes_since_discovery_checkpoint = 0;
+                    continue;
+                }
+
+                $bytes_since_discovery_checkpoint += strlen(
+                    $next_remote_index_json_line
+                );
+                if ($bytes_since_discovery_checkpoint >= 256 * 1024) {
+                    reprint_update_and_save_state_without_signal_interruption(
+                        function () use ($next_entry_byte_offset): void {
+                            $this->get_state()->index
+                                ->discovery_next_remote_index_byte_offset =
+                                    $next_entry_byte_offset;
+                        },
+                        [$this, 'save_state']
+                    );
+                    $bytes_since_discovery_checkpoint = 0;
+                    if ($this->shutdown_requested) {
+                        return;
+                    }
                 }
             }
-
-            // Scan newly added entries for more symlink targets
-            $new_targets = $this->extract_symlink_directories_from_next_remote_index($visited);
-            foreach ($new_targets as $target) {
-                if (!isset($visited[$target])) {
-                    $queue[] = $target;
-                }
+            $next_entry_byte_offset = ftell($next_remote_index_file_handle);
+            if (
+                is_int($next_entry_byte_offset)
+                && $next_entry_byte_offset
+                    !== $this->get_state()->index
+                        ->discovery_next_remote_index_byte_offset
+            ) {
+                reprint_update_and_save_state_without_signal_interruption(
+                    function () use ($next_entry_byte_offset): void {
+                        $this->get_state()->index
+                            ->discovery_next_remote_index_byte_offset =
+                                $next_entry_byte_offset;
+                    },
+                    [$this, 'save_state']
+                );
             }
+        } finally {
+            fclose($next_remote_index_file_handle);
         }
-    }
-
-    /**
-     * Scan the next remote index file for symlink entries whose targets are
-     * directories not already in $visited.  Returns an array of real paths.
-     *
-     * Skips entries marked as "intermediate" — those are path-component
-     * symlinks (e.g. /srv/wordpress -> /wordpress) emitted by the server's
-     * discover_path_symlinks() for local recreation only, not for indexing.
-     */
-    private function extract_symlink_directories_from_next_remote_index(array $visited): array
-    {
-        $symlink_targets = [];
-        if (!file_exists($this->next_remote_index_file)) {
-            return $symlink_targets;
-        }
-
-        $next_remote_index_file_handle = fopen($this->next_remote_index_file, "r");
-        if (!$next_remote_index_file_handle) {
-            return $symlink_targets;
-        }
-
-        while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
-            $next_remote_index_entry = json_decode($next_remote_index_json_line, true);
-            if (!is_array($next_remote_index_entry)) {
-                continue;
-            }
-            if (($next_remote_index_entry["type"] ?? "") !== "link") {
-                continue;
-            }
-            if (!empty($next_remote_index_entry["intermediate"])) {
-                continue;
-            }
-            $symlink_target_encoded = $next_remote_index_entry["target"] ?? null;
-            if (!is_string($symlink_target_encoded) || $symlink_target_encoded === "") {
-                continue;
-            }
-            $symlink_target = base64_decode($symlink_target_encoded);
-            if ($symlink_target === false || $symlink_target === "") {
-                continue;
-            }
-
-            // If we've seen this symlink target already, we can move on
-            // to the next one.
-            if (isset($visited[$symlink_target])) {
-                continue;
-            }
-
-            // Check containment: skip if already under a visited root
-            if (path_is_same_as_or_descendant_of($symlink_target, array_keys($visited))) {
-                continue;
-            }
-
-            $symlink_targets[] = $symlink_target;
-        }
-        fclose($next_remote_index_file_handle);
-
-        return array_values(array_unique($symlink_targets));
     }
 
     /**
@@ -6609,7 +6713,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
-        // Always send directory[] – see comment in fetch_next_remote_index().
+        // Always send directory[] – see comment in fetch_next_remote_index_with_journal().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
@@ -6847,10 +6951,12 @@ class ImportClient
         return $complete;
     }
 
-    /**
-     * Download the next remote index stream and write to disk.
-     */
-    private function fetch_next_remote_index(?string $list_dir_override = null): bool
+    /** Downloads one request while retaining the traversal journal handle. */
+    private function fetch_next_remote_index_with_journal(
+        RemoteIndexTraversalJournal $traversal_journal,
+        ?string $list_dir_override,
+        int $discovery_byte_offset_after_completion
+    ): bool
     {
         $index_state = $this->get_state()->index;
         $traversal = $index_state->active_traversal_request();
@@ -6874,14 +6980,17 @@ class ImportClient
                 $start = $export_dirs[0] ?? $roots[0];
             }
             $request_list_directory = $list_dir_override ?? $start;
+            $requested_directories = $list_dir_override === null
+                ? $export_dirs
+                : [$request_list_directory];
             reprint_update_and_save_state_without_signal_interruption(
                 function () use (
                     $request_list_directory,
-                    $export_dirs
+                    $requested_directories
                 ): void {
                     $this->get_state()->index->start_traversal(
                         $request_list_directory,
-                        $export_dirs,
+                        $requested_directories,
                         $this->follow_symlinks,
                         $this->include_caches
                     );
@@ -6963,6 +7072,8 @@ class ImportClient
         $next_remote_index_is_complete = false;
         $completion_cursor = null;
         $remote_index_error = null;
+        $canonical_list_directory_from_remote = null;
+        $indexed_roots_from_remote = null;
 
         $params = $this->get_tuned_params("file_index");
 
@@ -6997,6 +7108,8 @@ class ImportClient
             &$entries_counted_at_confirmed_boundary,
             &$next_remote_index_is_complete,
             &$remote_index_error,
+            &$canonical_list_directory_from_remote,
+            &$indexed_roots_from_remote,
             $next_remote_index_file_handle,
             $context
         ) {
@@ -7151,6 +7264,31 @@ class ImportClient
             } elseif ($chunk_type === "progress") {
                 $this->handle_progress($chunk, "index");
             } elseif ($chunk_type === "metadata") {
+                $metadata = json_decode($chunk["body"] ?? "", true);
+                if (
+                    !is_array($metadata)
+                    || !isset($metadata["list_dir"])
+                    || !is_string($metadata["list_dir"])
+                    || !isset($metadata["indexed_roots"])
+                    || !is_array($metadata["indexed_roots"])
+                    || array_values($metadata["indexed_roots"])
+                        !== $metadata["indexed_roots"]
+                    || $metadata["indexed_roots"] === []
+                ) {
+                    throw new RuntimeException(
+                        "Remote file index metadata must contain its canonical list directory and indexed roots."
+                    );
+                }
+                $canonical_list_directory_from_remote =
+                    RemoteIndexTraversalJournal::decode_canonical_path(
+                        $metadata["list_dir"],
+                        "list directory"
+                    );
+                $indexed_roots_from_remote =
+                    RemoteIndexTraversalJournal::decode_canonical_paths(
+                        $metadata["indexed_roots"],
+                        "indexed root"
+                    );
                 $this->handle_metadata_chunk($chunk);
             } elseif ($chunk_type === "completion") {
                 $completion_status =
@@ -7261,6 +7399,19 @@ class ImportClient
             );
             // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
+        if (
+            $next_remote_index_is_complete
+            && (
+                !is_string($canonical_list_directory_from_remote)
+                || !is_array($indexed_roots_from_remote)
+            )
+        ) {
+            $discard_unconfirmed_response();
+            fclose($next_remote_index_file_handle);
+            throw new RuntimeException(
+                "The completed remote file index response did not report its canonical traversal roots."
+            );
+        }
         if (!$next_remote_index_is_complete && $completion_cursor === null) {
             $discard_unconfirmed_response();
             fclose($next_remote_index_file_handle);
@@ -7290,12 +7441,33 @@ class ImportClient
             $context->response_stats ?? [],
         );
 
+        $traversal_journal_byte_offset =
+            $this->get_state()->index->traversal_journal_byte_offset;
         try {
+            if ($next_remote_index_is_complete) {
+                $active_traversal = $this->get_state()->index
+                    ->active_traversal;
+                if (!is_array($active_traversal)) {
+                    throw new LogicException(
+                        "A completed remote index requires an active traversal."
+                    );
+                }
+                $traversal_journal_byte_offset =
+                    $traversal_journal->complete_traversal(
+                        $active_traversal['next_remote_index_start_byte_offset'],
+                        $next_remote_index_byte_offset,
+                        $canonical_list_directory_from_remote,
+                        $indexed_roots_from_remote
+                    );
+            }
+
             reprint_update_and_save_state_without_signal_interruption(
                 function () use (
                     $completion_cursor,
                     $next_remote_index_byte_offset,
-                    $next_remote_index_is_complete
+                    $next_remote_index_is_complete,
+                    $traversal_journal_byte_offset,
+                    $discovery_byte_offset_after_completion
                 ): void {
                     $this->get_state()->consecutive_interrupted_responses = 0;
                     $this->get_state()->index->cursor =
@@ -7304,8 +7476,13 @@ class ImportClient
                             : $completion_cursor;
                     $this->get_state()->index->next_remote_index_byte_offset =
                         $next_remote_index_byte_offset;
+                    $this->get_state()->index->traversal_journal_byte_offset =
+                        $traversal_journal_byte_offset;
                     if ($next_remote_index_is_complete) {
                         $this->get_state()->index->active_traversal = null;
+                        $this->get_state()->index
+                            ->discovery_next_remote_index_byte_offset =
+                                $discovery_byte_offset_after_completion;
                     }
                 },
                 [$this, 'save_state']

--- a/packages/reprint-client/src/lib/pull/class-remote-index-traversal-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-traversal-journal.php
@@ -1,0 +1,346 @@
+<?php
+declare(strict_types=1);
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\normalize_path;
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal errors contain local paths and protocol field names, never HTML.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Stores the raw index range and indexed roots for each completed traversal.
+ *
+ * Raw index byte ranges remain meaningful until sort. Base64 paths and
+ * canonical-root markers keep the journal byte-safe and bounded-memory.
+ */
+final class RemoteIndexTraversalJournal
+{
+    private string $path;
+    /** @var resource|null Open journal handle. */
+    private $handle = null;
+    private string $root_markers_directory;
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+        $this->root_markers_directory = dirname($path)
+            . '/remote-index-traversal-roots.next';
+    }
+    /**
+     * Opens the journal at its durable append boundary.
+     *
+     * Unconfirmed tail bytes are discarded. Boundary zero starts a fresh
+     * lifecycle and streams removal of every marker from the preceding one.
+     */
+    public function open_and_truncate_to_saved_byte_offset(int $byte_offset): void
+    {
+        if (is_resource($this->handle)) {
+            throw new LogicException('Remote-index traversal journal is already open.');
+        }
+        if ($byte_offset === 0) {
+            $this->delete_root_markers();
+        }
+        $this->handle = fopen($this->path, 'c+b');
+        $stat = is_resource($this->handle) ? fstat($this->handle) : false;
+        if (
+            !is_resource($this->handle)
+            || $stat === false
+            || $byte_offset < 0
+            || $byte_offset > $stat['size']
+            || !ftruncate($this->handle, $byte_offset)
+            || fseek($this->handle, $byte_offset) !== 0
+        ) {
+            $this->close();
+            throw new RuntimeException(
+                "Failed to resume the remote-index traversal journal at byte offset {$byte_offset}."
+            );
+        }
+    }
+
+    /**
+     * Durably records one completed traversal and writes its root markers.
+     *
+     * Markers are written before the returned boundary is saved in state. A
+     * marker left by a failed state save remains harmless because lookups
+     * validate its record against the state's saved journal boundary.
+     *
+     * @param string[] $indexed_roots Ordered canonical roots from the server.
+     * @return int First journal byte after the durable completion record.
+     */
+    public function complete_traversal(
+        int $next_remote_index_start_byte_offset,
+        int $next_remote_index_end_byte_offset,
+        string $canonical_list_directory,
+        array $indexed_roots
+    ): int {
+        $this->require_handle();
+        self::assert_path($canonical_list_directory, 'canonical list directory');
+        if (
+            $next_remote_index_start_byte_offset < 0
+            || $next_remote_index_end_byte_offset
+                < $next_remote_index_start_byte_offset
+            || $indexed_roots === []
+            || array_values($indexed_roots) !== $indexed_roots
+        ) {
+            throw new InvalidArgumentException(
+                'Remote-index traversal roots or byte range are invalid.'
+            );
+        }
+        foreach ($indexed_roots as $indexed_root) {
+            if (!is_string($indexed_root)) {
+                throw new InvalidArgumentException(
+                    'Each remote-index traversal root must be a string.'
+                );
+            }
+            self::assert_path($indexed_root, 'indexed root');
+        }
+        if (
+            $indexed_roots[0] !== $canonical_list_directory
+            || count($indexed_roots) !== count(array_unique($indexed_roots))
+        ) {
+            throw new InvalidArgumentException(
+                'Remote-index traversal roots or byte range are invalid.'
+            );
+        }
+
+        if (fseek($this->handle, 0, SEEK_END) !== 0) {
+            throw new RuntimeException('Failed to seek to the traversal journal append position.');
+        }
+        $completion_record_byte_offset = ftell($this->handle);
+        $json = json_encode([
+            'type' => 'traversal_complete',
+            'indexed_roots_b64' => array_map('base64_encode', $indexed_roots),
+            'next_remote_index_start_byte_offset' =>
+                $next_remote_index_start_byte_offset,
+            'next_remote_index_end_byte_offset' =>
+                $next_remote_index_end_byte_offset,
+        ], JSON_UNESCAPED_SLASHES);
+        if (!is_int($completion_record_byte_offset) || $json === false) {
+            throw new RuntimeException('Failed to encode the traversal journal record.');
+        }
+        $line = $json . "\n";
+        if (fwrite($this->handle, $line) !== strlen($line)) {
+            throw new RuntimeException('Failed to append the traversal journal record.');
+        }
+        if (!fflush($this->handle)) {
+            throw new RuntimeException('Failed to flush the remote-index traversal journal.');
+        }
+        $journal_byte_offset = ftell($this->handle);
+        if (!is_int($journal_byte_offset)) {
+            throw new RuntimeException('Failed to read the traversal journal byte offset.');
+        }
+
+        if (
+            !is_dir($this->root_markers_directory)
+            && !mkdir($this->root_markers_directory, 0777, true)
+            && !is_dir($this->root_markers_directory)
+        ) {
+            throw new RuntimeException('Failed to create the traversal root marker directory.');
+        }
+        foreach ($indexed_roots as $indexed_root) {
+            if ($this->root_marker_is_valid($indexed_root, $journal_byte_offset)) {
+                continue;
+            }
+            $marker_path = $this->root_marker_path($indexed_root);
+            $marker_json = json_encode([
+                'completion_record_byte_offset' =>
+                    $completion_record_byte_offset,
+            ], JSON_UNESCAPED_SLASHES);
+            if ($marker_json === false) {
+                throw new RuntimeException('Failed to encode a traversal root marker.');
+            }
+            $swap_path = $marker_path . '.swap';
+            if (
+                file_put_contents($swap_path, $marker_json . "\n") === false
+                || !rename($swap_path, $marker_path)
+            ) {
+                @unlink($swap_path);
+                throw new RuntimeException('Failed to save a traversal root marker.');
+            }
+        }
+        return $journal_byte_offset;
+    }
+
+    /** Reports whether a canonical path is inside a durably completed root. */
+    public function covers_canonical_path(
+        string $canonical_path,
+        int $journal_byte_offset
+    ): bool {
+        self::assert_path($canonical_path, 'remote-index traversal target');
+        $candidate = $canonical_path;
+        while (true) {
+            if ($this->root_marker_is_valid($candidate, $journal_byte_offset)) {
+                return true;
+            }
+            $parent = dirname($candidate);
+            if ($parent === $candidate) {
+                return false;
+            }
+            $candidate = $parent;
+        }
+    }
+
+    /** Decodes one canonical base64 path from protocol metadata. */
+    public static function decode_canonical_path($encoded_path, string $field_name): string
+    {
+        $path = is_string($encoded_path)
+            ? base64_decode($encoded_path, true)
+            : false;
+        if (!is_string($path) || base64_encode($path) !== $encoded_path) {
+            throw new UnexpectedValueException("{$field_name} contains invalid base64.");
+        }
+        self::assert_path($path, $field_name);
+        return $path;
+    }
+
+    /** @return string[] Decoded non-empty canonical protocol paths. */
+    public static function decode_canonical_paths($encoded_paths, string $field_name): array
+    {
+        if (
+            !is_array($encoded_paths)
+            || $encoded_paths === []
+            || array_values($encoded_paths) !== $encoded_paths
+        ) {
+            throw new UnexpectedValueException("{$field_name} must be a non-empty list.");
+        }
+        $paths = [];
+        foreach ($encoded_paths as $encoded_path) {
+            $paths[] = self::decode_canonical_path($encoded_path, $field_name);
+        }
+        return $paths;
+    }
+
+    /** Idempotently closes the journal. */
+    public function close(): void
+    {
+        if (!is_resource($this->handle)) {
+            $this->handle = null;
+            return;
+        }
+        if (!fclose($this->handle)) {
+            $this->handle = null;
+            throw new RuntimeException('Failed to close the traversal journal.');
+        }
+        $this->handle = null;
+    }
+
+    /** @return string[] Canonical indexed roots from one durable completion. */
+    private function read_indexed_roots_at(
+        int $record_byte_offset,
+        int $journal_byte_offset
+    ): array {
+        $this->require_handle();
+        if (
+            $record_byte_offset < 0
+            || $record_byte_offset >= $journal_byte_offset
+            || fseek($this->handle, $record_byte_offset) !== 0
+        ) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal completion offset is invalid.'
+            );
+        }
+        $line = fgets($this->handle);
+        $end_byte_offset = ftell($this->handle);
+        $record = is_string($line) && substr($line, -1) === "\n"
+            ? json_decode(substr($line, 0, -1), true)
+            : null;
+        if (
+            !is_int($end_byte_offset)
+            || $end_byte_offset > $journal_byte_offset
+            || !is_array($record)
+            || count($record) !== 4
+            || ( $record['type'] ?? null ) !== 'traversal_complete'
+            || !isset($record['indexed_roots_b64'])
+            || !isset($record['next_remote_index_start_byte_offset'])
+            || !is_int($record['next_remote_index_start_byte_offset'])
+            || $record['next_remote_index_start_byte_offset'] < 0
+            || !isset($record['next_remote_index_end_byte_offset'])
+            || !is_int($record['next_remote_index_end_byte_offset'])
+            || $record['next_remote_index_end_byte_offset']
+                < $record['next_remote_index_start_byte_offset']
+        ) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal completion is outside the durable journal or invalid.'
+            );
+        }
+        $indexed_roots = self::decode_canonical_paths(
+            $record['indexed_roots_b64'],
+            'indexed_roots_b64'
+        );
+        if (count($indexed_roots) !== count(array_unique($indexed_roots))) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal roots must contain no duplicates.'
+            );
+        }
+        return $indexed_roots;
+    }
+
+    private function root_marker_path(string $canonical_root): string
+    {
+        return $this->root_markers_directory . '/'
+            . hash('sha256', $canonical_root) . '.json';
+    }
+
+    private function root_marker_is_valid(
+        string $canonical_root,
+        int $journal_byte_offset
+    ): bool {
+        $marker_json = @file_get_contents(
+            $this->root_marker_path($canonical_root)
+        );
+        $marker = is_string($marker_json)
+            ? json_decode($marker_json, true)
+            : null;
+        if (
+            !is_array($marker)
+            || count($marker) !== 1
+            || !isset($marker['completion_record_byte_offset'])
+            || !is_int($marker['completion_record_byte_offset'])
+        ) {
+            return false;
+        }
+        try {
+            $indexed_roots = $this->read_indexed_roots_at(
+                $marker['completion_record_byte_offset'],
+                $journal_byte_offset
+            );
+            return in_array($canonical_root, $indexed_roots, true);
+        } catch (Throwable $exception) {
+            return false;
+        }
+    }
+
+    /** Streams deletion of derived root markers without materializing names. */
+    private function delete_root_markers(): void
+    {
+        $directory_handle = @opendir($this->root_markers_directory);
+        if (!is_resource($directory_handle)) {
+            return;
+        }
+        while (true) {
+            $entry = readdir($directory_handle);
+            if ($entry === false) {
+                break;
+            }
+            if ($entry !== '.' && $entry !== '..') {
+                @unlink($this->root_markers_directory . '/' . $entry);
+            }
+        }
+        closedir($directory_handle);
+        @rmdir($this->root_markers_directory);
+    }
+
+    /** Validates one absolute decoded path. */
+    private static function assert_path(string $path, string $field_name): void
+    {
+        assert_valid_path($path, $field_name);
+        if (normalize_path($path) !== $path) {
+            throw new UnexpectedValueException("{$field_name} must be normalized.");
+        }
+    }
+
+    private function require_handle(): void
+    {
+        if (!is_resource($this->handle)) {
+            throw new LogicException('Remote-index traversal journal is not open.');
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/state/class-remote-file-index-state.php
+++ b/packages/reprint-client/src/lib/state/class-remote-file-index-state.php
@@ -9,13 +9,18 @@ class RemoteFileIndexState {
     public ?string $cursor = null;
     /** Next remote index bytes which are safe to keep when resuming from cursor. */
     public int $next_remote_index_byte_offset = 0;
+    /** Next traversal journal byte after the durable completion records. */
+    public int $traversal_journal_byte_offset = 0;
+    /** @var int|null First next-index byte not durably inspected for followed targets. */
+    public ?int $discovery_next_remote_index_byte_offset = null;
     /**
      * @var array|null JSON-safe request identity retained until traversal completion.
      * @phpstan-var array{
      *     list_directory_b64:string,
      *     requested_directories_b64:list<string>,
      *     follow_symlinks:bool,
-     *     include_caches:bool
+     *     include_caches:bool,
+     *     next_remote_index_start_byte_offset:int
      * }|null
      */
     public ?array $active_traversal = null;
@@ -33,16 +38,35 @@ class RemoteFileIndexState {
             );
         }
         $state->cursor = $data['cursor'];
+        foreach (
+            [
+                'next_remote_index_byte_offset',
+                'traversal_journal_byte_offset',
+            ] as $field
+        ) {
+            if (!is_int($data[$field]) || $data[$field] < 0) {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Persisted field name, never HTML.
+                throw new \UnexpectedValueException(
+                    self::class . " {$field} must be a non-negative integer."
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+            $state->{$field} = $data[$field];
+        }
+        $discovery_byte_offset = $data['discovery_next_remote_index_byte_offset'];
         if (
-            !is_int($data['next_remote_index_byte_offset'])
-            || $data['next_remote_index_byte_offset'] < 0
+            $discovery_byte_offset !== null
+            && (
+                !is_int($discovery_byte_offset)
+                || $discovery_byte_offset < 0
+                || $discovery_byte_offset > $state->next_remote_index_byte_offset
+            )
         ) {
             throw new \UnexpectedValueException(
-                self::class . ' next remote index byte offset must be a non-negative integer.'
+                self::class . ' discovery byte offset must be null or inside the durable next index.'
             );
         }
-        $state->next_remote_index_byte_offset =
-            $data['next_remote_index_byte_offset'];
+        $state->discovery_next_remote_index_byte_offset = $discovery_byte_offset;
         $state->active_traversal = self::validate_active_traversal(
             $data['active_traversal']
         );
@@ -51,16 +75,25 @@ class RemoteFileIndexState {
                 self::class . ' remote file-index cursor requires an active traversal.'
             );
         }
+        if (
+            $state->active_traversal !== null
+            && $state->active_traversal['next_remote_index_start_byte_offset']
+                > $state->next_remote_index_byte_offset
+        ) {
+            throw new \UnexpectedValueException(
+                self::class . ' active traversal starts after the durable next index.'
+            );
+        }
         return $state;
     }
 
     /**
      * Retains one traversal request as base64-safe state before network I/O.
      *
-     * @param string   $list_directory       Raw list_dir request value.
+     * @param string   $list_directory     Raw list_dir request value.
      * @param string[] $requested_directories Raw directory[] request values.
-     * @param bool     $follow_symlinks      Whether links may leave requested roots.
-     * @param bool     $include_caches       Whether cache paths are included.
+     * @param bool     $follow_symlinks    Whether links may leave requested roots.
+     * @param bool     $include_caches     Whether cache paths are included.
      */
     public function start_traversal(
         string $list_directory,
@@ -76,6 +109,8 @@ class RemoteFileIndexState {
             ),
             'follow_symlinks' => $follow_symlinks,
             'include_caches' => $include_caches,
+            'next_remote_index_start_byte_offset' =>
+                $this->next_remote_index_byte_offset,
         ]);
         $this->cursor = null;
     }
@@ -86,10 +121,11 @@ class RemoteFileIndexState {
      * @return array|null {
      *     Active request, or null before one starts or after it completes.
      *
-     *     @type string   $list_directory       Raw list_dir value.
-     *     @type string[] $requested_directories Raw directory[] values.
-     *     @type bool     $follow_symlinks      Whether links may leave roots.
-     *     @type bool     $include_caches       Whether caches are included.
+     *     @type string   $list_directory                      Raw list_dir value.
+     *     @type string[] $requested_directories                Raw directory[] values.
+     *     @type bool     $follow_symlinks                      Whether links may leave roots.
+     *     @type bool     $include_caches                       Whether caches are included.
+     *     @type int      $next_remote_index_start_byte_offset  Raw index range start.
      * }
      */
     public function active_traversal_request(): ?array
@@ -110,6 +146,8 @@ class RemoteFileIndexState {
             ),
             'follow_symlinks' => $this->active_traversal['follow_symlinks'],
             'include_caches' => $this->active_traversal['include_caches'],
+            'next_remote_index_start_byte_offset' =>
+                $this->active_traversal['next_remote_index_start_byte_offset'],
         ];
     }
 
@@ -119,6 +157,10 @@ class RemoteFileIndexState {
             'cursor' => $this->cursor,
             'next_remote_index_byte_offset' =>
                 $this->next_remote_index_byte_offset,
+            'traversal_journal_byte_offset' =>
+                $this->traversal_journal_byte_offset,
+            'discovery_next_remote_index_byte_offset' =>
+                $this->discovery_next_remote_index_byte_offset,
             'active_traversal' => $this->active_traversal,
         ];
     }
@@ -136,9 +178,12 @@ class RemoteFileIndexState {
                 'requested_directories_b64',
                 'follow_symlinks',
                 'include_caches',
+                'next_remote_index_start_byte_offset',
             ]
             || !is_bool($traversal['follow_symlinks'])
             || !is_bool($traversal['include_caches'])
+            || !is_int($traversal['next_remote_index_start_byte_offset'])
+            || $traversal['next_remote_index_start_byte_offset'] < 0
             || !self::is_encoded_path($traversal['list_directory_b64'])
             || !is_array($traversal['requested_directories_b64'])
             || $traversal['requested_directories_b64'] === []

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -13,9 +13,10 @@ require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 /**
  * Verify recovery from cURL timeouts during streaming fetches.
  *
- * Each fetch method (fetch_sql, fetch_file_batch, fetch_next_remote_index,
- * fetch_database_index) is tested by injecting a CurlTimeoutException. SQL retries
- * in the same invocation; the other phases save partial state for a later run.
+ * Each fetch method (fetch_sql, fetch_file_batch,
+ * fetch_next_remote_index_with_journal, fetch_database_index) is tested by
+ * injecting a CurlTimeoutException. SQL retries in the same invocation; the
+ * other phases save partial state for a later run.
  *
  * Also verifies the no-progress safety net: after repeated interrupted
  * responses with no cursor progress, the importer gives up.
@@ -96,9 +97,11 @@ class CurlTimeoutRecoveryTest extends TestCase
             false,
             false
         );
-        $indexState->cursor = $cursor;
 
-        return $indexState->to_array();
+        return [
+            'cursor' => $cursor,
+            'active_traversal' => $indexState->active_traversal,
+        ];
     }
 
     public static function fileCursorForBytes(int $bytes): string
@@ -300,7 +303,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // fetch_next_remote_index: timeout saves state and returns false
+    // fetch_next_remote_index_with_journal: timeout saves state and returns false
     // ---------------------------------------------------------------
 
     public function testNextRemoteIndexTimeoutSavesPartialState()
@@ -329,12 +332,11 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $fetchNextRemoteIndex = $reflection->getMethod('fetch_next_remote_index');
-        $result = $fetchNextRemoteIndex->invoke($client);
+        $result = $this->fetchNextRemoteIndex($client, $reflection);
 
         $this->assertFalse(
             $result,
-            "fetch_next_remote_index should return false on timeout"
+            "Remote-index fetch should return false on timeout"
         );
 
         $state = $this->readState();
@@ -699,8 +701,7 @@ PHP);
             SuccessTestClient::class,
         );
 
-        $fetchNextRemoteIndex = $reflection->getMethod('fetch_next_remote_index');
-        $fetchNextRemoteIndex->invoke($client);
+        $this->fetchNextRemoteIndex($client, $reflection);
 
         $state = $this->readState();
         $this->assertEquals(
@@ -708,6 +709,25 @@ PHP);
             $state["consecutive_interrupted_responses"],
             "Successful request should reset consecutive_interrupted_responses to 0"
         );
+    }
+
+    private function fetchNextRemoteIndex(
+        \ImportClient $client,
+        \ReflectionClass $reflection
+    ): bool {
+        $journal = new \RemoteIndexTraversalJournal(
+            $this->pullStateDirectory . '/remote-index-traversals.next.jsonl'
+        );
+        $journal->open_and_truncate_to_saved_byte_offset(
+            $client->get_state()->index->traversal_journal_byte_offset
+        );
+        try {
+            return $reflection
+                ->getMethod('fetch_next_remote_index_with_journal')
+                ->invoke($client, $journal, null, 0);
+        } finally {
+            $journal->close();
+        }
     }
 
 }
@@ -791,6 +811,14 @@ class SuccessTestClient extends \ImportClient
         ?array $post_data = null,
         ?string $endpoint = null
     ): void {
+        ( $context->on_chunk )([
+            'headers' => ['x-chunk-type' => 'metadata'],
+            'body' => json_encode([
+                'list_dir' => base64_encode('/srv/htdocs'),
+                'requested_directories' => [base64_encode('/srv/htdocs')],
+                'indexed_roots' => [base64_encode('/srv/htdocs')],
+            ]),
+        ]);
         ( $context->on_chunk )([
             'headers' => [
                 'x-chunk-type' => 'completion',

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -1032,6 +1032,18 @@ $write_part = static function (array $headers, string $body = '') use ($boundary
 };
 
 if ($endpoint === 'file_index') {
+    $list_directory = $_GET['list_dir'] ?? '/var/www/html';
+    $indexed_roots = array_values(array_unique(array_merge(
+        array($list_directory),
+        $selected_directories
+    )));
+    $write_part(
+        array('X-Chunk-Type' => 'metadata'),
+        json_encode(array(
+            'list_dir' => base64_encode($list_directory),
+            'indexed_roots' => array_map('base64_encode', $indexed_roots),
+        ), JSON_UNESCAPED_SLASHES)
+    );
     $write_part(
         array(
             'X-Chunk-Type' => 'index_batch',

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -99,6 +99,22 @@ file_put_contents($log, json_encode(array(
 
 $boundary = 'reprint-test-boundary';
 header('Content-Type: multipart/mixed; boundary=' . $boundary);
+if (($_GET['endpoint'] ?? null) === 'file_index') {
+    $directories = $_GET['directory'] ?? array();
+    $list_directory = $_GET['list_dir'] ?? ($directories[0] ?? '/');
+    $indexed_roots = array_values(array_unique(array_merge(
+        array($list_directory),
+        $directories
+    )));
+    $metadata = json_encode(array(
+        'list_dir' => base64_encode($list_directory),
+        'indexed_roots' => array_map('base64_encode', $indexed_roots),
+    ), JSON_UNESCAPED_SLASHES);
+    echo "--{$boundary}\r\n";
+    echo "X-Chunk-Type: metadata\r\n";
+    echo 'Content-Length: ' . strlen($metadata) . "\r\n\r\n";
+    echo $metadata . "\r\n";
+}
 echo "--{$boundary}\r\n";
 echo "X-Chunk-Type: completion\r\n";
 echo "X-Status: complete\r\n";

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -110,32 +110,6 @@ class PullSymlinkTest extends TestCase
         $this->assertSame(strlen($remoteTarget), $record['remote_path_size']);
     }
 
-    public function testSymlinkTargetBesideVisitedRootRemainsQueued()
-    {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
-        $indexPath = $this->tempDir . '/remote-index.jsonl';
-        file_put_contents($indexPath, implode("\n", [
-            json_encode([
-                'type' => 'link',
-                'target' => base64_encode('/srv/site/covered'),
-            ]),
-            json_encode([
-                'type' => 'link',
-                'target' => base64_encode('/srv/site-old/queued'),
-            ]),
-            '',
-        ]));
-
-        $reflection = new \ReflectionClass($client);
-        $reflection->getProperty('next_remote_index_file')->setValue($client, $indexPath);
-        $targets = $reflection->getMethod('extract_symlink_directories_from_next_remote_index')->invoke(
-            $client,
-            ['/srv/site' => true]
-        );
-
-        $this->assertSame(['/srv/site-old/queued'], $targets);
-    }
-
     /**
      * A relative symlink that escapes the filesystem root should be rejected.
      * Path /a/link with target ../../../escape resolves to

--- a/tests/Import/RemoteFileIndexConfirmedBatchTest.php
+++ b/tests/Import/RemoteFileIndexConfirmedBatchTest.php
@@ -69,7 +69,7 @@ final class RemoteFileIndexConfirmedBatchTest extends TestCase
         parent::tearDown();
     }
 
-    public function testRejectedFollowedTargetIsAbandonedBeforeTheNextQueuedTarget(): void
+    public function testRejectedFollowedTargetStopsBeforeTheNextTarget(): void
     {
         $rejectedTarget = $this->tempDir . '/remote-target-a';
         $indexedTarget = $this->tempDir . '/remote-target-b';
@@ -88,12 +88,20 @@ final class RemoteFileIndexConfirmedBatchTest extends TestCase
         ]);
 
         $client = $this->newFilesIndexClient();
-        $client->run([
-            'command' => 'files-index',
-            'follow_symlinks' => true,
-            'include_caches' => false,
-            'progress' => 'jsonl',
-        ]);
+        try {
+            $client->run([
+                'command' => 'files-index',
+                'follow_symlinks' => true,
+                'include_caches' => false,
+                'progress' => 'jsonl',
+            ]);
+            $this->fail('Expected the rejected followed target to stop the run.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'The requested directory is no longer available.',
+                $exception->getMessage()
+            );
+        }
 
         $startedDirectories = [];
         foreach ($this->fileIndexRequests() as $request) {
@@ -109,21 +117,254 @@ final class RemoteFileIndexConfirmedBatchTest extends TestCase
             [
                 $this->siteDir,
                 $canonicalRejectedTarget,
-                $canonicalIndexedTarget,
             ],
             $startedDirectories
         );
         $this->assertFalse(is_dir($rejectedTarget));
-        $this->assertContains(
+        $this->assertNotContains(
             base64_encode( (string) realpath($indexedFile) ),
             $this->nextRemoteIndexPaths()
         );
         $state = $this->readState();
         $this->assertSame(
-            'complete',
+            'in_progress',
             $state['active_resumable_command']['completion_state']
         );
-        $this->assertNull($state['index']['active_traversal']);
+        $this->assertSame(
+            base64_encode($canonicalRejectedTarget),
+            $state['index']['active_traversal']['list_directory_b64']
+        );
+    }
+
+    public function testInitialRequestFailureEndsTheInvocationAndResumeContinuesProtocolPartial(): void
+    {
+        $largeDirectory = $this->siteDir . '/initial-request-failure';
+        mkdir($largeDirectory);
+        for ($index = 0; $index < 360; ++$index) {
+            file_put_contents(
+                $largeDirectory . '/file-' . str_pad(
+                    (string) $index,
+                    3,
+                    '0',
+                    STR_PAD_LEFT
+                ),
+                'x'
+            );
+        }
+        $this->writeControl([
+            'file_index_batch_size' => 100,
+            'file_index_max_execution_time' => 60,
+            'interrupt_before_file_index_batch' => 2,
+        ]);
+
+        $client = $this->newFilesIndexClient();
+        $client->run([
+            'command' => 'files-index',
+            'follow_symlinks' => true,
+            'include_caches' => false,
+            'progress' => 'jsonl',
+        ]);
+
+        $this->assertCount(
+            1,
+            $this->fileIndexRequests(),
+            'A request failure must end the current invocation before another request.'
+        );
+        $state = $this->readState();
+        $this->assertSame(
+            'partial',
+            $state['active_resumable_command']['completion_state']
+        );
+        $this->assertNotNull($state['index']['cursor']);
+        $this->assertNotNull($state['index']['active_traversal']);
+
+        $this->writeControl([
+            'file_index_batch_size' => 100,
+            'file_index_max_execution_time' => 1,
+            'file_index_batch_delay_microseconds' => 600000,
+        ]);
+        $this->newLoadedClient()->run([
+            'command' => 'files-index',
+            'follow_symlinks' => true,
+            'include_caches' => false,
+            'progress' => 'jsonl',
+        ]);
+
+        $resumedRequests = array_slice($this->fileIndexRequests(), 1);
+        $this->assertGreaterThan(1, count($resumedRequests));
+        foreach ($resumedRequests as $resumedRequest) {
+            $this->assertIsString($resumedRequest['cursor']);
+        }
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testFollowedRequestFailureEndsTheCurrentFilesIndexInvocation(): void
+    {
+        $followedTarget = $this->tempDir . '/interrupted-followed-target';
+        mkdir($followedTarget);
+        $followedTargetHookDirectory = $followedTarget
+            . '/wp-content/plugins/site-export';
+        mkdir($followedTargetHookDirectory, 0755, true);
+        copy(
+            $this->siteDir . '/wp-content/plugins/site-export/test-hooks.php',
+            $followedTargetHookDirectory . '/test-hooks.php'
+        );
+        for ($index = 0; $index < 240; ++$index) {
+            file_put_contents(
+                $followedTarget . '/file-' . str_pad(
+                    (string) $index,
+                    3,
+                    '0',
+                    STR_PAD_LEFT
+                ),
+                'x'
+            );
+        }
+        $canonicalFollowedTarget = realpath($followedTarget);
+        $this->assertIsString($canonicalFollowedTarget);
+        symlink($followedTarget, $this->siteDir . '/followed-link');
+        $this->writeControl([
+            'file_index_batch_size' => 100,
+            'file_index_max_execution_time' => 60,
+            'interrupt_before_file_index_batch' => 2,
+            'interrupt_file_index_directory' => $canonicalFollowedTarget,
+        ]);
+
+        $client = $this->newFilesIndexClient();
+        $client->run([
+            'command' => 'files-index',
+            'follow_symlinks' => true,
+            'include_caches' => false,
+            'progress' => 'jsonl',
+        ]);
+
+        $requests = $this->fileIndexRequests();
+        $this->assertCount(
+            2,
+            $requests,
+            'A followed-target request failure must end the current invocation.'
+        );
+        $this->assertSame(
+            base64_encode($canonicalFollowedTarget),
+            $requests[1]['list_directory_b64']
+        );
+        $state = $this->readState();
+        $this->assertSame(
+            'partial',
+            $state['active_resumable_command']['completion_state']
+        );
+        $this->assertNotNull($state['index']['cursor']);
+        $this->assertSame(
+            base64_encode($canonicalFollowedTarget),
+            $state['index']['active_traversal']['list_directory_b64']
+        );
+    }
+
+    public function testResumedPartialFilesPullContinuesNormalFollowedTraversalResponses(): void
+    {
+        $followedTarget = $this->tempDir . '/normal-partial-followed-target';
+        $followedTargetHookDirectory = $followedTarget
+            . '/wp-content/plugins/site-export';
+        mkdir($followedTargetHookDirectory, 0755, true);
+        copy(
+            $this->siteDir . '/wp-content/plugins/site-export/test-hooks.php',
+            $followedTargetHookDirectory . '/test-hooks.php'
+        );
+        file_put_contents($followedTarget . '/target.txt', 'target');
+        for ($index = 0; $index < 360; ++$index) {
+            $fileName = '/file-' . str_pad(
+                (string) $index,
+                3,
+                '0',
+                STR_PAD_LEFT
+            );
+            file_put_contents($this->siteDir . $fileName, 'site');
+            file_put_contents($followedTarget . $fileName, 'target');
+        }
+        $canonicalFollowedTarget = realpath($followedTarget);
+        $this->assertIsString($canonicalFollowedTarget);
+        symlink($followedTarget, $this->siteDir . '/followed-link');
+        $this->writeControl([
+            'file_index_batch_size' => 100,
+            'file_index_max_execution_time' => 60,
+            'interrupt_before_file_index_batch' => 2,
+            'interrupt_file_index_directory' => $canonicalFollowedTarget,
+        ]);
+
+        $client = $this->newClient();
+        \write_current_pull_state($client, [
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'runtime' => ['document_root' => $this->siteDir],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => $this->siteDir],
+                            ['path' => $this->extraDir],
+                        ],
+                    ],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => true,
+            'include_caches' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+        ]);
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('follow_symlinks')->setValue($client, true);
+
+        $client->run_files_pull();
+        $this->assertSame(
+            'partial',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+        $stateAfterFailure = $this->readState();
+        $this->assertCount(2, $this->fileIndexRequests());
+        $this->assertSame(
+            'index',
+            $stateAfterFailure['active_resumable_command']['current_stage']
+        );
+        $this->assertSame(
+            base64_encode($canonicalFollowedTarget),
+            $stateAfterFailure['index']['active_traversal']
+                ['list_directory_b64']
+        );
+
+        $this->writeControl([
+            'file_index_batch_size' => 100,
+            'file_index_max_execution_time' => 1,
+            'file_index_batch_delay_microseconds' => 600000,
+            'interrupt_file_index_directory' => $canonicalFollowedTarget,
+        ]);
+        $this->newLoadedClient()->run_files_pull();
+
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+        $followedRequests = array_values(array_filter(
+            $this->fileIndexRequests(),
+            static function (array $request) use (
+                $canonicalFollowedTarget
+            ): bool {
+                return ( $request['list_directory_b64'] ?? null )
+                    === base64_encode($canonicalFollowedTarget)
+                    || (
+                        ( $request['list_directory_b64'] ?? null ) === null
+                        && ( $request['requested_directories_b64'] ?? null )
+                            === [base64_encode($canonicalFollowedTarget)]
+                    );
+            }
+        ));
+        $this->assertGreaterThan(2, count($followedRequests));
+        $this->assertNull($followedRequests[0]['cursor']);
+        foreach (array_slice($followedRequests, 1) as $resumedRequest) {
+            $this->assertIsString($resumedRequest['cursor']);
+        }
     }
 
     public function testDirectoryErrorDiscardsTheRealWireResponseAtTheSavedBoundary(): void
@@ -401,9 +642,20 @@ final class RemoteFileIndexConfirmedBatchTest extends TestCase
 
     private function fetchNextRemoteIndex(\ImportClient $client): bool
     {
-        return ( new \ReflectionClass(\ImportClient::class) )
-            ->getMethod('fetch_next_remote_index')
-            ->invoke($client);
+        $journal = new \RemoteIndexTraversalJournal(
+            $this->pullStateDirectory()
+            . '/remote-index-traversals.next.jsonl'
+        );
+        $journal->open_and_truncate_to_saved_byte_offset(
+            $client->get_state()->index->traversal_journal_byte_offset
+        );
+        try {
+            return ( new \ReflectionClass(\ImportClient::class) )
+                ->getMethod('fetch_next_remote_index_with_journal')
+                ->invoke($client, $journal, null, 0);
+        } finally {
+            $journal->close();
+        }
     }
 
     private function readState(): array
@@ -466,9 +718,25 @@ function test_hook_during_dir_scan($directory, &$entries) {
 }
 
 function test_hook_before_index_batch(&$batch_items, $directory_stack) {
+    $control = json_decode((string) file_get_contents(%s), true);
+    $interrupt_directory = $control['interrupt_file_index_directory'] ?? null;
+    if (is_string($interrupt_directory)) {
+        $matches_interrupt_directory = false;
+        foreach ($directory_stack as $frame) {
+            if (($frame['dir'] ?? null) === $interrupt_directory) {
+                $matches_interrupt_directory = true;
+                break;
+            }
+        }
+        if (!$matches_interrupt_directory) {
+            return;
+        }
+    }
+    if (isset($control['file_index_batch_delay_microseconds'])) {
+        usleep((int) $control['file_index_batch_delay_microseconds']);
+    }
     static $batch_count = 0;
     ++$batch_count;
-    $control = json_decode((string) file_get_contents(%s), true);
     if (
         isset($control['interrupt_before_file_index_batch'])
         && $batch_count === (int) $control['interrupt_before_file_index_batch']
@@ -529,6 +797,12 @@ if (
     && isset($control['file_index_batch_size'])
 ) {
     $_GET['batch_size'] = (string) $control['file_index_batch_size'];
+}
+if (
+    ($_GET['endpoint'] ?? null) === 'file_index'
+    && isset($control['file_index_max_execution_time'])
+) {
+    $_GET['max_execution_time'] = (string) $control['file_index_max_execution_time'];
 }
 if (
     ($_GET['endpoint'] ?? null) === 'file_index'

--- a/tests/Import/RemoteFileIndexStateTest.php
+++ b/tests/Import/RemoteFileIndexStateTest.php
@@ -16,6 +16,7 @@ final class RemoteFileIndexStateTest extends TestCase
         $listDirectory = "/srv/site-\xff";
         $requestedDirectories = [$listDirectory, '/srv/shared'];
         $state = new RemoteFileIndexState();
+        $state->next_remote_index_byte_offset = 17;
         $state->start_traversal(
             $listDirectory,
             $requestedDirectories,
@@ -24,17 +25,23 @@ final class RemoteFileIndexStateTest extends TestCase
         );
         $state->cursor = 'cursor-1';
         $state->next_remote_index_byte_offset = 123;
+        $state->traversal_journal_byte_offset = 91;
 
         $loaded = RemoteFileIndexState::from_array($state->to_array());
 
         $this->assertSame('cursor-1', $loaded->cursor);
         $this->assertSame(123, $loaded->next_remote_index_byte_offset);
+        $this->assertSame(91, $loaded->traversal_journal_byte_offset);
+        $this->assertNull(
+            $loaded->discovery_next_remote_index_byte_offset
+        );
         $this->assertSame(
             [
                 'list_directory' => $listDirectory,
                 'requested_directories' => $requestedDirectories,
                 'follow_symlinks' => true,
                 'include_caches' => false,
+                'next_remote_index_start_byte_offset' => 17,
             ],
             $loaded->active_traversal_request()
         );
@@ -61,7 +68,8 @@ final class RemoteFileIndexStateTest extends TestCase
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage(
-            'missing active_traversal, next_remote_index_byte_offset'
+            'missing active_traversal, discovery_next_remote_index_byte_offset, ' .
+            'next_remote_index_byte_offset, traversal_journal_byte_offset'
         );
 
         RemoteFileIndexState::from_array(['cursor' => null]);
@@ -87,6 +95,16 @@ final class RemoteFileIndexStateTest extends TestCase
 
         $invalidOffset = $valid;
         $invalidOffset['next_remote_index_byte_offset'] = '1';
+
+        $invalidJournalOffset = $valid;
+        $invalidJournalOffset['traversal_journal_byte_offset'] = -1;
+
+        $invalidDiscoveryOffset = $valid;
+        $invalidDiscoveryOffset['discovery_next_remote_index_byte_offset'] = 1;
+
+        $invalidTraversalStart = $valid;
+        $invalidTraversalStart['active_traversal']
+            ['next_remote_index_start_byte_offset'] = 1;
 
         $relativeListDirectory = $valid;
         $relativeListDirectory['active_traversal']['list_directory_b64'] =
@@ -115,7 +133,19 @@ final class RemoteFileIndexStateTest extends TestCase
             ],
             'numeric-string offset' => [
                 $invalidOffset,
-                'byte offset must be a non-negative integer',
+                'next_remote_index_byte_offset must be a non-negative integer',
+            ],
+            'negative journal offset' => [
+                $invalidJournalOffset,
+                'traversal_journal_byte_offset must be a non-negative integer',
+            ],
+            'discovery beyond durable index' => [
+                $invalidDiscoveryOffset,
+                'discovery byte offset must be null or inside the durable next index',
+            ],
+            'traversal starts beyond durable index' => [
+                $invalidTraversalStart,
+                'active traversal starts after the durable next index',
             ],
             'relative list directory' => [
                 $relativeListDirectory,

--- a/tests/Import/RemoteFileIndexTraversalReplayTest.php
+++ b/tests/Import/RemoteFileIndexTraversalReplayTest.php
@@ -1,0 +1,832 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the next line.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Boundary clients live with the lifecycle tests which use them.
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export -- The generated local router needs literal PHP values.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+/** Exercises remote file-index traversal boundaries through the real HTTP endpoint. */
+final class RemoteFileIndexTraversalReplayTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $filesystemRoot;
+    private $siteDir;
+    private $extraDir;
+    private $requestLog;
+    private $remoteUrl;
+    private $serverProcess;
+    private $serverPipes = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/remote-index-traversal-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->filesystemRoot = $this->tempDir . '/local';
+        $this->siteDir = $this->tempDir . '/remote-site';
+        $this->extraDir = $this->tempDir . '/remote-extra';
+        $this->requestLog = $this->tempDir . '/requests.jsonl';
+        foreach (
+            [
+                $this->stateDir,
+                $this->filesystemRoot,
+                $this->siteDir,
+                $this->extraDir,
+            ] as $directory
+        ) {
+            mkdir($directory, 0755, true);
+        }
+        file_put_contents($this->siteDir . '/index.php', '<?php');
+        $this->remoteUrl = $this->startRealExporter();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess, 9);
+            foreach ($this->serverPipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            proc_close($this->serverProcess);
+        }
+        $this->removeTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testCompletedInitialAndFollowedTraversalsAreNotRequestedAgain(): void
+    {
+        $firstTarget = $this->tempDir . '/followed-target';
+        $secondTarget = $this->tempDir . '/followed target,%"';
+        mkdir($firstTarget);
+        mkdir($secondTarget);
+        file_put_contents($firstTarget . '/first.txt', 'first');
+        file_put_contents($secondTarget . '/second.txt', 'second');
+        symlink($firstTarget, $this->siteDir . '/first-link');
+        symlink($secondTarget, $firstTarget . '/second-link');
+
+        $this->newFilesIndexClient(true);
+        try {
+            $this->runClient(
+                $this->newLoadedClientThatFailsBeforeSort(),
+                ['command' => 'files-index']
+            );
+            $this->fail('Expected the pre-sort state save to stop the command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop before the remote index sort.',
+                $exception->getMessage()
+            );
+        }
+
+        $stateBeforeResume = $this->readState();
+        $this->assertSame(
+            'index',
+            $stateBeforeResume['active_resumable_command']['current_stage']
+        );
+        $this->assertNull($stateBeforeResume['index']['active_traversal']);
+        $journalRecords = $this->readTraversalJournalRecords();
+        $this->assertCount(3, $journalRecords);
+        $this->assertSame(
+            base64_encode( (string) realpath($secondTarget) ),
+            $journalRecords[2]['indexed_roots_b64'][0]
+        );
+        $requestsBeforeResume = $this->fileIndexRequests();
+        $this->assertCount(3, $requestsBeforeResume);
+        $this->assertSame(
+            [$requestsBeforeResume[1]['list_directory_b64']],
+            $requestsBeforeResume[1]['requested_directories_b64']
+        );
+        $this->assertSame(
+            [$requestsBeforeResume[2]['list_directory_b64']],
+            $requestsBeforeResume[2]['requested_directories_b64']
+        );
+
+        $this->runClient($this->newLoadedClient(), ['command' => 'files-index']);
+
+        $this->assertCount(
+            count($requestsBeforeResume),
+            $this->fileIndexRequests(),
+            'A resumed stage must consume durable traversal completions without another HTTP request.'
+        );
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testEmptyInitialTraversalResumesFromZeroWithoutAnotherRequest(): void
+    {
+        $this->removeTree($this->siteDir);
+        mkdir($this->siteDir);
+        $this->newFilesIndexClient(true);
+
+        try {
+            $this->runClient(
+                $this->newLoadedClientThatFailsBeforeSort(),
+                ['command' => 'files-index']
+            );
+            $this->fail('Expected the pre-sort state save to stop the command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop before the remote index sort.',
+                $exception->getMessage()
+            );
+        }
+
+        $stateBeforeResume = $this->readState();
+        $this->assertCount(1, $this->fileIndexRequests());
+        $this->assertSame(0, filesize($this->nextRemoteIndexPath()));
+        $this->assertCount(1, $this->readTraversalJournalRecords());
+        $this->assertNull($stateBeforeResume['index']['active_traversal']);
+        $this->assertSame(
+            0,
+            $stateBeforeResume['index']['next_remote_index_byte_offset']
+        );
+        $this->assertSame(
+            0,
+            $stateBeforeResume['index']
+                ['discovery_next_remote_index_byte_offset']
+        );
+        $this->assertSame(
+            'index',
+            $stateBeforeResume['active_resumable_command']['current_stage']
+        );
+
+        $this->runClient($this->newLoadedClient(), ['command' => 'files-index']);
+
+        $this->assertCount(1, $this->fileIndexRequests());
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testFirstLinkAtByteZeroStartsOnlyItsFollowedTraversal(): void
+    {
+        $canonicalSiteDirectory = realpath($this->siteDir);
+        $canonicalExtraDirectory = realpath($this->extraDir);
+        $this->assertIsString($canonicalSiteDirectory);
+        $this->assertIsString($canonicalExtraDirectory);
+        $this->removeTree($this->siteDir);
+        $this->siteDir = $canonicalSiteDirectory;
+        $this->extraDir = $canonicalExtraDirectory;
+        mkdir($this->siteDir);
+        $outsideTarget = $this->tempDir . '/first-link-target';
+        mkdir($outsideTarget);
+        $outsideTarget = realpath($outsideTarget);
+        $this->assertIsString($outsideTarget);
+        file_put_contents($outsideTarget . '/outside.txt', 'outside');
+        symlink($outsideTarget, $this->siteDir . '/first-link');
+        $this->newFilesIndexClient(true);
+
+        try {
+            $this->runClient(
+                $this->newLoadedClientThatFailsAfterDiscoveryCheckpoint(),
+                ['command' => 'files-index']
+            );
+            $this->fail('Expected the discovery checkpoint to stop the command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop after the followed-target discovery checkpoint.',
+                $exception->getMessage()
+            );
+        }
+
+        $nextRemoteIndexHandle = fopen($this->nextRemoteIndexPath(), 'r');
+        $this->assertIsResource($nextRemoteIndexHandle);
+        $firstLine = fgets($nextRemoteIndexHandle);
+        fclose($nextRemoteIndexHandle);
+        $this->assertIsString($firstLine);
+        $firstEntry = json_decode($firstLine, true);
+        $this->assertIsArray($firstEntry);
+        $this->assertSame('link', $firstEntry['type']);
+        $this->assertSame(
+            base64_encode( (string) realpath($outsideTarget) ),
+            $firstEntry['target']
+        );
+        $this->assertSame(
+            strlen($firstLine),
+            $this->readState()['index']
+                ['discovery_next_remote_index_byte_offset']
+        );
+
+        $requests = $this->fileIndexRequests();
+        $this->assertCount(2, $requests);
+        $canonicalTarget = base64_encode(
+            (string) realpath($outsideTarget)
+        );
+        $this->assertSame($canonicalTarget, $requests[1]['list_directory_b64']);
+        $this->assertSame(
+            [$canonicalTarget],
+            $requests[1]['requested_directories_b64']
+        );
+
+        $this->runClient($this->newLoadedClient(), ['command' => 'files-index']);
+
+        $this->assertCount(2, $this->fileIndexRequests());
+        $this->assertSame(
+            'complete',
+            $this->readState()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testFollowedTargetDiscoveryResumesFromItsDurableByteOffset(): void
+    {
+        $outsideTarget = $this->tempDir . '/late-outside-target';
+        mkdir($outsideTarget);
+        file_put_contents($outsideTarget . '/outside.txt', 'outside');
+        for ($index = 0; $index < 1200; ++$index) {
+            file_put_contents(
+                $this->siteDir . '/file-' . str_pad(
+                    (string) $index,
+                    4,
+                    '0',
+                    STR_PAD_LEFT
+                ) . '-' . str_repeat('x', 120),
+                'x'
+            );
+        }
+        symlink($outsideTarget, $this->siteDir . '/zz-outside-link');
+        $this->newFilesIndexClient(true);
+
+        try {
+            $this->runClient(
+                $this->newLoadedClientThatFailsAfterDiscoveryCheckpoint(),
+                ['command' => 'files-index']
+            );
+            $this->fail('Expected the discovery checkpoint to stop the command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop after the followed-target discovery checkpoint.',
+                $exception->getMessage()
+            );
+        }
+
+        $savedDiscoveryByteOffset = $this->readState()['index']
+            ['discovery_next_remote_index_byte_offset'];
+        $this->assertGreaterThan(0, $savedDiscoveryByteOffset);
+        $this->assertLessThan(
+            filesize($this->nextRemoteIndexPath()),
+            $savedDiscoveryByteOffset
+        );
+        $this->assertCount(1, $this->fileIndexRequests());
+
+        $this->runClient($this->newLoadedClient(), ['command' => 'files-index']);
+        $requests = $this->fileIndexRequests();
+        $this->assertCount(2, $requests);
+        $this->assertSame(
+            [base64_encode( (string) realpath($outsideTarget) )],
+            $requests[1]['requested_directories_b64']
+        );
+    }
+
+    public function testProcessDeathDiscardsRowsPastTheDurableOffsetBeforeDiscoveryResume(): void
+    {
+        $followedTarget = $this->tempDir . '/followed-root';
+        $staleTarget = $this->tempDir . '/stale-target';
+        $freshTarget = $this->tempDir . '/fresh-target';
+        foreach ([$followedTarget, $staleTarget, $freshTarget] as $directory) {
+            mkdir($directory);
+        }
+        file_put_contents($staleTarget . '/stale.txt', 'stale');
+        file_put_contents($freshTarget . '/fresh.txt', 'fresh');
+        symlink($staleTarget, $followedTarget . '/old-link');
+        symlink($followedTarget, $this->siteDir . '/followed-link');
+        $canonicalFollowedTarget = realpath($followedTarget);
+        $canonicalStaleTarget = realpath($staleTarget);
+        $canonicalFreshTarget = realpath($freshTarget);
+        $this->assertIsString($canonicalFollowedTarget);
+        $this->assertIsString($canonicalStaleTarget);
+        $this->assertIsString($canonicalFreshTarget);
+        $this->newFilesIndexClient(true);
+
+        $childScript = $this->tempDir . '/stop-during-followed-index.php';
+        $checkpointFile = $this->tempDir . '/followed-batch-written';
+        file_put_contents(
+            $childScript,
+            sprintf(
+                <<<'PHP'
+<?php
+require_once %s;
+
+final class StopDuringFollowedRemoteIndexBatchClient extends ImportClient
+{
+    private $followedTarget;
+    private $checkpointFile;
+
+    public function __construct(
+        string $remoteUrl,
+        string $stateDirectory,
+        string $filesystemRoot,
+        string $followedTarget,
+        string $checkpointFile
+    ) {
+        parent::__construct($remoteUrl, $stateDirectory, $filesystemRoot);
+        $this->followedTarget = $followedTarget;
+        $this->checkpointFile = $checkpointFile;
+    }
+
+    public function save_state(): void
+    {
+        $indexState = $this->get_state()->index;
+        $traversal = $indexState->active_traversal_request();
+        if (
+            is_array($traversal)
+            && $traversal['list_directory'] === $this->followedTarget
+            && $indexState->cursor !== null
+            && $indexState->next_remote_index_byte_offset
+                > $traversal['next_remote_index_start_byte_offset']
+        ) {
+            file_put_contents($this->checkpointFile, 'ready');
+            while (true) {
+                usleep(100000);
+            }
+        }
+        parent::save_state();
+    }
+}
+
+$client = new StopDuringFollowedRemoteIndexBatchClient(
+    %s,
+    %s,
+    %s,
+    %s,
+    %s
+);
+$reflection = new ReflectionClass(ImportClient::class);
+$state = $reflection->getMethod('load_state')->invoke($client);
+$reflection->getProperty('state')->setValue($client, $state);
+$reflection->getProperty('follow_symlinks')->setValue(
+    $client,
+    $state->follow_symlinks
+);
+$reflection->getProperty('include_caches')->setValue(
+    $client,
+    $state->include_caches
+);
+$output = fopen('php://temp', 'w+');
+$reflection->getProperty('progress_fd')->setValue($client, $output);
+$progress = $reflection->getProperty('progress')->getValue($client);
+(new ReflectionClass($progress))->getProperty('progress_fd')->setValue(
+    $progress,
+    $output
+);
+$client->run(['command' => 'files-index']);
+PHP,
+                var_export(
+                    realpath(
+                        __DIR__
+                        . '/../../packages/reprint-client/src/import.php'
+                    ),
+                    true
+                ),
+                var_export($this->remoteUrl, true),
+                var_export($this->stateDir, true),
+                var_export($this->filesystemRoot, true),
+                var_export($canonicalFollowedTarget, true),
+                var_export($checkpointFile, true)
+            )
+        );
+
+        $childPipes = [];
+        $childProcess = proc_open(
+            [PHP_BINARY, $childScript],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $childPipes,
+            $this->tempDir,
+            getenv()
+        );
+        $this->assertIsResource($childProcess);
+        fclose($childPipes[0]);
+        $reachedCheckpoint = false;
+        for ($attempt = 0; $attempt < 200; ++$attempt) {
+            if (is_file($checkpointFile)) {
+                $reachedCheckpoint = true;
+                break;
+            }
+            $childStatus = proc_get_status($childProcess);
+            if (!$childStatus['running']) {
+                break;
+            }
+            usleep(50000);
+        }
+        if (!$reachedCheckpoint) {
+            $childStatus = proc_get_status($childProcess);
+            if ($childStatus['running']) {
+                proc_terminate($childProcess, 9);
+            }
+            $childOutput = stream_get_contents($childPipes[1]);
+            $childError = stream_get_contents($childPipes[2]);
+            fclose($childPipes[1]);
+            fclose($childPipes[2]);
+            proc_close($childProcess);
+            $this->fail(
+                "Child process did not reach the followed-index save boundary.\n"
+                . $childOutput . "\n" . $childError
+            );
+        }
+        $this->assertTrue(proc_terminate($childProcess, 9));
+        for ($attempt = 0; $attempt < 100; ++$attempt) {
+            if (!proc_get_status($childProcess)['running']) {
+                break;
+            }
+            usleep(50000);
+        }
+        fclose($childPipes[1]);
+        fclose($childPipes[2]);
+        proc_close($childProcess);
+
+        $stateAfterProcessDeath = $this->readState();
+        $durableNextIndexByteOffset = $stateAfterProcessDeath['index']
+            ['next_remote_index_byte_offset'];
+        clearstatcache(true, $this->nextRemoteIndexPath());
+        $this->assertGreaterThan(
+            $durableNextIndexByteOffset,
+            filesize($this->nextRemoteIndexPath())
+        );
+        $nextIndexHandle = fopen($this->nextRemoteIndexPath(), 'r');
+        $this->assertIsResource($nextIndexHandle);
+        $this->assertSame(0, fseek(
+            $nextIndexHandle,
+            $durableNextIndexByteOffset
+        ));
+        $bytesPastDurableOffset = stream_get_contents($nextIndexHandle);
+        fclose($nextIndexHandle);
+        $this->assertIsString($bytesPastDurableOffset);
+        $this->assertStringContainsString(
+            base64_encode($canonicalFollowedTarget . '/old-link'),
+            $bytesPastDurableOffset
+        );
+
+        unlink($followedTarget . '/old-link');
+        symlink($freshTarget, $followedTarget . '/new-link');
+        $this->runClient($this->newLoadedClient(), ['command' => 'files-index']);
+
+        $requestedListDirectories = array_map(
+            static function (array $request): string {
+                return (string) base64_decode(
+                    $request['list_directory_b64'],
+                    true
+                );
+            },
+            $this->fileIndexRequests()
+        );
+        $this->assertSame(
+            [
+                $this->siteDir,
+                $canonicalFollowedTarget,
+                $canonicalFollowedTarget,
+                $canonicalFreshTarget,
+            ],
+            $requestedListDirectories
+        );
+        $this->assertNotContains(
+            $canonicalStaleTarget,
+            $requestedListDirectories,
+            'Rows past the durable byte offset must not start a traversal after resume.'
+        );
+        $nextRemoteIndexPaths = $this->nextRemoteIndexPaths();
+        $this->assertNotContains(
+            base64_encode($canonicalFollowedTarget . '/old-link'),
+            $nextRemoteIndexPaths
+        );
+        $this->assertContains(
+            base64_encode($canonicalFollowedTarget . '/new-link'),
+            $nextRemoteIndexPaths
+        );
+    }
+
+    private function newFilesIndexClient(bool $followSymlinks): \ImportClient
+    {
+        $client = $this->newClient();
+        \write_current_pull_state($client, [
+            'active_resumable_command' => [
+                'command_name' => 'files-index',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'index',
+                'remote_cursor' => null,
+            ],
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'runtime' => ['document_root' => $this->siteDir],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => $this->siteDir],
+                            ['path' => $this->extraDir],
+                        ],
+                    ],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => $followSymlinks,
+            'include_caches' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+        ]);
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('follow_symlinks')->setValue(
+            $client,
+            $followSymlinks
+        );
+        return $client;
+    }
+
+    private function newLoadedClient(): \ImportClient
+    {
+        return $this->loadClientState($this->newClient());
+    }
+
+    private function newLoadedClientThatFailsBeforeSort(): \ImportClient
+    {
+        $client = new FailBeforeRemoteIndexSortClient(
+            $this->remoteUrl,
+            $this->stateDir,
+            $this->filesystemRoot
+        );
+        $this->configureClientOutput($client);
+        return $this->loadClientState($client);
+    }
+
+    private function newLoadedClientThatFailsAfterDiscoveryCheckpoint(): \ImportClient
+    {
+        $client = new FailAfterRemoteIndexDiscoveryCheckpointClient(
+            $this->remoteUrl,
+            $this->stateDir,
+            $this->filesystemRoot
+        );
+        $this->configureClientOutput($client);
+        return $this->loadClientState($client);
+    }
+
+    private function loadClientState(\ImportClient $client): \ImportClient
+    {
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $state = $reflection->getMethod('load_state')->invoke($client);
+        $reflection->getProperty('state')->setValue($client, $state);
+        $reflection->getProperty('follow_symlinks')->setValue(
+            $client,
+            $state->follow_symlinks
+        );
+        $reflection->getProperty('include_caches')->setValue(
+            $client,
+            $state->include_caches
+        );
+        return $client;
+    }
+
+    private function newClient(): \ImportClient
+    {
+        $client = new \ImportClient(
+            $this->remoteUrl,
+            $this->stateDir,
+            $this->filesystemRoot
+        );
+        $this->configureClientOutput($client);
+        return $client;
+    }
+
+    private function configureClientOutput(\ImportClient $client): void
+    {
+        $output = fopen('php://temp', 'w+');
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('progress_fd')->setValue($client, $output);
+        $progress = $reflection->getProperty('progress')->getValue($client);
+        ( new \ReflectionClass($progress) )->getProperty('progress_fd')->setValue(
+            $progress,
+            $output
+        );
+    }
+
+    private function runClient(\ImportClient $client, array $options): void
+    {
+        $client->run($options);
+    }
+
+    private function readState(): array
+    {
+        return json_decode(
+            file_get_contents($this->pullStateDirectory() . '/state.json'),
+            true
+        );
+    }
+
+    private function readTraversalJournalRecords(): array
+    {
+        $lines = file($this->traversalJournalPath(), FILE_IGNORE_NEW_LINES);
+        return array_map(
+            static function (string $line): array {
+                return json_decode($line, true);
+            },
+            $lines ?: []
+        );
+    }
+
+    /** @return string[] Base64 paths in the next remote index. */
+    private function nextRemoteIndexPaths(): array
+    {
+        $lines = file($this->nextRemoteIndexPath(), FILE_IGNORE_NEW_LINES);
+        $paths = [];
+        foreach ($lines ?: [] as $line) {
+            $record = json_decode($line, true);
+            if (is_array($record) && is_string($record['path'] ?? null)) {
+                $paths[] = $record['path'];
+            }
+        }
+        return $paths;
+    }
+
+    private function fileIndexRequests(): array
+    {
+        $lines = is_file($this->requestLog)
+            ? file($this->requestLog, FILE_IGNORE_NEW_LINES)
+            : [];
+        $requests = [];
+        foreach ($lines ?: [] as $line) {
+            $request = json_decode($line, true);
+            if ( ( $request['endpoint'] ?? null ) === 'file_index' ) {
+                $requests[] = $request;
+            }
+        }
+        return $requests;
+    }
+
+    private function startRealExporter(): string
+    {
+        $router = $this->tempDir . '/router.php';
+        $serverClass = realpath(
+            __DIR__ . '/../../packages/reprint-server/src/class-http-server.php'
+        );
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $this->assertIsString($serverClass);
+        $this->assertIsString($autoload);
+        file_put_contents(
+            $router,
+            sprintf(
+                <<<'PHP'
+<?php
+$directories = $_GET['directory'] ?? [];
+if (!is_array($directories)) {
+    $directories = [$directories];
+}
+file_put_contents(
+    %s,
+    json_encode([
+        'endpoint' => $_GET['endpoint'] ?? null,
+        'list_directory_b64' => isset($_GET['list_dir'])
+            ? base64_encode((string) $_GET['list_dir'])
+            : null,
+        'requested_directories_b64' => array_map('base64_encode', $directories),
+        'cursor' => $_GET['cursor'] ?? null,
+    ], JSON_UNESCAPED_SLASHES) . "\n",
+    FILE_APPEND
+);
+require_once %s;
+require_once %s;
+Site_Export_HTTP_Server::serve(['default_directory' => %s]);
+PHP,
+                var_export($this->requestLog, true),
+                var_export($autoload, true),
+                var_export($serverClass, true),
+                var_export($this->siteDir, true)
+            )
+        );
+
+        $socket = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $errorNumber,
+            $errorMessage
+        );
+        $this->assertIsResource($socket, $errorMessage);
+        $socketName = stream_socket_get_name($socket, false);
+        $this->assertIsString($socketName);
+        fclose($socket);
+        $port = (int) substr(strrchr($socketName, ':'), 1);
+        $environment = getenv();
+        if (!is_array($environment)) {
+            $environment = [];
+        }
+        $environment['SITE_EXPORT_TEST_MODE'] = '1';
+        $this->serverProcess = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, $router],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->serverPipes,
+            $this->tempDir,
+            $environment
+        );
+        $this->assertIsResource($this->serverProcess);
+        fclose($this->serverPipes[0]);
+        for ($attempt = 0; $attempt < 50; ++$attempt) {
+            $connection = @fsockopen(
+                '127.0.0.1',
+                $port,
+                $errorNumber,
+                $errorMessage,
+                0.1
+            );
+            if (is_resource($connection)) {
+                fclose($connection);
+                return 'http://127.0.0.1:' . $port
+                    . '/export.php?site-export-api';
+            }
+            usleep(100000);
+        }
+        $this->fail('Real exporter did not start.');
+    }
+
+    private function pullStateDirectory(): string
+    {
+        return $this->stateDir . '/remotes/'
+            . md5(rtrim($this->remoteUrl, '?&'))
+            . '/pull';
+    }
+
+    private function nextRemoteIndexPath(): string
+    {
+        return $this->pullStateDirectory() . '/remote-index.next.jsonl';
+    }
+
+    private function traversalJournalPath(): string
+    {
+        return $this->pullStateDirectory()
+            . '/remote-index-traversals.next.jsonl';
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}
+
+final class FailBeforeRemoteIndexSortClient extends \ImportClient
+{
+    private $failed = false;
+
+    public function save_state(): void
+    {
+        $activeCommand = $this->get_state()->active_resumable_command;
+        if (
+            !$this->failed
+            && $activeCommand->command_name === 'files-index'
+            && $activeCommand->completion_state === 'in_progress'
+            && $activeCommand->current_stage === 'sort'
+        ) {
+            $this->failed = true;
+            throw new \RuntimeException('Stop before the remote index sort.');
+        }
+        parent::save_state();
+    }
+}
+
+final class FailAfterRemoteIndexDiscoveryCheckpointClient extends \ImportClient
+{
+    private $failed = false;
+
+    public function save_state(): void
+    {
+        parent::save_state();
+        $indexState = $this->get_state()->index;
+        if (
+            !$this->failed
+            && $this->get_state()->active_resumable_command->current_stage
+                === 'index'
+            && $indexState->active_traversal === null
+            && $indexState->discovery_next_remote_index_byte_offset > 0
+            && $indexState->discovery_next_remote_index_byte_offset
+                < $indexState->next_remote_index_byte_offset
+        ) {
+            $this->failed = true;
+            throw new \RuntimeException(
+                'Stop after the followed-target discovery checkpoint.'
+            );
+        }
+    }
+}

--- a/tests/Import/RemoteIndexTraversalJournalTest.php
+++ b/tests/Import/RemoteIndexTraversalJournalTest.php
@@ -1,0 +1,222 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the following line.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+final class RemoteIndexTraversalJournalTest extends TestCase
+{
+    private $tempDir;
+    private $journalPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/remote-index-journal-' . uniqid();
+        mkdir($this->tempDir);
+        $this->journalPath = $this->tempDir . '/traversals.jsonl';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testCompletionStoresOnlyReplayFieldsAndKeepsPathsByteSafe(): void
+    {
+        $listDirectory = "/remote/\x80-target";
+        $requestedDirectories = [$listDirectory, '/remote/plain'];
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $durableByteOffset = $journal->complete_traversal(
+            17,
+            43,
+            $listDirectory,
+            $requestedDirectories
+        );
+
+        $this->assertTrue(
+            $journal->covers_canonical_path(
+                $listDirectory . '/nested',
+                $durableByteOffset
+            )
+        );
+        $this->assertFalse(
+            $journal->covers_canonical_path(
+                $listDirectory . '-old/nested',
+                $durableByteOffset
+            )
+        );
+        $journal->close();
+
+        $rawJournal = file_get_contents($this->journalPath);
+        $this->assertIsString($rawJournal);
+        $this->assertStringNotContainsString("\x80", $rawJournal);
+        $record = json_decode(trim($rawJournal), true);
+        $this->assertSame(
+            [
+                'type' => 'traversal_complete',
+                'indexed_roots_b64' => array_map(
+                    'base64_encode',
+                    $requestedDirectories
+                ),
+                'next_remote_index_start_byte_offset' => 17,
+                'next_remote_index_end_byte_offset' => 43,
+            ],
+            $record
+        );
+        $this->assertSame($durableByteOffset, strlen($rawJournal));
+
+        $marker = json_decode(
+            file_get_contents(
+                $this->markersDirectory() . '/'
+                . hash('sha256', $listDirectory) . '.json'
+            ),
+            true
+        );
+        $this->assertSame(
+            ['completion_record_byte_offset' => 0],
+            $marker
+        );
+    }
+
+    public function testFreshBoundaryStreamsMarkerCleanup(): void
+    {
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $journal->complete_traversal(
+            0,
+            10,
+            '/remote/site',
+            ['/remote/site']
+        );
+        $journal->close();
+        $this->assertDirectoryExists($this->markersDirectory());
+
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $this->assertSame(0, filesize($this->journalPath));
+        $this->assertDirectoryDoesNotExist($this->markersDirectory());
+        $this->assertFalse(
+            $journal->covers_canonical_path('/remote/site/nested', 0)
+        );
+        $journal->close();
+    }
+
+    public function testMarkerBeyondSavedCompletionBoundaryIsIgnored(): void
+    {
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $savedBoundary = $journal->complete_traversal(
+            0,
+            10,
+            '/remote/site',
+            ['/remote/site']
+        );
+        $journal->complete_traversal(
+            10,
+            20,
+            '/remote/outside',
+            ['/remote/outside']
+        );
+        $journal->close();
+
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset($savedBoundary);
+        $this->assertTrue(
+            $journal->covers_canonical_path('/remote/site/child', $savedBoundary)
+        );
+        $this->assertFalse(
+            $journal->covers_canonical_path('/remote/outside/child', $savedBoundary)
+        );
+        $journal->close();
+    }
+
+    public function testCompletionRequiresCanonicalListDirectoryAsFirstRoot(): void
+    {
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        try {
+            $journal->complete_traversal(
+                0,
+                10,
+                '/remote/site',
+                ['/remote/unrequested', '/remote/site']
+            );
+            $this->fail('Expected completion roots in the wrong order to be rejected.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'roots or byte range are invalid',
+                $exception->getMessage()
+            );
+        } finally {
+            $journal->close();
+        }
+    }
+
+    public function testUncommittedMarkerCannotCoverARegrownJournal(): void
+    {
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $savedBoundary = $journal->complete_traversal(
+            0,
+            10,
+            '/remote/site',
+            ['/remote/site']
+        );
+        $journal->complete_traversal(
+            10,
+            20,
+            '/remote/outside',
+            ['/remote/outside']
+        );
+        $journal->close();
+
+        // A process stopped after the second marker was written but before
+        // its completion boundary reached state. Resume truncates that record,
+        // then another completion reuses the same journal byte offset.
+        $journal = new \RemoteIndexTraversalJournal($this->journalPath);
+        $journal->open_and_truncate_to_saved_byte_offset($savedBoundary);
+        $regrownBoundary = $journal->complete_traversal(
+            10,
+            20,
+            '/remote/other',
+            ['/remote/other']
+        );
+
+        $this->assertFalse(
+            $journal->covers_canonical_path(
+                '/remote/outside/child',
+                $regrownBoundary
+            )
+        );
+        $journal->close();
+    }
+
+    private function markersDirectory(): string
+    {
+        return $this->tempDir . '/remote-index-traversal-roots.next';
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
Completed initial and followed remote-index traversals now resume without issuing the same traversal again.

Each traversal records its target-confirmed raw index range and canonical roots before its state advances. Followed-target discovery moves forward from a durable byte offset through the growing index, while disk-backed root markers prevent canonical targets from being revisited without loading the target set into memory. A followed request indexes only that target instead of walking the primary roots again.

Request failures stop the current run at the last durable boundary. Resume removes any unconfirmed index tail before discovery reads it, so buffered stale rows cannot start another traversal.

## Testing

Interrupt initial and followed traversals at request, batch, discovery, and pre-sort boundaries, then resume through the real exporter. Confirm completed requests are not repeated, empty indexes preserve the zero-byte sentinel, the first link at byte zero is consumed once, target-only requests discover nested links, and unconfirmed rows are discarded before discovery resumes.
