### PR TITLE
[PHP] Record completed files-pull ownership by selection

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -114,6 +114,7 @@ require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
 require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
 require_once __DIR__ . '/lib/pull/class-remote-index-traversal-journal.php';
+require_once __DIR__ . '/lib/pull/class-files-pull-ownership-processor.php';
 
 /**
  * The wire-protocol version this importer speaks.
@@ -151,7 +152,7 @@ register_shutdown_function(function () {
 
 class ImportClient
 {
-
+    private const FILES_PULL_OWNERSHIP_CHECKPOINT_STEPS = 200;
     /** Commands executed by ImportClient. */
     public const COMMANDS = [
         "pull",
@@ -253,6 +254,8 @@ class ImportClient
 
     /** @var string Durable traversal boundaries for pull/remote-index.next.jsonl. */
     private $next_remote_index_traversal_journal_file;
+
+    private $files_pull_ownership_directory;
 
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by comparing the next remote index with the remote index. */
     private $fetch_list_file;
@@ -503,6 +506,7 @@ class ImportClient
                 $this->pull_state_directory,
                 "remote-index-traversals.next.jsonl"
             );
+        $this->files_pull_ownership_directory = wp_join_unix_paths($this->pull_state_directory, 'files-pull-ownership');
         $this->fetch_list_file =
             wp_join_unix_paths($this->pull_state_directory, "fetch-list.jsonl");
         $this->audit_log_file = wp_join_unix_paths($this->state_dir, "audit.log");
@@ -2431,9 +2435,31 @@ class ImportClient
             "RESTART | Clearing files-pull progress (keeping remote index and files)",
             true,
         );
-        $this->reset_state();
-        $this->get_state()->include_caches = false;
-        $this->get_state()->extra_directory = null;
+        $ownership = $this->get_state()->files_pull_ownership;
+        $selection_fingerprint = $this->get_state()->files_pull_path_selection_fingerprint;
+        $current_stage = $this->get_state()->active_resumable_command->current_stage;
+        $processor_snapshot_id = FilesPullOwnershipProcessor::snapshot_id_from_cursor($ownership->processor_cursor);
+        // Save cleared ownership before deleting transient inputs so a signal cannot
+        // persist an ID in both cursor and cleanup. Applying the WAL replaces the
+        // remote index read by the diff cursor. Save the cleared cursor first so the
+        // next run applies the WAL again after interruption.
+        reprint_update_and_save_state_without_signal_interruption(
+            function () use ($ownership, $selection_fingerprint, $current_stage, $processor_snapshot_id): void {
+                if (is_string($selection_fingerprint)) {
+                    $ownership->abort_active_snapshot(
+                        $selection_fingerprint,
+                        in_array($current_stage, ['diff', 'fetch'], true),
+                        $processor_snapshot_id
+                    );
+                }
+                $this->reset_state();
+                $this->get_state()->include_caches = false;
+                $this->get_state()->extra_directory = null;
+                $this->get_state()->index = new RemoteFileIndexState();
+                $this->get_state()->fetch = new FetchListProgressState();
+            },
+            [$this, 'save_state']
+        );
 
         if (file_exists($this->next_remote_index_file)) {
             @unlink($this->next_remote_index_file);
@@ -2453,13 +2479,8 @@ class ImportClient
             @unlink($this->volatile_files_file);
             $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
         }
-        $this->get_state()->index = new RemoteFileIndexState();
-        $this->get_state()->fetch = new FetchListProgressState();
+        $this->remove_next_files_pull_ownership_snapshot();
 
-        // Applying the WAL replaces the remote index read by the diff cursor.
-        // Save the cleared cursor first. If applying the WAL stops partway, the
-        // next run starts with the cleared cursor and applies the WAL again.
-        $this->save_state();
         $this->pull_index_journal->apply_pending_records();
         $this->pull_index_journal->remove_empty_wal();
     }
@@ -3064,7 +3085,7 @@ class ImportClient
      * - Prior completed files-pull → delta mode (re-index, diff, fetch changes)
      * - In-progress files-pull → resume from saved state
      *
-     * Both modes share the same pipeline: index → sort → diff → fetch.
+     * Both modes share the same pipeline: index → ownership → sort → diff → fetch.
      */
     public function run_files_pull(): void
     {
@@ -3080,7 +3101,7 @@ class ImportClient
                 "Finish the unfinished files-push before running files-pull."
             );
         }
-
+        $this->remove_next_files_pull_ownership_snapshot();
         $active_resumable_command =
             $this->get_state()->active_resumable_command;
         $state_command = $active_resumable_command->command_name ?? null;
@@ -3291,11 +3312,68 @@ class ImportClient
             } finally {
                 $traversal_journal->close();
             }
-            // Sorting replaces the index atomically. Save its phase first so
-            // interruption after the replacement reruns the idempotent sort
-            // instead of requesting the remote index again.
-            $this->get_state()->active_resumable_command->current_stage = "sort";
-            $this->save_state();
+            // Ownership must consume the raw traversal ranges before sorting
+            // replaces the index and removes their byte positions.
+            reprint_update_and_save_state_without_signal_interruption(
+                function (): void {
+                    $this->get_state()->files_pull_ownership->processor_cursor = FilesPullOwnershipProcessor::initial_cursor();
+                    $this->get_state()->active_resumable_command->current_stage = "ownership";
+                },
+                [$this, 'save_state']
+            );
+            $stage = "ownership";
+        }
+
+        if ($stage === "ownership") {
+            $ownership_processor = FilesPullOwnershipProcessor::resume(
+                $this->next_remote_index_traversal_journal_file,
+                $this->get_state()->index->traversal_journal_byte_offset,
+                $this->next_remote_index_file,
+                $this->get_state()->index->next_remote_index_byte_offset,
+                $this->files_pull_ownership_directory,
+                $this->get_state()->files_pull_ownership->processor_cursor
+            );
+            try {
+                $steps_since_checkpoint = 0;
+                $saved_processor_phase = $ownership_processor->get_checkpoint_phase();
+                while ($ownership_processor->next_step()) {
+                    if ($this->shutdown_requested) {
+                        $this->get_state()->files_pull_ownership->processor_cursor = $ownership_processor->get_cursor();
+                        $this->get_state()->active_resumable_command->completion_state = "partial";
+                        $this->save_state();
+                        return;
+                    }
+                    if (
+                        ++$steps_since_checkpoint === self::FILES_PULL_OWNERSHIP_CHECKPOINT_STEPS
+                        || $ownership_processor->get_checkpoint_phase() !== $saved_processor_phase
+                    ) {
+                        $this->get_state()->files_pull_ownership->processor_cursor = $ownership_processor->get_cursor();
+                        $this->save_state();
+                        $saved_processor_phase = $ownership_processor->get_checkpoint_phase();
+                        $steps_since_checkpoint = 0;
+                    }
+                }
+                $snapshot_id = $ownership_processor->get_snapshot_id();
+                if (FilesPullOwnershipProcessor::snapshot_id_from_cursor(
+                    $this->get_state()->files_pull_ownership->processor_cursor
+                ) !== $snapshot_id) {
+                    throw new RuntimeException('Completed ownership snapshot ID does not match its durable cursor.');
+                }
+                // Save the snapshot and sort phase together so a signal cannot
+                // leave ownership without either its cursor or completed ID.
+                // Sorting replaces the index atomically. Save its phase first so
+                // interruption after the replacement reruns the idempotent sort
+                // instead of requesting the remote index again.
+                reprint_update_and_save_state_without_signal_interruption(
+                    function () use ($snapshot_id): void {
+                        $this->get_state()->files_pull_ownership->complete_processor($snapshot_id);
+                        $this->get_state()->active_resumable_command->current_stage = "sort";
+                    },
+                    [$this, 'save_state']
+                );
+            } finally {
+                $ownership_processor->close();
+            }
             $stage = "sort";
         }
 
@@ -3384,9 +3462,18 @@ class ImportClient
         $this->pull_index_journal->apply_pending_records();
 
         $this->ensure_local_index_exists();
-        $this->get_state()->active_resumable_command->completion_state = "complete";
-        $this->get_state()->active_resumable_command->current_stage = null;
-        $this->save_state();
+        $selection_fingerprint = $this->get_state()->files_pull_path_selection_fingerprint;
+        if (!is_string($selection_fingerprint)) {
+            throw new RuntimeException('Completed files-pull has no path-selection fingerprint.');
+        }
+        reprint_update_and_save_state_without_signal_interruption(
+            function () use ($selection_fingerprint): void {
+                $this->get_state()->files_pull_ownership->commit_active_snapshot($selection_fingerprint);
+                $this->get_state()->active_resumable_command->completion_state = "complete";
+                $this->get_state()->active_resumable_command->current_stage = null;
+            },
+            [$this, 'save_state']
+        );
         $this->pull_index_journal->remove_empty_wal();
 
         $this->progress->clear_progress_line();
@@ -3411,6 +3498,18 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    private function remove_next_files_pull_ownership_snapshot(): void
+    {
+        $ownership = $this->get_state()->files_pull_ownership;
+        $snapshot_id = $ownership->next_snapshot_id_pending_removal();
+        if ($snapshot_id === null) {
+            return;
+        }
+        FilesPullOwnershipProcessor::remove_snapshot($this->files_pull_ownership_directory, $snapshot_id);
+        $ownership->confirm_snapshot_removed($snapshot_id);
+        $this->save_state();
     }
 
     /** Creates an empty local index when files-pull recorded no local paths. */
@@ -11420,6 +11519,7 @@ class ImportClient
         $this->state->fs_root_nonempty_behavior = $previous_state->fs_root_nonempty_behavior;
         $this->state->max_allowed_packet = $previous_state->max_allowed_packet;
         $this->state->resolved_path_mappings_fingerprint = $previous_state->resolved_path_mappings_fingerprint;
+        $this->state->files_pull_ownership = $previous_state->files_pull_ownership;
         $this->state->pull_pipeline = $previous_state->pull_pipeline;
     }
 

