### PR TITLE
[PHP] Match Unicode source hostnames through IDNA

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7,6 +7,93 @@
     "content-hash": "40247d2cff4fefbc84888dc43a867877",
     "packages": [
         {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-normalizer",
             "version": "v1.38.0",
             "source": {
@@ -453,6 +540,7 @@
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
+                "symfony/polyfill-intl-idn": "^1.31",
                 "symfony/polyfill-intl-normalizer": "^1.31",
                 "wp-php-toolkit/data-liberation": "^0.8.0",
                 "wp-php-toolkit/html": "^0.8.0",

--- a/packages/reprint-client/composer.json
+++ b/packages/reprint-client/composer.json
@@ -10,6 +10,7 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
+        "symfony/polyfill-intl-idn": "^1.31",
         "symfony/polyfill-intl-normalizer": "^1.31",
         "wp-php-toolkit/data-liberation": "^0.8.0",
         "wp-php-toolkit/html": "^0.8.0",

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -37,7 +37,8 @@
  *
  * Supported sources:
  *
- * - ASCII domains and IPv4 or IPv6 addresses, with an optional port.
+ * - ASCII or Unicode IDN source domains and IPv4 or IPv6 addresses, with
+ *   an optional port. Unicode and Punycode spellings of the same IDN match.
  * - An optional initial path containing valid UTF-8 without whitespace or
  *   control characters. NFC and NFD spellings of the configured path match
  *   the same source base. That path is part of the source base and is removed
@@ -70,14 +71,16 @@
  *   of the surrounding text.
  * - Target user information, queries, fragments, IPv4/IPv6 addresses, and
  *   Unicode domains are not supported. Punycode domains are supported.
- * - Unicode source domains are not supported.
  *
  * CSS hexadecimal escapes such as https\3a \2f \2f ... and percent-encoded
  * separators are not recognized. They need a parser for the enclosing format.
  * Complete PHP serializations, JSON documents, and block markup must likewise
  * be parsed first; pass only the resulting text leaves to this processor.
  *
- * The HTTP(S) scheme and authority are matched case-insensitively. A configured
+ * Ordinary ASCII authorities use a literal pattern and never run IDNA. A
+ * mapping with a Unicode or `xn--` source hostname also checks literal Unicode
+ * candidates through IDNA. The HTTP(S) scheme and authority are matched
+ * case-insensitively. A configured
  * source path remains case-sensitive because URL paths may name different
  * resources when their case differs. Canonically equivalent composed and
  * decomposed Unicode spellings match. A scheme may begin at the start of the
@@ -110,6 +113,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @var array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -128,6 +133,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @var array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -247,6 +254,8 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     /**
      * @return array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -266,13 +275,45 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     {
         $next_match = null;
         foreach ($this->url_mappings as $mapping) {
-            $found = preg_match(
-                $mapping['pattern'],
-                $this->text,
-                $matches,
-                PREG_OFFSET_CAPTURE,
-                $this->bytes_already_scanned
-            );
+            if (!$mapping['source_host_uses_idn']) {
+                $found = preg_match(
+                    $mapping['pattern'],
+                    $this->text,
+                    $matches,
+                    PREG_OFFSET_CAPTURE,
+                    $this->bytes_already_scanned
+                );
+            } else {
+                $search_from = $this->bytes_already_scanned;
+                while (true) {
+                    $found = preg_match(
+                        $mapping['pattern'],
+                        $this->text,
+                        $matches,
+                        PREG_OFFSET_CAPTURE,
+                        $search_from
+                    );
+                    if (
+                        $found !== 1
+                        || !isset($matches['unicode_host'])
+                        || $matches['unicode_host'][1] === -1
+                    ) {
+                        break;
+                    }
+
+                    $candidate_ascii_host =
+                        CautiousURLBaseRewriteMapping::to_ascii_idn_hostname(
+                            $matches['unicode_host'][0]
+                        );
+                    if ($candidate_ascii_host === $mapping['source_ascii_host']) {
+                        break;
+                    }
+
+                    $search_from =
+                        $matches['authority'][1]
+                        + strlen($matches['authority'][0]);
+                }
+            }
             if ($found !== 1) {
                 continue;
             }

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -13,6 +13,8 @@ class CautiousURLBaseRewriteMapping {
     /**
      * @var array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -64,6 +66,8 @@ class CautiousURLBaseRewriteMapping {
      *
      * @return array<int, array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -81,6 +85,8 @@ class CautiousURLBaseRewriteMapping {
     /**
      * @return array{
      *     source_authority: string,
+     *     source_ascii_host: string,
+     *     source_host_uses_idn: bool,
      *     source_path: string,
      *     source_base: string,
      *     target_domain: string,
@@ -101,18 +107,32 @@ class CautiousURLBaseRewriteMapping {
         // A source URL ending at its authority uses / as the URL separator,
         // not as an initial path to remove. Leave its original spelling alone.
         $source_path = $source['path'] === '/' ? '' : $source['path'];
+        $source_authority_pattern = '(?i:' . preg_quote($source['authority'], '~') . ')';
+        if ($source['host_uses_idn']) {
+            // This branch locates Unicode authority candidates. IDNA below
+            // decides whether each candidate names the configured host.
+            $unicode_host_character = "[^\\s<>@/\\\\:?#,!;()\\[\\]{}>\"']";
+            $source_authority_pattern =
+                '(?:' . $source_authority_pattern
+                . '|(?<unicode_host>(?=' . $unicode_host_character . '*[\\x80-\\xFF])'
+                . $unicode_host_character . '+)'
+                . ( $source['port'] === null ? '' : ':' . $source['port'] )
+                . ')';
+        }
 
         return [
-            'source_authority' => $source['authority'],
-            'source_path'      => $source_path,
-            'source_base'      => $source['authority'] . $source_path,
-            'target_domain'    => $target['host'],
-            'target_scheme'    => $target['scheme'],
-            'target_path'      => $target['path'],
-            'target_port'      => $target['port'],
-            'pattern'          => $this->create_url_candidate_pattern(
+            'source_authority'     => $source['authority'],
+            'source_ascii_host'    => $source['ascii_host'],
+            'source_host_uses_idn' => $source['host_uses_idn'],
+            'source_path'          => $source_path,
+            'source_base'          => $source['authority'] . $source_path,
+            'target_domain'        => $target['host'],
+            'target_scheme'        => $target['scheme'],
+            'target_path'          => $target['path'],
+            'target_port'          => $target['port'],
+            'pattern'              => $this->create_url_candidate_pattern(
                 $source['scheme'],
-                $source['authority'],
+                $source_authority_pattern,
                 $source_path,
                 $target['path'] !== ''
             ),
@@ -129,7 +149,7 @@ class CautiousURLBaseRewriteMapping {
      */
     private function create_url_candidate_pattern(
         string $source_scheme,
-        string $source_authority,
+        string $source_authority_pattern,
         string $source_path,
         bool $requires_path_slash
     ): string
@@ -195,7 +215,7 @@ class CautiousURLBaseRewriteMapping {
                 (?:[^\s<>@/\\\\]+@)?
             )?
             (?<base>
-                (?<authority>(?i:' . preg_quote($source_authority, '~') . '))
+                (?<authority>' . $source_authority_pattern . ')
                 ' . $source_path_pattern . '
             )
             ' . $candidate_boundary_pattern . '
@@ -203,7 +223,15 @@ class CautiousURLBaseRewriteMapping {
     }
 
     /**
-     * @return array{scheme: string, host: string, authority: string, path: string, port: int|null}|null
+     * @return array{
+     *     scheme: string,
+     *     host: string,
+     *     ascii_host: string,
+     *     host_uses_idn: bool,
+     *     authority: string,
+     *     path: string,
+     *     port: int|null
+     * }|null
      */
     private function get_supported_url_parts(string $url, bool $is_source_url): ?array
     {
@@ -223,15 +251,62 @@ class CautiousURLBaseRewriteMapping {
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
         if ($is_source_url) {
             // parse_url() replaces control-valued bytes with underscores.
-            // Some UTF-8 continuation bytes fall in that range, so retain the
-            // source path directly from the configured URL.
+            // Some UTF-8 continuation bytes fall in that range. Read the
+            // source authority and path from the configured URL after
+            // parse_url() has checked its structure.
             $authority_separator_at = strpos($url, '://');
             if ($authority_separator_at === false) {
                 return null;
             }
-            $path_starts_at = strpos($url, '/', $authority_separator_at + 3);
+            $authority_starts_at = $authority_separator_at + 3;
+            $path_starts_at = strpos($url, '/', $authority_starts_at);
+            $source_authority = $path_starts_at === false
+                ? substr($url, $authority_starts_at)
+                : substr(
+                    $url,
+                    $authority_starts_at,
+                    $path_starts_at - $authority_starts_at
+                );
+            if (isset($parts['port'])) {
+                $port_suffix = ':' . $parts['port'];
+                if (substr($source_authority, -strlen($port_suffix)) !== $port_suffix) {
+                    return null;
+                }
+                $host = substr($source_authority, 0, -strlen($port_suffix));
+            } else {
+                $host = $source_authority;
+            }
             $path = $path_starts_at === false ? '' : substr($url, $path_starts_at);
         }
+
+        $host_is_ascii_domain = $this->is_alphanumeric_dot_hyphen_domain_name($host);
+        $host_is_ip_address =
+            $is_source_url
+            && !$host_is_ascii_domain
+            && $this->is_ip_address($host);
+        $host_contains_punycode_label =
+            $host_is_ascii_domain
+            && stripos('.' . $host, '.xn--') !== false;
+        $host_uses_idn =
+            $is_source_url
+            && (
+                $host_contains_punycode_label
+                || ( !$host_is_ascii_domain && !$host_is_ip_address )
+            );
+        $ascii_host = $host;
+        if ($host_uses_idn) {
+            if (
+                !$host_is_ascii_domain
+                && preg_match('/^[\p{L}\p{M}\p{N}.-]+$/u', $host) !== 1
+            ) {
+                return null;
+            }
+            $ascii_host = self::to_ascii_idn_hostname($host);
+            if ($ascii_host === null) {
+                return null;
+            }
+        }
+
         $has_unsupported_target_path =
             !$is_source_url
             && $path !== ''
@@ -239,20 +314,54 @@ class CautiousURLBaseRewriteMapping {
         $path_is_supported = $is_source_url
             ? preg_match('/^[^\p{Z}\p{C}]*$/u', $path) === 1
             : $this->contains_only_exclamation_mark_through_tilde_bytes($path);
+        $host_is_supported =
+            $host_is_ascii_domain
+            || $host_is_ip_address
+            || (
+                $host_uses_idn
+                && $this->is_alphanumeric_dot_hyphen_domain_name($ascii_host)
+            );
         if (( $scheme !== 'http' && $scheme !== 'https' )
             || ( !$is_source_url && $has_unsupported_target_path )
-            || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
+            || !$host_is_supported
             || !$path_is_supported) {
             return null;
         }
 
         return [
-            'scheme'    => $scheme,
-            'host'      => $host,
-            'authority' => $host . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ),
-            'path'      => $path,
-            'port'      => isset($parts['port']) ? (int) $parts['port'] : null,
+            'scheme'        => $scheme,
+            'host'          => $host,
+            'ascii_host'    => $ascii_host,
+            'host_uses_idn' => $host_uses_idn,
+            'authority'     => $ascii_host . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ),
+            'path'          => $path,
+            'port'          => isset($parts['port']) ? (int) $parts['port'] : null,
         ];
+    }
+
+    /**
+     * Converts a Unicode or Punycode hostname to its lowercase ASCII form.
+     *
+     * Returns null when IDNA rejects the hostname.
+     */
+    public static function to_ascii_idn_hostname(string $hostname): ?string
+    {
+        $idn_info = [];
+        $ascii_hostname = idn_to_ascii(
+            $hostname,
+            IDNA_NONTRANSITIONAL_TO_ASCII | IDNA_USE_STD3_RULES,
+            INTL_IDNA_VARIANT_UTS46,
+            $idn_info
+        );
+        if (
+            !is_string($ascii_hostname)
+            || $ascii_hostname === ''
+            || ( $idn_info['errors'] ?? 0 ) !== 0
+        ) {
+            return null;
+        }
+
+        return strtolower($ascii_hostname);
     }
 
     private function is_ip_address(string $host): bool

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -173,6 +173,41 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'url("https:\\/\\/xn--bcher-kva.example\\/media\\/logo.png");',
                 ['https://source.example' => 'https://xn--bcher-kva.example'],
             ],
+            'decomposed Unicode source host' => [
+                'https://mu' . "\u{0308}" . 'nich.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'all-Arabic Unicode source host' => [
+                'https://مثال.إختبار/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://مثال.إختبار' => 'https://destination.example'],
+            ],
+            'Unicode source host with a configured path' => [
+                'https://bücher.example/media/logo.png',
+                'https://destination.example/logo.png',
+                ['https://bücher.example/media' => 'https://destination.example'],
+            ],
+            'Punycode candidate for a Unicode source host' => [
+                'https://xn--mnich-kva.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'Unicode candidate for a Punycode source host' => [
+                'https://münich.example/media/logo.png',
+                'https://destination.example/media/logo.png',
+                ['https://xn--mnich-kva.example' => 'https://destination.example'],
+            ],
+            'escaped Unicode source host with a configured port' => [
+                'https:\\/\\/mu' . "\u{0308}" . 'nich.example:8443\\/media\\/logo.png',
+                'https:\\/\\/destination.example\\/media\\/logo.png',
+                ['https://münich.example:8443' => 'https://destination.example'],
+            ],
+            'configured Unicode host after a different Unicode host' => [
+                'https://zürich.example/media/a.png https://münich.example/media/b.png',
+                'https://zürich.example/media/a.png https://destination.example/media/b.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
             'complete literal source base' => [
                 'https://source.example/media/logo.png',
                 'https://destination.example/logo.png',
@@ -470,11 +505,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 ['https://source.example/media' => 'https://destination.example#part'],
             ],
-            'source domain contains Unicode characters' => [
-                'https://bücher.example/media/logo.png',
-                'https://bücher.example/media/logo.png',
-                ['https://bücher.example/media' => 'https://destination.example'],
-            ],
             'source mapping has a username and password' => [
                 'https://user:password@source.example/media/logo.png',
                 'https://user:password@source.example/media/logo.png',
@@ -559,6 +589,21 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
                 ['https://source.example' => 'https://🚤.example'],
+            ],
+            'Unicode target domain' => [
+                'https://source.example/media/logo.png',
+                'https://source.example/media/logo.png',
+                ['https://source.example' => 'https://bücher.example'],
+            ],
+            'Unicode candidate has an unconfigured port' => [
+                'https://münich.example:8443/media/logo.png',
+                'https://münich.example:8443/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
+            ],
+            'Unicode candidate is a subdomain of the configured host' => [
+                'https://cdn.münich.example/media/logo.png',
+                'https://cdn.münich.example/media/logo.png',
+                ['https://münich.example' => 'https://destination.example'],
             ],
             'source domain contains an emoji' => [
                 'https://🚤.example/media/logo.png',


### PR DESCRIPTION
Matches Unicode and Punycode spellings of the same configured source hostname.

For example, this mapping:

```php
[
    'https://münich.example' => 'https://destination.example',
]
```

now matches `münich.example`, its decomposed Unicode spelling, and `xn--mnich-kva.example`.

The mapping prepares one ASCII hostname with UTS #46 non-transitional processing. Its regexp matches that ASCII spelling directly. IDN mappings also accept a Unicode authority candidate and compare its ASCII form with the prepared hostname. Ordinary ASCII mappings keep the existing literal authority regexp and do not call IDNA.

The Symfony IDN polyfill supplies the same function on PHP installations without `ext-intl`. Unicode target hostnames remain unsupported.

## Testing

```text
cd tests
../vendor/bin/phpunit --do-not-cache-result UrlRewriting
cd ..
composer analyze -- --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
```
