### PR TITLE
[PHP] Bound files-pull catch-up to completed ownership

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -25,7 +25,6 @@ use Reprint\Importer\Tuning\AdaptiveTuner;
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
-use function Reprint\Importer\file_sync_index_path_may_change;
 use function Reprint\Importer\file_sync_result_contains_path_or_descendant;
 use function Reprint\Importer\find_file_sync_deletion_root;
 use function Reprint\Importer\register_sqlite_function;
@@ -39,7 +38,6 @@ use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\parse_size;
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Exporter\path_is_descendant_of;
-use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\realpath_with_missing_tail;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
@@ -88,6 +86,7 @@ require_once __DIR__ . '/lib/merge/load.php';
 require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/index/class-file-index-diff-processor.php';
+require_once __DIR__ . '/lib/index/class-file-sync-change-scope.php';
 require_once __DIR__ . '/lib/index/file-sync-path-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
@@ -7603,20 +7602,35 @@ class ImportClient
         }
 
         $file_diff_progress_state = $this->get_state()->diff;
-        $index_diff = FileIndexDiffProcessor::resume(
-            $this->remote_index_file,
-            $this->next_remote_index_file,
-            $file_diff_progress_state->index_diff_cursor,
-            [RemoteIndexReader::class, "decode_index_line"]
-        );
-        $remote_to_local_path_mapper = new RemoteToLocalPathMapper(
-            $this->filesystem_root,
-            $this->get_export_directories(),
-            $this->resolved_path_mappings,
-            $this->local_followed_symlinks_root
-        );
+        $selection_fingerprint =
+            $this->get_state()->files_pull_path_selection_fingerprint;
+        if (!is_string($selection_fingerprint)) {
+            throw new RuntimeException(
+                'Files-pull diff has no path-selection fingerprint.'
+            );
+        }
+        $file_sync_change_scope = $this->get_state()->files_pull_ownership
+            ->create_remote_change_scope(
+                $this->files_pull_ownership_directory,
+                $selection_fingerprint,
+                $this->pull_excluded_files_with_path_prefixes,
+                $this->get_state()->include_caches
+            );
+        $index_diff = null;
         $fetch_list_file_handle = null;
         try {
+            $index_diff = FileIndexDiffProcessor::resume(
+                $this->remote_index_file,
+                $this->next_remote_index_file,
+                $file_diff_progress_state->index_diff_cursor,
+                [RemoteIndexReader::class, "decode_index_line"]
+            );
+            $remote_to_local_path_mapper = new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                $this->get_export_directories(),
+                $this->resolved_path_mappings,
+                $this->local_followed_symlinks_root
+            );
             $fetch_list_file_handle = fopen($this->fetch_list_file, "c+b");
             $fetch_list_file_stat = is_resource($fetch_list_file_handle)
                 ? fstat($fetch_list_file_handle)
@@ -7666,7 +7680,15 @@ class ImportClient
                     $remote_absolute_path = $index_diff->get_path();
                     $transition = $index_diff->get_path_transition();
                     if ($transition === "deleted") {
-                        $deleted_path_is_empty_directory = $index_diff->get_path_type_in_old_index() === "dir";
+                        $deleted_path_type =
+                            $index_diff->get_path_type_in_old_index();
+                        $deleted_path_is_empty_directory =
+                            $deleted_path_type === "dir";
+                        $deleted_index_entry_may_change =
+                            $file_sync_change_scope->index_entry_may_change(
+                                $remote_absolute_path,
+                                $deleted_path_type
+                            );
                         $empty_directory_is_now_implied_by_a_descendant =
                             $deleted_path_is_empty_directory
                             && file_sync_result_contains_path_or_descendant(
@@ -7674,13 +7696,10 @@ class ImportClient
                                 $index_diff->get_preceding_path_in_new_index(),
                                 $index_diff->get_following_path_in_new_index()
                             );
-                        // The remote index is a union across files-pull path
-                        // selections. Keep paths outside this run's selection.
+                        // The remote index is a union across completed files-pull
+                        // selections. Keep paths owned by another selection.
                         if (
-                            $this->is_selected_for_pulling(
-                                $remote_absolute_path,
-                                false
-                            )
+                            $deleted_index_entry_may_change
                             || $empty_directory_is_now_implied_by_a_descendant
                         ) {
                             $local_absolute_path =
@@ -7697,7 +7716,11 @@ class ImportClient
                                     $index_diff->get_preceding_path_in_new_index(),
                                     $index_diff->get_following_path_in_new_index(),
                                     function (string $candidate_path) use (
+                                        $deleted_index_entry_may_change,
+                                        $deleted_path_type,
                                         $local_index_path,
+                                        $remote_absolute_path,
+                                        $file_sync_change_scope,
                                         $remote_to_local_path_mapper
                                     ): bool {
                                         $candidate_local_absolute_path =
@@ -7717,6 +7740,10 @@ class ImportClient
                                         ) {
                                             return false;
                                         }
+                                        // Removing a directory is recursive even
+                                        // at the original missing path. Exact
+                                        // entry authority is enough only for a
+                                        // file or link.
                                         if (
                                             !$remote_to_local_path_mapper
                                                 ->remote_path_owns_mapped_local_subtree(
@@ -7725,11 +7752,17 @@ class ImportClient
                                         ) {
                                             return false;
                                         }
-                                        return file_sync_index_path_may_change(
-                                            $candidate_path,
-                                            $this->get_export_directories(),
-                                            $this->pull_excluded_files_with_path_prefixes
-                                        );
+                                        if (
+                                            $candidate_path ===
+                                                $remote_absolute_path
+                                            && $deleted_path_type !== 'dir'
+                                        ) {
+                                            return $deleted_index_entry_may_change;
+                                        }
+                                        return $file_sync_change_scope
+                                            ->subtree_may_change(
+                                                $candidate_path
+                                            );
                                     },
                                     $deleted_path_is_empty_directory
                                 );
@@ -7770,9 +7803,9 @@ class ImportClient
                         }
                     } elseif (
                         $transition !== "unchanged"
-                        && $this->is_selected_for_pulling(
+                        && $file_sync_change_scope->index_entry_may_change(
                             $remote_absolute_path,
-                            true
+                            $index_diff->get_path_type_in_new_index()
                         )
                     ) {
                         // Preserve-local protects only paths which no earlier
@@ -7834,7 +7867,10 @@ class ImportClient
                 }
             }
         } finally {
-            $index_diff->close();
+            if ($index_diff !== null) {
+                $index_diff->close();
+            }
+            $file_sync_change_scope->close();
             if (is_resource($fetch_list_file_handle)) {
                 fclose($fetch_list_file_handle);
             }
@@ -9530,51 +9566,6 @@ class ImportClient
         }
 
         return $minimal;