--- a/packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php
+++ b/packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php
@@ -1,0 +1,948 @@
+<?php
+declare(strict_types=1);
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\normalize_path;
+
+require_once __DIR__ . '/../class-external-sort-processor.php';
+require_once __DIR__ . '/class-remote-index-reader.php';
+require_once __DIR__ . '/class-remote-index-traversal-journal.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Errors contain private state paths, never HTML.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer processors use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer processors place braces on the following line.
+
+/**
+ * Builds one files-pull ownership snapshot from completed index traversals.
+ *
+ * Scanning and lookup steps read one durable input, write one atom or lookup
+ * row, or change phase. ExternalSortProcessor owns both bounded, resumable
+ * sorts. Root atoms own strict descendants, exact atoms own only intermediate
+ * links, and ancestor atoms only protect recursive work. Output is flushed
+ * before its cursor advances; resume truncates its tail. Sorted `paths.jsonl`
+ * rows and a fixed-width hash-to-offset `lookup` use one opaque snapshot ID.
+ *
+ * @phpstan-type Cursor array{phase:'scanning'|'starting_paths_sort'|'sorting_paths'|'building_lookup'|'starting_lookup_sort'|'sorting_lookup'|'preparing_snapshot'|'snapshot_prepared'|'paths_published'|'lookup_published'|'cleaning_work_files'|'complete',traversal_journal_byte_offset:int,current_completion_journal_end_byte_offset:int|null,current_root_index:int,current_range_end_byte_offset:int|null,next_remote_index_byte_offset:int,pending_atom_kind:'root'|'exact'|'ancestor'|null,pending_atom_path_b64:string|null,pending_next_remote_index_byte_offset:int|null,paths_byte_offset:int,lookup_paths_byte_offset:int,lookup_byte_offset:int,paths_sort_cursor:array|null,lookup_sort_cursor:array|null,snapshot_id:string|null,next_work_file_cleanup_index:int}
+ */
+final class FilesPullOwnershipProcessor
+{
+    private const LOOKUP_RECORD_BYTES = 82;
+    /** Bounds each physical row read by one ownership step. */
+    private const MAXIMUM_ROW_BYTES = 65536;
+    private const PHASES_WITHOUT_SNAPSHOT_ID = [
+        'scanning', 'starting_paths_sort', 'sorting_paths',
+        'building_lookup', 'starting_lookup_sort', 'sorting_lookup',
+        'preparing_snapshot',
+    ];
+    private const PHASES_WITH_SNAPSHOT_ID = [
+        'snapshot_prepared', 'paths_published', 'lookup_published',
+        'cleaning_work_files', 'complete',
+    ];
+
+    private string $traversal_journal_path;
+    private int $durable_traversal_journal_byte_offset;
+    private string $next_remote_index_path;
+    private int $durable_next_remote_index_byte_offset;
+    private string $ownership_directory;
+    private string $work_directory;
+    private string $paths_work_path;
+    private string $sorted_paths_work_path;
+    private string $lookup_work_path;
+    private string $sorted_lookup_work_path;
+    /** @var Cursor */
+    private array $cursor;
+    private ?RemoteIndexTraversalJournal $traversal_journal = null;
+    /** @var resource|null Phase input handle. */
+    private $input_handle = null;
+    /** @var resource|null Phase output handle. */
+    private $output_handle = null;
+    private ?ExternalSortProcessor $sort_processor = null;
+    /** @var array|null Current traversal completion retained between steps. */
+    private ?array $current_completion = null;
+    private bool $closed = false;
+
+    public static function initial_cursor(): array
+    {
+        return [
+            'phase' => 'scanning',
+            'traversal_journal_byte_offset' => 0,
+            'current_completion_journal_end_byte_offset' => null,
+            'current_root_index' => 0,
+            'current_range_end_byte_offset' => null,
+            'next_remote_index_byte_offset' => 0,
+            'pending_atom_kind' => null,
+            'pending_atom_path_b64' => null,
+            'pending_next_remote_index_byte_offset' => null,
+            'paths_byte_offset' => 0,
+            'lookup_paths_byte_offset' => 0,
+            'lookup_byte_offset' => 0,
+            'paths_sort_cursor' => null,
+            'lookup_sort_cursor' => null,
+            'snapshot_id' => null,
+            'next_work_file_cleanup_index' => 0,
+        ];
+    }
+
+    /** @phpstan-param Cursor $cursor */
+    public static function resume(
+        string $traversal_journal_path,
+        int $durable_traversal_journal_byte_offset,
+        string $next_remote_index_path,
+        int $durable_next_remote_index_byte_offset,
+        string $ownership_directory,
+        array $cursor
+    ): self {
+        $processor = new self();
+        $processor->traversal_journal_path = $traversal_journal_path;
+        $processor->durable_traversal_journal_byte_offset = $durable_traversal_journal_byte_offset;
+        $processor->next_remote_index_path = $next_remote_index_path;
+        $processor->durable_next_remote_index_byte_offset = $durable_next_remote_index_byte_offset;
+        $processor->ownership_directory = $ownership_directory;
+        $processor->work_directory = $ownership_directory . '/work';
+        $processor->paths_work_path = $processor->work_directory . '/paths.next.jsonl';
+        $processor->sorted_paths_work_path = $processor->work_directory . '/paths.sorted.jsonl';
+        $processor->lookup_work_path = $processor->work_directory . '/lookup.next';
+        $processor->sorted_lookup_work_path = $processor->work_directory . '/lookup.sorted';
+        $processor->cursor = $cursor;
+        $processor->assert_cursor();
+        if (
+            !is_dir($processor->work_directory)
+            && !mkdir($processor->work_directory, 0777, true)
+            && !is_dir($processor->work_directory)
+        ) {
+            throw new RuntimeException("Failed to create ownership work directory: {$processor->work_directory}.");
+        }
+        try {
+            $processor->open_phase_handles();
+            if ($cursor['phase'] === 'complete') {
+                $snapshot_id = $processor->allocated_snapshot_id();
+                if (
+                    !is_file($processor->snapshot_paths_path($snapshot_id))
+                    || !is_file($processor->snapshot_lookup_path($snapshot_id))
+                ) {
+                    throw new UnexpectedValueException('Completed ownership snapshot artifacts do not exist.');
+                }
+            }
+        } catch (Throwable $throwable) {
+            $processor->close();
+            throw $throwable;
+        }
+        return $processor;
+    }
+
+    public function next_step(): bool
+    {
+        if ($this->cursor['phase'] === 'complete') {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException('Cannot take an ownership step after close().');
+        }
+        switch ($this->cursor['phase']) {
+            case 'scanning':
+                return $this->scan_next_step();
+            case 'starting_paths_sort':
+                return $this->start_paths_sort();
+            case 'sorting_paths':
+                return $this->sort_paths_next_step();
+            case 'building_lookup':
+                return $this->build_next_lookup_record();
+            case 'starting_lookup_sort':
+                return $this->start_lookup_sort();
+            case 'sorting_lookup':
+                return $this->sort_lookup_next_step();
+            case 'preparing_snapshot':
+                return $this->prepare_snapshot();
+            case 'snapshot_prepared':
+                return $this->publish_paths();
+            case 'paths_published':
+                return $this->publish_lookup();
+            case 'lookup_published':
+                $this->cursor['phase'] = 'cleaning_work_files';
+                return true;
+            case 'cleaning_work_files':
+                return $this->remove_next_work_file();
+        }
+    }
+
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Includes the subordinate sort phase which requires an immediate save. */
+    public function get_checkpoint_phase(): string
+    {
+        if ($this->cursor['phase'] === 'sorting_paths') {
+            return 'sorting_paths:' . $this->cursor['paths_sort_cursor']['phase'];
+        }
+        if ($this->cursor['phase'] === 'sorting_lookup') {
+            return 'sorting_lookup:' . $this->cursor['lookup_sort_cursor']['phase'];
+        }
+        return $this->cursor['phase'];
+    }
+
+    /** Extracts only a phase-owned allocated ID from an opaque saved cursor. */
+    public static function snapshot_id_from_cursor(?array $cursor): ?string
+    {
+        if ($cursor === null) {
+            return null;
+        }
+        if (!isset($cursor['phase']) || !array_key_exists('snapshot_id', $cursor)) {
+            throw new UnexpectedValueException('Ownership processor cursor cannot identify its snapshot.');
+        }
+        if (
+            !in_array($cursor['phase'], self::PHASES_WITH_SNAPSHOT_ID, true)
+            && !in_array($cursor['phase'], self::PHASES_WITHOUT_SNAPSHOT_ID, true)
+        ) {
+            throw new UnexpectedValueException('Ownership processor cursor phase is invalid.');
+        }
+        $has_snapshot_id = in_array(
+            $cursor['phase'],
+            self::PHASES_WITH_SNAPSHOT_ID,
+            true
+        );
+        if (!$has_snapshot_id && $cursor['snapshot_id'] === null) {
+            return null;
+        }
+        if (
+            $has_snapshot_id
+            && is_string($cursor['snapshot_id'])
+            && preg_match('/^[0-9a-f]{64}$/D', $cursor['snapshot_id']) === 1
+        ) {
+            return $cursor['snapshot_id'];
+        }
+        throw new UnexpectedValueException('Ownership processor snapshot ID is inconsistent with its phase.');
+    }
+
+    public function get_snapshot_id(): string
+    {
+        if ($this->cursor['phase'] !== 'complete') {
+            throw new LogicException('Ownership snapshot is not complete.');
+        }
+        return $this->allocated_snapshot_id();
+    }
+
+    public function close(): void
+    {
+        if (!$this->closed) {
+            $this->closed = true;
+            $this->close_phase_handles();
+        }
+    }
+
+    /** Idempotently removes one opaque snapshot artifact pair. */
+    public static function remove_snapshot(
+        string $ownership_directory,
+        string $snapshot_id
+    ): void {
+        if (preg_match('/^[0-9a-f]{64}$/D', $snapshot_id) !== 1) {
+            throw new InvalidArgumentException('Ownership snapshot ID must be 64 lowercase hexadecimal characters.');
+        }
+        foreach (['paths.jsonl', 'lookup'] as $suffix) {
+            $path = self::snapshot_path($ownership_directory, $snapshot_id, $suffix);
+            if (is_file($path) && !unlink($path)) {
+                throw new RuntimeException("Failed to remove ownership snapshot artifact: {$path}.");
+            }
+        }
+    }
+
+    private function scan_next_step(): bool
+    {
+        if ($this->cursor['pending_atom_kind'] !== null) {
+            return $this->write_pending_atom_step();
+        }
+        if ($this->cursor['current_completion_journal_end_byte_offset'] === null) {
+            $completion = $this->traversal_journal->read_completed_traversal_at(
+                $this->cursor['traversal_journal_byte_offset'],
+                $this->durable_traversal_journal_byte_offset
+            );
+            if ($completion === null) {
+                if (
+                    $this->cursor['next_remote_index_byte_offset']
+                        !== $this->durable_next_remote_index_byte_offset
+                ) {
+                    throw new UnexpectedValueException('Completed traversals do not cover the durable next remote index.');
+                }
+                $this->cursor['phase'] = 'starting_paths_sort';
+                return true;
+            }
+            if (
+                $completion['next_remote_index_start_byte_offset']
+                    !== $this->cursor['next_remote_index_byte_offset']
+                || $completion['next_remote_index_end_byte_offset']
+                    > $this->durable_next_remote_index_byte_offset
+            ) {
+                throw new UnexpectedValueException('Traversal ranges must be contiguous inside the durable next index.');
+            }
+            $this->cursor['current_completion_journal_end_byte_offset'] = $completion['next_traversal_journal_byte_offset'];
+            $this->cursor['current_range_end_byte_offset'] = $completion['next_remote_index_end_byte_offset'];
+            $this->current_completion = $completion;
+            return true;
+        }
+
+        if ($this->current_completion === null) {
+            $this->current_completion =
+                $this->traversal_journal->read_completed_traversal_at(
+                    $this->cursor['traversal_journal_byte_offset'],
+                    $this->durable_traversal_journal_byte_offset
+                );
+        }
+        $completion = $this->current_completion;
+        if (
+            !is_array($completion)
+            || $completion['next_traversal_journal_byte_offset']
+                !== $this->cursor['current_completion_journal_end_byte_offset']
+            || $completion['next_remote_index_end_byte_offset']
+                !== $this->cursor['current_range_end_byte_offset']
+            || $this->cursor['current_root_index'] > count($completion['indexed_roots'])
+        ) {
+            throw new UnexpectedValueException('Ownership cursor does not match its traversal completion.');
+        }
+        if ($this->cursor['current_root_index'] < count($completion['indexed_roots'])) {
+            $this->start_pending_atom('root', $completion['indexed_roots'][$this->cursor['current_root_index']], null);
+            return $this->write_pending_atom_step();
+        }
+        $range_end_byte_offset = $this->cursor['current_range_end_byte_offset'];
+        if ($this->cursor['next_remote_index_byte_offset'] < $range_end_byte_offset) {
+            return $this->read_next_index_line($range_end_byte_offset);
+        }
+        if ($this->cursor['next_remote_index_byte_offset'] !== $range_end_byte_offset) {
+            throw new UnexpectedValueException('Ownership cursor passed its traversal range.');
+        }
+        $this->cursor['traversal_journal_byte_offset'] = $this->cursor['current_completion_journal_end_byte_offset'];
+        $this->cursor['current_completion_journal_end_byte_offset'] = null;
+        $this->cursor['current_root_index'] = 0;
+        $this->cursor['current_range_end_byte_offset'] = null;
+        $this->current_completion = null;
+        return true;
+    }
+
+    private function read_next_index_line(int $range_end_byte_offset): bool
+    {
+        if (fseek($this->input_handle, $this->cursor['next_remote_index_byte_offset']) !== 0) {
+            throw new RuntimeException('Failed to seek to the next ownership index entry.');
+        }
+        $line = self::read_bounded_row(
+            $this->input_handle,
+            'remote-index'
+        );
+        $line_end_byte_offset = ftell($this->input_handle);
+        if (
+            !is_string($line)
+            || substr($line, -1) !== "\n"
+            || !is_int($line_end_byte_offset)
+            || $line_end_byte_offset > $range_end_byte_offset
+        ) {
+            throw new UnexpectedValueException('Remote-index traversal range ends inside an index entry.');
+        }
+        $raw_entry = json_decode(substr($line, 0, -1), true);
+        if (!is_array($raw_entry)) {
+            throw new UnexpectedValueException('Traversal range contains invalid JSON.');
+        }
+        $decoded_entry = RemoteIndexReader::decode_index_line($line);
+        $remote_absolute_path = RemoteIndexTraversalJournal::decode_canonical_path(
+            $raw_entry['path'] ?? null,
+            'remote-index ownership path'
+        );
+        if (
+            array_key_exists('intermediate', $raw_entry)
+            && !is_bool($raw_entry['intermediate'])
+        ) {
+            throw new UnexpectedValueException('Remote-index intermediate must be boolean.');
+        }
+        if (!empty($raw_entry['intermediate'])) {
+            if ($decoded_entry['type'] !== 'link') {
+                throw new UnexpectedValueException('Only a link may be intermediate.');
+            }
+            $this->start_pending_atom('exact', $remote_absolute_path, $line_end_byte_offset);
+            return $this->write_pending_atom_step();
+        }
+        $this->cursor['next_remote_index_byte_offset'] = $line_end_byte_offset;
+        return true;
+    }
+
+    private function start_pending_atom(
+        string $kind,
+        string $remote_absolute_path,
+        ?int $next_remote_index_byte_offset
+    ): void {
+        self::assert_remote_absolute_path($remote_absolute_path);
+        $this->cursor['pending_atom_kind'] = $kind;
+        $this->cursor['pending_atom_path_b64'] = base64_encode($remote_absolute_path);
+        $this->cursor['pending_next_remote_index_byte_offset'] = $next_remote_index_byte_offset;
+    }
+
+    private function write_pending_atom_step(): bool
+    {
+        $remote_absolute_path = base64_decode(
+            $this->cursor['pending_atom_path_b64'],
+            true
+        );
+        if (!is_string($remote_absolute_path)) {
+            throw new UnexpectedValueException('Ownership cursor has an invalid path.');
+        }
+        $this->append_atom($this->cursor['pending_atom_kind'], $remote_absolute_path);
+        $parent = self::strict_parent($remote_absolute_path);
+        if ($parent !== null) {
+            $this->cursor['pending_atom_kind'] = 'ancestor';
+            $this->cursor['pending_atom_path_b64'] = base64_encode($parent);
+            return true;
+        }
+        if ($this->cursor['pending_next_remote_index_byte_offset'] === null) {
+            ++$this->cursor['current_root_index'];
+        } else {
+            $this->cursor['next_remote_index_byte_offset'] = $this->cursor['pending_next_remote_index_byte_offset'];
+        }
+        $this->cursor['pending_atom_kind'] = null;
+        $this->cursor['pending_atom_path_b64'] = null;
+        $this->cursor['pending_next_remote_index_byte_offset'] = null;
+        return true;
+    }
+
+    private function append_atom(string $kind, string $remote_absolute_path): void
+    {
+        $line = json_encode([
+            'kind' => $kind,
+            'path_b64' => base64_encode($remote_absolute_path),
+        ], JSON_UNESCAPED_SLASHES) . "\n";
+        if (
+            fwrite($this->output_handle, $line) !== strlen($line)
+            || !fflush($this->output_handle)
+        ) {
+            throw new RuntimeException('Failed to append an ownership atom.');
+        }
+        $byte_offset = ftell($this->output_handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException('Failed to read the ownership paths offset.');
+        }
+        $this->cursor['paths_byte_offset'] = $byte_offset;
+    }
+
+    private function build_next_lookup_record(): bool
+    {
+        $paths_byte_offset = ftell($this->input_handle);
+        $line = self::read_bounded_row(
+            $this->input_handle,
+            'sorted ownership paths'
+        );
+        if ($line === false) {
+            if (!feof($this->input_handle)) {
+                throw new RuntimeException('Failed to read sorted ownership paths.');
+            }
+            $this->cursor['phase'] = 'starting_lookup_sort';
+            return true;
+        }
+        if (!is_int($paths_byte_offset)) {
+            throw new RuntimeException('Failed to read the ownership paths position.');
+        }
+        $atom = self::decode_atom_line($line);
+        $record = hash('sha256', $atom['kind'] . "\0" . $atom['path'])
+            . ' ' . sprintf('%016x', $paths_byte_offset) . "\n";
+        if (
+            strlen($record) !== self::LOOKUP_RECORD_BYTES
+            || fwrite($this->output_handle, $record) !== self::LOOKUP_RECORD_BYTES
+            || !fflush($this->output_handle)
+        ) {
+            throw new RuntimeException('Failed to append the ownership lookup.');
+        }
+        $lookup_paths_byte_offset = ftell($this->input_handle);
+        $lookup_byte_offset = ftell($this->output_handle);
+        if (!is_int($lookup_paths_byte_offset) || !is_int($lookup_byte_offset)) {
+            throw new RuntimeException('Failed to read ownership lookup offsets.');
+        }
+        $this->cursor['lookup_paths_byte_offset'] = $lookup_paths_byte_offset;
+        $this->cursor['lookup_byte_offset'] = $lookup_byte_offset;
+        return true;
+    }
+
+    private function start_paths_sort(): bool
+    {
+        $this->close_phase_handles();
+        $this->sort_processor = ExternalSortProcessor::start(
+            $this->paths_work_path,
+            $this->sorted_paths_work_path,
+            $this->work_directory,
+            'ownership-paths',
+            [self::class, 'paths_sort_key'],
+            true
+        );
+        $this->cursor['paths_sort_cursor'] = $this->sort_processor->get_cursor();
+        $this->cursor['phase'] = 'sorting_paths';
+        return true;
+    }
+
+    private function sort_paths_next_step(): bool
+    {
+        $sort_processor = $this->current_sort_processor();
+        $has_next = $sort_processor->next_step();
+        $this->cursor['paths_sort_cursor'] = $sort_processor->get_cursor();
+        if ($has_next) {
+            return true;
+        }
+        $sort_processor->close();
+        $this->sort_processor = null;
+        $this->cursor['paths_sort_cursor'] = null;
+        $this->cursor['paths_byte_offset'] = $this->file_size($this->sorted_paths_work_path);
+        $this->cursor['phase'] = 'building_lookup';
+        $this->open_phase_handles();
+        return true;
+    }
+
+    private function start_lookup_sort(): bool
+    {
+        $this->close_phase_handles();
+        $this->sort_processor = ExternalSortProcessor::start(
+            $this->lookup_work_path,
+            $this->sorted_lookup_work_path,
+            $this->work_directory,
+            'ownership-lookup',
+            [self::class, 'lookup_sort_key'],
+            false
+        );
+        $this->cursor['lookup_sort_cursor'] = $this->sort_processor->get_cursor();
+        $this->cursor['phase'] = 'sorting_lookup';
+        return true;
+    }
+
+    private function sort_lookup_next_step(): bool
+    {
+        $sort_processor = $this->current_sort_processor();
+        $has_next = $sort_processor->next_step();
+        $this->cursor['lookup_sort_cursor'] = $sort_processor->get_cursor();
+        if ($has_next) {
+            return true;
+        }
+        $sort_processor->close();
+        $this->sort_processor = null;
+        $this->cursor['lookup_sort_cursor'] = null;
+        $this->cursor['lookup_byte_offset'] = $this->file_size($this->sorted_lookup_work_path);
+        $this->cursor['phase'] = 'preparing_snapshot';
+        return true;
+    }
+
+    public static function paths_sort_key(string $line): string
+    {
+        $atom = self::decode_atom_line($line);
+        return $atom['path'] . "\0" . $atom['kind'];
+    }
+
+    public static function lookup_sort_key(string $line): string
+    {
+        if (preg_match('/^([0-9a-f]{64}) [0-9a-f]{16}$/D', $line, $matches) !== 1) {
+            throw new UnexpectedValueException('Ownership lookup row is invalid.');
+        }
+        return $matches[1];
+    }
+
+    private function prepare_snapshot(): bool
+    {
+        $snapshots_directory = $this->ownership_directory . '/snapshots';
+        if (
+            !is_dir($snapshots_directory)
+            && !mkdir($snapshots_directory, 0777, true)
+            && !is_dir($snapshots_directory)
+        ) {
+            throw new RuntimeException("Failed to create snapshot directory: {$snapshots_directory}.");
+        }
+        $snapshot_id = bin2hex(random_bytes(32));
+        if (
+            file_exists($this->snapshot_paths_path($snapshot_id))
+            || is_link($this->snapshot_paths_path($snapshot_id))
+            || file_exists($this->snapshot_lookup_path($snapshot_id))
+            || is_link($this->snapshot_lookup_path($snapshot_id))
+        ) {
+            throw new RuntimeException('Generated ownership snapshot ID is already in use.');
+        }
+        $this->cursor['snapshot_id'] = $snapshot_id;
+        $this->cursor['phase'] = 'snapshot_prepared';
+        return true;
+    }
+
+    private function publish_paths(): bool
+    {
+        $this->publish_artifact(
+            $this->sorted_paths_work_path,
+            $this->snapshot_paths_path($this->allocated_snapshot_id())
+        );
+        $this->cursor['phase'] = 'paths_published';
+        return true;
+    }
+
+    private function publish_lookup(): bool
+    {
+        $this->publish_artifact(
+            $this->sorted_lookup_work_path,
+            $this->snapshot_lookup_path($this->allocated_snapshot_id())
+        );
+        $this->cursor['phase'] = 'lookup_published';
+        return true;
+    }
+
+    private function publish_artifact(string $source, string $destination): void
+    {
+        if (is_file($source)) {
+            if (file_exists($destination) || is_link($destination)) {
+                throw new RuntimeException("Ownership snapshot destination already exists: {$destination}.");
+            }
+            if (!rename($source, $destination)) {
+                throw new RuntimeException("Failed to publish ownership snapshot artifact: {$destination}.");
+            }
+            return;
+        }
+        if (!is_file($destination) || is_link($destination)) {
+            throw new RuntimeException("Ownership snapshot artifact disappeared: {$destination}.");
+        }
+    }
+
+    private function remove_next_work_file(): bool
+    {
+        $work_files = [$this->paths_work_path, $this->lookup_work_path];
+        $index = $this->cursor['next_work_file_cleanup_index'];
+        if ($index < count($work_files)) {
+            if (is_file($work_files[$index]) && !unlink($work_files[$index])) {
+                throw new RuntimeException("Failed to remove ownership work file: {$work_files[$index]}.");
+            }
+            ++$this->cursor['next_work_file_cleanup_index'];
+            return true;
+        }
+        $this->cursor['phase'] = 'complete';
+        return false;
+    }
+
+    private static function snapshot_path(
+        string $ownership_directory,
+        string $snapshot_id,
+        string $suffix
+    ): string {
+        return $ownership_directory . '/snapshots/'
+            . $snapshot_id . '.' . $suffix;
+    }
+
+    private function snapshot_paths_path(string $snapshot_id): string
+    {
+        return self::snapshot_path(
+            $this->ownership_directory,
+            $snapshot_id,
+            'paths.jsonl'
+        );
+    }
+
+    private function snapshot_lookup_path(string $snapshot_id): string
+    {
+        return self::snapshot_path(
+            $this->ownership_directory,
+            $snapshot_id,
+            'lookup'
+        );
+    }
+
+    private function allocated_snapshot_id(): string
+    {
+        if (!is_string($this->cursor['snapshot_id'])) {
+            throw new LogicException('Ownership snapshot ID has not been allocated.');
+        }
+        return $this->cursor['snapshot_id'];
+    }
+
+    private function current_sort_processor(): ExternalSortProcessor
+    {
+        if ($this->sort_processor === null) {
+            throw new LogicException('Ownership sort processor is not open.');
+        }
+        return $this->sort_processor;
+    }
+
+    private function open_phase_handles(): void
+    {
+        if ($this->cursor['phase'] === 'scanning') {
+            $this->traversal_journal = new RemoteIndexTraversalJournal(
+                $this->traversal_journal_path
+            );
+            $this->traversal_journal->open_and_truncate_to_saved_byte_offset(
+                $this->durable_traversal_journal_byte_offset
+            );
+            $this->input_handle = @fopen($this->next_remote_index_path, 'rb');
+            $stat = is_resource($this->input_handle) ? fstat($this->input_handle) : false;
+            if (
+                $stat === false
+                || $this->durable_next_remote_index_byte_offset > $stat['size']
+            ) {
+                throw new RuntimeException('Failed to open the durable next remote index.');
+            }
+            $this->output_handle = self::open_output(
+                $this->paths_work_path,
+                $this->cursor['paths_byte_offset']
+            );
+        } elseif ($this->cursor['phase'] === 'sorting_paths') {
+            $this->sort_processor = ExternalSortProcessor::resume(
+                $this->paths_work_path,
+                $this->sorted_paths_work_path,
+                $this->work_directory,
+                'ownership-paths',
+                [self::class, 'paths_sort_key'],
+                true,
+                $this->cursor['paths_sort_cursor']
+            );
+        } elseif ($this->cursor['phase'] === 'building_lookup') {
+            $this->input_handle = @fopen($this->sorted_paths_work_path, 'rb');
+            if (
+                !is_resource($this->input_handle)
+                || fseek($this->input_handle, $this->cursor['lookup_paths_byte_offset']) !== 0
+            ) {
+                throw new RuntimeException('Failed to resume ownership lookup input.');
+            }
+            $this->output_handle = self::open_output(
+                $this->lookup_work_path,
+                $this->cursor['lookup_byte_offset']
+            );
+        } elseif ($this->cursor['phase'] === 'sorting_lookup') {
+            $this->sort_processor = ExternalSortProcessor::resume(
+                $this->lookup_work_path,
+                $this->sorted_lookup_work_path,
+                $this->work_directory,
+                'ownership-lookup',
+                [self::class, 'lookup_sort_key'],
+                false,
+                $this->cursor['lookup_sort_cursor']
+            );
+        }
+    }
+
+    private function close_phase_handles(): void
+    {
+        if ($this->sort_processor !== null) {
+            $this->sort_processor->close();
+            $this->sort_processor = null;
+        }
+        if ($this->traversal_journal !== null) {
+            $this->traversal_journal->close();
+            $this->traversal_journal = null;
+        }
+        foreach (['input_handle', 'output_handle'] as $property) {
+            if (is_resource($this->{$property})) {
+                fclose($this->{$property});
+            }
+            $this->{$property} = null;
+        }
+    }
+
+    /** Strictly validates the opaque persisted cursor before opening files. */
+    private function assert_cursor(): void
+    {
+        $expected_keys = array_keys(self::initial_cursor());
+        $actual_keys = array_keys($this->cursor);
+        sort($actual_keys);
+        sort($expected_keys);
+        if ($actual_keys !== $expected_keys) {
+            throw new InvalidArgumentException('Ownership cursor fields are invalid.');
+        }
+        if (!in_array($this->cursor['phase'], array_merge(
+            self::PHASES_WITHOUT_SNAPSHOT_ID,
+            self::PHASES_WITH_SNAPSHOT_ID
+        ), true)) {
+            throw new InvalidArgumentException('Ownership cursor phase is invalid.');
+        }
+        foreach ([
+            'traversal_journal_byte_offset', 'current_root_index',
+            'next_remote_index_byte_offset', 'paths_byte_offset',
+            'lookup_paths_byte_offset', 'lookup_byte_offset',
+            'next_work_file_cleanup_index',
+        ] as $field) {
+            if (!is_int($this->cursor[$field]) || $this->cursor[$field] < 0) {
+                throw new InvalidArgumentException("Ownership cursor {$field} is invalid.");
+            }
+        }
+        foreach ([
+            'current_completion_journal_end_byte_offset',
+            'current_range_end_byte_offset',
+            'pending_next_remote_index_byte_offset',
+        ] as $field) {
+            if (
+                $this->cursor[$field] !== null
+                && ( !is_int($this->cursor[$field]) || $this->cursor[$field] < 0 )
+            ) {
+                throw new InvalidArgumentException("Ownership cursor {$field} is invalid.");
+            }
+        }
+        if (
+            !in_array($this->cursor['pending_atom_kind'], [
+                'root', 'exact', 'ancestor', null,
+            ], true)
+            || ( $this->cursor['pending_atom_kind'] === null )
+                !== ( $this->cursor['pending_atom_path_b64'] === null )
+        ) {
+            throw new InvalidArgumentException('Ownership cursor pending atom is invalid.');
+        }
+        $pending_path = is_string($this->cursor['pending_atom_path_b64'])
+            ? base64_decode($this->cursor['pending_atom_path_b64'], true)
+            : false;
+        if (
+            $this->cursor['pending_atom_path_b64'] !== null
+            && ( !is_string($pending_path)
+                || base64_encode($pending_path) !== $this->cursor['pending_atom_path_b64'] )
+        ) {
+            throw new InvalidArgumentException('Ownership cursor pending path is invalid.');
+        }
+        if (is_string($pending_path)) {
+            self::assert_remote_absolute_path($pending_path);
+        }
+        $has_completion =
+            $this->cursor['current_completion_journal_end_byte_offset'] !== null;
+        if (
+            $has_completion !== ( $this->cursor['current_range_end_byte_offset'] !== null )
+            || ( !$has_completion && $this->cursor['current_root_index'] !== 0 )
+            || ( $this->cursor['pending_atom_kind'] === null
+                && $this->cursor['pending_next_remote_index_byte_offset'] !== null )
+            || ( $this->cursor['pending_atom_kind'] === 'root'
+                && $this->cursor['pending_next_remote_index_byte_offset'] !== null )
+            || ( $this->cursor['pending_atom_kind'] === 'exact'
+                && $this->cursor['pending_next_remote_index_byte_offset'] === null )
+        ) {
+            throw new InvalidArgumentException('Ownership cursor boundaries are inconsistent.');
+        }
+        if (
+            $this->durable_traversal_journal_byte_offset < 0
+            || $this->durable_next_remote_index_byte_offset < 0
+            || $this->cursor['traversal_journal_byte_offset']
+                > $this->durable_traversal_journal_byte_offset
+            || $this->cursor['next_remote_index_byte_offset']
+                > $this->durable_next_remote_index_byte_offset
+        ) {
+            throw new InvalidArgumentException('Ownership cursor exceeds a durable input boundary.');
+        }
+        $sorting_paths = $this->cursor['phase'] === 'sorting_paths';
+        $sorting_lookup = $this->cursor['phase'] === 'sorting_lookup';
+        if (
+            ( $sorting_paths && !is_array($this->cursor['paths_sort_cursor']) )
+            || ( !$sorting_paths && $this->cursor['paths_sort_cursor'] !== null )
+            || ( $sorting_lookup && !is_array($this->cursor['lookup_sort_cursor']) )
+            || ( !$sorting_lookup && $this->cursor['lookup_sort_cursor'] !== null )
+        ) {
+            throw new InvalidArgumentException('Ownership nested sort cursor is inconsistent with its phase.');
+        }
+        try {
+            self::snapshot_id_from_cursor($this->cursor);
+        } catch (UnexpectedValueException $exception) {
+            throw new InvalidArgumentException(
+                'Ownership snapshot cursor is inconsistent with its phase.',
+                0,
+                $exception
+            );
+        }
+        if (
+            $this->cursor['next_work_file_cleanup_index'] > 2
+            || ( !in_array($this->cursor['phase'], ['cleaning_work_files', 'complete'], true)
+                && $this->cursor['next_work_file_cleanup_index'] !== 0 )
+            || ( $this->cursor['phase'] === 'complete'
+                && $this->cursor['next_work_file_cleanup_index'] !== 2 )
+        ) {
+            throw new InvalidArgumentException('Ownership work-file cleanup cursor is invalid.');
+        }
+    }
+
+    /**
+     * @param resource $handle Open input stream.
+     * @return string|false One complete row, or false at EOF.
+     */
+    private static function read_bounded_row($handle, string $name)
+    {
+        $byte_offset = ftell($handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException("Failed to read the {$name} row offset.");
+        }
+        $row = fgets($handle, self::MAXIMUM_ROW_BYTES + 1);
+        if ($row === false) {
+            if (feof($handle)) {
+                return false;
+            }
+            throw new RuntimeException("Failed to read the {$name} row at byte offset {$byte_offset}.");
+        }
+        if (substr($row, -1) !== "\n") {
+            $row_bytes = strlen($row);
+            if (feof($handle)) {
+                throw new UnexpectedValueException(
+                    "The {$name} row at byte offset {$byte_offset} is unterminated after {$row_bytes} bytes."
+                );
+            }
+            throw new UnexpectedValueException(
+                "The {$name} row at byte offset {$byte_offset} exceeds the maximum of "
+                . self::MAXIMUM_ROW_BYTES . " bytes; read {$row_bytes} bytes without LF."
+            );
+        }
+        return $row;
+    }
+
+    private static function decode_atom_line(string $line): array
+    {
+        $atom = json_decode(rtrim($line, "\n"), true);
+        if (!is_array($atom) || array_keys($atom) !== ['kind', 'path_b64']) {
+            throw new UnexpectedValueException('Ownership paths contain an invalid atom.');
+        }
+        if (!in_array($atom['kind'], ['root', 'exact', 'ancestor'], true)) {
+            throw new UnexpectedValueException('Ownership atom kind is invalid.');
+        }
+        $path = is_string($atom['path_b64'])
+            ? base64_decode($atom['path_b64'], true)
+            : false;
+        if (!is_string($path) || base64_encode($path) !== $atom['path_b64']) {
+            throw new UnexpectedValueException('Ownership atom path has invalid base64.');
+        }
+        self::assert_remote_absolute_path($path);
+        return ['kind' => $atom['kind'], 'path' => $path];
+    }
+
+    private static function strict_parent(string $remote_absolute_path): ?string
+    {
+        if ($remote_absolute_path === '/') {
+            return null;
+        }
+        $last_separator = strrpos($remote_absolute_path, '/');
+        return $last_separator === 0
+            ? '/'
+            : substr($remote_absolute_path, 0, $last_separator);
+    }
+
+    /** @return resource */
+    private static function open_output(string $path, int $byte_offset)
+    {
+        $handle = @fopen($path, 'c+b');
+        $stat = is_resource($handle) ? fstat($handle) : false;
+        if (
+            $stat === false
+            || $byte_offset > $stat['size']
+            || !ftruncate($handle, $byte_offset)
+            || fseek($handle, $byte_offset) !== 0
+        ) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            throw new RuntimeException("Failed to resume ownership output: {$path}.");
+        }
+        return $handle;
+    }
+
+    private function file_size(string $path): int
+    {
+        clearstatcache(true, $path);
+        $size = @filesize($path);
+        if (!is_int($size)) {
+            throw new RuntimeException("Failed to read ownership file size: {$path}.");
+        }
+        return $size;
+    }
+
+    private static function assert_remote_absolute_path(string $remote_absolute_path): void
+    {
+        assert_valid_path($remote_absolute_path, 'ownership path');
+        if (
+            $remote_absolute_path === ''
+            || $remote_absolute_path[0] !== '/'
+            || normalize_path($remote_absolute_path) !== $remote_absolute_path
+        ) {
+            throw new UnexpectedValueException(
+                'Ownership path must be a normalized remote absolute path.'
+            );
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/pull/class-remote-index-traversal-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-traversal-journal.php
@@ -208,6 +208,84 @@ final class RemoteIndexTraversalJournal
         return $paths;
     }
 
+    /**
+     * Reads one completed traversal from a durable forward journal position.
+     *
+     * The returned byte offset is the start of the next completion. Null means
+     * the supplied position is exactly the saved journal boundary.
+     *
+     * @return array|null {
+     *     One durable traversal completion, or null at the saved boundary.
+     *
+     *     @type string[] $indexed_roots                         Canonical indexed roots.
+     *     @type int      $next_remote_index_start_byte_offset   Raw range start.
+     *     @type int      $next_remote_index_end_byte_offset     Raw range end.
+     *     @type int      $next_traversal_journal_byte_offset    Following journal byte.
+     * }
+     */
+    public function read_completed_traversal_at(
+        int $record_byte_offset,
+        int $journal_byte_offset
+    ): ?array {
+        $this->require_handle();
+        if ($record_byte_offset === $journal_byte_offset) {
+            return null;
+        }
+        if (
+            $record_byte_offset < 0
+            || $record_byte_offset > $journal_byte_offset
+            || fseek($this->handle, $record_byte_offset) !== 0
+        ) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal completion offset is invalid.'
+            );
+        }
+        $line = fgets($this->handle);
+        $next_record_byte_offset = ftell($this->handle);
+        $record = is_string($line) && substr($line, -1) === "\n"
+            ? json_decode(substr($line, 0, -1), true)
+            : null;
+        if (
+            !is_int($next_record_byte_offset)
+            || $next_record_byte_offset > $journal_byte_offset
+            || !is_array($record)
+            || array_keys($record) !== [
+                'type',
+                'indexed_roots_b64',
+                'next_remote_index_start_byte_offset',
+                'next_remote_index_end_byte_offset',
+            ]
+            || $record['type'] !== 'traversal_complete'
+            || !is_int($record['next_remote_index_start_byte_offset'])
+            || $record['next_remote_index_start_byte_offset'] < 0
+            || !is_int($record['next_remote_index_end_byte_offset'])
+            || $record['next_remote_index_end_byte_offset']
+                < $record['next_remote_index_start_byte_offset']
+        ) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal completion is outside the durable journal or invalid.'
+            );
+        }
+        $indexed_roots = self::decode_canonical_paths(
+            $record['indexed_roots_b64'],
+            'indexed_roots_b64'
+        );
+        if (count($indexed_roots) !== count(array_unique($indexed_roots))) {
+            throw new UnexpectedValueException(
+                'Remote-index traversal roots must contain no duplicates.'
+            );
+        }
+        return [
+            'indexed_roots' => $indexed_roots,
+            'next_remote_index_start_byte_offset' =>
+                $record['next_remote_index_start_byte_offset'],
+            'next_remote_index_end_byte_offset' =>
+                $record['next_remote_index_end_byte_offset'],
+            'next_traversal_journal_byte_offset' =>
+                $next_record_byte_offset,
+        ];
+    }
+
     /** Idempotently closes the journal. */
     public function close(): void
     {
@@ -227,50 +305,16 @@ final class RemoteIndexTraversalJournal
         int $record_byte_offset,
         int $journal_byte_offset
     ): array {
-        $this->require_handle();
-        if (
-            $record_byte_offset < 0
-            || $record_byte_offset >= $journal_byte_offset
-            || fseek($this->handle, $record_byte_offset) !== 0
-        ) {
+        $completion = $this->read_completed_traversal_at(
+            $record_byte_offset,
+            $journal_byte_offset
+        );
+        if ($completion === null) {
             throw new UnexpectedValueException(
                 'Remote-index traversal completion offset is invalid.'
             );
         }
-        $line = fgets($this->handle);
-        $end_byte_offset = ftell($this->handle);
-        $record = is_string($line) && substr($line, -1) === "\n"
-            ? json_decode(substr($line, 0, -1), true)
-            : null;
-        if (
-            !is_int($end_byte_offset)
-            || $end_byte_offset > $journal_byte_offset
-            || !is_array($record)
-            || count($record) !== 4
-            || ( $record['type'] ?? null ) !== 'traversal_complete'
-            || !isset($record['indexed_roots_b64'])
-            || !isset($record['next_remote_index_start_byte_offset'])
-            || !is_int($record['next_remote_index_start_byte_offset'])
-            || $record['next_remote_index_start_byte_offset'] < 0
-            || !isset($record['next_remote_index_end_byte_offset'])
-            || !is_int($record['next_remote_index_end_byte_offset'])
-            || $record['next_remote_index_end_byte_offset']
-                < $record['next_remote_index_start_byte_offset']
-        ) {
-            throw new UnexpectedValueException(
-                'Remote-index traversal completion is outside the durable journal or invalid.'
-            );
-        }
-        $indexed_roots = self::decode_canonical_paths(
-            $record['indexed_roots_b64'],
-            'indexed_roots_b64'
-        );
-        if (count($indexed_roots) !== count(array_unique($indexed_roots))) {
-            throw new UnexpectedValueException(
-                'Remote-index traversal roots must contain no duplicates.'
-            );
-        }
-        return $indexed_roots;
+        return $completion['indexed_roots'];
     }
 
     private function root_marker_path(string $canonical_root): string

--- a/packages/reprint-client/src/lib/state/class-files-pull-ownership-state.php
+++ b/packages/reprint-client/src/lib/state/class-files-pull-ownership-state.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace Reprint\Importer\State;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- State errors contain schema fields, never HTML.
+
+/** Retains files-pull ownership snapshot IDs and one active processor cursor. */
+class FilesPullOwnershipState {
+    /** @var array<string,list<string>> Snapshot IDs keyed by path-selection fingerprint. */
+    public array $committed_snapshot_ids_by_selection_fingerprint = [];
+    public ?string $active_snapshot_id = null;
+    /** @var array|null Opaque FilesPullOwnershipProcessor cursor. */
+    public ?array $processor_cursor = null;
+    /** @var list<string> */
+    public array $snapshot_ids_pending_removal = [];
+
+    public static function from_array(array $data): self
+    {
+        $state = new self();
+        \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
+        if (!is_array($data['committed_snapshot_ids_by_selection_fingerprint'])) {
+            throw new \UnexpectedValueException(self::class . ' committed snapshots must be an object.');
+        }
+        foreach ($data['committed_snapshot_ids_by_selection_fingerprint'] as $selection_fingerprint => $snapshot_ids) {
+            self::assert_identifier($selection_fingerprint, 'path-selection fingerprint');
+            self::assert_snapshot_id_list($snapshot_ids, 'committed snapshot IDs');
+        }
+        $state->committed_snapshot_ids_by_selection_fingerprint = $data['committed_snapshot_ids_by_selection_fingerprint'];
+        ksort($state->committed_snapshot_ids_by_selection_fingerprint, SORT_STRING);
+
+        if ($data['active_snapshot_id'] !== null) {
+            self::assert_identifier($data['active_snapshot_id'], 'active snapshot ID');
+        }
+        if ($data['processor_cursor'] !== null && !is_array($data['processor_cursor'])) {
+            throw new \UnexpectedValueException(self::class . ' processor cursor must be an array or null.');
+        }
+        if ($data['active_snapshot_id'] !== null && $data['processor_cursor'] !== null) {
+            throw new \UnexpectedValueException(self::class . ' cannot retain a snapshot and processor cursor together.');
+        }
+        self::assert_snapshot_id_list($data['snapshot_ids_pending_removal'], 'snapshot IDs pending removal');
+        $state->active_snapshot_id = $data['active_snapshot_id'];
+        $state->processor_cursor = $data['processor_cursor'];
+        $state->snapshot_ids_pending_removal = $data['snapshot_ids_pending_removal'];
+        foreach ($state->snapshot_ids_pending_removal as $snapshot_id) {
+            if ($state->references_snapshot($snapshot_id)) {
+                throw new \UnexpectedValueException(self::class . ' cannot remove a referenced snapshot.');
+            }
+        }
+        return $state;
+    }
+
+    /** Moves the processor's ID to active after both snapshot artifacts exist. */
+    public function complete_processor(string $snapshot_id): void
+    {
+        self::assert_identifier($snapshot_id, 'active snapshot ID');
+        if (
+            $this->processor_cursor === null
+            || $this->active_snapshot_id !== null
+        ) {
+            throw new \LogicException('Files-pull ownership has no processor to complete.');
+        }
+        $this->processor_cursor = null;
+        $this->active_snapshot_id = $snapshot_id;
+        $this->snapshot_ids_pending_removal = array_values(array_diff($this->snapshot_ids_pending_removal, [$snapshot_id]));
+    }
+
+    /** Replaces only the successful selection's committed ownership. */
+    public function commit_active_snapshot(string $selection_fingerprint): void
+    {
+        self::assert_identifier($selection_fingerprint, 'path-selection fingerprint');
+        if ($this->active_snapshot_id === null) {
+            throw new \LogicException('Files-pull ownership has no snapshot to commit.');
+        }
+        $replaced_snapshot_ids = $this->committed_snapshot_ids_by_selection_fingerprint[$selection_fingerprint] ?? [];
+        $this->committed_snapshot_ids_by_selection_fingerprint[$selection_fingerprint] = [$this->active_snapshot_id];
+        ksort($this->committed_snapshot_ids_by_selection_fingerprint, SORT_STRING);
+        $this->active_snapshot_id = null;
+        $this->queue_unreferenced_snapshots($replaced_snapshot_ids);
+    }
+
+    /** Retains a candidate at diff or later, and discards it before diff. */
+    public function abort_active_snapshot(
+        string $selection_fingerprint,
+        bool $diff_or_later,
+        ?string $processor_snapshot_id
+    ): void {
+        self::assert_identifier($selection_fingerprint, 'path-selection fingerprint');
+        if ($processor_snapshot_id !== null) {
+            if ($this->processor_cursor === null) {
+                throw new \LogicException('Files-pull ownership has no processor snapshot to abort.');
+            }
+            self::assert_identifier($processor_snapshot_id, 'processor snapshot ID');
+            $this->queue_unreferenced_snapshots([$processor_snapshot_id]);
+        }
+        $this->processor_cursor = null;
+        if ($this->active_snapshot_id === null) {
+            return;
+        }
+        $active_snapshot_id = $this->active_snapshot_id;
+        $this->active_snapshot_id = null;
+        if ($diff_or_later) {
+            $snapshot_ids = $this->committed_snapshot_ids_by_selection_fingerprint[$selection_fingerprint] ?? [];
+            $snapshot_ids[] = $active_snapshot_id;
+            sort($snapshot_ids, SORT_STRING);
+            $this->committed_snapshot_ids_by_selection_fingerprint[$selection_fingerprint] = array_values(array_unique($snapshot_ids));
+            ksort($this->committed_snapshot_ids_by_selection_fingerprint, SORT_STRING);
+            $this->snapshot_ids_pending_removal = array_values(array_diff($this->snapshot_ids_pending_removal, [$active_snapshot_id]));
+            return;
+        }
+        $this->queue_unreferenced_snapshots([$active_snapshot_id]);
+    }
+
+    public function next_snapshot_id_pending_removal(): ?string
+    {
+        return $this->snapshot_ids_pending_removal === []
+            ? null
+            : $this->snapshot_ids_pending_removal[count($this->snapshot_ids_pending_removal) - 1];
+    }
+
+    /** Confirms the one pending snapshot artifact pair removed by the caller. */
+    public function confirm_snapshot_removed(string $snapshot_id): void
+    {
+        if ($this->next_snapshot_id_pending_removal() !== $snapshot_id) {
+            throw new \LogicException('Files-pull ownership did not schedule that snapshot next.');
+        }
+        array_pop($this->snapshot_ids_pending_removal);
+    }
+
+    public function to_array(): array
+    {
+        return [
+            'committed_snapshot_ids_by_selection_fingerprint' => $this->committed_snapshot_ids_by_selection_fingerprint,
+            'active_snapshot_id' => $this->active_snapshot_id,
+            'processor_cursor' => $this->processor_cursor,
+            'snapshot_ids_pending_removal' => $this->snapshot_ids_pending_removal,
+        ];
+    }
+
+    /** Adds only IDs no longer referenced by a selection or active snapshot. */
+    private function queue_unreferenced_snapshots(array $snapshot_ids): void
+    {
+        foreach ($snapshot_ids as $snapshot_id) {
+            self::assert_identifier($snapshot_id, 'snapshot ID');
+            if (!$this->references_snapshot($snapshot_id)) {
+                $this->snapshot_ids_pending_removal[] = $snapshot_id;
+            }
+        }
+        sort($this->snapshot_ids_pending_removal, SORT_STRING);
+        $this->snapshot_ids_pending_removal = array_values(array_unique($this->snapshot_ids_pending_removal));
+    }
+
+    private function references_snapshot(string $snapshot_id): bool
+    {
+        if ($this->active_snapshot_id === $snapshot_id) {
+            return true;
+        }
+        foreach ($this->committed_snapshot_ids_by_selection_fingerprint as $snapshot_ids) {
+            if (in_array($snapshot_id, $snapshot_ids, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function assert_snapshot_id_list($snapshot_ids, string $name): void
+    {
+        if (!is_array($snapshot_ids) || array_values($snapshot_ids) !== $snapshot_ids) {
+            throw new \UnexpectedValueException(self::class . " {$name} must be a list.");
+        }
+        foreach ($snapshot_ids as $snapshot_id) {
+            self::assert_identifier($snapshot_id, $name);
+        }
+        $sorted_snapshot_ids = $snapshot_ids;
+        sort($sorted_snapshot_ids, SORT_STRING);
+        if (
+            $snapshot_ids !== $sorted_snapshot_ids
+            || count($snapshot_ids) !== count(array_unique($snapshot_ids))
+        ) {
+            throw new \UnexpectedValueException(self::class . " {$name} must be byte-sorted with no duplicates.");
+        }
+    }
+
+    private static function assert_identifier($identifier, string $name): void
+    {
+        if (!is_string($identifier) || preg_match('/^[0-9a-f]{64}$/D', $identifier) !== 1) {
+            throw new \UnexpectedValueException(self::class . " {$name} must be 64 lowercase hexadecimal characters.");
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -7,6 +7,7 @@ use Reprint\Importer\State\DatabaseTableIndexState;
 use Reprint\Importer\State\FetchListProgressState;
 use Reprint\Importer\State\FileDiffProgressState;
 use Reprint\Importer\State\FilesPullSummaryState;
+use Reprint\Importer\State\FilesPullOwnershipState;
 use Reprint\Importer\State\PullPipelineCheckpointState;
 use Reprint\Importer\State\RemoteFileIndexState;
 use Reprint\Importer\State\ResumableCommandCheckpointState;
@@ -64,6 +65,7 @@ class PullState
     public ?string $resolved_path_mappings_fingerprint = null;
     /** @var string|null Files-pull path-selection fingerprint; guards resume. */
     public ?string $files_pull_path_selection_fingerprint = null;
+    public FilesPullOwnershipState $files_pull_ownership;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
     public FileDiffProgressState $diff;
@@ -107,6 +109,7 @@ class PullState
         $this->index = new RemoteFileIndexState();
         $this->fetch = new FetchListProgressState();
         $this->files_pull_summary = new FilesPullSummaryState();
+        $this->files_pull_ownership = new FilesPullOwnershipState();
         $this->apply = new DatabaseApplyCommandState();
         $this->tuning = new AdaptiveTuningState();
         $this->pull_pipeline = new PullPipelineCheckpointState();
@@ -141,6 +144,9 @@ class PullState
         $state->max_allowed_packet = $data['max_allowed_packet'];
         $state->resolved_path_mappings_fingerprint = $data['resolved_path_mappings_fingerprint'];
         $state->files_pull_path_selection_fingerprint = $data['files_pull_path_selection_fingerprint'];
+        $state->files_pull_ownership = FilesPullOwnershipState::from_array(
+            $data['files_pull_ownership']
+        );
         $state->files_pull_summary = FilesPullSummaryState::from_array($data['files_pull_summary']);
         $state->db_index = DatabaseTableIndexState::from_array($data['db_index']);
         $state->diff = FileDiffProgressState::from_array($data['diff']);
@@ -247,6 +253,7 @@ class PullState
             'max_allowed_packet' => $this->max_allowed_packet,
             'resolved_path_mappings_fingerprint' => $this->resolved_path_mappings_fingerprint,
             'files_pull_path_selection_fingerprint' => $this->files_pull_path_selection_fingerprint,
+            'files_pull_ownership' => $this->files_pull_ownership->to_array(),
             'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),
             'diff' => $this->diff->to_array(),

--- a/packages/reprint-client/src/lib/state/load.php
+++ b/packages/reprint-client/src/lib/state/load.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/class-file-diff-progress-state.php';
 require_once __DIR__ . '/class-remote-file-index-state.php';
 require_once __DIR__ . '/class-fetch-list-progress-state.php';
 require_once __DIR__ . '/class-files-pull-summary-state.php';
+require_once __DIR__ . '/class-files-pull-ownership-state.php';
 require_once __DIR__ . '/class-database-apply-command-state.php';
 require_once __DIR__ . '/class-adaptive-tuning-state.php';
 require_once __DIR__ . '/class-pull-pipeline-checkpoint-state.php';

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -491,6 +491,10 @@ final class FilesPullDiffCheckpointTest extends TestCase
     private function newClientAtDiffStage(): DiffCheckpointTestClient
     {
         $client = $this->newClient();
+        $ownershipSnapshotId = reprint_test_write_root_ownership_snapshot(
+            $this->pullStateDirectory,
+            ['/']
+        );
         \write_current_pull_state($client, [
             'active_resumable_command' => [
                 'command_name' => 'files-pull',
@@ -521,6 +525,9 @@ final class FilesPullDiffCheckpointTest extends TestCase
                     'include_caches' => false,
                 ], JSON_UNESCAPED_SLASHES)
             ),
+            'files_pull_ownership' => [
+                'active_snapshot_id' => $ownershipSnapshotId,
+            ],
         ]);
         return $client;
     }

--- a/tests/Import/FilesPullOwnershipProcessorTest.php
+++ b/tests/Import/FilesPullOwnershipProcessorTest.php
@@ -1,0 +1,613 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the following line.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php';
+
+final class FilesPullOwnershipProcessorTest extends TestCase
+{
+    private string $tempDir;
+    private string $nextRemoteIndexPath;
+    private string $traversalJournalPath;
+    private string $ownershipDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/files-pull-ownership-' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        $this->nextRemoteIndexPath = $this->tempDir . '/remote-index.next.jsonl';
+        $this->traversalJournalPath = $this->tempDir . '/traversals.jsonl';
+        $this->ownershipDirectory = $this->tempDir . '/ownership';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testBuildsByteSafeOwnershipAndFixedWidthLookup(): void
+    {
+        [$journalByteOffset, $indexByteOffset] = $this->writeTwoTraversals();
+
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        $steps = 0;
+        while ($processor->next_step()) {
+            ++$steps;
+        }
+        $snapshotId = $processor->get_snapshot_id();
+        $this->assertFalse($processor->next_step());
+        $processor->close();
+        $processor->close();
+
+        $this->assertGreaterThan(10, $steps);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/D', $snapshotId);
+        $pathsFile = $this->snapshotPathsFile($snapshotId);
+        $lookupFile = $this->snapshotLookupFile($snapshotId);
+        $atoms = $this->readAtoms($pathsFile);
+        $this->assertSame([
+            ['kind' => 'ancestor', 'path' => '/'],
+            ['kind' => 'ancestor', 'path' => '/outside'],
+            ['kind' => 'exact', 'path' => '/outside-alias'],
+            ['kind' => 'root', 'path' => '/outside/target'],
+            ['kind' => 'ancestor', 'path' => '/srv'],
+            ['kind' => 'ancestor', 'path' => "/srv/\xFFsite"],
+            ['kind' => 'root', 'path' => "/srv/\xFFsite/child"],
+        ], $atoms);
+        $this->assertNotContains(
+            ['kind' => 'root', 'path' => '/outside-alias-target'],
+            $atoms
+        );
+        $this->assertLookupMatchesAtoms($pathsFile, $lookupFile, $atoms);
+    }
+
+    public function testResumeTruncatesUnconfirmedOutputAndPublishesSameContent(): void
+    {
+        [$journalByteOffset, $indexByteOffset] = $this->writeTwoTraversals();
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        $this->assertTrue($processor->next_step());
+        $this->assertTrue($processor->next_step());
+        $cursor = $processor->get_cursor();
+        $this->assertSame(base64_encode("/srv/\xFFsite"), $cursor['pending_atom_path_b64']);
+        $cursorJson = json_encode($cursor);
+        if (!is_string($cursorJson)) {
+            $this->fail('Ownership cursor was not JSON encodable.');
+        }
+        $cursor = json_decode($cursorJson, true);
+        $this->assertIsArray($cursor);
+        $processor->close();
+        file_put_contents(
+            $this->ownershipDirectory . '/work/paths.next.jsonl',
+            json_encode([
+                'kind' => 'root',
+                'path_b64' => base64_encode('/unconfirmed'),
+            ]) . "\n",
+            FILE_APPEND
+        );
+
+        $resumed = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            $cursor
+        );
+        while ($resumed->next_step()) {
+            $cursor = $resumed->get_cursor();
+        }
+        $resumedSnapshotId = $resumed->get_snapshot_id();
+        $completeCursor = $resumed->get_cursor();
+        $resumed->close();
+        $resumedPaths = file_get_contents(
+            $this->snapshotPathsFile($resumedSnapshotId)
+        );
+        $resumedLookup = file_get_contents(
+            $this->snapshotLookupFile($resumedSnapshotId)
+        );
+        $this->assertNotContains(
+            ['kind' => 'root', 'path' => '/unconfirmed'],
+            $this->readAtoms($this->snapshotPathsFile($resumedSnapshotId))
+        );
+
+        $cleanOwnershipDirectory = $this->tempDir . '/clean-ownership';
+        $clean = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $cleanOwnershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        while ($clean->next_step()) {
+            $this->assertNotSame('complete', $clean->get_cursor()['phase']);
+        }
+        $cleanSnapshotId = $clean->get_snapshot_id();
+        $this->assertSame(
+            $resumedPaths,
+            file_get_contents($this->snapshotPathsFile(
+                $cleanSnapshotId,
+                $cleanOwnershipDirectory
+            ))
+        );
+        $this->assertSame(
+            $resumedLookup,
+            file_get_contents($this->snapshotLookupFile(
+                $cleanSnapshotId,
+                $cleanOwnershipDirectory
+            ))
+        );
+        $clean->close();
+
+        $completed = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            $completeCursor
+        );
+        $this->assertFalse($completed->next_step());
+        $this->assertSame($resumedSnapshotId, $completed->get_snapshot_id());
+        $completed->close();
+    }
+
+    public function testLargeInputPerformsAtMostOneAtomWritePerScanningStep(): void
+    {
+        $lines = [];
+        for ($index = 0; $index < 64; ++$index) {
+            $lines[] = $this->indexLine(
+                '/aliases/' . str_pad( (string) $index, 3, '0', STR_PAD_LEFT ),
+                'link',
+                true
+            );
+        }
+        file_put_contents($this->nextRemoteIndexPath, implode('', $lines));
+        $journalByteOffset = $this->writeJournal([
+            [0, filesize($this->nextRemoteIndexPath), ['/source']],
+        ]);
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            filesize($this->nextRemoteIndexPath),
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        $steps = 0;
+        while (true) {
+            $phase = $processor->get_cursor()['phase'];
+            $before = $processor->get_cursor()['paths_byte_offset'];
+            $hasNext = $processor->next_step();
+            $after = $processor->get_cursor()['paths_byte_offset'];
+            if ($phase === 'scanning') {
+                $this->assertLessThanOrEqual(1, $this->countNewlinesBetween($before, $after));
+            }
+            ++$steps;
+            if (!$hasNext) {
+                break;
+            }
+        }
+        $this->assertGreaterThan(64 * 3, $steps);
+        $processor->close();
+    }
+
+    public function testResumesEveryNestedSortAndPublicationBoundary(): void
+    {
+        $lines = [];
+        for ($index = 0; $index < 60; ++$index) {
+            $lines[] = $this->indexLine(
+                '/aliases/' . sprintf('%03d', $index) . str_repeat('x', 19980),
+                'link',
+                true
+            );
+        }
+        file_put_contents($this->nextRemoteIndexPath, implode('', $lines));
+        $indexByteOffset = filesize($this->nextRemoteIndexPath);
+        $journalByteOffset = $this->writeJournal([
+            [0, $indexByteOffset, ['/source']],
+        ]);
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        $checkpointPhases = [];
+        while (true) {
+            $beforePhase = $processor->get_checkpoint_phase();
+            $hasNext = $processor->next_step();
+            $afterPhase = $processor->get_checkpoint_phase();
+            if ($afterPhase !== $beforePhase) {
+                $checkpointPhases[] = $afterPhase;
+                if ($hasNext) {
+                    $savedCursor = $this->jsonCursor(
+                        $processor->get_cursor()
+                    );
+                    $allocatedSnapshotId = $savedCursor['snapshot_id'];
+                    if (in_array($afterPhase, ['snapshot_prepared', 'paths_published'], true)) {
+                        $this->assertIsString($allocatedSnapshotId);
+                    }
+                    if ($afterPhase === 'snapshot_prepared') {
+                        $this->assertFileDoesNotExist(
+                            $this->snapshotPathsFile($allocatedSnapshotId)
+                        );
+                        $this->assertFileDoesNotExist(
+                            $this->snapshotLookupFile($allocatedSnapshotId)
+                        );
+                    }
+                    $processor->next_step();
+                    if ($afterPhase === 'snapshot_prepared') {
+                        $this->assertFileExists(
+                            $this->snapshotPathsFile($allocatedSnapshotId)
+                        );
+                        $this->assertFileDoesNotExist(
+                            $this->snapshotLookupFile($allocatedSnapshotId)
+                        );
+                    } elseif ($afterPhase === 'paths_published') {
+                        $this->assertFileExists(
+                            $this->snapshotLookupFile($allocatedSnapshotId)
+                        );
+                    }
+                    $processor->close();
+                    $processor = $this->newProcessor(
+                        $journalByteOffset,
+                        $indexByteOffset,
+                        $this->ownershipDirectory,
+                        $savedCursor
+                    );
+                }
+            }
+            if (!$hasNext) {
+                break;
+            }
+        }
+        $snapshotId = $processor->get_snapshot_id();
+        $processor->close();
+
+        foreach ([
+            'sorting_paths:merge_pass_complete',
+            'sorting_paths:publishing_output',
+            'sorting_paths:cleaning_work_files',
+            'sorting_lookup:publishing_output',
+            'sorting_lookup:cleaning_work_files',
+            'snapshot_prepared',
+            'paths_published',
+            'lookup_published',
+            'cleaning_work_files',
+            'complete',
+        ] as $phase) {
+            $this->assertContains($phase, $checkpointPhases);
+        }
+        $atoms = $this->readAtoms($this->snapshotPathsFile($snapshotId));
+        $this->assertCount(63, $atoms);
+        $this->assertLookupMatchesAtoms(
+            $this->snapshotPathsFile($snapshotId),
+            $this->snapshotLookupFile($snapshotId),
+            $atoms
+        );
+    }
+
+    public function testLookupSortCursorBindsDeduplicationDisabled(): void
+    {
+        [$journalByteOffset, $indexByteOffset] = $this->writeTwoTraversals();
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        while ($processor->get_cursor()['phase'] !== 'sorting_lookup') {
+            $this->assertTrue($processor->next_step());
+        }
+        $sortCursor = $processor->get_cursor()['lookup_sort_cursor'];
+        $processor->close();
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('configuration changed');
+        \ExternalSortProcessor::resume(
+            $this->ownershipDirectory . '/work/lookup.next',
+            $this->ownershipDirectory . '/work/lookup.sorted',
+            $this->ownershipDirectory . '/work',
+            'ownership-lookup',
+            static fn(string $line): string => substr($line, 0, 64),
+            true,
+            $sortCursor
+        );
+    }
+
+    public function testSnapshotRemovalResumesBetweenArtifactsAndIsIdempotent(): void
+    {
+        [$journalByteOffset, $indexByteOffset] = $this->writeTwoTraversals();
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        while ($processor->next_step()) {
+            $this->assertNotSame('complete', $processor->get_cursor()['phase']);
+        }
+        $snapshotId = $processor->get_snapshot_id();
+        $processor->close();
+
+        unlink($this->snapshotPathsFile($snapshotId));
+        $this->assertFileExists($this->snapshotLookupFile($snapshotId));
+        \FilesPullOwnershipProcessor::remove_snapshot(
+            $this->ownershipDirectory,
+            $snapshotId
+        );
+        $this->assertFileDoesNotExist($this->snapshotLookupFile($snapshotId));
+        \FilesPullOwnershipProcessor::remove_snapshot(
+            $this->ownershipDirectory,
+            $snapshotId
+        );
+    }
+
+    public function testRejectsTraversalGapBeforeReadingRawIndex(): void
+    {
+        $line = $this->indexLine('/source/file.txt');
+        file_put_contents($this->nextRemoteIndexPath, $line);
+        $journalByteOffset = $this->writeJournal([
+            [1, strlen($line), ['/source']],
+        ]);
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            strlen($line),
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('contiguous');
+        try {
+            $processor->next_step();
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testRejectsOversizedRawIndexRowWithoutUnboundedRead(): void
+    {
+        $line = $this->indexLine('/' . str_repeat('x', 50000));
+        $this->assertGreaterThan(65536, strlen($line));
+        file_put_contents($this->nextRemoteIndexPath, $line);
+        $journalByteOffset = $this->writeJournal([
+            [0, strlen($line), ['/source']],
+        ]);
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            strlen($line),
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'remote-index row at byte offset 0 exceeds the maximum of 65536 bytes'
+        );
+        try {
+            while ($processor->next_step()) {
+                $this->assertSame('scanning', $processor->get_cursor()['phase']);
+            }
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testResumeRejectsNumericStringCursorOffset(): void
+    {
+        file_put_contents($this->nextRemoteIndexPath, '');
+        $journalByteOffset = $this->writeJournal([[0, 0, ['/source']]]);
+        $cursor = \FilesPullOwnershipProcessor::initial_cursor();
+        $cursor['paths_byte_offset'] = '0';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->newProcessor(
+            $journalByteOffset,
+            0,
+            $this->ownershipDirectory,
+            $cursor
+        );
+    }
+
+    /** @dataProvider invalidSnapshotCursorProvider */
+    public function testSnapshotAccessorRejectsInvalidCursor(array $cursor): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        \FilesPullOwnershipProcessor::snapshot_id_from_cursor($cursor);
+    }
+
+    public static function invalidSnapshotCursorProvider(): array
+    {
+        $unknownPhase = \FilesPullOwnershipProcessor::initial_cursor();
+        $unknownPhase['phase'] = 'future';
+        $missingId = \FilesPullOwnershipProcessor::initial_cursor();
+        unset($missingId['snapshot_id']);
+        $idInScanning = \FilesPullOwnershipProcessor::initial_cursor();
+        $idInScanning['snapshot_id'] = str_repeat('a', 64);
+        return [
+            'unknown phase' => [$unknownPhase],
+            'missing ID field' => [$missingId],
+            'ID outside publication' => [$idInScanning],
+        ];
+    }
+
+    /** @return array{int,int} */
+    private function writeTwoTraversals(): array
+    {
+        $firstLines = $this->indexLine("/srv/\xFFsite/child/index.php")
+            . $this->indexLine('/outside-alias', 'link', true);
+        $secondLines = $this->indexLine('/outside/target/data.bin');
+        file_put_contents($this->nextRemoteIndexPath, $firstLines . $secondLines);
+        $firstEnd = strlen($firstLines);
+        $indexEnd = $firstEnd + strlen($secondLines);
+        return [
+            $this->writeJournal([
+                [0, $firstEnd, ["/srv/\xFFsite/child"]],
+                [$firstEnd, $indexEnd, ['/outside/target']],
+            ]),
+            $indexEnd,
+        ];
+    }
+
+    /** @param array<int,array{int,int,list<string>}> $records */
+    private function writeJournal(array $records): int
+    {
+        $journal = new \RemoteIndexTraversalJournal($this->traversalJournalPath);
+        $journal->open_and_truncate_to_saved_byte_offset(0);
+        $journalByteOffset = 0;
+        foreach ($records as [$start, $end, $roots]) {
+            $journalByteOffset = $journal->complete_traversal(
+                $start,
+                $end,
+                $roots[0],
+                $roots
+            );
+        }
+        $journal->close();
+        return $journalByteOffset;
+    }
+
+    private function indexLine(
+        string $path,
+        string $type = 'file',
+        bool $intermediate = false
+    ): string {
+        $entry = [
+            'path' => base64_encode($path),
+            'ctime' => 1,
+            'size' => 1,
+            'type' => $type,
+        ];
+        if ($intermediate) {
+            $entry['target'] = base64_encode('/outside-alias-target');
+            $entry['intermediate'] = true;
+        }
+        return json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n";
+    }
+
+    private function newProcessor(
+        int $journalByteOffset,
+        int $indexByteOffset,
+        string $ownershipDirectory,
+        array $cursor
+    ): \FilesPullOwnershipProcessor {
+        return \FilesPullOwnershipProcessor::resume(
+            $this->traversalJournalPath,
+            $journalByteOffset,
+            $this->nextRemoteIndexPath,
+            $indexByteOffset,
+            $ownershipDirectory,
+            $cursor
+        );
+    }
+
+    private function jsonCursor(array $cursor): array
+    {
+        $json = json_encode($cursor);
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+        return $decoded;
+    }
+
+    /** @return list<array{kind:string,path:string}> */
+    private function readAtoms(string $pathsFile): array
+    {
+        $atoms = [];
+        foreach (file($pathsFile, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $atom = json_decode($line, true);
+            $atoms[] = [
+                'kind' => $atom['kind'],
+                'path' => base64_decode($atom['path_b64'], true),
+            ];
+        }
+        return $atoms;
+    }
+
+    private function assertLookupMatchesAtoms(
+        string $pathsFile,
+        string $lookupFile,
+        array $atoms
+    ): void {
+        $records = file($lookupFile) ?: [];
+        $this->assertCount(count($atoms), $records);
+        $previousDigest = null;
+        $pathsHandle = fopen($pathsFile, 'rb');
+        foreach ($records as $record) {
+            $this->assertSame(1, preg_match(
+                '/^([0-9a-f]{64}) ([0-9a-f]{16})\n$/D',
+                $record,
+                $matches
+            ));
+            $this->assertTrue(
+                $previousDigest === null
+                || strcmp($previousDigest, $matches[1]) < 0
+            );
+            $previousDigest = $matches[1];
+            fseek($pathsHandle, intval($matches[2], 16));
+            $atom = json_decode( (string) fgets($pathsHandle), true );
+            $path = base64_decode($atom['path_b64'], true);
+            $this->assertSame(
+                $matches[1],
+                hash('sha256', $atom['kind'] . "\0" . $path)
+            );
+        }
+        fclose($pathsHandle);
+    }
+
+    private function snapshotPathsFile(
+        string $snapshotId,
+        ?string $ownershipDirectory = null
+    ): string
+    {
+        return ( $ownershipDirectory ?? $this->ownershipDirectory )
+            . '/snapshots/' . $snapshotId . '.paths.jsonl';
+    }
+
+    private function snapshotLookupFile(
+        string $snapshotId,
+        ?string $ownershipDirectory = null
+    ): string
+    {
+        return ( $ownershipDirectory ?? $this->ownershipDirectory )
+            . '/snapshots/' . $snapshotId . '.lookup';
+    }
+
+    private function countNewlinesBetween(int $before, int $after): int
+    {
+        if ($after <= $before) {
+            return 0;
+        }
+        $handle = fopen($this->ownershipDirectory . '/work/paths.next.jsonl', 'rb');
+        fseek($handle, $before);
+        $bytes = fread($handle, $after - $before);
+        fclose($handle);
+        return substr_count( (string) $bytes, "\n" );
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_file($path) || is_link($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/FilesPullOwnershipStateTest.php
+++ b/tests/Import/FilesPullOwnershipStateTest.php
@@ -1,0 +1,220 @@
+<?php
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the following line.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\State\FilesPullOwnershipState;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/state/load.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php';
+
+final class FilesPullOwnershipStateTest extends TestCase
+{
+    private const FIRST_SELECTION =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    private const SECOND_SELECTION =
+        '2222222222222222222222222222222222222222222222222222222222222222';
+    private const FIRST_SNAPSHOT =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    private const SECOND_SNAPSHOT =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    private const THIRD_SNAPSHOT =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+    public function testSuccessReplacesOnlyItsSelectionAndQueuesUnreferencedSnapshots(): void
+    {
+        $state = FilesPullOwnershipState::from_array([
+            'committed_snapshot_ids_by_selection_fingerprint' => [
+                self::FIRST_SELECTION => [
+                    self::FIRST_SNAPSHOT,
+                    self::SECOND_SNAPSHOT,
+                ],
+                self::SECOND_SELECTION => [self::FIRST_SNAPSHOT],
+            ],
+            'active_snapshot_id' => self::THIRD_SNAPSHOT,
+            'processor_cursor' => null,
+            'snapshot_ids_pending_removal' => [],
+        ]);
+
+        $state->commit_active_snapshot(self::FIRST_SELECTION);
+
+        $this->assertSame(
+            [self::THIRD_SNAPSHOT],
+            $state->committed_snapshot_ids_by_selection_fingerprint[
+                self::FIRST_SELECTION
+            ]
+        );
+        $this->assertSame(
+            [self::FIRST_SNAPSHOT],
+            $state->committed_snapshot_ids_by_selection_fingerprint[
+                self::SECOND_SELECTION
+            ]
+        );
+        $this->assertSame(
+            [self::SECOND_SNAPSHOT],
+            $state->snapshot_ids_pending_removal
+        );
+        $this->assertNull($state->active_snapshot_id);
+    }
+
+    public function testAbortBeforeDiffDiscardsCandidate(): void
+    {
+        $state = $this->stateWithActiveSnapshot();
+
+        $state->abort_active_snapshot(self::FIRST_SELECTION, false, null);
+
+        $this->assertSame(
+            [self::FIRST_SNAPSHOT],
+            $state->committed_snapshot_ids_by_selection_fingerprint[
+                self::FIRST_SELECTION
+            ]
+        );
+        $this->assertSame(
+            [self::SECOND_SNAPSHOT],
+            $state->snapshot_ids_pending_removal
+        );
+    }
+
+    public function testAbortAtDiffRetainsCandidateBesideCommittedOwnership(): void
+    {
+        $state = $this->stateWithActiveSnapshot();
+
+        $state->abort_active_snapshot(self::FIRST_SELECTION, true, null);
+
+        $this->assertSame(
+            [self::FIRST_SNAPSHOT, self::SECOND_SNAPSHOT],
+            $state->committed_snapshot_ids_by_selection_fingerprint[
+                self::FIRST_SELECTION
+            ]
+        );
+        $this->assertSame([], $state->snapshot_ids_pending_removal);
+    }
+
+    public function testIncompleteProcessorHasNoActiveSnapshot(): void
+    {
+        $state = new FilesPullOwnershipState();
+        $cursor = \FilesPullOwnershipProcessor::initial_cursor();
+        $cursor['phase'] = 'complete';
+        $cursor['snapshot_id'] = self::FIRST_SNAPSHOT;
+        $cursor['next_work_file_cleanup_index'] = 2;
+
+        $state->processor_cursor = $cursor;
+
+        $this->assertSame($cursor, $state->processor_cursor);
+        $this->assertNull($state->active_snapshot_id);
+        $state->complete_processor(self::FIRST_SNAPSHOT);
+        $this->assertNull($state->processor_cursor);
+        $this->assertSame(self::FIRST_SNAPSHOT, $state->active_snapshot_id);
+    }
+
+    public function testAbortQueuesAllocatedProcessorIdBeforeClearingCursor(): void
+    {
+        $state = new FilesPullOwnershipState();
+        $cursor = \FilesPullOwnershipProcessor::initial_cursor();
+        $cursor['phase'] = 'paths_published';
+        $cursor['snapshot_id'] = self::SECOND_SNAPSHOT;
+        $state->processor_cursor = $cursor;
+
+        $state->abort_active_snapshot(
+            self::FIRST_SELECTION,
+            false,
+            \FilesPullOwnershipProcessor::snapshot_id_from_cursor($cursor)
+        );
+
+        $this->assertNull($state->processor_cursor);
+        $this->assertNull($state->active_snapshot_id);
+        $this->assertSame(
+            [self::SECOND_SNAPSHOT],
+            $state->snapshot_ids_pending_removal
+        );
+    }
+
+    public function testConfirmsOnlyTheNextPendingSnapshotRemoval(): void
+    {
+        $state = FilesPullOwnershipState::from_array([
+            'committed_snapshot_ids_by_selection_fingerprint' => [],
+            'active_snapshot_id' => null,
+            'processor_cursor' => null,
+            'snapshot_ids_pending_removal' => [
+                self::FIRST_SNAPSHOT,
+                self::SECOND_SNAPSHOT,
+            ],
+        ]);
+
+        $this->assertSame(
+            self::SECOND_SNAPSHOT,
+            $state->next_snapshot_id_pending_removal()
+        );
+        $state->confirm_snapshot_removed(self::SECOND_SNAPSHOT);
+        $this->assertSame(
+            self::FIRST_SNAPSHOT,
+            $state->next_snapshot_id_pending_removal()
+        );
+        $state->confirm_snapshot_removed(self::FIRST_SNAPSHOT);
+        $this->assertNull($state->next_snapshot_id_pending_removal());
+    }
+
+    /** @dataProvider invalidStateProvider */
+    public function testRejectsInvalidPersistentState(array $data): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        FilesPullOwnershipState::from_array($data);
+    }
+
+    public static function invalidStateProvider(): array
+    {
+        $valid = [
+            'committed_snapshot_ids_by_selection_fingerprint' => [],
+            'active_snapshot_id' => null,
+            'processor_cursor' => null,
+            'snapshot_ids_pending_removal' => [],
+        ];
+        $unsortedSnapshots = $valid;
+        $unsortedSnapshots[
+            'committed_snapshot_ids_by_selection_fingerprint'
+        ] = [
+            self::FIRST_SELECTION => [
+                self::SECOND_SNAPSHOT,
+                self::FIRST_SNAPSHOT,
+            ],
+        ];
+        $activeAndCursor = $valid;
+        $activeAndCursor['active_snapshot_id'] = self::FIRST_SNAPSHOT;
+        $activeAndCursor['processor_cursor'] =
+            \FilesPullOwnershipProcessor::initial_cursor();
+        $referencedRemoval = $valid;
+        $referencedRemoval[
+            'committed_snapshot_ids_by_selection_fingerprint'
+        ] = [self::FIRST_SELECTION => [self::FIRST_SNAPSHOT]];
+        $referencedRemoval['snapshot_ids_pending_removal'] =
+            [self::FIRST_SNAPSHOT];
+        return [
+            'invalid fingerprint' => [array_replace($valid, [
+                'committed_snapshot_ids_by_selection_fingerprint' => [
+                    'not-a-fingerprint' => [self::FIRST_SNAPSHOT],
+                ],
+            ])],
+            'uppercase snapshot' => [array_replace($valid, [
+                'active_snapshot_id' => strtoupper(self::FIRST_SNAPSHOT),
+            ])],
+            'unsorted committed list' => [$unsortedSnapshots],
+            'active and processor' => [$activeAndCursor],
+            'referenced pending removal' => [$referencedRemoval],
+            'unexpected key' => [array_replace($valid, ['old' => true])],
+        ];
+    }
+
+    private function stateWithActiveSnapshot(): FilesPullOwnershipState
+    {
+        return FilesPullOwnershipState::from_array([
+            'committed_snapshot_ids_by_selection_fingerprint' => [
+                self::FIRST_SELECTION => [self::FIRST_SNAPSHOT],
+            ],
+            'active_snapshot_id' => self::SECOND_SNAPSHOT,
+            'processor_cursor' => null,
+            'snapshot_ids_pending_removal' => [],
+        ]);
+    }
+}

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -2,6 +2,8 @@
 
 namespace ImportTests;
 
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Boundary client records ownership state saves for lifecycle tests.
+
 use PHPUnit\Framework\TestCase;
 use Reprint\Importer\StreamingContext;
 
@@ -123,10 +125,10 @@ class FilesPullStateTest extends TestCase
     /**
      * Set up a client with state loaded and preserve-local mode.
      */
-    private function prepareClient(): array
+    private function prepareClient(?\ImportClient $client = null): array
     {
-        $client = $this->makeClient();
-        $reflection = new \ReflectionClass($client);
+        $client = $client ?? $this->makeClient();
+        $reflection = new \ReflectionClass(\ImportClient::class);
 
         $stateProperty = $reflection->getProperty('state');
         $loadState = $reflection->getMethod('load_state');
@@ -232,6 +234,232 @@ class FilesPullStateTest extends TestCase
             "After abort + re-run, the sync should start fresh, not report 'already complete'",
         );
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
+    }
+
+    public function testAbortResumesOneOwnershipSnapshotRemovalPerInvocation(): void
+    {
+        $firstSnapshotId = str_repeat('a', 64);
+        $secondSnapshotId = str_repeat('b', 64);
+        $ownershipDirectory =
+            $this->pullStateDirectory . '/files-pull-ownership';
+        $snapshotsDirectory = $ownershipDirectory . '/snapshots';
+        mkdir($snapshotsDirectory, 0755, true);
+        foreach (['paths.jsonl', 'lookup'] as $suffix) {
+            file_put_contents(
+                "{$snapshotsDirectory}/{$firstSnapshotId}.{$suffix}",
+                'first'
+            );
+        }
+        // The paths artifact was removed before the earlier process stopped.
+        file_put_contents(
+            "{$snapshotsDirectory}/{$secondSnapshotId}.lookup",
+            'second'
+        );
+        $this->writeState([
+            'files_pull_ownership' => [
+                'committed_snapshot_ids_by_selection_fingerprint' => [],
+                'active_snapshot_id' => null,
+                'processor_cursor' => null,
+                'snapshot_ids_pending_removal' => [
+                    $firstSnapshotId,
+                    $secondSnapshotId,
+                ],
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $reflection->getMethod('handle_abort')->invoke($client, 'files-pull');
+
+        $this->assertFileExists(
+            "{$snapshotsDirectory}/{$firstSnapshotId}.paths.jsonl"
+        );
+        $this->assertFileDoesNotExist(
+            "{$snapshotsDirectory}/{$secondSnapshotId}.lookup"
+        );
+        $this->assertSame(
+            [$firstSnapshotId],
+            $this->readState()['files_pull_ownership']
+                ['snapshot_ids_pending_removal']
+        );
+
+        // Both artifacts were removed before the next state save completed.
+        \FilesPullOwnershipProcessor::remove_snapshot(
+            $ownershipDirectory,
+            $firstSnapshotId
+        );
+        [$resumedClient, $resumedReflection] = $this->prepareClient();
+        $resumedReflection->getMethod('handle_abort')->invoke(
+            $resumedClient,
+            'files-pull'
+        );
+        $this->assertSame(
+            [],
+            $this->readState()['files_pull_ownership']
+                ['snapshot_ids_pending_removal']
+        );
+    }
+
+    /** @dataProvider cursorOwnedSnapshotAbortProvider */
+    public function testAbortRemovesCursorOwnedSnapshotArtifacts(
+        string $savedPhase,
+        array $publishedArtifactSuffixes
+    ): void
+    {
+        $selectionFingerprint = str_repeat('1', 64);
+        $snapshotId = str_repeat('a', 64);
+        $cursor = \FilesPullOwnershipProcessor::initial_cursor();
+        $cursor['phase'] = $savedPhase;
+        $cursor['snapshot_id'] = $snapshotId;
+        $snapshotsDirectory = $this->pullStateDirectory
+            . '/files-pull-ownership/snapshots';
+        mkdir($snapshotsDirectory, 0755, true);
+        foreach ($publishedArtifactSuffixes as $suffix) {
+            file_put_contents(
+                "{$snapshotsDirectory}/{$snapshotId}.{$suffix}",
+                "published before state save\n"
+            );
+        }
+        $this->writeState([
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'ownership',
+            ],
+            'files_pull_path_selection_fingerprint' => $selectionFingerprint,
+            'files_pull_ownership' => [
+                'committed_snapshot_ids_by_selection_fingerprint' => [],
+                'active_snapshot_id' => null,
+                'processor_cursor' => $cursor,
+                'snapshot_ids_pending_removal' => [],
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $reflection->getMethod('handle_abort')->invoke($client, 'files-pull');
+
+        $ownership = $this->readState()['files_pull_ownership'];
+        $this->assertNull($ownership['processor_cursor']);
+        $this->assertNull($ownership['active_snapshot_id']);
+        $this->assertSame([], $ownership['snapshot_ids_pending_removal']);
+        foreach ($publishedArtifactSuffixes as $suffix) {
+            $this->assertFileDoesNotExist(
+                "{$snapshotsDirectory}/{$snapshotId}.{$suffix}"
+            );
+        }
+    }
+
+    public static function cursorOwnedSnapshotAbortProvider(): array
+    {
+        return [
+            'after paths rename' => [
+                'snapshot_prepared',
+                ['paths.jsonl'],
+            ],
+            'after lookup rename before cursor save' => [
+                'paths_published',
+                ['paths.jsonl', 'lookup'],
+            ],
+        ];
+    }
+
+    public function testOwnershipAbortAndClearedStateShareSignalBoundary(): void
+    {
+        $selectionFingerprint = str_repeat('1', 64);
+        $snapshotId = str_repeat('a', 64);
+        $cursor = \FilesPullOwnershipProcessor::initial_cursor();
+        $cursor['phase'] = 'snapshot_prepared';
+        $cursor['snapshot_id'] = $snapshotId;
+        $snapshotsDirectory = $this->pullStateDirectory
+            . '/files-pull-ownership/snapshots';
+        mkdir($snapshotsDirectory, 0755, true);
+        file_put_contents(
+            "{$snapshotsDirectory}/{$snapshotId}.paths.jsonl",
+            "published before abort\n"
+        );
+        $this->writeState([
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'ownership',
+            ],
+            'files_pull_path_selection_fingerprint' => $selectionFingerprint,
+            'files_pull_ownership' => [
+                'committed_snapshot_ids_by_selection_fingerprint' => [],
+                'active_snapshot_id' => null,
+                'processor_cursor' => $cursor,
+                'snapshot_ids_pending_removal' => [],
+            ],
+        ]);
+        $client = new OwnershipStateBoundaryClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->filesystem_root
+        );
+        [$client] = $this->prepareClient($client);
+
+        $client->clear_files_pull_progress();
+
+        $saves = $client->ownership_abort_saves();
+        $this->assertSame([
+            'cursor' => false,
+            'pending' => [$snapshotId],
+            'stage' => null,
+            'async_signals_enabled' => function_exists('pcntl_async_signals')
+                ? false
+                : null,
+        ], $saves[0]);
+        $this->assertSame([], $saves[1]['pending']);
+        foreach ($saves as $save) {
+            $this->assertFalse($save['cursor'] && $save['pending'] !== []);
+            $this->assertFalse($save['stage'] === 'ownership' && !$save['cursor']);
+        }
+    }
+
+    public function testOwnershipCommitAndCommandCompletionShareSignalBoundary(): void
+    {
+        $selectionFingerprint = hash('sha256', json_encode([
+            'only_path_prefixes_b64' => [],
+            'excluded_path_prefixes_b64' => [],
+            'extra_directory_b64' => null,
+            'follow_symlinks' => false,
+            'include_caches' => false,
+        ], JSON_UNESCAPED_SLASHES));
+        $snapshotId = str_repeat('a', 64);
+        $this->writeState([
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'fetch',
+            ],
+            'files_pull_path_selection_fingerprint' => $selectionFingerprint,
+            'files_pull_ownership' => [
+                'committed_snapshot_ids_by_selection_fingerprint' => [],
+                'active_snapshot_id' => $snapshotId,
+                'processor_cursor' => null,
+                'snapshot_ids_pending_removal' => [],
+            ],
+        ]);
+        $client = new OwnershipStateBoundaryClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->filesystem_root
+        );
+        [$client, $reflection] = $this->prepareClient($client);
+        $reflection->getProperty('follow_symlinks')->setValue($client, false);
+
+        $reflection->getMethod('run_files_pull')->invoke($client);
+
+        $this->assertSame([[
+            'completion_state' => 'complete',
+            'stage' => null,
+            'active' => null,
+            'committed' => [
+                $selectionFingerprint => [$snapshotId],
+            ],
+            'async_signals_enabled' => function_exists('pcntl_async_signals')
+                ? false
+                : null,
+        ]], $client->ownership_completion_saves());
     }
 
     // ---------------------------------------------------------------
@@ -373,5 +601,54 @@ class FilesPullStateTest extends TestCase
             file_get_contents($localFile),
             "Fetch stage must overwrite existing files that were placed in the fetch list",
         );
+    }
+}
+
+final class OwnershipStateBoundaryClient extends \ImportClient {
+    private $ownershipCompletionSaves = [];
+    private $ownershipAbortSaves = [];
+
+    public function save_state(): void
+    {
+        $ownership = $this->get_state()->files_pull_ownership;
+        if ($ownership->committed_snapshot_ids_by_selection_fingerprint !== []) {
+            $command = $this->get_state()->active_resumable_command;
+            $this->ownershipCompletionSaves[] = [
+                'completion_state' => $command->completion_state,
+                'stage' => $command->current_stage,
+                'active' => $ownership->active_snapshot_id,
+                'committed' =>
+                    $ownership->committed_snapshot_ids_by_selection_fingerprint,
+                'async_signals_enabled' =>
+                    function_exists('pcntl_async_signals')
+                        ? pcntl_async_signals()
+                        : null,
+            ];
+        } elseif (
+            $ownership->processor_cursor === null
+            && $ownership->active_snapshot_id === null
+        ) {
+            $this->ownershipAbortSaves[] = [
+                'cursor' => false,
+                'pending' => $ownership->snapshot_ids_pending_removal,
+                'stage' => $this->get_state()->active_resumable_command
+                    ->current_stage,
+                'async_signals_enabled' =>
+                    function_exists('pcntl_async_signals')
+                        ? pcntl_async_signals()
+                        : null,
+            ];
+        }
+        parent::save_state();
+    }
+
+    public function ownership_completion_saves(): array
+    {
+        return $this->ownershipCompletionSaves;
+    }
+
+    public function ownership_abort_saves(): array
+    {
+        return $this->ownershipAbortSaves;
     }
 }

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -141,6 +141,20 @@ class OnlyFilesPathPrefixTest extends TestCase
         );
     }
 
+    /** @param list<string> $remoteRoots */
+    private function writeCompletableFilesPullState(
+        array $state,
+        array $remoteRoots
+    ): void {
+        $state['files_pull_ownership'] = array(
+            'active_snapshot_id' => reprint_test_write_root_ownership_snapshot(
+                $this->pullStateDirectory,
+                $remoteRoots
+            ),
+        );
+        $this->writeFilesPullState($state);
+    }
+
     private function runFilesPull(array $fileSelectionOptions): \ImportClient
     {
         return $this->runCommand('files-pull', $fileSelectionOptions);
@@ -345,9 +359,9 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunAllowsSameOnlyPrefixesWhileFilesPullIsInProgress(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
-        $this->writeFilesPullState(array(
+        $this->writeCompletableFilesPullState(array(
             'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
-        ));
+        ), array('/var/www/html/wp-content/plugins'));
 
         $this->runFilesPull(array('include' => array(':wp-content:/plugins')));
 
@@ -362,11 +376,11 @@ class OnlyFilesPathPrefixTest extends TestCase
     public function testRunRestoresIncludeCachesWhileFilesPullIsInProgress(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
-        $this->writeFilesPullState(array(
+        $this->writeCompletableFilesPullState(array(
             'include_caches' => true,
             'files_pull_path_selection_fingerprint' =>
                 $this->pathSelectionFingerprint(array(), array(), false, true),
-        ));
+        ), array('/var/www/html'));
 
         $this->runFilesPull(array());
 
@@ -431,7 +445,7 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $extraDirectory = "/srv/extra-\x80";
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
-        $this->writeFilesPullState(array(
+        $this->writeCompletableFilesPullState(array(
             'extra_directory' => $extraDirectory,
             'files_pull_path_selection_fingerprint' =>
                 $this->pathSelectionFingerprint(
@@ -441,7 +455,7 @@ class OnlyFilesPathPrefixTest extends TestCase
                     false,
                     $extraDirectory
                 ),
-        ));
+        ), array('/var/www/html', $extraDirectory));
 
         $client = $this->runFilesPull(array());
 

--- a/tests/Import/RemoteFileIndexTraversalReplayTest.php
+++ b/tests/Import/RemoteFileIndexTraversalReplayTest.php
@@ -508,6 +508,133 @@ PHP,
         );
     }
 
+    public function testFilesPullOwnershipRecordsFollowedTraversalRootAndIntermediateLink(): void
+    {
+        $realTarget = $this->tempDir . '/real/target';
+        $alias = $this->tempDir . '/alias';
+        mkdir($realTarget, 0755, true);
+        file_put_contents($realTarget . '/outside.txt', 'outside');
+        for ($index = 0; $index < 205; ++$index) {
+            file_put_contents($realTarget . "/file-{$index}.txt", 'content');
+        }
+        symlink($this->tempDir . '/real', $alias);
+        symlink('../alias/./target', $this->siteDir . '/followed-link');
+
+        $client = $this->newFilesPullClientThatStopsAfterOwnership();
+        try {
+            $this->runClient(
+                $client,
+                [
+                    'command' => 'files-pull',
+                    'follow_symlinks' => true,
+                    'fs_root_nonempty_behavior' => 'preserve-local',
+                ]
+            );
+            $this->fail('Expected the post-ownership checkpoint to stop the command.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame(
+                'Stop after files-pull ownership.',
+                $exception->getMessage()
+            );
+        }
+
+        $state = $this->readState();
+        $this->assertSame(
+            'sort',
+            $state['active_resumable_command']['current_stage']
+        );
+        $snapshotId = $state['files_pull_ownership']['active_snapshot_id'];
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/D', $snapshotId);
+        $pathsFile = $this->pullStateDirectory()
+            . '/files-pull-ownership/snapshots/'
+            . $snapshotId . '.paths.jsonl';
+        $atoms = [];
+        foreach (file($pathsFile, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $atom = json_decode($line, true);
+            $atoms[] = [
+                'kind' => $atom['kind'],
+                'path' => base64_decode($atom['path_b64'], true),
+            ];
+        }
+        $this->assertContains(
+            ['kind' => 'root', 'path' => (string) realpath($this->siteDir)],
+            $atoms
+        );
+        $this->assertContains(
+            ['kind' => 'root', 'path' => (string) realpath($realTarget)],
+            $atoms
+        );
+        $canonicalAlias = (string) realpath(dirname($alias)) . '/alias';
+        $this->assertContains(
+            ['kind' => 'exact', 'path' => $canonicalAlias],
+            $atoms
+        );
+        $this->assertNotContains(
+            [
+                'kind' => 'exact',
+                'path' => (string) realpath($this->siteDir) . '/followed-link',
+            ],
+            $atoms
+        );
+        $this->assertCount(1, array_filter(
+            $this->fileIndexRequests(),
+            static function (array $request) use ($realTarget): bool {
+                return $request['list_directory_b64'] === base64_encode(
+                    (string) realpath($realTarget)
+                );
+            }
+        ));
+        $ownershipStateSaves = $client->ownership_state_saves();
+        $savedPhases = array_column($ownershipStateSaves, 'processor_phase');
+        foreach ([
+            'scanning',
+            'starting_paths_sort',
+            'sorting_paths:publishing_output',
+            'sorting_paths:cleaning_work_files',
+            'building_lookup',
+            'starting_lookup_sort',
+            'sorting_lookup:publishing_output',
+            'sorting_lookup:cleaning_work_files',
+            'preparing_snapshot',
+            'snapshot_prepared',
+            'paths_published',
+            'lookup_published',
+            'cleaning_work_files',
+        ] as $phase) {
+            $this->assertContains($phase, $savedPhases);
+        }
+        $this->assertSame(
+            ['stage' => 'sort', 'processor_phase' => null, 'cursor' => false, 'active' => true],
+            array_diff_key(end($ownershipStateSaves), ['async_signals_enabled' => true])
+        );
+        if (function_exists('pcntl_async_signals')) {
+            $signalStates = array_column($ownershipStateSaves, 'async_signals_enabled');
+            $this->assertFalse(array_shift($signalStates));
+            $this->assertFalse(array_pop($signalStates));
+            $this->assertNotContains(false, $signalStates);
+        }
+
+        $this->runClient(
+            $this->newLoadedClient(),
+            ['command' => 'files-pull', 'abort' => true]
+        );
+        $abortedOwnership = $this->readState()['files_pull_ownership'];
+        $this->assertNull($abortedOwnership['active_snapshot_id']);
+        $this->assertSame([], $abortedOwnership[
+            'committed_snapshot_ids_by_selection_fingerprint'
+        ]);
+        $this->assertSame(
+            [],
+            $abortedOwnership['snapshot_ids_pending_removal']
+        );
+        $this->assertFileDoesNotExist($pathsFile);
+        $this->assertFileDoesNotExist(
+            $this->pullStateDirectory()
+                . '/files-pull-ownership/snapshots/'
+                . $snapshotId . '.lookup'
+        );
+    }
+
     private function newFilesIndexClient(bool $followSymlinks): \ImportClient
     {
         $client = $this->newClient();
@@ -569,6 +696,36 @@ PHP,
         );
         $this->configureClientOutput($client);
         return $this->loadClientState($client);
+    }
+
+    private function newFilesPullClientThatStopsAfterOwnership(): \ImportClient
+    {
+        $client = new StopAfterFilesPullOwnershipClient(
+            $this->remoteUrl,
+            $this->stateDir,
+            $this->filesystemRoot
+        );
+        $this->configureClientOutput($client);
+        \write_current_pull_state($client, [
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'runtime' => ['document_root' => $this->siteDir],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => $this->siteDir],
+                            ['path' => $this->extraDir],
+                        ],
+                    ],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => true,
+            'include_caches' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+        ]);
+        return $client;
     }
 
     private function loadClientState(\ImportClient $client): \ImportClient
@@ -828,5 +985,62 @@ final class FailAfterRemoteIndexDiscoveryCheckpointClient extends \ImportClient
                 'Stop after the followed-target discovery checkpoint.'
             );
         }