-    }
-
-    /**
-     * Whether a path is selected by the active --include and --exclude prefixes.
-     *
-     * The exporter has already applied --include to entries in the next remote
-     * index, including followed symlink targets outside an --include prefix. Other
-     * paths are checked against --include locally. An included root itself is not
-     * selected because the next remote index lists its contents, not the root
-     * entry. Exclusions always win.
-     *
-     * @param bool $is_next_remote_index_entry Whether the path came from the
-     *                                         current next remote index.
-     */
-    private function is_selected_for_pulling(
-        string $path,
-        bool $is_next_remote_index_entry
-    ): bool
-    {
-        if (!$is_next_remote_index_entry) {
-            $selected = empty($this->pull_only_files_with_path_prefixes);
-
-            foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-                $remainder = path_remainder_under($path, $prefix);
-                if ($remainder === "") {
-                    return false;
-                }
-                if ($remainder !== null) {
-                    $selected = true;
-                    break;
-                }
-            }
-
-            if (!$selected) {
-                return false;
-            }
-        }
-
-        foreach ($this->pull_excluded_files_with_path_prefixes as $prefix) {
-            if (path_remainder_under($path, $prefix) !== null) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3456,7 +3456,15 @@ class ImportClient
         // works locally.  The server discovers these (e.g. /srv/wordpress
         // -> /wordpress) and includes them in the next remote index.
         if ($this->follow_symlinks) {
-            $this->recreate_intermediate_symlinks();
+            $file_sync_change_scope =
+                $this->create_files_pull_remote_change_scope();
+            try {
+                $this->recreate_intermediate_symlinks(
+                    $file_sync_change_scope
+                );
+            } finally {
+                $file_sync_change_scope->close();
+            }
         }
         $this->pull_index_journal->apply_pending_records();
 
@@ -3977,7 +3985,9 @@ class ImportClient
      * (e.g. filesystem root/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
-    private function recreate_intermediate_symlinks(): void
+    private function recreate_intermediate_symlinks(
+        FileSyncChangeScope $file_sync_change_scope
+    ): void
     {
         if (!file_exists($this->next_remote_index_file)) {
             return;
@@ -4026,6 +4036,15 @@ class ImportClient
                 continue;
             }
 
+            if (
+                !$file_sync_change_scope->index_entry_may_change(
+                    $remote_absolute_path,
+                    'link'
+                )
+            ) {
+                continue;
+            }
+
             try {
                 $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
                     $remote_absolute_path
@@ -4035,6 +4054,18 @@ class ImportClient
                     "INTERMEDIATE SYMLINK SKIP: invalid path {$remote_absolute_path}: " . $e->getMessage(),
                     true,
                 );
+                continue;
+            }
+
+            $preserve_local_skip_reason =
+                $this->symlink_preserve_local_skip_reason(
+                    $remote_absolute_path,
+                    $local_absolute_path,
+                    $symlink_target
+                );
+            if ($preserve_local_skip_reason !== null) {
+                $this->audit_log($preserve_local_skip_reason, true);
+                $this->emit_skip_progress($remote_absolute_path);
                 continue;
             }
 
@@ -7602,20 +7633,8 @@ class ImportClient
         }
 
         $file_diff_progress_state = $this->get_state()->diff;
-        $selection_fingerprint =
-            $this->get_state()->files_pull_path_selection_fingerprint;
-        if (!is_string($selection_fingerprint)) {
-            throw new RuntimeException(
-                'Files-pull diff has no path-selection fingerprint.'
-            );
-        }
-        $file_sync_change_scope = $this->get_state()->files_pull_ownership
-            ->create_remote_change_scope(
-                $this->files_pull_ownership_directory,
-                $selection_fingerprint,
-                $this->pull_excluded_files_with_path_prefixes,
-                $this->get_state()->include_caches
-            );
+        $file_sync_change_scope =
+            $this->create_files_pull_remote_change_scope();
         $index_diff = null;
         $fetch_list_file_handle = null;
         try {
@@ -7878,6 +7897,25 @@ class ImportClient
         }
 
         return !$has_path;
+    }
+
+    /** Opens the remote-index change scope for the active files-pull. */
+    private function create_files_pull_remote_change_scope(): FileSyncChangeScope
+    {
+        $selection_fingerprint =
+            $this->get_state()->files_pull_path_selection_fingerprint;
+        if (!is_string($selection_fingerprint)) {
+            throw new RuntimeException(
+                'The active files-pull has no path-selection fingerprint.'
+            );
+        }
+        return $this->get_state()->files_pull_ownership
+            ->create_remote_change_scope(
+                $this->files_pull_ownership_directory,
+                $selection_fingerprint,
+                $this->pull_excluded_files_with_path_prefixes,
+                $this->get_state()->include_caches
+            );
     }
 
     /**
@@ -10206,21 +10244,16 @@ class ImportClient
             $target,
         );
 
-        // In preserve-local mode, if something already exists at the symlink
-        // path, keep it — whether it's a file, directory, or another symlink.
-        // Also skip if any parent component is a symlink — we never create
-        // new content through symlinked directories.
-        if ($this->fs_root_nonempty_behavior === 'preserve-local') {
-            if (file_exists($local_absolute_path) || is_link($local_absolute_path)) {
-                $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
-                $this->emit_skip_progress($path);
-                return;
-            }
-            if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
-                $this->audit_log("PRESERVE-LOCAL skip symlink (symlink in path): {$path} -> {$target}", true);
-                $this->emit_skip_progress($path);
-                return;
-            }
+        $preserve_local_skip_reason =
+            $this->symlink_preserve_local_skip_reason(
+                $path,
+                $local_absolute_path,
+                $target
+            );
+        if ($preserve_local_skip_reason !== null) {
+            $this->audit_log($preserve_local_skip_reason, true);
+            $this->emit_skip_progress($path);
+            return;
         }
 
         // Validate that the symlink target doesn't escape the filesystem root.
@@ -10330,6 +10363,34 @@ class ImportClient
             "target" => $target_for_local,
             "message" => "Symlink: {$path} -> {$target}",
         ]);
+    }
+
+    /**
+     * Reports why preserve-local keeps a symlink path untouched.
+     *
+     * Existing paths belong to the local installation. A symlinked parent may
+     * lead to shared hosting content, so files-pull must not write through it.
+     */
+    private function symlink_preserve_local_skip_reason(
+        string $remote_absolute_path,
+        string $local_absolute_path,
+        string $symlink_target
+    ): ?string {
+        if ($this->fs_root_nonempty_behavior !== 'preserve-local') {
+            return null;
+        }
+        if (
+            file_exists($local_absolute_path)
+            || is_link($local_absolute_path)
+        ) {
+            return "PRESERVE-LOCAL skip symlink (path exists): "
+                . "{$remote_absolute_path} -> {$symlink_target}";
+        }
+        if ($this->path_traverses_symlink(dirname($local_absolute_path))) {
+            return "PRESERVE-LOCAL skip symlink (symlink in path): "
+                . "{$remote_absolute_path} -> {$symlink_target}";
+        }
+        return null;
     }
 
     /**

--- a/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
@@ -1,0 +1,795 @@
+<?php
+declare(strict_types=1);
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\normalize_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Errors contain private state paths, never HTML.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Decides which remote-index changes belong to one files-pull selection.
+ *
+ * The current snapshot describes this run and is authoritative where it owns
+ * a path. Earlier snapshots for the same selection cover paths which have
+ * disappeared. Snapshots for other selections protect their paths from those
+ * earlier snapshots. Explicit exclusions always override ownership.
+ * Root-derived ownership replays the producer's default-skip checks below the
+ * deepest owning root. An exact atom confirms that the producer emitted that
+ * intermediate link, so default-skip checks do not override it.
+ *
+ * Snapshot lookups use the fixed-width hash index published by
+ * FilesPullOwnershipProcessor. Each atom probe uses binary search, then reads
+ * hash-collision candidates one bounded path row at a time. Only one snapshot
+ * pair remains open, and snapshot contents are never materialized in memory.
+ *
+ * @phpstan-type Config array{index_path_coordinates:'remote_absolute',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool}
+ */
+final class FileSyncChangeScope
+{
+    private const LOOKUP_RECORD_BYTES = 82;
+    private const MAX_PATH_ROW_BYTES = 64 * 1024;
+
+    /** @phpstan-var Config */
+    private array $config;
+    private string $ownership_directory;
+    /** @var list<string> */
+    private array $excluded_remote_absolute_path_roots = [];
+    private ?string $open_snapshot_id = null;
+    /** @var resource|null */
+    private $open_paths_handle = null;
+    /** @var resource|null */
+    private $open_lookup_handle = null;
+    private int $open_lookup_record_count = 0;
+    private int $open_paths_bytes = 0;
+    private bool $closed = false;
+
+    /**
+     * Opens every snapshot named by an opaque identifier in a strict saved config.
+     *
+     * @phpstan-param Config $config
+     */
+    public static function from_config(array $config): self
+    {
+        $scope = new self();
+        $scope->set_config($config);
+
+        $snapshot_ids = array_merge(
+            [$scope->config['current_snapshot_id']],
+            $scope->config['prior_snapshot_ids'],
+            $scope->config['protected_snapshot_ids']
+        );
+        $snapshot_ids = array_values(array_unique($snapshot_ids));
+        try {
+            foreach ($snapshot_ids as $snapshot_id) {
+                $scope->open_snapshot($snapshot_id);
+                $scope->close_open_snapshot();
+            }
+        } catch (Throwable $throwable) {
+            $scope->close();
+            throw $throwable;
+        }
+        return $scope;
+    }
+
+    /** @phpstan-return Config */
+    public function get_config(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * Reports whether this lifecycle may change one index entry.
+     *
+     * Root atoms own strict descendants. Exact atoms own only a link at the
+     * same path. Current ownership wins over another selection's protection;
+     * earlier ownership does not.
+     */
+    public function index_entry_may_change(
+        string $index_path,
+        string $type
+    ): bool {
+        return $this->remote_index_entry_change_decision(
+            $index_path,
+            $type
+        ) === 'allow';
+    }
+
+    /** @return 'allow'|'block'|'unowned' */
+    private function remote_index_entry_change_decision(
+        string $remote_absolute_path,
+        string $type
+    ): string {
+        $this->assert_open();
+        self::assert_remote_absolute_path($remote_absolute_path);
+        if (!in_array($type, ['file', 'link', 'dir'], true)) {
+            throw new InvalidArgumentException(
+                "Index entry type must be file, link, or dir; got {$type}."
+            );
+        }
+        $current_ownership = $this->snapshots_entry_ownership(
+            [$this->config['current_snapshot_id']],
+            $remote_absolute_path,
+            $type
+        );
+        if ($current_ownership !== 'unowned') {
+            return $this->entry_is_blocked(
+                $remote_absolute_path,
+                $current_ownership
+            )
+                ? 'block'
+                : 'allow';
+        }
+        $protected_ownership = $this->snapshots_entry_ownership(
+            $this->config['protected_snapshot_ids'],
+            $remote_absolute_path,
+            $type
+        );
+        if ($protected_ownership !== 'unowned') {
+            return 'block';
+        }
+        $prior_ownership = $this->snapshots_entry_ownership(
+            $this->config['prior_snapshot_ids'],
+            $remote_absolute_path,
+            $type
+        );
+        if ($prior_ownership === 'unowned') {
+            return 'unowned';
+        }
+        return $this->entry_is_blocked(
+            $remote_absolute_path,
+            $prior_ownership
+        )
+            ? 'block'
+            : 'allow';
+    }
+
+    /** @param 'owned'|'default_skipped' $ownership */
+    private function entry_is_blocked(
+        string $remote_absolute_path,
+        string $ownership
+    ): bool {
+        return (
+            $this->path_is_excluded($remote_absolute_path)
+            || $ownership === 'default_skipped'
+        );
+    }
+
+    /**
+     * Reports whether this lifecycle may change a path and its whole subtree.
+     *
+     * Without caches, no remote index can show every default-skipped child, so
+     * recursive work is never safe. Current whole-subtree ownership wins. Any
+     * other current intersection blocks prior authority, as does any protected
+     * intersection.
+     */
+    public function subtree_may_change(
+        string $index_path
+    ): bool {
+        return $this->remote_subtree_change_decision(
+            $index_path
+        ) === 'allow';
+    }
+
+    /** @return 'allow'|'block'|'unowned' */
+    private function remote_subtree_change_decision(
+        string $remote_absolute_path
+    ): string {
+        $this->assert_open();
+        self::assert_remote_absolute_path($remote_absolute_path);
+        $current_relation = $this->snapshots_subtree_relation(
+            [$this->config['current_snapshot_id']],
+            $remote_absolute_path
+        );
+        if ($current_relation === 'owns') {
+            return $this->subtree_is_blocked($remote_absolute_path)
+                ? 'block'
+                : 'allow';
+        }
+        if ($current_relation === 'intersects') {
+            return 'block';
+        }
+        $protected_relation = $this->snapshots_subtree_relation(
+            $this->config['protected_snapshot_ids'],
+            $remote_absolute_path
+        );
+        if ($protected_relation !== 'none') {
+            return 'block';
+        }
+        $prior_relation = $this->snapshots_subtree_relation(
+            $this->config['prior_snapshot_ids'],
+            $remote_absolute_path
+        );
+        if ($prior_relation !== 'owns') {
+            return 'unowned';
+        }
+        return $this->subtree_is_blocked($remote_absolute_path)
+            ? 'block'
+            : 'allow';
+    }
+
+    private function subtree_is_blocked(string $remote_absolute_path): bool
+    {
+        return (
+            !$this->config['include_caches']
+            || $this->subtree_intersects_exclusion($remote_absolute_path)
+        );
+    }
+
+    public function includes_caches(): bool
+    {
+        return $this->config['include_caches'];
+    }
+
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->closed = true;
+        $this->close_open_snapshot();
+    }
+
+    /**
+     * @param list<string> $snapshot_ids
+     * @return 'owned'|'default_skipped'|'unowned'
+     */
+    private function snapshots_entry_ownership(
+        array $snapshot_ids,
+        string $remote_absolute_path,
+        string $type
+    ): string {
+        $has_exact_ownership = (
+            $type === 'link'
+            && $this->snapshots_contain_atom(
+                $snapshot_ids,
+                'exact',
+                $remote_absolute_path
+            )
+        );
+        $owning_root = $this->deepest_owning_root(
+            $snapshot_ids,
+            $remote_absolute_path
+        );
+        if (!$has_exact_ownership && $owning_root === null) {
+            return 'unowned';
+        }
+        if ($has_exact_ownership || $this->config['include_caches']) {
+            return 'owned';
+        }
+        if (
+            $owning_root !== null
+            && !$this->root_traversal_has_default_skip(
+                $owning_root,
+                $remote_absolute_path
+            )
+        ) {
+            return 'owned';
+        }
+        return 'default_skipped';
+    }
+
+    /**
+     * @param list<string> $snapshot_ids
+     * @return 'owns'|'intersects'|'none'
+     */
+    private function snapshots_subtree_relation(
+        array $snapshot_ids,
+        string $remote_absolute_path
+    ): string {
+        if ($this->deepest_owning_root(
+            $snapshot_ids,
+            $remote_absolute_path
+        ) !== null) {
+            return 'owns';
+        }
+        $intersects = $this->snapshots_contain_atom(
+            $snapshot_ids,
+            'root',
+            $remote_absolute_path
+        ) || $this->snapshots_contain_atom(
+            $snapshot_ids,
+            'exact',
+            $remote_absolute_path
+        ) || $this->snapshots_contain_atom(
+            $snapshot_ids,
+            'ancestor',
+            $remote_absolute_path
+        );
+        return $intersects ? 'intersects' : 'none';
+    }
+
+    /** @param list<string> $snapshot_ids */
+    private function snapshots_contain_atom(
+        array $snapshot_ids,
+        string $kind,
+        string $remote_absolute_path
+    ): bool {
+        foreach ($snapshot_ids as $snapshot_id) {
+            if ($this->snapshot_contains_atom(
+                $snapshot_id,
+                $kind,
+                $remote_absolute_path
+            )) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @param list<string> $snapshot_ids */
+    private function deepest_owning_root(
+        array $snapshot_ids,
+        string $remote_absolute_path
+    ): ?string {
+        $ancestor = self::strict_parent($remote_absolute_path);
+        while ($ancestor !== null) {
+            if ($this->snapshots_contain_atom(
+                $snapshot_ids,
+                'root',
+                $ancestor
+            )) {
+                return $ancestor;
+            }
+            $ancestor = self::strict_parent($ancestor);
+        }
+        return null;
+    }
+
+    private function root_traversal_has_default_skip(
+        string $root,
+        string $remote_absolute_path
+    ): bool {
+        // The producer schedules the root without classifying it, then checks
+        // each child using that child's full absolute path.
+        $relative_path = $root === '/'
+            ? substr($remote_absolute_path, 1)
+            : substr($remote_absolute_path, strlen($root) + 1);
+        $prefix = $root;
+        foreach (explode('/', $relative_path) as $component) {
+            $prefix = $prefix === '/'
+                ? '/' . $component
+                : $prefix . '/' . $component;
+            if (FileIndexProcessor::path_is_default_skipped($prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function snapshot_contains_atom(
+        string $snapshot_id,
+        string $kind,
+        string $remote_absolute_path
+    ): bool {
+        $this->open_snapshot($snapshot_id);
+        $digest = hash('sha256', $kind . "\0" . $remote_absolute_path);
+        $lower = 0;
+        $upper = $this->open_lookup_record_count;
+        while ($lower < $upper) {
+            $middle = $lower + intdiv($upper - $lower, 2);
+            $record = $this->read_lookup_record($snapshot_id, $middle);
+            if (strcmp($record['digest'], $digest) < 0) {
+                $lower = $middle + 1;
+            } else {
+                $upper = $middle;
+            }
+        }
+
+        for (
+            $record_index = $lower;
+            $record_index < $this->open_lookup_record_count;
+            ++$record_index
+        ) {
+            $record = $this->read_lookup_record($snapshot_id, $record_index);
+            if ($record['digest'] !== $digest) {
+                return false;
+            }
+            $atom = $this->read_path_atom($snapshot_id, $record['paths_byte_offset']);
+            if ($atom['kind'] === $kind && $atom['path'] === $remote_absolute_path) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @return array{digest:string,paths_byte_offset:int} */
+    private function read_lookup_record(string $snapshot_id, int $record_index): array
+    {
+        if (
+            $this->open_snapshot_id !== $snapshot_id
+            || !is_resource($this->open_lookup_handle)
+        ) {
+            throw new LogicException('Ownership lookup read the wrong open snapshot.');
+        }
+        $byte_offset = $record_index * self::LOOKUP_RECORD_BYTES;
+        if (fseek($this->open_lookup_handle, $byte_offset) !== 0) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} lookup byte {$byte_offset} cannot be read."
+            );
+        }
+        $record = fread(
+            $this->open_lookup_handle,
+            self::LOOKUP_RECORD_BYTES
+        );
+        if ($record === false) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} lookup read failed at byte {$byte_offset}."
+            );
+        }
+        if (strlen($record) !== self::LOOKUP_RECORD_BYTES) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} lookup record at byte {$byte_offset} "
+                . 'has ' . strlen($record) . ' bytes; expected 82.'
+            );
+        }
+        if (preg_match(
+            '/^([0-9a-f]{64}) ([0-9a-f]{16})\n$/D',
+            $record,
+            $matches
+        ) !== 1) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} lookup record at byte {$byte_offset} "
+                . 'must contain a lowercase SHA-256 digest, one 16-digit offset, and a newline.'
+            );
+        }
+        $maximum_offset_hex = sprintf('%016x', PHP_INT_MAX);
+        if (strcmp($matches[2], $maximum_offset_hex) > 0) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} has a path offset larger than PHP_INT_MAX."
+            );
+        }
+        $paths_byte_offset = hexdec($matches[2]);
+        if (
+            !is_int($paths_byte_offset)
+            || $paths_byte_offset >= $this->open_paths_bytes
+        ) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path offset {$matches[2]} "
+                . "is outside its {$this->open_paths_bytes}-byte paths file."
+            );
+        }
+        return [
+            'digest' => $matches[1],
+            'paths_byte_offset' => $paths_byte_offset,
+        ];
+    }
+
+    /** @return array{kind:'root'|'exact'|'ancestor',path:string} */
+    private function read_path_atom(string $snapshot_id, int $paths_byte_offset): array
+    {
+        if (
+            $this->open_snapshot_id !== $snapshot_id
+            || !is_resource($this->open_paths_handle)
+        ) {
+            throw new LogicException('Ownership path read the wrong open snapshot.');
+        }
+        if (fseek($this->open_paths_handle, $paths_byte_offset) !== 0) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path offset cannot be read."
+            );
+        }
+        $line = fgets($this->open_paths_handle, self::MAX_PATH_ROW_BYTES + 1);
+        if (!is_string($line)) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path row at byte {$paths_byte_offset} cannot be read."
+            );
+        }
+        if (substr($line, -1) !== "\n") {
+            $condition = feof($this->open_paths_handle)
+                ? 'has no final newline'
+                : 'exceeds the 65536-byte path-row limit';
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path row at byte {$paths_byte_offset} {$condition}."
+            );
+        }
+        $atom = json_decode(substr($line, 0, -1), true);
+        if (!is_array($atom)) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path row at byte {$paths_byte_offset} must be JSON."
+            );
+        }
+        if (array_keys($atom) !== ['kind', 'path_b64']) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} path row at byte {$paths_byte_offset} "
+                . 'must contain only kind and path_b64, in that order.'
+            );
+        }
+        if (!in_array($atom['kind'], ['root', 'exact', 'ancestor'], true)) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} has an invalid atom kind."
+            );
+        }
+        $path = is_string($atom['path_b64'])
+            ? base64_decode($atom['path_b64'], true)
+            : false;
+        if (!is_string($path) || base64_encode($path) !== $atom['path_b64']) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} has an invalid atom path."
+            );
+        }
+        try {
+            self::assert_remote_absolute_path($path);
+        } catch (InvalidArgumentException $exception) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} atom path must be normalized and absolute.",
+                0,
+                $exception
+            );
+        }
+        return ['kind' => $atom['kind'], 'path' => $path];
+    }
+
+    private function open_snapshot(string $snapshot_id): void
+    {
+        if ($this->open_snapshot_id === $snapshot_id) {
+            return;
+        }
+        $this->close_open_snapshot();
+        $snapshot_path_prefix = $this->ownership_directory
+            . '/snapshots/' . $snapshot_id;
+        $paths_path = $snapshot_path_prefix . '.paths.jsonl';
+        $lookup_path = $snapshot_path_prefix . '.lookup';
+        $paths_handle = @fopen($paths_path, 'rb');
+        if (!is_resource($paths_handle)) {
+            throw new RuntimeException(
+                "Ownership snapshot {$snapshot_id} paths file is not readable: {$paths_path}."
+            );
+        }
+        $lookup_handle = @fopen($lookup_path, 'rb');
+        if (!is_resource($lookup_handle)) {
+            fclose($paths_handle);
+            throw new RuntimeException(
+                "Ownership snapshot {$snapshot_id} lookup file is not readable: {$lookup_path}."
+            );
+        }
+        $paths_stat = fstat($paths_handle);
+        $lookup_stat = fstat($lookup_handle);
+        if ($paths_stat === false || $lookup_stat === false) {
+            fclose($paths_handle);
+            fclose($lookup_handle);
+            throw new RuntimeException(
+                "Ownership snapshot {$snapshot_id} file size cannot be read."
+            );
+        }
+        if ($lookup_stat['size'] % self::LOOKUP_RECORD_BYTES !== 0) {
+            fclose($paths_handle);
+            fclose($lookup_handle);
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} lookup has {$lookup_stat['size']} bytes; "
+                . 'its size must be a multiple of 82.'
+            );
+        }
+        $paths_are_empty = $paths_stat['size'] === 0;
+        $lookup_is_empty = $lookup_stat['size'] === 0;
+        if ($paths_are_empty !== $lookup_is_empty) {
+            fclose($paths_handle);
+            fclose($lookup_handle);
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} has {$paths_stat['size']} path bytes "
+                . "and {$lookup_stat['size']} lookup bytes; both files must be empty together."
+            );
+        }
+        $this->open_snapshot_id = $snapshot_id;
+        $this->open_paths_handle = $paths_handle;
+        $this->open_lookup_handle = $lookup_handle;
+        $this->open_lookup_record_count = intdiv(
+            $lookup_stat['size'],
+            self::LOOKUP_RECORD_BYTES
+        );
+        $this->open_paths_bytes = $paths_stat['size'];
+    }
+
+    private function close_open_snapshot(): void
+    {
+        if (is_resource($this->open_paths_handle)) {
+            fclose($this->open_paths_handle);
+        }
+        if (is_resource($this->open_lookup_handle)) {
+            fclose($this->open_lookup_handle);
+        }
+        $this->open_snapshot_id = null;
+        $this->open_paths_handle = null;
+        $this->open_lookup_handle = null;
+        $this->open_lookup_record_count = 0;
+        $this->open_paths_bytes = 0;
+    }
+
+    private function path_is_excluded(string $remote_absolute_path): bool
+    {
+        return path_is_same_as_or_descendant_of(
+            $remote_absolute_path,
+            $this->excluded_remote_absolute_path_roots
+        );
+    }
+
+    private function subtree_intersects_exclusion(
+        string $remote_absolute_path
+    ): bool {
+        return path_is_same_as_or_descendant_of(
+            $remote_absolute_path,
+            $this->excluded_remote_absolute_path_roots
+        ) || path_is_same_as_or_descendant_of(
+            $this->excluded_remote_absolute_path_roots,
+            $remote_absolute_path
+        );
+    }
+
+    private function set_config(array $config): void
+    {
+        $expected_keys = [
+            'index_path_coordinates',
+            'ownership_directory_b64',
+            'current_snapshot_id',
+            'prior_snapshot_ids',
+            'protected_snapshot_ids',
+            'excluded_remote_absolute_path_roots_b64',
+            'include_caches',
+        ];
+        $actual_keys = array_keys($config);
+        sort($actual_keys, SORT_STRING);
+        $sorted_expected_keys = $expected_keys;
+        sort($sorted_expected_keys, SORT_STRING);
+        if ($actual_keys !== $sorted_expected_keys) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope config fields must be exactly '
+                . implode(', ', $expected_keys)
+                . '; received '
+                . json_encode(array_keys($config), JSON_UNESCAPED_SLASHES)
+                . '.'
+            );
+        }
+        if ($config['index_path_coordinates'] !== 'remote_absolute') {
+            throw new InvalidArgumentException(
+                'File-sync change-scope index_path_coordinates must be remote_absolute.'
+            );
+        }
+        $this->ownership_directory = self::decode_config_path(
+            $config['ownership_directory_b64'],
+            'ownership directory'
+        );
+        self::assert_snapshot_id($config['current_snapshot_id'], 'current snapshot ID');
+        self::assert_snapshot_id_list(
+            $config['prior_snapshot_ids'],
+            'prior snapshot IDs'
+        );
+        self::assert_snapshot_id_list(
+            $config['protected_snapshot_ids'],
+            'protected snapshot IDs'
+        );
+        $this->excluded_remote_absolute_path_roots =
+            self::decode_remote_absolute_path_list(
+                $config['excluded_remote_absolute_path_roots_b64']
+            );
+        if (!is_bool($config['include_caches'])) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope include_caches must be a boolean.'
+            );
+        }
+        /** @var Config $config */
+        $this->config = $config;
+    }
+
+    private static function assert_snapshot_id_list($snapshot_ids, string $name): void
+    {
+        if (!is_array($snapshot_ids) || array_values($snapshot_ids) !== $snapshot_ids) {
+            throw new InvalidArgumentException(
+                "File-sync change-scope {$name} must be a list."
+            );
+        }
+        foreach ($snapshot_ids as $snapshot_id) {
+            self::assert_snapshot_id($snapshot_id, $name);
+        }
+        $sorted_snapshot_ids = $snapshot_ids;
+        sort($sorted_snapshot_ids, SORT_STRING);
+        if (
+            $snapshot_ids !== $sorted_snapshot_ids
+            || count($snapshot_ids) !== count(array_unique($snapshot_ids))
+        ) {
+            throw new InvalidArgumentException(
+                "File-sync change-scope {$name} must be byte-sorted with no duplicates."
+            );
+        }
+    }
+
+    private static function assert_snapshot_id($snapshot_id, string $name): void
+    {
+        if (
+            !is_string($snapshot_id)
+            || preg_match('/^[0-9a-f]{64}$/D', $snapshot_id) !== 1
+        ) {
+            throw new InvalidArgumentException(
+                "File-sync change-scope {$name} must contain 64 lowercase hexadecimal characters."
+            );
+        }
+    }
+
+    /** @return list<string> */
+    private static function decode_remote_absolute_path_list($encoded_paths): array
+    {
+        if (!is_array($encoded_paths) || array_values($encoded_paths) !== $encoded_paths) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope exclusions must be a list.'
+            );
+        }
+        $decoded_paths = [];
+        foreach ($encoded_paths as $encoded_path) {
+            $decoded_paths[] = self::decode_remote_absolute_path(
+                $encoded_path,
+                'excluded remote absolute path root'
+            );
+        }
+        $sorted_paths = $decoded_paths;
+        sort($sorted_paths, SORT_STRING);
+        if (
+            $decoded_paths !== $sorted_paths
+            || count($decoded_paths) !== count(array_unique($decoded_paths))
+        ) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope exclusions must be byte-sorted with no duplicates.'
+            );
+        }
+        return $decoded_paths;
+    }
+
+    private static function decode_config_path($encoded_path, string $name): string
+    {
+        $path = is_string($encoded_path)
+            ? base64_decode($encoded_path, true)
+            : false;
+        if (
+            !is_string($path)
+            || base64_encode($path) !== $encoded_path
+            || $path === ''
+            || strpos($path, "\0") !== false
+        ) {
+            throw new InvalidArgumentException(
+                "File-sync change-scope {$name} must be canonical base64 for a nonempty path."
+            );
+        }
+        return $path;
+    }
+
+    private static function decode_remote_absolute_path(
+        $encoded_path,
+        string $name
+    ): string {
+        $path = self::decode_config_path($encoded_path, $name);
+        self::assert_remote_absolute_path($path);
+        return $path;
+    }
+
+    private static function assert_remote_absolute_path(string $path): void
+    {
+        assert_valid_path($path, 'file-sync change-scope remote absolute path');
+        if (
+            $path === ''
+            || $path[0] !== '/'
+            || normalize_path($path) !== $path
+        ) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope paths must be normalized remote absolute paths.'
+            );
+        }
+    }
+
+    private static function strict_parent(string $remote_absolute_path): ?string
+    {
+        if ($remote_absolute_path === '/') {
+            return null;
+        }
+        $last_separator = strrpos($remote_absolute_path, '/');
+        return $last_separator === 0
+            ? '/'
+            : substr($remote_absolute_path, 0, $last_separator);
+    }
+
+    private function assert_open(): void
+    {
+        if ($this->closed) {
+            throw new LogicException('Cannot query a file-sync change scope after close().');
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/state/class-files-pull-ownership-state.php
+++ b/packages/reprint-client/src/lib/state/class-files-pull-ownership-state.php
@@ -50,6 +50,66 @@ class FilesPullOwnershipState {
         return $state;
     }
 
+    /**
+     * Opens the remote-index change scope for the active files-pull.
+     *
+     * @param string       $ownership_directory                       Directory containing published ownership snapshots.
+     * @param string       $selection_fingerprint                     Active path-selection fingerprint.
+     * @param list<string> $excluded_remote_absolute_path_roots       Explicit remote path exclusions.
+     * @param bool         $include_caches                            Whether the saved selection includes cache paths.
+     */
+    public function create_remote_change_scope(
+        string $ownership_directory,
+        string $selection_fingerprint,
+        array $excluded_remote_absolute_path_roots,
+        bool $include_caches
+    ): \FileSyncChangeScope {
+        self::assert_identifier($selection_fingerprint, 'path-selection fingerprint');
+        if ($this->active_snapshot_id === null) {
+            throw new \LogicException(
+                'Files-pull ownership has no active snapshot for its remote change scope.'
+            );
+        }
+
+        $protected_snapshot_ids = [];
+        foreach (
+            $this->committed_snapshot_ids_by_selection_fingerprint
+                as $committed_selection_fingerprint => $snapshot_ids
+        ) {
+            if ($committed_selection_fingerprint !== $selection_fingerprint) {
+                $protected_snapshot_ids = array_merge(
+                    $protected_snapshot_ids,
+                    $snapshot_ids
+                );
+            }
+        }
+        sort($protected_snapshot_ids, SORT_STRING);
+        $protected_snapshot_ids = array_values(array_unique(
+            $protected_snapshot_ids
+        ));
+
+        sort($excluded_remote_absolute_path_roots, SORT_STRING);
+        $excluded_remote_absolute_path_roots = array_values(array_unique(
+            $excluded_remote_absolute_path_roots
+        ));
+
+        return \FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode($ownership_directory),
+            'current_snapshot_id' => $this->active_snapshot_id,
+            'prior_snapshot_ids' =>
+                $this->committed_snapshot_ids_by_selection_fingerprint[
+                    $selection_fingerprint
+                ] ?? [],
+            'protected_snapshot_ids' => $protected_snapshot_ids,
+            'excluded_remote_absolute_path_roots_b64' => array_map(
+                'base64_encode',
+                $excluded_remote_absolute_path_roots
+            ),
+            'include_caches' => $include_caches,
+        ]);
+    }
+
     /** Moves the processor's ID to active after both snapshot artifacts exist. */
     public function complete_processor(string $snapshot_id): void
     {

--- a/tests/Import/FileSyncChangeScopeTest.php
+++ b/tests/Import/FileSyncChangeScopeTest.php
@@ -1,0 +1,639 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Test namespace follows the suite convention.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-change-scope.php';
+
+class FileSyncChangeScopeTest extends TestCase {
+    private string $temporaryDirectory;
+    private string $ownershipDirectory;
+    private int $nextSnapshotNumber = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporaryDirectory = sys_get_temp_dir()
+            . '/file-sync-change-scope-' . uniqid('', true);
+        $this->ownershipDirectory = $this->temporaryDirectory
+            . "/ownership-\nname";
+        mkdir($this->ownershipDirectory . '/snapshots', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+        parent::tearDown();
+    }
+
+    public function testCurrentRootAndExactOwnershipUseTheirOwnDimensions(): void
+    {
+        $arbitraryByteLink = "/outside/linked-\xFF\npath";
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+            ['kind' => 'exact', 'path' => $arbitraryByteLink],
+        ]);
+        $scope = $this->scope($currentSnapshotId);
+
+        $this->assertFalse($scope->index_entry_may_change('/site', 'dir'));
+        $this->assertTrue($scope->index_entry_may_change('/site/file.php', 'file'));
+        $this->assertTrue($scope->index_entry_may_change($arbitraryByteLink, 'link'));
+        $this->assertFalse($scope->index_entry_may_change($arbitraryByteLink, 'file'));
+        $this->assertFalse($scope->index_entry_may_change('/outside/file.php', 'file'));
+
+        $scope->close();
+    }
+
+    public function testCurrentOwnershipWinsAndPriorOwnershipLosesToProtection(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site/current'],
+        ]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site/current'],
+            ['kind' => 'root', 'path' => '/site/shared'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/current/file.php', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/shared/file.php', 'file')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/old/file.php', 'file')
+        );
+
+        $scope->close();
+    }
+
+    public function testDisappearedIntermediateLinkUsesPriorExactOwnership(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/outside/followed'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/outside/protected'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+
+        $this->assertTrue(
+            $scope->index_entry_may_change('/outside/followed', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/outside/followed', 'file')
+        );
+
+        $scope->close();
+
+        $protectedPriorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/outside/followed'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedPriorSnapshotId]
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/outside/followed', 'link')
+        );
+        $scope->close();
+    }
+
+    public function testExclusionsAndDefaultSkipsApplyBeforeCurrentOwnership(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+            ['kind' => 'exact', 'path' => '/site/private/link'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            ['/site/private'],
+            false
+        );
+
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/private/file.php', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/private/link', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/.git/config', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/wp-content/cache/a', 'file')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/cache/a', 'file')
+        );
+        $this->assertFalse($scope->includes_caches());
+        $scope->close();
+
+        $scope = $this->scope($currentSnapshotId, [], [], [], true);
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.git/config', 'file')
+        );
+        $this->assertTrue($scope->includes_caches());
+        $scope->close();
+    }
+
+    public function testShallowRootChecksEveryDefaultSkippedPrefix(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/'],
+        ]);
+        $scope = $this->scope($currentSnapshotId);
+
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/.DS_Store/child', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/wp-content/cache/child', 'file')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/cache/child', 'file')
+        );
+
+        $scope->close();
+    }
+
+    public function testDeepestExplicitSkippedNameRootSetsTheTraversalBoundary(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $priorSnapshotIds = [
+            $this->publishSnapshot([
+                ['kind' => 'root', 'path' => '/site'],
+            ]),
+            $this->publishSnapshot([
+                ['kind' => 'root', 'path' => '/site/.DS_Store'],
+                ['kind' => 'root', 'path' => '/site/.git'],
+            ]),
+        ];
+        sort($priorSnapshotIds, SORT_STRING);
+        $scope = $this->scope($currentSnapshotId, $priorSnapshotIds);
+
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.DS_Store/child', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/.git/child', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/.DS_Store', 'dir')
+        );
+
+        $scope->close();
+    }
+
+    public function testNestedSkippedDirectoryBelowAnExplicitRootIsBlocked(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site/.DS_Store'],
+        ]);
+        $scope = $this->scope($currentSnapshotId);
+
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.DS_Store/content/file', 'file')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change(
+                '/site/.DS_Store/content/.DS_Store/child',
+                'file'
+            )
+        );
+
+        $scope->close();
+    }
+
+    public function testExactLinkOwnershipConfirmsDefaultSkippedNames(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/site/.git'],
+            ['kind' => 'exact', 'path' => '/site/.git/link'],
+            ['kind' => 'exact', 'path' => '/site/.git/node_modules'],
+            ['kind' => 'exact', 'path' => '/site/.DS_Store'],
+            ['kind' => 'exact', 'path' => '/site/.DS_Store/link'],
+            ['kind' => 'exact', 'path' => '/site/wp-content/cache'],
+        ]);
+        $scope = $this->scope($currentSnapshotId);
+
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.git/link', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.DS_Store/link', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.git', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.git/node_modules', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/.DS_Store', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/site/wp-content/cache', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/site/.git/link', 'file')
+        );
+
+        $scope->close();
+    }
+
+    public function testSubtreeRequiresCompleteCurrentOrUnprotectedPriorOwnership(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/current'],
+        ]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/'],
+            ['kind' => 'root', 'path' => '/prior'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/current/overlap'],
+            ['kind' => 'root', 'path' => '/prior/blocked/root'],
+            ['kind' => 'exact', 'path' => '/prior/contains/link'],
+            ['kind' => 'ancestor', 'path' => '/prior'],
+            ['kind' => 'ancestor', 'path' => '/prior/blocked'],
+            ['kind' => 'ancestor', 'path' => '/prior/contains'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId],
+            [],
+            true
+        );
+
+        $this->assertTrue($scope->subtree_may_change('/current/overlap'));
+        $this->assertFalse($scope->subtree_may_change('/current'));
+        $this->assertTrue($scope->subtree_may_change('/prior/open'));
+        $this->assertFalse($scope->subtree_may_change('/prior/blocked'));
+        $this->assertFalse($scope->subtree_may_change('/prior/contains'));
+
+        $scope->close();
+    }
+
+    public function testSubtreeRejectsHiddenDefaultSkipsAndExcludedDescendants(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+        ]);
+        $scope = $this->scope($currentSnapshotId, [], [], [], false);
+        $this->assertFalse($scope->subtree_may_change('/site/old'));
+        $scope->close();
+
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            ['/site/old/keep'],
+            true
+        );
+        $this->assertFalse($scope->subtree_may_change('/site/old'));
+        $this->assertTrue($scope->subtree_may_change('/site/other'));
+        $scope->close();
+    }
+
+    public function testConfigRoundTripsCanonicalArbitraryBytes(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $config = $this->config(
+            $currentSnapshotId,
+            [],
+            [],
+            ["/excluded-\xFE"],
+            true
+        );
+        $scope = \FileSyncChangeScope::from_config($config);
+
+        $this->assertSame($config, $scope->get_config());
+        $scope->close();
+        $scope->close();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('after close()');
+        $scope->index_entry_may_change('/path', 'file');
+    }
+
+    public function testStrictConfigRejectsUnknownFieldsAndUnsortedRawPaths(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $config = $this->config($currentSnapshotId);
+        $config['unexpected'] = true;
+        try {
+            \FileSyncChangeScope::from_config($config);
+            $this->fail('Unknown config field was accepted.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString('must be exactly', $exception->getMessage());
+        }
+
+        $config = $this->config(
+            $currentSnapshotId,
+            [],
+            [],
+            ['/z', '/a']
+        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('byte-sorted');
+        \FileSyncChangeScope::from_config($config);
+    }
+
+    public function testStrictConfigRejectsNoncanonicalBase64(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $config = $this->config($currentSnapshotId);
+        $config['ownership_directory_b64'] .= '=';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('canonical base64');
+        \FileSyncChangeScope::from_config($config);
+    }
+
+    public function testStrictConfigRejectsOtherIndexPathCoordinates(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $config = $this->config($currentSnapshotId);
+        $config['index_path_coordinates'] = 'local_relative';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'index_path_coordinates must be remote_absolute'
+        );
+        \FileSyncChangeScope::from_config($config);
+    }
+
+    public function testLargeSnapshotLookupRemainsBounded(): void
+    {
+        $atoms = [];
+        for ($index = 0; $index < 100000; ++$index) {
+            $atoms[] = [
+                'kind' => 'exact',
+                'path' => sprintf('/links/%06d', $index),
+            ];
+        }
+        $currentSnapshotId = $this->publishSnapshot($atoms);
+        $configPath = $this->temporaryDirectory . '/bounded-config.json';
+        file_put_contents(
+            $configPath,
+            json_encode($this->config($currentSnapshotId), JSON_THROW_ON_ERROR)
+        );
+        $scriptPath = $this->temporaryDirectory . '/bounded-lookup.php';
+        file_put_contents($scriptPath, <<<'PHP'
+<?php
+require $argv[1];
+require $argv[2];
+
+$config = json_decode(file_get_contents($argv[3]), true, 512, JSON_THROW_ON_ERROR);
+$scope = FileSyncChangeScope::from_config($config);
+if (!$scope->index_entry_may_change('/links/099999', 'link')) {
+    fwrite(STDERR, "Expected the final exact link to be owned.\n");
+    exit(2);
+}
+if ($scope->index_entry_may_change('/links/missing', 'link')) {
+    fwrite(STDERR, "Unexpected ownership for the missing link.\n");
+    exit(3);
+}
+$scope->close();
+PHP
+        );
+        $process = proc_open(
+            [
+                PHP_BINARY,
+                '-d',
+                'memory_limit=8M',
+                $scriptPath,
+                __DIR__ . '/../../vendor/autoload.php',
+                __DIR__ . '/../../packages/reprint-client/src/lib/index/'
+                    . 'class-file-sync-change-scope.php',
+                $configPath,
+            ],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        $this->assertSame(
+            0,
+            $exitCode,
+            "Low-memory lookup failed.\nstdout: {$stdout}\nstderr: {$stderr}"
+        );
+    }
+
+    public function testManySnapshotsRetainOnlyOneOpenArtifactPair(): void
+    {
+        $descriptorsBefore = glob('/dev/fd/*');
+        if (!is_array($descriptorsBefore)) {
+            $this->markTestSkipped('/dev/fd is unavailable for the handle bound check.');
+        }
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $protectedSnapshotIds = [];
+        for ($index = 0; $index < 40; ++$index) {
+            $protectedSnapshotIds[] = $this->publishSnapshot([
+                [
+                    'kind' => 'exact',
+                    'path' => sprintf('/protected/%02d', $index),
+                ],
+            ]);
+        }
+        sort($protectedSnapshotIds, SORT_STRING);
+
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [],
+            $protectedSnapshotIds
+        );
+        $descriptorsAfterOpen = glob('/dev/fd/*');
+        $this->assertIsArray($descriptorsAfterOpen);
+        $this->assertLessThanOrEqual(
+            count($descriptorsBefore) + 2,
+            count($descriptorsAfterOpen)
+        );
+
+        $this->assertFalse(
+            $scope->index_entry_may_change('/protected/39', 'link')
+        );
+        $descriptorsAfterLookup = glob('/dev/fd/*');
+        $this->assertIsArray($descriptorsAfterLookup);
+        $this->assertLessThanOrEqual(
+            count($descriptorsBefore) + 2,
+            count($descriptorsAfterLookup)
+        );
+        $scope->close();
+    }
+
+    public function testCorruptOversizedPathRowIsRejectedAtTheReadBound(): void
+    {
+        $path = '/links/target';
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => $path],
+        ]);
+        file_put_contents(
+            $this->ownershipDirectory . '/snapshots/'
+                . $currentSnapshotId . '.paths.jsonl',
+            str_repeat('x', 64 * 1024 + 1)
+        );
+        $scope = $this->scope($currentSnapshotId);
+
+        try {
+            $scope->index_entry_may_change($path, 'link');
+            $this->fail('Oversized ownership path row was accepted.');
+        } catch (\UnexpectedValueException $exception) {
+            $this->assertStringContainsString(
+                'exceeds the 65536-byte path-row limit',
+                $exception->getMessage()
+            );
+        } finally {
+            $scope->close();
+        }
+    }
+
+    /**
+     * @param list<string> $priorSnapshotIds
+     * @param list<string> $protectedSnapshotIds
+     * @param list<string> $excludedRemoteAbsolutePathRoots
+     */
+    private function scope(
+        string $currentSnapshotId,
+        array $priorSnapshotIds = [],
+        array $protectedSnapshotIds = [],
+        array $excludedRemoteAbsolutePathRoots = [],
+        bool $includeCaches = false
+    ): \FileSyncChangeScope {
+        return \FileSyncChangeScope::from_config($this->config(
+            $currentSnapshotId,
+            $priorSnapshotIds,
+            $protectedSnapshotIds,
+            $excludedRemoteAbsolutePathRoots,
+            $includeCaches
+        ));
+    }
+
+    /**
+     * @param list<string> $priorSnapshotIds
+     * @param list<string> $protectedSnapshotIds
+     * @param list<string> $excludedRemoteAbsolutePathRoots
+     */
+    private function config(
+        string $currentSnapshotId,
+        array $priorSnapshotIds = [],
+        array $protectedSnapshotIds = [],
+        array $excludedRemoteAbsolutePathRoots = [],
+        bool $includeCaches = false
+    ): array {
+        return [
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode($this->ownershipDirectory),
+            'current_snapshot_id' => $currentSnapshotId,
+            'prior_snapshot_ids' => $priorSnapshotIds,
+            'protected_snapshot_ids' => $protectedSnapshotIds,
+            'excluded_remote_absolute_path_roots_b64' => array_map(
+                'base64_encode',
+                $excludedRemoteAbsolutePathRoots
+            ),
+            'include_caches' => $includeCaches,
+        ];
+    }
+
+    /**
+     * @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $atoms
+     */
+    private function publishSnapshot(array $atoms): string
+    {
+        usort(
+            $atoms,
+            static function (array $left, array $right): int {
+                return strcmp(
+                    $left['path'] . "\0" . $left['kind'],
+                    $right['path'] . "\0" . $right['kind']
+                );
+            }
+        );
+        $temporaryPrefix = $this->ownershipDirectory . '/snapshot-' . uniqid();
+        $pathsPath = $temporaryPrefix . '.paths.jsonl';
+        $lookupPath = $temporaryPrefix . '.lookup';
+        $pathsHandle = fopen($pathsPath, 'wb');
+        $lookupRows = [];
+        foreach ($atoms as $atom) {
+            $pathsByteOffset = ftell($pathsHandle);
+            $line = json_encode([
+                'kind' => $atom['kind'],
+                'path_b64' => base64_encode($atom['path']),
+            ], JSON_UNESCAPED_SLASHES) . "\n";
+            fwrite($pathsHandle, $line);
+            $lookupRows[] = hash(
+                'sha256',
+                $atom['kind'] . "\0" . $atom['path']
+            ) . ' ' . sprintf('%016x', $pathsByteOffset) . "\n";
+        }
+        fclose($pathsHandle);
+        sort($lookupRows, SORT_STRING);
+        file_put_contents($lookupPath, implode('', $lookupRows));
+
+        ++$this->nextSnapshotNumber;
+        $snapshotId = str_pad(
+            dechex($this->nextSnapshotNumber),
+            64,
+            '0',
+            STR_PAD_LEFT
+        );
+        rename(
+            $pathsPath,
+            $this->ownershipDirectory . '/snapshots/'
+                . $snapshotId . '.paths.jsonl'
+        );
+        rename(
+            $lookupPath,
+            $this->ownershipDirectory . '/snapshots/'
+                . $snapshotId . '.lookup'
+        );
+        return $snapshotId;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (scandir($directory) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -12,8 +12,9 @@ require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 /**
  * The local index used by files-pull, files-push, and files-diff.
  *
- * Files-pull records each non-skipped local path it changes. A later files-diff
- * therefore ignores pulled changes while still reporting unrelated local changes.
+ * Files-pull applies its mutation journal to the local and remote indexes. A
+ * later files-diff ignores journaled pull changes while still reporting local
+ * changes which the active selection did not apply.
  */
 final class FilesPullLocalIndexTest extends TestCase
 {
@@ -165,6 +166,57 @@ final class FilesPullLocalIndexTest extends TestCase
             $this->filesDiffRecords($diff['stdout'])[0][
                 'local_paths_to_push'
             ]
+        );
+    }
+
+    public function testIntermediateLinksHonorOwnershipAndPreserveLocalBeforeJournaling(): void
+    {
+        mkdir($this->localTree . '/local-shared', 0700, true);
+        symlink('local-git', $this->localTree . '/.git');
+        symlink('local-shared', $this->localTree . '/shared');
+        $this->writeRemoteOverrides([
+            'intermediate_links' => [
+                '.git' => 'remote-git',
+                '.svn' => 'remote-svn',
+                'shared/.cache' => 'remote-cache',
+                'node_modules' => 'remote-node-modules',
+            ],
+        ]);
+
+        $pull = $this->runFilesPull([
+            '--exclude=/var/www/html/.git',
+            '--exclude=/var/www/html/.svn',
+            '--on-fs-root-nonempty=preserve-local',
+        ]);
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertSame('local-git', readlink($this->localTree . '/.git'));
+        $this->assertFalse(
+            is_link($this->localTree . '/.svn'),
+            'An absent explicitly excluded intermediate link is not created.'
+        );
+        $this->assertFalse(
+            is_link($this->localTree . '/local-shared/.cache'),
+            'An allowed intermediate link below a preserved symlinked parent stays untouched.'
+        );
+        $this->assertTrue(is_link($this->localTree . '/node_modules'));
+        $this->assertSame(
+            'remote-node-modules',
+            readlink($this->localTree . '/node_modules')
+        );
+
+        $remoteIndex = $this->readIndex(
+            $this->pullStateDirectory . '/remote-index.jsonl'
+        );
+        $this->assertArrayNotHasKey('/var/www/html/.git', $remoteIndex);
+        $this->assertArrayNotHasKey('/var/www/html/.svn', $remoteIndex);
+        $this->assertArrayNotHasKey(
+            '/var/www/html/shared/.cache',
+            $remoteIndex
+        );
+        $this->assertArrayHasKey(
+            '/var/www/html/node_modules',
+            $remoteIndex
         );
     }
 
@@ -987,6 +1039,7 @@ $added_files = array_fill_keys(
     array_keys($overrides['added_files'] ?? array()),
     true
 );
+$intermediate_links = $overrides['intermediate_links'] ?? array();
 $remote_index = array();
 foreach ($remote_files as $path => $contents) {
     $remote_index['/var/www/html/' . $path] = array(
@@ -1004,6 +1057,16 @@ foreach ($added_directories as $path => $_) {
         'ctime' => 43,
         'size' => 0,
         'type' => 'dir',
+    );
+}
+foreach ($intermediate_links as $path => $target) {
+    $remote_index['/var/www/html/' . $path] = array(
+        'path' => base64_encode('/var/www/html/' . $path),
+        'ctime' => 43,
+        'size' => strlen($target),
+        'type' => 'link',
+        'target' => base64_encode($target),
+        'intermediate' => true,
     );
 }
 uksort($remote_index, static function (string $left, string $right): int {
@@ -1137,6 +1200,14 @@ if ($endpoint === 'file_index') {
                 'X-Chunk-Type' => 'directory',
                 'X-Directory-Path' => $part['entry']['path'],
                 'X-Directory-Ctime' => $part['entry']['ctime'],
+                'X-Cursor' => $part['cursor'],
+            ));
+        } elseif ($part['entry']['type'] === 'link') {
+            $write_part(array(
+                'X-Chunk-Type' => 'symlink',
+                'X-Symlink-Path' => $part['entry']['path'],
+                'X-Symlink-Target' => $part['entry']['target'],
+                'X-Symlink-Ctime' => $part['entry']['ctime'],
                 'X-Cursor' => $part['cursor'],
             ));
         } else {

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -133,7 +133,7 @@ final class FilesPullLocalIndexTest extends TestCase
         ]], $this->filesDiffRecords($diff['stdout']));
     }
 