+    }
+}
+
+final class StopAfterFilesPullOwnershipClient extends \ImportClient
+{
+    private $failed = false;
+    private $ownershipStateSaves = [];
+
+    public function save_state(): void
+    {
+        if (
+            $this->get_state()->active_resumable_command->command_name
+                === 'files-pull'
+            && in_array(
+                $this->get_state()->active_resumable_command->current_stage,
+                ['ownership', 'sort'],
+                true
+            )
+        ) {
+            $ownership = $this->get_state()->files_pull_ownership;
+            $processorPhase = $ownership->processor_cursor['phase'] ?? null;
+            if ($processorPhase === 'sorting_paths') {
+                $processorPhase .= ':' . $ownership->processor_cursor
+                    ['paths_sort_cursor']['phase'];
+            } elseif ($processorPhase === 'sorting_lookup') {
+                $processorPhase .= ':' . $ownership->processor_cursor
+                    ['lookup_sort_cursor']['phase'];
+            }
+            $this->ownershipStateSaves[] = [
+                'stage' => $this->get_state()->active_resumable_command
+                    ->current_stage,
+                'processor_phase' => $processorPhase,
+                'cursor' => $ownership->processor_cursor !== null,
+                'active' => $ownership->active_snapshot_id !== null,
+                'async_signals_enabled' =>
+                    function_exists('pcntl_async_signals')
+                        ? pcntl_async_signals()
+                        : null,
+            ];
+        }
+        parent::save_state();
+        $activeCommand = $this->get_state()->active_resumable_command;
+        if (
+            !$this->failed
+            && $activeCommand->command_name === 'files-pull'
+            && $activeCommand->current_stage === 'sort'
+            && $this->get_state()->files_pull_ownership->active_snapshot_id
+                !== null
+        ) {
+            $this->failed = true;
+            throw new \RuntimeException('Stop after files-pull ownership.');
+        }
+    }
+
+    public function ownership_state_saves(): array
+    {
+        return $this->ownershipStateSaves;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -60,5 +60,74 @@ function write_current_pull_state(ImportClient $client, array $changes): void
     $client->save_state();
 }
 
+/**
+ * Write the ownership artifacts produced for completed traversal roots.
+ *
+ * @param string       $pull_state_directory Pull state directory.
+ * @param list<string> $remote_roots         Completed remote traversal roots.
+ * @return string Opaque snapshot ID.
+ */
+function reprint_test_write_root_ownership_snapshot(
+    string $pull_state_directory,
+    array $remote_roots
+): string {
+    $snapshot_id = bin2hex(random_bytes(32));
+    $snapshot_directory =
+        $pull_state_directory . '/files-pull-ownership/snapshots';
+    if (
+        ! is_dir($snapshot_directory)
+        && ! mkdir($snapshot_directory, 0777, true)
+        && ! is_dir($snapshot_directory)
+    ) {
+        throw new RuntimeException(
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test-only temporary path, never HTML output.
+            "Failed to create test ownership snapshot directory: {$snapshot_directory}."
+        );
+    }
+
+    $path_rows = [];
+    foreach ($remote_roots as $remote_root) {
+        $kind = 'root';
+        $path = $remote_root;
+        while (true) {
+            $line = json_encode([
+                'kind' => $kind,
+                'path_b64' => base64_encode($path),
+            ], JSON_UNESCAPED_SLASHES) . "\n";
+            $path_rows[] = [
+                'kind' => $kind,
+                'path' => $path,
+                'line' => $line,
+            ];
+            if ($path === '/') {
+                break;
+            }
+            $kind = 'ancestor';
+            $path = dirname($path);
+        }
+    }
+    usort(
+        $path_rows,
+        static function (array $left, array $right): int {
+            return strcmp($left['line'], $right['line']);
+        }
+    );
+
+    $paths = '';
+    $lookup_records = [];
+    foreach ($path_rows as $path_row) {
+        $lookup_records[] =
+            hash('sha256', $path_row['kind'] . "\0" . $path_row['path'])
+            . ' ' . sprintf('%016x', strlen($paths)) . "\n";
+        $paths .= $path_row['line'];
+    }
+    sort($lookup_records, SORT_STRING);
+
+    $snapshot_prefix = $snapshot_directory . '/' . $snapshot_id;
+    file_put_contents($snapshot_prefix . '.paths.jsonl', $paths);
+    file_put_contents($snapshot_prefix . '.lookup', implode('', $lookup_records));
+    return $snapshot_id;
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';


### PR DESCRIPTION
Scoped file pulls now retain a durable record of the remote paths covered by each completed traversal, including followed roots and intermediate symlinks.

The raw traversal ranges are consumed before index sorting into a byte-safe, disk-backed snapshot. Snapshot construction is bounded and resumable through the external sorter. A successful pull replaces only that selection's committed snapshot; abort retains a completed candidate after diff or fetch and removes incomplete artifacts.

This gives later catch-up and mirror stages an ownership boundary without loading the path set into memory.