-    public function testPullDoesNotAddDefaultSkippedPathsToTheLocalIndex(): void
+    public function testPullDoesNotFetchRootDerivedDefaultSkippedPathFromInvalidIndex(): void
     {
         $this->writeRemoteOverrides([
             'added_files' => [
@@ -143,11 +143,11 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $this->completeFilesPull();
 
-        $this->assertSame(
-            'pulled dependency',
-            file_get_contents(
-                $this->localTree . '/node_modules/pulled-package.js'
-            )
+        // The fake router deliberately bypasses the producer's default-skip
+        // check. This guards the consumer scope against an invalid index; an
+        // exact intermediate link has separate authority.
+        $this->assertFileDoesNotExist(
+            $this->localTree . '/node_modules/pulled-package.js'
         );
         $index = $this->readIndex($this->localIndexPath());
         $this->assertArrayNotHasKey(
@@ -394,7 +394,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testPulledDeletionStopsAtNestedIncludedRoot(): void
+    public function testPulledDeletionKeepsLocalAdditionsUnderNestedSelection(): void
     {
         $this->completeFilesPull();
         file_put_contents($this->localTree . '/folder/local-added.txt', 'local addition');
@@ -408,7 +408,13 @@ final class FilesPullLocalIndexTest extends TestCase
         ]);
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
-        $this->assertDirectoryDoesNotExist($this->localTree . '/folder');
+        $this->assertSame(
+            'local addition',
+            file_get_contents($this->localTree . '/folder/local-added.txt')
+        );
+        $this->assertFileDoesNotExist(
+            $this->localTree . '/folder/remote-deleted.txt'
+        );
         $this->assertSame(
             $this->remoteFiles['unchanged.txt'],
             file_get_contents($this->localTree . '/unchanged.txt')
@@ -429,12 +435,15 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $diff = $this->runFilesDiff();
         $this->assertSame(0, $diff['exit'], $diff['output']);
-        $this->assertSame([[
-            'command' => 'files-diff',
-            'status' => 'complete',
-            'local_paths_to_push' => 0,
-            'local_paths_to_delete' => 0,
-        ]], $this->filesDiffRecords($diff['stdout']));
+        $this->assertSame([
+            $this->expectedPushRecord('folder/local-added.txt'),
+            [
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 1,
+                'local_paths_to_delete' => 0,
+            ],
+        ], $this->filesDiffRecords($diff['stdout']));
     }
 
     public function testPulledDeletionKeepsAnExcludedDescendant(): void
@@ -479,7 +488,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testPulledDeletionRemovesAnEntireRemappedSelection(): void
+    public function testPulledDeletionKeepsEmptyRemappedSelectionDirectoryTree(): void
     {
         $arguments = [
             '--include=/var/www/html',
@@ -502,7 +511,29 @@ final class FilesPullLocalIndexTest extends TestCase
         $pull = $this->runFilesPull($arguments);
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
-        $this->assertDirectoryDoesNotExist($this->rawFileRoot . '/remapped');
+        // A traversal root is not an indexed entry, and omitted cache paths
+        // make recursive removal unsafe. Exact descendant deletions therefore
+        // leave the mapped selection root and now-empty parents as an empty
+        // directory tree.
+        $remappedRoot = $this->rawFileRoot . '/remapped';
+        $this->assertDirectoryExists($remappedRoot);
+        $remainingFiles = [];
+        foreach (
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    $remappedRoot,
+                    \FilesystemIterator::SKIP_DOTS
+                )
+            ) as $remainingPath => $remainingEntry
+        ) {
+            if (!$remainingEntry->isDir() || is_link($remainingPath)) {
+                $remainingFiles[] = $remainingPath;
+            }
+        }
+        $this->assertSame(
+            [],
+            $remainingFiles
+        );
         $this->assertSame(
             'outside selection',
             file_get_contents($this->rawFileRoot . '/outside.txt')
@@ -628,7 +659,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testPulledDirectoryDeletionRemovesItsLocalIndexSubtree(): void
+    public function testPulledDirectoryDeletionKeepsEmptyDirectoryInLocalIndex(): void
     {
         $this->writeRemoteOverrides([
             'added_directories' => ['removed-tree'],
@@ -644,9 +675,20 @@ final class FilesPullLocalIndexTest extends TestCase
         $pull = $this->runFilesPull();
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
-        $this->assertDirectoryDoesNotExist($this->localTree . '/removed-tree');
+        // The tracked child is removed exactly. The explicit remote-index row
+        // is invalidated, but caches were omitted so recursive removal is
+        // unsafe and the locally retained empty directory remains indexed.
+        $removedTree = $this->localTree . '/removed-tree';
+        $this->assertDirectoryExists($removedTree);
+        $this->assertSame(
+            [],
+            array_values(array_diff(
+                scandir($removedTree) ?: [],
+                ['.', '..']
+            ))
+        );
         $index = $this->readIndex($this->localIndexPath());
-        $this->assertArrayNotHasKey(
+        $this->assertArrayHasKey(
             $this->localIndexEntryPath('removed-tree'),
             $index
         );

--- a/tests/Import/FilesPullOwnershipProcessorTest.php
+++ b/tests/Import/FilesPullOwnershipProcessorTest.php
@@ -7,6 +7,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-change-scope.php';
 
 final class FilesPullOwnershipProcessorTest extends TestCase
 {
@@ -69,6 +70,48 @@ final class FilesPullOwnershipProcessorTest extends TestCase
             $atoms
         );
         $this->assertLookupMatchesAtoms($pathsFile, $lookupFile, $atoms);
+    }
+
+    public function testPublishedSnapshotIsQueryableByFileSyncChangeScope(): void
+    {
+        [$journalByteOffset, $indexByteOffset] = $this->writeTwoTraversals();
+        $processor = $this->newProcessor(
+            $journalByteOffset,
+            $indexByteOffset,
+            $this->ownershipDirectory,
+            \FilesPullOwnershipProcessor::initial_cursor()
+        );
+        while ($processor->next_step()) {
+            $this->assertNotSame('complete', $processor->get_cursor()['phase']);
+        }
+        $snapshotId = $processor->get_snapshot_id();
+        $processor->close();
+
+        $scope = \FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode(
+                $this->ownershipDirectory
+            ),
+            'current_snapshot_id' => $snapshotId,
+            'prior_snapshot_ids' => [],
+            'protected_snapshot_ids' => [],
+            'excluded_remote_absolute_path_roots_b64' => [],
+            'include_caches' => false,
+        ]);
+        try {
+            $this->assertFalse(
+                $scope->index_entry_may_change('/outside/target', 'dir')
+            );
+            $this->assertTrue($scope->index_entry_may_change(
+                '/outside/target/data.bin',
+                'file'
+            ));
+            $this->assertTrue(
+                $scope->index_entry_may_change('/outside-alias', 'link')
+            );
+        } finally {
+            $scope->close();
+        }
     }
 
     public function testResumeTruncatesUnconfirmedOutputAndPublishesSameContent(): void

--- a/tests/Import/FilesPullOwnershipStateTest.php
+++ b/tests/Import/FilesPullOwnershipStateTest.php
@@ -9,6 +9,7 @@ use Reprint\Importer\State\FilesPullOwnershipState;
 
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/state/load.php';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-files-pull-ownership-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-change-scope.php';
 
 final class FilesPullOwnershipStateTest extends TestCase
 {
@@ -16,12 +17,106 @@ final class FilesPullOwnershipStateTest extends TestCase
         '1111111111111111111111111111111111111111111111111111111111111111';
     private const SECOND_SELECTION =
         '2222222222222222222222222222222222222222222222222222222222222222';
+    private const THIRD_SELECTION =
+        '3333333333333333333333333333333333333333333333333333333333333333';
     private const FIRST_SNAPSHOT =
         'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     private const SECOND_SNAPSHOT =
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     private const THIRD_SNAPSHOT =
         'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    private const FOURTH_SNAPSHOT =
+        'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+    public function testCreatesRemoteScopeFromActivePriorAndProtectedOwnership(): void
+    {
+        $ownership_directory = sys_get_temp_dir()
+            . "/files-pull-ownership-state-\n-"
+            . bin2hex(random_bytes(6));
+        mkdir($ownership_directory . '/snapshots', 0700, true);
+        foreach (
+            [
+                self::FIRST_SNAPSHOT,
+                self::SECOND_SNAPSHOT,
+                self::THIRD_SNAPSHOT,
+                self::FOURTH_SNAPSHOT,
+            ] as $snapshot_id
+        ) {
+            file_put_contents(
+                "{$ownership_directory}/snapshots/{$snapshot_id}.paths.jsonl",
+                ''
+            );
+            file_put_contents(
+                "{$ownership_directory}/snapshots/{$snapshot_id}.lookup",
+                ''
+            );
+        }
+        $state = FilesPullOwnershipState::from_array([
+            'committed_snapshot_ids_by_selection_fingerprint' => [
+                self::FIRST_SELECTION => [self::FIRST_SNAPSHOT],
+                self::SECOND_SELECTION => [
+                    self::SECOND_SNAPSHOT,
+                    self::THIRD_SNAPSHOT,
+                ],
+                self::THIRD_SELECTION => [self::SECOND_SNAPSHOT],
+            ],
+            'active_snapshot_id' => self::FOURTH_SNAPSHOT,
+            'processor_cursor' => null,
+            'snapshot_ids_pending_removal' => [],
+        ]);
+        $excluded_remote_absolute_path_roots = [
+            "/z-\xFF",
+            "/a\npath",
+            "/z-\xFF",
+        ];
+
+        try {
+            $scope = $state->create_remote_change_scope(
+                $ownership_directory,
+                self::FIRST_SELECTION,
+                $excluded_remote_absolute_path_roots,
+                true
+            );
+            $this->assertSame([
+                'index_path_coordinates' => 'remote_absolute',
+                'ownership_directory_b64' => base64_encode(
+                    $ownership_directory
+                ),
+                'current_snapshot_id' => self::FOURTH_SNAPSHOT,
+                'prior_snapshot_ids' => [self::FIRST_SNAPSHOT],
+                'protected_snapshot_ids' => [
+                    self::SECOND_SNAPSHOT,
+                    self::THIRD_SNAPSHOT,
+                ],
+                'excluded_remote_absolute_path_roots_b64' => [
+                    base64_encode("/a\npath"),
+                    base64_encode("/z-\xFF"),
+                ],
+                'include_caches' => true,
+            ], $scope->get_config());
+            $scope->close();
+        } finally {
+            foreach (glob($ownership_directory . '/snapshots/*') ?: [] as $path) {
+                unlink($path);
+            }
+            rmdir($ownership_directory . '/snapshots');
+            rmdir($ownership_directory);
+        }
+    }
+
+    public function testRemoteScopeRequiresAnActiveSnapshot(): void
+    {
+        $state = new FilesPullOwnershipState();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('no active snapshot');
+        $state->create_remote_change_scope(
+            sys_get_temp_dir(),
+            self::FIRST_SELECTION,
+            [],
+            false
+        );
+    }
 
     public function testSuccessReplacesOnlyItsSelectionAndQueuesUnreferencedSnapshots(): void
     {

--- a/tests/Import/FilesPullRemoteChangeScopeTest.php
+++ b/tests/Import/FilesPullRemoteChangeScopeTest.php
@@ -1,0 +1,391 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/** Exercises ownership-scoped deletions through the production files-pull diff. */
+final class FilesPullRemoteChangeScopeTest extends TestCase {
+    private const CURRENT_SELECTION =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    private const PROTECTED_SELECTION =
+        '2222222222222222222222222222222222222222222222222222222222222222';
+
+    private string $temporaryDirectory;
+    private string $stateDirectory;
+    private string $pullStateDirectory;
+    private string $filesystemRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporaryDirectory = sys_get_temp_dir()
+            . '/files-pull-remote-scope-'
+            . bin2hex(random_bytes(6));
+        $this->stateDirectory = $this->temporaryDirectory . '/state';
+        $this->pullStateDirectory = $this->stateDirectory
+            . '/remotes/' . md5('http://fake.url') . '/pull';
+        $this->filesystemRoot = $this->temporaryDirectory . '/files';
+        mkdir($this->pullStateDirectory, 0700, true);
+        mkdir($this->filesystemRoot, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->temporaryDirectory);
+        parent::tearDown();
+    }
+
+    public function testCurrentOwnershipWinsWhileProtectionBlocksPriorOwnership(): void
+    {
+        $currentPath = '/site/current/remove.txt';
+        $priorPath = '/site/old/remove.txt';
+        $protectedPath = '/site/shared/keep.txt';
+        $this->writeIndexes([
+            [$currentPath, 'file'],
+            [$priorPath, 'file'],
+            [$protectedPath, 'file'],
+        ]);
+        foreach ([$currentPath, $priorPath, $protectedPath] as $path) {
+            $this->seedLocalFile($path);
+        }
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/site/current']],
+            [['kind' => 'root', 'path' => '/site']],
+            [[
+                ['kind' => 'root', 'path' => '/site/current'],
+                ['kind' => 'root', 'path' => '/site/shared'],
+            ]]
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileDoesNotExist($this->localPath($currentPath));
+        $this->assertFileDoesNotExist($this->localPath($priorPath));
+        $this->assertFileExists($this->localPath($protectedPath));
+        $this->assertSame([$protectedPath], $this->retainedRemoteIndexPaths());
+    }
+
+    public function testExclusionsAndPersistedCachesSettingKeepStaleDescendants(): void
+    {
+        $cachePath = '/site/.git/config';
+        $excludedPath = '/site/excluded/remove.txt';
+        $ownedPath = '/site/remove.txt';
+        $this->writeIndexes([
+            [$cachePath, 'file'],
+            [$excludedPath, 'file'],
+            [$ownedPath, 'file'],
+        ]);
+        foreach ([$cachePath, $excludedPath, $ownedPath] as $path) {
+            $this->seedLocalFile($path);
+        }
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/site']],
+            [],
+            [],
+            ['/site/excluded'],
+            false,
+            true
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileExists($this->localPath($cachePath));
+        $this->assertFileExists($this->localPath($excludedPath));
+        $this->assertFileDoesNotExist($this->localPath($ownedPath));
+        $this->assertSame(
+            [$cachePath, $excludedPath],
+            $this->retainedRemoteIndexPaths()
+        );
+    }
+
+    public function testExactIntermediateLinkDoesNotAuthorizeItsAncestor(): void
+    {
+        $linkPath = '/outside/intermediate';
+        $this->writeIndexes([[$linkPath, 'link']]);
+        $localLinkPath = $this->localPath($linkPath);
+        mkdir(dirname($localLinkPath), 0700, true);
+        symlink('/remote/link/target', $localLinkPath);
+        $siblingPath = '/outside/keep.txt';
+        $this->seedLocalFile($siblingPath);
+
+        $client = $this->clientAtDiffStage([
+            ['kind' => 'exact', 'path' => $linkPath],
+        ], [], [], [], true);
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileDoesNotExist($localLinkPath);
+        $this->assertFileExists($this->localPath($siblingPath));
+        $this->assertSame([], $this->retainedRemoteIndexPaths());
+    }
+
+    public function testDefaultSkippedExactIntermediateLinkIsFetched(): void
+    {
+        $linkPath = '/site/.git';
+        $this->writeIndexes([], [[$linkPath, 'link']]);
+
+        $client = $this->clientAtDiffStage([
+            ['kind' => 'exact', 'path' => $linkPath],
+        ]);
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertSame([$linkPath], $this->fetchListPaths());
+    }
+
+    public function testImpliedDirectoryInvalidatesOnlyItsStaleExplicitRow(): void
+    {
+        $directoryPath = '/site/sparse';
+        $descendantPath = $directoryPath . '/remote.txt';
+        $this->writeIndexes(
+            [[$directoryPath, 'dir']],
+            [[$descendantPath, 'file']]
+        );
+        $localMarkerPath = $directoryPath . '/local-marker.txt';
+        $this->seedLocalFile($localMarkerPath);
+
+        $client = $this->clientAtDiffStage([
+            ['kind' => 'root', 'path' => $directoryPath],
+        ]);
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileExists($this->localPath($localMarkerPath));
+        $this->assertSame([], $this->retainedRemoteIndexPaths());
+        $this->assertSame(
+            [$descendantPath],
+            $this->indexFilePaths('remote-index.next.jsonl')
+        );
+        $this->assertSame([$descendantPath], $this->fetchListPaths());
+    }
+
+    public function testMissingExplicitDirectoryKeepsItsLocalDescendant(): void
+    {
+        $directoryPath = '/site/old';
+        $localDescendantPath = $directoryPath . '/local.txt';
+        $this->writeIndexes([[$directoryPath, 'dir']]);
+        $this->seedLocalFile($localDescendantPath);
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/site']],
+            [],
+            [],
+            [$localDescendantPath],
+            false
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileExists($this->localPath($localDescendantPath));
+        $this->assertSame([], $this->retainedRemoteIndexPaths());
+    }
+
+    /**
+     * @param list<array{0:string,1:'file'|'link'|'dir'}> $retainedEntries
+     * @param list<array{0:string,1:'file'|'link'|'dir'}> $nextEntries
+     */
+    private function writeIndexes(
+        array $retainedEntries,
+        array $nextEntries = []
+    ): void {
+        file_put_contents(
+            $this->pullStateDirectory . '/remote-index.jsonl',
+            $this->indexRows($retainedEntries)
+        );
+        file_put_contents(
+            $this->pullStateDirectory . '/remote-index.next.jsonl',
+            $this->indexRows($nextEntries)
+        );
+    }
+
+    /**
+     * @param list<array{0:string,1:'file'|'link'|'dir'}> $entries
+     */
+    private function indexRows(array $entries): string
+    {
+        usort(
+            $entries,
+            static function (array $left, array $right): int {
+                return strcmp($left[0], $right[0]);
+            }
+        );
+        $rows = '';
+        foreach ($entries as [$path, $type]) {
+            $rows .= json_encode([
+                'path' => base64_encode($path),
+                'ctime' => 1,
+                'size' => $type === 'file' ? 1 : 0,
+                'type' => $type,
+            ], JSON_UNESCAPED_SLASHES) . "\n";
+        }
+        return $rows;
+    }
+
+    /**
+     * @param list<array{kind:'root'|'exact',path:string}> $currentAtoms
+     * @param list<array{kind:'root'|'exact',path:string}> $priorAtoms
+     * @param list<list<array{kind:'root'|'exact',path:string}>> $protectedAtomGroups
+     * @param list<string> $excludedRemoteAbsolutePathRoots
+     */
+    private function clientAtDiffStage(
+        array $currentAtoms,
+        array $priorAtoms = [],
+        array $protectedAtomGroups = [],
+        array $excludedRemoteAbsolutePathRoots = [],
+        bool $persistedIncludeCaches = false,
+        bool $invocationIncludeCaches = false
+    ): \ImportClient {
+        $activeSnapshotId = reprint_test_write_ownership_snapshot(
+            $this->pullStateDirectory,
+            $currentAtoms
+        );
+        $committedSnapshotIds = [];
+        if ($priorAtoms !== []) {
+            $committedSnapshotIds[self::CURRENT_SELECTION] = [
+                reprint_test_write_ownership_snapshot(
+                    $this->pullStateDirectory,
+                    $priorAtoms
+                ),
+            ];
+        }
+        foreach ($protectedAtomGroups as $protectedAtoms) {
+            $committedSnapshotIds[self::PROTECTED_SELECTION][] =
+                reprint_test_write_ownership_snapshot(
+                    $this->pullStateDirectory,
+                    $protectedAtoms
+                );
+        }
+        foreach ($committedSnapshotIds as &$snapshotIds) {
+            sort($snapshotIds, SORT_STRING);
+        }
+        unset($snapshotIds);
+
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->stateDirectory,
+            $this->filesystemRoot
+        );
+        \write_current_pull_state($client, [
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'in_progress',
+                'current_stage' => 'diff',
+            ],
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'wp_detect' => ['roots' => [['path' => '/']]],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => false,
+            'include_caches' => $persistedIncludeCaches,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'files_pull_path_selection_fingerprint' =>
+                self::CURRENT_SELECTION,
+            'files_pull_ownership' => [
+                'committed_snapshot_ids_by_selection_fingerprint' =>
+                    $committedSnapshotIds,
+                'active_snapshot_id' => $activeSnapshotId,
+                'processor_cursor' => null,
+                'snapshot_ids_pending_removal' => [],
+            ],
+        ]);
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client)
+        );
+        $reflection->getProperty('is_tty')->setValue($client, false);
+        $reflection->getProperty('fs_root_nonempty_behavior')->setValue(
+            $client,
+            'preserve-local'
+        );
+        $reflection->getProperty('include_caches')->setValue(
+            $client,
+            $invocationIncludeCaches
+        );
+        $reflection->getProperty(
+            'pull_excluded_files_with_path_prefixes'
+        )->setValue($client, $excludedRemoteAbsolutePathRoots);
+        return $client;
+    }
+
+    private function runDiffAndApplyJournal(\ImportClient $client): void
+    {
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $this->assertTrue(
+            $reflection->getMethod(
+                'compare_remote_indexes_and_build_fetch_list'
+            )->invoke($client)
+        );
+        $reflection->getProperty('pull_index_journal')
+            ->getValue($client)
+            ->apply_pending_records();
+    }
+
+    private function seedLocalFile(string $remoteAbsolutePath): void
+    {
+        $localPath = $this->localPath($remoteAbsolutePath);
+        if (!is_dir(dirname($localPath))) {
+            mkdir(dirname($localPath), 0700, true);
+        }
+        file_put_contents($localPath, 'x');
+    }
+
+    private function localPath(string $remoteAbsolutePath): string
+    {
+        return $this->filesystemRoot . $remoteAbsolutePath;
+    }
+
+    /** @return list<string> */
+    private function retainedRemoteIndexPaths(): array
+    {
+        return $this->indexFilePaths('remote-index.jsonl');
+    }
+
+    /** @return list<string> */
+    private function fetchListPaths(): array
+    {
+        return $this->indexFilePaths('fetch-list.jsonl');
+    }
+
+    /** @return list<string> */
+    private function indexFilePaths(string $fileName): array
+    {
+        $rows = file(
+            $this->pullStateDirectory . '/' . $fileName,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        ) ?: [];
+        return array_map(
+            static function (string $row): string {
+                $entry = json_decode($row, true, 512, JSON_THROW_ON_ERROR);
+                $path = base64_decode($entry['path'], true);
+                if (!is_string($path)) {
+                    throw new \RuntimeException('Invalid remote index fixture path.');
+                }
+                return $path;
+            },
+            $rows
+        );
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+        if (is_link($path) || !is_dir($path)) {
+            unlink($path);
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -73,6 +73,36 @@ class FilesPullStateTest extends TestCase
      */
     private function writeState(array $state): void
     {
+        if (
+            ( $state['active_resumable_command']['current_stage'] ?? null )
+                === 'diff'
+        ) {
+            $selectionFingerprint = hash(
+                'sha256',
+                json_encode([
+                    'only_path_prefixes_b64' => [],
+                    'excluded_path_prefixes_b64' => [],
+                    'extra_directory_b64' => null,
+                    'follow_symlinks' => false,
+                    'include_caches' => false,
+                ], JSON_UNESCAPED_SLASHES)
+            );
+            $state = array_replace_recursive([
+                'include_caches' => false,
+                'files_pull_path_selection_fingerprint' =>
+                    $selectionFingerprint,
+                'files_pull_ownership' => [
+                    'committed_snapshot_ids_by_selection_fingerprint' => [],
+                    'active_snapshot_id' =>
+                        reprint_test_write_root_ownership_snapshot(
+                            $this->pullStateDirectory,
+                            ['/']
+                        ),
+                    'processor_cursor' => null,
+                    'snapshot_ids_pending_removal' => [],
+                ],
+            ], $state);
+        }
         \write_current_pull_state($this->makeClient(), array_replace_recursive([
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => PULL_PROTOCOL_VERSION,

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -320,8 +320,32 @@ class FollowedSymlinksRootTest extends TestCase
             'intermediate' => true,
         ]);
         file_put_contents($c->pull_state_directory . '/remote-index.next.jsonl', $entry . "\n");
-
-        $rc->getMethod('recreate_intermediate_symlinks')->invoke($c);
+        $snapshotId = \reprint_test_write_ownership_snapshot(
+            $c->pull_state_directory,
+            [[
+                'kind' => 'exact',
+                'path' => '/src/wp-content/data',
+            ]]
+        );
+        $scope = \FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode(
+                $c->pull_state_directory . '/files-pull-ownership'
+            ),
+            'current_snapshot_id' => $snapshotId,
+            'prior_snapshot_ids' => [],
+            'protected_snapshot_ids' => [],
+            'excluded_remote_absolute_path_roots_b64' => [],
+            'include_caches' => false,
+        ]);
+        try {
+            $rc->getMethod('recreate_intermediate_symlinks')->invoke(
+                $c,
+                $scope
+            );
+        } finally {
+            $scope->close();
+        }
 
         $link = $this->root . '/src/wp-content/data';
         $this->assertTrue(is_link($link), 'intermediate link is created');

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -109,18 +109,57 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
     /** Load state + preserve-local, then set the file path selection. */
     private function prepareClient(
         array $pull_only_files_with_path_prefixes,
-        array $pull_excluded_files_with_path_prefixes = []
+        array $pull_excluded_files_with_path_prefixes = [],
+        array $followed_path_roots = []
     ): array
     {
+        $selectionFingerprint = hash(
+            'sha256',
+            json_encode([
+                'only_path_prefixes_b64' => array_map(
+                    'base64_encode',
+                    $pull_only_files_with_path_prefixes
+                ),
+                'excluded_path_prefixes_b64' => array_map(
+                    'base64_encode',
+                    $pull_excluded_files_with_path_prefixes
+                ),
+                'extra_directory_b64' => null,
+                'follow_symlinks' => false,
+                'include_caches' => false,
+            ], JSON_UNESCAPED_SLASHES)
+        );
+        $selectionRoots = $pull_only_files_with_path_prefixes === []
+            ? ['/']
+            : $pull_only_files_with_path_prefixes;
+        $ownershipRoots = array_merge($selectionRoots, $followed_path_roots);
+        $activeSnapshotId = reprint_test_write_root_ownership_snapshot(
+            $this->pullStateDirectory,
+            $ownershipRoots
+        );
         $state = [
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "in_progress",
                 "current_stage" => "diff",
             ],
-            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "wp_detect" => ["roots" => [["path" => "/"]]],
+                ],
+                "http_code" => 200,
+            ],
             "follow_symlinks" => false,
+            "include_caches" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
+            "files_pull_path_selection_fingerprint" => $selectionFingerprint,
+            "files_pull_ownership" => [
+                "committed_snapshot_ids_by_selection_fingerprint" => [],
+                "active_snapshot_id" => $activeSnapshotId,
+                "processor_cursor" => null,
+                "snapshot_ids_pending_removal" => [],
+            ],
         ];
         \write_current_pull_state(
             new \ImportClient('http://fake.url', $this->stateDir, $this->filesystem_root),
@@ -244,7 +283,11 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             $this->indexLine('/shared/themes/indice/style.css', 1000, 10)
         );
 
-        [$client, $reflection] = $this->prepareClient(['/wp-content/plugins']);
+        [$client, $reflection] = $this->prepareClient(
+            ['/wp-content/plugins'],
+            [],
+            ['/shared/themes/indice']
+        );
         $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')->invoke($client);
 
         $fetch_entry = json_decode(

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -11,7 +11,6 @@ require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
  *   - resolve_remote_paths(): :token: templates / absolute paths → remote absolute
  *     prefixes (sharing --remap's WordPress path token table), with expansion for plugins, mu-plugins, and uploads
  *     directories outside WP_CONTENT_DIR and covered-prefix collapse.
- *   - is_selected_for_pulling(): per-path --include/--exclude membership.
  *   - get_export_directories(): with --include, a *replace* of the export roots.
  * Orthogonal to --remap (--include file prefixes decide what gets pulled, not where it lands).
  */
@@ -256,34 +255,6 @@ class OnlyFilesPathPrefixTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('preflight');
         $this->call($c, 'resolve_remote_paths', array(array(':abspath:/wp-admin'), 'include'));
-    }
-
-    public function testPullOnlyFilesPrefixSelectionDefaultsToTrueAndIsSlashAware(): void
-    {
-        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        // No --include: every file path is selected (keeps the diff deleting orphans).
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/anything/at/all.php', false)));
-
-        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php', false)));
-        // Byte-order sibling must not match the prefix.
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content.bak/x', false)));
-    }
-
-    public function testIncludeAndExcludePathPrefixSelection(): void
-    {
-        $c = $this->withPaths(array('content_dir' => '/var/www/html/wp-content'));
-        $this->set($c, 'pull_only_files_with_path_prefixes', array('/var/www/html/wp-content'));
-        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/var/www/html/wp-content/uploads'));
-
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads/a.jpg', false)));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-config.php', false)));
-        $this->assertTrue($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/uploads.backup/a.jpg', false)));
-
-        $this->set($c, 'pull_excluded_files_with_path_prefixes', array('/'));
-        $this->assertFalse($this->call($c, 'is_selected_for_pulling', array('/var/www/html/wp-content/themes/a.css', false)));
     }
 
     public function testFilterModesRewriteToUploadPathSelections(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,6 +71,28 @@ function reprint_test_write_root_ownership_snapshot(
     string $pull_state_directory,
     array $remote_roots
 ): string {
+    return reprint_test_write_ownership_snapshot(
+        $pull_state_directory,
+        array_map(
+            static function (string $remote_root): array {
+                return ['kind' => 'root', 'path' => $remote_root];
+            },
+            $remote_roots
+        )
+    );
+}
+
+/**
+ * Write one production-shaped ownership snapshot for importer tests.
+ *
+ * @param string $pull_state_directory Pull state directory.
+ * @param list<array{kind:'root'|'exact',path:string}> $atoms Root and intermediate-link ownership atoms.
+ * @return string Opaque snapshot ID.
+ */
+function reprint_test_write_ownership_snapshot(
+    string $pull_state_directory,
+    array $atoms
+): string {
     $snapshot_id = bin2hex(random_bytes(32));
     $snapshot_directory =
         $pull_state_directory . '/files-pull-ownership/snapshots';
@@ -85,16 +107,16 @@ function reprint_test_write_root_ownership_snapshot(
         );
     }
 
-    $path_rows = [];
-    foreach ($remote_roots as $remote_root) {
-        $kind = 'root';
-        $path = $remote_root;
+    $path_rows_by_atom = [];
+    foreach ($atoms as $atom) {
+        $kind = $atom['kind'];
+        $path = $atom['path'];
         while (true) {
             $line = json_encode([
                 'kind' => $kind,
                 'path_b64' => base64_encode($path),
             ], JSON_UNESCAPED_SLASHES) . "\n";
-            $path_rows[] = [
+            $path_rows_by_atom[$kind . "\0" . $path] = [
                 'kind' => $kind,
                 'path' => $path,
                 'line' => $line,
@@ -106,10 +128,14 @@ function reprint_test_write_root_ownership_snapshot(
             $path = dirname($path);
         }
     }
+    $path_rows = array_values($path_rows_by_atom);
     usort(
         $path_rows,
         static function (array $left, array $right): int {
-            return strcmp($left['line'], $right['line']);
+            return strcmp(
+                $left['path'] . "\0" . $left['kind'],
+                $right['path'] . "\0" . $right['kind']
+            );
         }
     );
 

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -2,9 +2,10 @@
  * Test 32: Delta sync deletions + type swaps (file/dir/symlink)
  *
  * Covers:
- * - Deleting file, deep directory tree, symlink to file, symlink to directory
+ * - Deleting files within a deep directory tree, symlink to file, symlink to directory
+ * - Retaining directory containers when omitted cache paths make recursive removal unsafe
  * - Replacing paths across types: file<->dir<->symlink
- * - Ensuring local directory deletion does not follow symlink targets
+ * - Ensuring tracked-content deletion does not follow symlink targets
  * - State path persistence uses base64-encoded values
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -166,17 +167,35 @@ chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
     });
 
-    it('deleted file, deep directory tree, and symlinks are removed locally', () => {
+    it('deleted files and symlinks are removed without recursively deleting directories', () => {
         const base = localScenarioRoot();
 
         assert.equal(existsSync(join(base, 'file-delete.txt')), false, 'Expected deleted file to be removed');
-        assert.equal(existsSync(join(base, 'dir-delete')), false, 'Expected deleted deep directory tree to be removed');
+        assert.equal(
+            existsSync(join(base, 'dir-delete', 'level1', 'level2', 'level3', 'deep.txt')),
+            false,
+            'Expected deleted deep file to be removed',
+        );
+        assert.equal(
+            existsSync(join(base, 'dir-delete', 'level1', 'level2', 'sibling.txt')),
+            false,
+            'Expected deleted sibling file to be removed',
+        );
         assert.equal(lstatIfExists(join(base, 'symlink-delete-file')), null, 'Expected deleted file symlink to be removed');
         assert.equal(lstatIfExists(join(base, 'symlink-delete-dir')), null, 'Expected deleted directory symlink to be removed');
-        assert.equal(existsSync(join(base, 'delete-dir-with-symlink')), false, 'Expected deleted directory with symlink to be removed');
+        assert.equal(
+            existsSync(join(base, 'delete-dir-with-symlink', 'sub', 'nested.txt')),
+            false,
+            'Expected the deleted nested file to be removed',
+        );
+        assert.equal(
+            lstatIfExists(join(base, 'delete-dir-with-symlink', 'escape-link')),
+            null,
+            'Expected the deleted escape symlink to be removed',
+        );
     });
 
-    it('directory deletion does not follow symlinks outside the deleted directory', () => {
+    it('deleting tracked directory contents does not follow symlinks outside it', () => {
         const preserveFile = localPreserveFile();
         assert.equal(existsSync(preserveFile), true, `Expected preserve file to remain: ${preserveFile}`);
         assert.equal(readFileSync(preserveFile, 'utf-8'), 'must-survive-local-delete\n');

--- a/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
+++ b/tests/e2e/tests/import-51-only-remap-managed-composition.test.js
@@ -31,12 +31,12 @@
  *
  * Phase 2 — scoped delta re-sync (--include :wp-content:/plugins). Verifies the
  * re-sync behavior against the same managed target:
- *   A. Delta-delete   — a file the SOURCE removed that is IN the current scope
- *                       and was previously synced is deleted on the target.
+ *   A. Delta-delete   — a tracked file the SOURCE removed that is IN the
+ *                       current scope and was previously synced is deleted on
+ *                       the target. Its empty directory may remain.
  *   B. Scope-survival — content synced by the earlier, broader run but OUTSIDE
- *                       the current scope is NOT deleted (the delete-drain is
- *                       guarded by in_scope(); the remote index is a union across
- *                       scoped runs).
+ *                       the current scope is protected by that completed
+ *                       broader selection.
  *   plus a control: an in-scope file the source still has is retained.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -64,7 +64,8 @@ describe('Import: --include + --remap onto a managed Atomic docroot', () => {
                 const wpContent = join(remoteSiteDir, 'wp-content');
 
                 // custom-plugin — imported in phase 1, then REMOVED from the
-                // source before the phase 2 delta (in-scope deletion).
+                // source before the phase 2 delta. Its tracked PHP file is the
+                // in-scope target deletion.
                 const pluginDir = join(wpContent, 'plugins', 'custom-plugin');
                 mkdirSync(pluginDir, { recursive: true });
                 writeFileSync(join(pluginDir, 'custom-plugin.php'),
@@ -240,9 +241,9 @@ describe('Import: --include + --remap onto a managed Atomic docroot', () => {
     });
 
     // A — delta delete
-    it('delta-deletes the in-scope plugin the source removed', () => {
-        assert.ok(!existsSync(tgtPlugin('custom-plugin')),
-            'custom-plugin should be deleted (in scope, removed from source)');
+    it('delta-deletes the tracked file from the in-scope plugin the source removed', () => {
+        assert.ok(!existsSync(join(tgtPlugin('custom-plugin'), 'custom-plugin.php')),
+            'custom-plugin.php should be deleted (in scope, removed from source)');
     });
 
     // control — in-scope, still on source
@@ -254,7 +255,7 @@ describe('Import: --include + --remap onto a managed Atomic docroot', () => {
     // B — scope survival
     it('preserves the out-of-scope theme synced by the earlier broader run', () => {
         assert.ok(existsSync(join(tgtTheme('custom-theme'), 'style.css')),
-            'custom-theme should survive (out of scope in the delta run — delete-drain skips it)');
+            'custom-theme should survive under the earlier completed broader selection');
     });
 
     it('managed layer stays intact through the delta', () => {


### PR DESCRIPTION
Files-pull catch-up now changes only remote-index paths owned by the active selection or its earlier completed snapshots.

The current snapshot wins in overlaps. Other selections protect their paths; explicit exclusions and ordinary default-skipped descendants stay unchanged. Producer-emitted intermediate symlinks remain selectable through exact ownership. Final intermediate-symlink recreation uses the same ownership and preserve-local decisions, so excluded or preserved links are neither rewritten nor journaled. Missing directories require subtree ownership before recursive removal, so local additions under a deleted remote directory survive and appear in `files-diff`.

Ownership lookups stay disk-backed and bounded through the snapshot hash indexes.
