### PR TITLE
[PHP] Map files-pull ownership into local index paths

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
@@ -1,16 +1,19 @@
 <?php
 declare(strict_types=1);
 
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_relative_path;
 use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\normalize_path;
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Errors contain private state paths, never HTML.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
 
 /**
- * Decides which remote-index changes belong to one files-pull selection.
+ * Decides which indexed changes belong to one files-pull selection.
  *
  * The current snapshot describes this run and is authoritative where it owns
  * a path. Earlier snapshots for the same selection cover paths which have
@@ -25,7 +28,10 @@ use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
  * hash-collision candidates one bounded path row at a time. Only one snapshot
  * pair remains open, and snapshot contents are never materialized in memory.
  *
- * @phpstan-type Config array{index_path_coordinates:'remote_absolute',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool}
+ * @phpstan-type MapperConfig array{filesystem_root_b64:string,original_remote_roots_b64:list<string>,resolved_path_mappings:list<array{remote_prefix_b64:string,local_prefix_b64:string}>,local_followed_symlinks_root_b64:string|null}
+ * @phpstan-type RemoteAbsoluteConfig array{index_path_coordinates:'remote_absolute',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool}
+ * @phpstan-type LocalRelativeConfig array{index_path_coordinates:'local_relative',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool,remote_to_local_path_mapper_config:MapperConfig}
+ * @phpstan-type Config RemoteAbsoluteConfig|LocalRelativeConfig
  */
 final class FileSyncChangeScope
 {
@@ -35,6 +41,7 @@ final class FileSyncChangeScope
     /** @phpstan-var Config */
     private array $config;
     private string $ownership_directory;
+    private ?RemoteToLocalPathMapper $remote_to_local_path_mapper = null;
     /** @var list<string> */
     private array $excluded_remote_absolute_path_roots = [];
     private ?string $open_snapshot_id = null;
@@ -86,15 +93,42 @@ final class FileSyncChangeScope
      * Root atoms own strict descendants. Exact atoms own only a link at the
      * same path. Current ownership wins over another selection's protection;
      * earlier ownership does not.
+     * A local-relative entry needs one allowing alias and no blocking alias.
      */
     public function index_entry_may_change(
         string $index_path,
         string $type
     ): bool {
-        return $this->remote_index_entry_change_decision(
-            $index_path,
-            $type
-        ) === 'allow';
+        $this->assert_open();
+        if (!in_array($type, ['file', 'link', 'dir'], true)) {
+            throw new InvalidArgumentException(
+                "Index entry type must be file, link, or dir; got {$type}."
+            );
+        }
+        if ($this->config['index_path_coordinates'] === 'remote_absolute') {
+            return $this->remote_index_entry_change_decision(
+                $index_path,
+                $type
+            ) === 'allow';
+        }
+
+        $change_is_allowed = false;
+        foreach (
+            $this->remote_paths_mapping_to_local_index_path($index_path)
+            as $remote_absolute_path
+        ) {
+            $decision = $this->remote_index_entry_change_decision(
+                $remote_absolute_path,
+                $type
+            );
+            if ($decision === 'block') {
+                return false;
+            }
+            if ($decision === 'allow') {
+                $change_is_allowed = true;
+            }
+        }
+        return $change_is_allowed;
     }
 
     /** @return 'allow'|'block'|'unowned' */
@@ -104,11 +138,6 @@ final class FileSyncChangeScope
     ): string {
         $this->assert_open();
         self::assert_remote_absolute_path($remote_absolute_path);
-        if (!in_array($type, ['file', 'link', 'dir'], true)) {
-            throw new InvalidArgumentException(
-                "Index entry type must be file, link, or dir; got {$type}."
-            );
-        }
         $current_ownership = $this->snapshots_entry_ownership(
             [$this->config['current_snapshot_id']],
             $remote_absolute_path,
@@ -164,13 +193,42 @@ final class FileSyncChangeScope
      * recursive work is never safe. Current whole-subtree ownership wins. Any
      * other current intersection blocks prior authority, as does any protected
      * intersection.
+     * A local-relative subtree also needs continuous remote-to-local mapping.
      */
     public function subtree_may_change(
         string $index_path
     ): bool {
-        return $this->remote_subtree_change_decision(
-            $index_path
-        ) === 'allow';
+        $this->assert_open();
+        if ($this->config['index_path_coordinates'] === 'remote_absolute') {
+            return $this->remote_subtree_change_decision(
+                $index_path
+            ) === 'allow';
+        }
+
+        $path_mapper = $this->get_local_path_mapper();
+        $change_is_allowed = false;
+        foreach (
+            $this->remote_paths_mapping_to_local_index_path($index_path)
+            as $remote_absolute_path
+        ) {
+            $decision = $this->remote_subtree_change_decision(
+                $remote_absolute_path
+            );
+            if ($decision === 'block') {
+                return false;
+            }
+            if ($decision === 'allow') {
+                if (
+                    !$path_mapper->remote_path_owns_mapped_local_subtree(
+                        $remote_absolute_path
+                    )
+                ) {
+                    return false;
+                }
+                $change_is_allowed = true;
+            }
+        }
+        return $change_is_allowed;
     }
 
     /** @return 'allow'|'block'|'unowned' */
@@ -218,6 +276,35 @@ final class FileSyncChangeScope
         );
     }
 
+    /**
+     * Maps one remote absolute path into this local-relative index.
+     *
+     * @return string Local path relative to the filesystem root.
+     */
+    public function map_remote_absolute_path_to_index_path(
+        string $remote_absolute_path
+    ): string {
+        $path_mapper = $this->get_local_path_mapper();
+        self::assert_remote_absolute_path($remote_absolute_path);
+        $local_absolute_path = $path_mapper->map_path($remote_absolute_path);
+        $local_relative_path = relative_path_under(
+            $local_absolute_path,
+            $path_mapper->get_filesystem_root()
+        );
+        if ($local_relative_path === null) {
+            throw new LogicException(
+                'Remote-to-local path mapping escaped the filesystem root.'
+            );
+        }
+        return $local_relative_path;
+    }
+
+    /** Returns the filesystem root of this local-relative index. */
+    public function get_filesystem_root(): string
+    {
+        return $this->get_local_path_mapper()->get_filesystem_root();
+    }
+
     public function includes_caches(): bool
     {
         return $this->config['include_caches'];
@@ -230,6 +317,37 @@ final class FileSyncChangeScope
         }
         $this->closed = true;
         $this->close_open_snapshot();
+    }
+
+    /** @return list<string> */
+    private function remote_paths_mapping_to_local_index_path(
+        string $local_relative_path
+    ): array {
+        $path_mapper = $this->get_local_path_mapper();
+        if ($local_relative_path === '') {
+            $local_absolute_path = $path_mapper->get_filesystem_root();
+        } else {
+            assert_valid_relative_path(
+                $local_relative_path,
+                'file-sync change-scope local relative path'
+            );
+            $local_absolute_path = wp_join_unix_paths(
+                $path_mapper->get_filesystem_root(),
+                $local_relative_path
+            );
+        }
+        return $path_mapper->remote_paths_mapping_to($local_absolute_path);
+    }
+
+    private function get_local_path_mapper(): RemoteToLocalPathMapper
+    {
+        if ($this->remote_to_local_path_mapper === null) {
+            throw new LogicException(
+                'The file-sync change scope uses remote_absolute index paths. '
+                . 'Map it to local_relative before asking for local filesystem coordinates.'
+            );
+        }
+        return $this->remote_to_local_path_mapper;
     }
 
     /**
@@ -619,6 +737,16 @@ final class FileSyncChangeScope
 
     private function set_config(array $config): void
     {
+        $index_path_coordinates = $config['index_path_coordinates'] ?? null;
+        if (
+            $index_path_coordinates !== 'remote_absolute'
+            && $index_path_coordinates !== 'local_relative'
+        ) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope index_path_coordinates must be '
+                . 'remote_absolute or local_relative.'
+            );
+        }
         $expected_keys = [
             'index_path_coordinates',
             'ownership_directory_b64',
@@ -628,6 +756,9 @@ final class FileSyncChangeScope
             'excluded_remote_absolute_path_roots_b64',
             'include_caches',
         ];
+        if ($index_path_coordinates === 'local_relative') {
+            $expected_keys[] = 'remote_to_local_path_mapper_config';
+        }
         $actual_keys = array_keys($config);
         sort($actual_keys, SORT_STRING);
         $sorted_expected_keys = $expected_keys;
@@ -639,11 +770,6 @@ final class FileSyncChangeScope
                 . '; received '
                 . json_encode(array_keys($config), JSON_UNESCAPED_SLASHES)
                 . '.'
-            );
-        }
-        if ($config['index_path_coordinates'] !== 'remote_absolute') {
-            throw new InvalidArgumentException(
-                'File-sync change-scope index_path_coordinates must be remote_absolute.'
             );
         }
         $this->ownership_directory = self::decode_config_path(
@@ -667,6 +793,51 @@ final class FileSyncChangeScope
             throw new InvalidArgumentException(
                 'File-sync change-scope include_caches must be a boolean.'
             );
+        }
+        if ($index_path_coordinates === 'local_relative') {
+            $mapper_config = $config['remote_to_local_path_mapper_config'];
+            $expected_mapper_keys = [
+                'filesystem_root_b64',
+                'original_remote_roots_b64',
+                'resolved_path_mappings',
+                'local_followed_symlinks_root_b64',
+            ];
+            if (!is_array($mapper_config)) {
+                throw new InvalidArgumentException(
+                    'Local-relative file-sync change scope requires a path-mapper config.'
+                );
+            }
+            $actual_mapper_keys = array_keys($mapper_config);
+            sort($actual_mapper_keys, SORT_STRING);
+            $sorted_expected_mapper_keys = $expected_mapper_keys;
+            sort($sorted_expected_mapper_keys, SORT_STRING);
+            if ($actual_mapper_keys !== $sorted_expected_mapper_keys) {
+                throw new InvalidArgumentException(
+                    'Remote-to-local path-mapper config fields must be exactly '
+                    . implode(', ', $expected_mapper_keys)
+                    . '.'
+                );
+            }
+            try {
+                $path_mapper = RemoteToLocalPathMapper::from_config(
+                    $mapper_config
+                );
+            } catch (Throwable $throwable) {
+                throw new InvalidArgumentException(
+                    'Local-relative file-sync change scope has an invalid path-mapper config.',
+                    0,
+                    $throwable
+                );
+            }
+            $canonical_mapper_config = $path_mapper->get_config();
+            foreach ($expected_mapper_keys as $mapper_key) {
+                if ($canonical_mapper_config[$mapper_key] !== $mapper_config[$mapper_key]) {
+                    throw new InvalidArgumentException(
+                        'Remote-to-local path-mapper config paths must use canonical base64.'
+                    );
+                }
+            }
+            $this->remote_to_local_path_mapper = $path_mapper;
         }
         /** @var Config $config */
         $this->config = $config;

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -143,6 +143,23 @@ final class RemoteToLocalPathMapper
         ];
     }
 
+    /**
+     * Re-expresses a remote-absolute change scope in local-index coordinates.
+     */
+    public function map_change_scope_to_local_index(
+        FileSyncChangeScope $remote_change_scope
+    ): FileSyncChangeScope {
+        $config = $remote_change_scope->get_config();
+        if ($config["index_path_coordinates"] !== "remote_absolute") {
+            throw new InvalidArgumentException(
+                "Only a remote_absolute file-sync change scope can be mapped to a local index."
+            );
+        }
+        $config["index_path_coordinates"] = "local_relative";
+        $config["remote_to_local_path_mapper_config"] = $this->get_config();
+        return FileSyncChangeScope::from_config($config);
+    }
+
     /** Returns the local filesystem root used by map_path(). */
     public function get_filesystem_root(): string
     {
@@ -188,6 +205,9 @@ final class RemoteToLocalPathMapper
                 }
             }
             if (!$path_is_within_original_remote_roots) {
+                if ($remote_absolute_path === "/") {
+                    return $this->local_followed_symlinks_root;
+                }
                 return wp_join_unix_paths(
                     $this->local_followed_symlinks_root,
                     $remote_absolute_path
@@ -195,39 +215,163 @@ final class RemoteToLocalPathMapper
             }
         }
 
+        if ($remote_absolute_path === "/") {
+            return $this->filesystem_root;
+        }
         return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
+    }
+
+    /**
+     * Returns every remote path which maps to one local absolute path.
+     *
+     * The identity placement, each explicit remap target, and the followed-
+     * symlinks placement may overlap. Candidates are returned only when the
+     * forward mapping confirms the requested local path.
+     *
+     * @param string $local_absolute_path Local absolute path.
+     * @return list<string> Remote absolute paths mapping to the local path.
+     */
+    public function remote_paths_mapping_to(string $local_absolute_path): array
+    {
+        assert_valid_path($local_absolute_path, "local absolute path");
+        $remote_absolute_path_candidates = [];
+
+        $remainder = path_remainder_under(
+            $local_absolute_path,
+            $this->filesystem_root
+        );
+        if ($remainder !== null) {
+            $remote_absolute_path_candidates[] =
+                $remainder === "" ? "/" : $remainder;
+        }
+
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = path_remainder_under($local_absolute_path, $local_prefix);
+            if ($remainder !== null) {
+                $remote_absolute_path_candidates[] = wp_join_unix_paths(
+                    $remote_prefix,
+                    $remainder
+                );
+            }
+        }
+
+        if ($this->local_followed_symlinks_root !== null) {
+            $remainder = path_remainder_under(
+                $local_absolute_path,
+                $this->local_followed_symlinks_root
+            );
+            if ($remainder !== null) {
+                $remote_absolute_path_candidates[] =
+                    $remainder === "" ? "/" : $remainder;
+            }
+        }
+
+        $remote_absolute_paths = [];
+        foreach ($remote_absolute_path_candidates as $remote_absolute_path) {
+            if (
+                !in_array($remote_absolute_path, $remote_absolute_paths, true)
+                && $this->map_path($remote_absolute_path) === $local_absolute_path
+            ) {
+                $remote_absolute_paths[] = $remote_absolute_path;
+            }
+        }
+        return $remote_absolute_paths;
     }
 
     /**
      * Whether one remote path owns its mapped local subtree.
      *
-     * A recursive local change at this path must not cross a remap used by a
-     * different remote subtree. This covers remap targets both below this path
-     * and above it.
+     * Every remote descendant must retain the same suffix below the mapped
+     * local path. A nested remap or a transition between the original and
+     * followed-symlink placements must not leave a local hole. A separately
+     * selected remote subtree must not map to an intersecting local subtree.
      */
     public function remote_path_owns_mapped_local_subtree(
         string $remote_absolute_path
     ): bool
     {
         $local_absolute_path = $this->map_path($remote_absolute_path);
-        foreach ($this->resolved_path_mappings as $remote_root => $local_root) {
+        foreach (
+            $this->remote_paths_mapping_to($local_absolute_path)
+            as $mapped_remote_path
+        ) {
             if (
-                !path_is_same_as_or_descendant_of(
-                    $remote_absolute_path,
-                    $remote_root
-                )
-                && (
-                    path_is_same_as_or_descendant_of(
-                        $local_absolute_path,
-                        $local_root
-                    )
+                (
+                    $this->local_followed_symlinks_root !== null
                     || path_is_same_as_or_descendant_of(
-                        $local_root,
-                        $local_absolute_path
+                        $mapped_remote_path,
+                        $this->original_remote_roots
                     )
+                )
+                && !path_is_same_as_or_descendant_of(
+                    $mapped_remote_path,
+                    $remote_absolute_path
                 )
             ) {
                 return false;
+            }
+        }
+
+        $remote_mapping_boundaries = array_merge(
+            array_keys($this->resolved_path_mappings),
+            $this->original_remote_roots
+        );
+        foreach ($remote_mapping_boundaries as $remote_mapping_boundary) {
+            if (
+                path_is_same_as_or_descendant_of(
+                    $remote_absolute_path,
+                    $remote_mapping_boundary
+                )
+            ) {
+                continue;
+            }
+
+            $mapped_boundary = $this->map_path($remote_mapping_boundary);
+            $remainder = path_remainder_under(
+                $remote_mapping_boundary,
+                $remote_absolute_path
+            );
+            if ($remainder !== null) {
+                if (
+                    $mapped_boundary
+                    !== wp_join_unix_paths($local_absolute_path, $remainder)
+                ) {
+                    return false;
+                }
+            } elseif (
+                path_is_same_as_or_descendant_of(
+                    $local_absolute_path,
+                    $mapped_boundary
+                )
+                || path_is_same_as_or_descendant_of(
+                    $mapped_boundary,
+                    $local_absolute_path
+                )
+            ) {
+                return false;
+            }
+        }
+
+        if (
+            $this->local_followed_symlinks_root !== null
+            && $this->local_followed_symlinks_root !== $local_absolute_path
+            && path_is_same_as_or_descendant_of(
+                $this->local_followed_symlinks_root,
+                $local_absolute_path
+            )
+        ) {
+            foreach (
+                $this->remote_paths_mapping_to($this->local_followed_symlinks_root)
+                as $mapped_remote_path
+            ) {
+                if (
+                    !path_is_same_as_or_descendant_of(
+                        $mapped_remote_path,
+                        $remote_absolute_path
+                    )
+                ) {
+                    return false;
+                }
             }
         }
 

--- a/tests/Import/FileSyncChangeScopeTest.php
+++ b/tests/Import/FileSyncChangeScopeTest.php
@@ -7,6 +7,7 @@ namespace ImportTests;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-change-scope.php';
 
 class FileSyncChangeScopeTest extends TestCase {
@@ -338,6 +339,274 @@ class FileSyncChangeScopeTest extends TestCase {
         $scope->index_entry_may_change('/path', 'file');
     }
 
+    public function testLocalEntryAliasesRequireOneAllowAndRejectAnyBlock(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/current'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/protected'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [$protectedSnapshotId]
+        );
+
+        $mapper = new \RemoteToLocalPathMapper(
+            '/local',
+            ['/current', '/protected'],
+            [
+                '/current' => '/local/shared',
+                '/protected' => '/local/shared',
+            ]
+        );
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $this->assertFalse(
+            $localScope->index_entry_may_change('shared/file.php', 'file')
+        );
+        $localScope->close();
+
+        $mapper = new \RemoteToLocalPathMapper(
+            '/local',
+            ['/current'],
+            ['/current' => '/local/shared']
+        );
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $this->assertTrue(
+            $localScope->index_entry_may_change('shared/file.php', 'file')
+        );
+        $this->assertFalse(
+            $localScope->index_entry_may_change('unowned/file.php', 'file')
+        );
+        $localScope->close();
+        $remoteScope->close();
+    }
+
+    public function testLocalSubtreeRequiresContinuousMappingAcrossSourceHoles(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/a'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            [],
+            true
+        );
+
+        $continuousMapper = new \RemoteToLocalPathMapper(
+            '/local',
+            ['/a'],
+            ['/a' => '/local/shared']
+        );
+        $localScope = $continuousMapper->map_change_scope_to_local_index(
+            $remoteScope
+        );
+        $this->assertTrue($localScope->subtree_may_change('shared/dir'));
+        $localScope->close();
+
+        $mapperWithFilledHole = new \RemoteToLocalPathMapper(
+            '/local',
+            ['/a', '/b'],
+            [
+                '/a' => '/local/shared',
+                '/a/dir/hole' => '/local/elsewhere',
+                '/b' => '/local/shared/dir/hole',
+            ]
+        );
+        $localScope = $mapperWithFilledHole->map_change_scope_to_local_index(
+            $remoteScope
+        );
+        $this->assertFalse($localScope->subtree_may_change('shared/dir'));
+        $localScope->close();
+        $remoteScope->close();
+    }
+
+    public function testFollowedPlacementAliasProtectionBlocksLocalEntry(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/outside'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/followed/outside'],
+        ]);
+        $mapper = new \RemoteToLocalPathMapper(
+            '/local',
+            ['/followed/outside'],
+            [],
+            '/local/followed'
+        );
+
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [$protectedSnapshotId]
+        );
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $this->assertFalse(
+            $localScope->index_entry_may_change(
+                'followed/outside/file.php',
+                'file'
+            )
+        );
+        $localScope->close();
+        $remoteScope->close();
+
+        $remoteScope = $this->scope($currentSnapshotId);
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $this->assertTrue(
+            $localScope->index_entry_may_change(
+                'followed/outside/file.php',
+                'file'
+            )
+        );
+        $localScope->close();
+        $remoteScope->close();
+    }
+
+    public function testLocalExactLinkAndArbitraryBytesRoundTrip(): void
+    {
+        $remoteRoot = "/remote-\xFF";
+        $remoteLink = $remoteRoot . "/link-\xFC";
+        $filesystemRoot = "/local-\xFD";
+        $localPrefix = $filesystemRoot . "/mapped-\xFE";
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => $remoteLink],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            [],
+            true
+        );
+        $mapper = new \RemoteToLocalPathMapper(
+            $filesystemRoot,
+            [$remoteRoot],
+            [$remoteRoot => $localPrefix]
+        );
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localRelativeLink = "mapped-\xFE/link-\xFC";
+
+        $this->assertTrue(
+            $localScope->index_entry_may_change($localRelativeLink, 'link')
+        );
+        $this->assertFalse(
+            $localScope->index_entry_may_change($localRelativeLink, 'file')
+        );
+        $this->assertSame(
+            $localRelativeLink,
+            $localScope->map_remote_absolute_path_to_index_path($remoteLink)
+        );
+        $this->assertSame($filesystemRoot, $localScope->get_filesystem_root());
+        $this->assertTrue($localScope->includes_caches());
+
+        $config = $localScope->get_config();
+        $this->assertSame('local_relative', $config['index_path_coordinates']);
+        $this->assertSame(
+            $mapper->get_config(),
+            $config['remote_to_local_path_mapper_config']
+        );
+        $this->assertIsString(json_encode($config, JSON_THROW_ON_ERROR));
+        $resumedScope = \FileSyncChangeScope::from_config($config);
+        $this->assertTrue(
+            $resumedScope->index_entry_may_change($localRelativeLink, 'link')
+        );
+
+        $resumedScope->close();
+        $localScope->close();
+        $remoteScope->close();
+    }
+
+    public function testLocalConfigDiscriminatorAndAccessorsAreStrict(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $remoteScope = $this->scope($currentSnapshotId);
+        try {
+            $remoteScope->get_filesystem_root();
+            $this->fail('Remote-coordinate scope exposed a local filesystem root.');
+        } catch (\LogicException $exception) {
+            $this->assertStringContainsString(
+                'uses remote_absolute index paths',
+                $exception->getMessage()
+            );
+        }
+        try {
+            $remoteScope->map_remote_absolute_path_to_index_path('/site');
+            $this->fail('Remote-coordinate scope exposed local path mapping.');
+        } catch (\LogicException $exception) {
+            $this->assertStringContainsString(
+                'uses remote_absolute index paths',
+                $exception->getMessage()
+            );
+        }
+
+        $mapper = new \RemoteToLocalPathMapper('/local', ['/site']);
+        $config = $remoteScope->get_config();
+        $config['index_path_coordinates'] = 'local_relative';
+        try {
+            \FileSyncChangeScope::from_config($config);
+            $this->fail('Local-relative config omitted its path mapper.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'fields must be exactly',
+                $exception->getMessage()
+            );
+        }
+
+        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        try {
+            $mapper->map_change_scope_to_local_index($localScope);
+            $this->fail('A local-relative scope was mapped a second time.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'Only a remote_absolute',
+                $exception->getMessage()
+            );
+        }
+
+        $config = $remoteScope->get_config();
+        $config['remote_to_local_path_mapper_config'] = $mapper->get_config();
+        try {
+            \FileSyncChangeScope::from_config($config);
+            $this->fail('Remote-absolute config accepted a local mapper.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'fields must be exactly',
+                $exception->getMessage()
+            );
+        }
+
+        $config = $localScope->get_config();
+        $config['remote_to_local_path_mapper_config']['unexpected'] = true;
+        try {
+            \FileSyncChangeScope::from_config($config);
+            $this->fail('Local-relative config accepted an unknown mapper field.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'path-mapper config fields must be exactly',
+                $exception->getMessage()
+            );
+        }
+
+        $config = $localScope->get_config();
+        $config['remote_to_local_path_mapper_config']['filesystem_root_b64'] .= '=';
+        try {
+            \FileSyncChangeScope::from_config($config);
+            $this->fail('Local-relative config accepted noncanonical mapper base64.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'invalid path-mapper config',
+                $exception->getMessage()
+            );
+        }
+
+        $localScope->close();
+        $remoteScope->close();
+    }
+
     public function testStrictConfigRejectsUnknownFieldsAndUnsortedRawPaths(): void
     {
         $currentSnapshotId = $this->publishSnapshot([]);
@@ -376,11 +645,11 @@ class FileSyncChangeScopeTest extends TestCase {
     {
         $currentSnapshotId = $this->publishSnapshot([]);
         $config = $this->config($currentSnapshotId);
-        $config['index_path_coordinates'] = 'local_relative';
+        $config['index_path_coordinates'] = 'document_root_relative';
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'index_path_coordinates must be remote_absolute'
+            'must be remote_absolute or local_relative'
         );
         \FileSyncChangeScope::from_config($config);
     }

--- a/tests/Import/RemoteToLocalPathMapperTest.php
+++ b/tests/Import/RemoteToLocalPathMapperTest.php
@@ -80,6 +80,82 @@ final class RemoteToLocalPathMapperTest extends TestCase
         );
     }
 
+    public function testReturnsEveryVerifiedRemoteAliasForOverlappingRemapTargets(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/remote/site', '/remote/shared'],
+            [
+                '/remote/site' => '/local/content',
+                '/remote/site/plugins' => '/local/plugins',
+                '/remote/shared' => '/local/content/shared',
+            ]
+        );
+
+        $this->assertSame(
+            [
+                '/content/shared/file.txt',
+                '/remote/site/shared/file.txt',
+                '/remote/shared/file.txt',
+            ],
+            $mapper->remote_paths_mapping_to('/local/content/shared/file.txt')
+        );
+        $this->assertSame(
+            ['/plugins/hello.php', '/remote/site/plugins/hello.php'],
+            $mapper->remote_paths_mapping_to('/local/plugins/hello.php')
+        );
+        $this->assertSame(
+            ['/content/plugins/hello.php'],
+            $mapper->remote_paths_mapping_to('/local/content/plugins/hello.php')
+        );
+    }
+
+    public function testReturnsIdentityAndFollowedPlacementAliasesOnlyWhenTheyMapForward(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/followed/site'],
+            [],
+            '/local/followed'
+        );
+
+        $this->assertSame(
+            ['/followed/site/file.txt', '/site/file.txt'],
+            $mapper->remote_paths_mapping_to('/local/followed/site/file.txt')
+        );
+        $this->assertSame(
+            ['/mnt/shared/file.txt'],
+            $mapper->remote_paths_mapping_to('/local/followed/mnt/shared/file.txt')
+        );
+    }
+
+    public function testExactPlacementRootsReturnVerifiedRootAliases(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/'],
+            ['/mapped' => '/local']
+        );
+        $this->assertSame(
+            ['/', '/mapped'],
+            $mapper->remote_paths_mapping_to('/local')
+        );
+        $this->assertFalse(
+            $mapper->remote_path_owns_mapped_local_subtree('/')
+        );
+
+        $followedMapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/site'],
+            [],
+            '/local/followed'
+        );
+        $this->assertSame(
+            ['/'],
+            $followedMapper->remote_paths_mapping_to('/local/followed')
+        );
+    }
+
     public function testRemotePathDoesNotOwnLocalSubtreeContainingAnotherRemapTarget(): void
     {
         $mapper = new RemoteToLocalPathMapper(
@@ -112,6 +188,118 @@ final class RemoteToLocalPathMapperTest extends TestCase
         $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/b/file.txt'));
     }
 
+    public function testRemotePathsDoNotOwnTheSameMappedLocalRoot(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a', '/b'],
+            [
+                '/a' => '/local/shared',
+                '/b' => '/local/shared',
+            ]
+        );
+
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/a'));
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/b'));
+    }
+
+    public function testRemotePathDoesNotOwnSubtreeWithDescendantRemapSourceHole(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a', '/b'],
+            [
+                '/a' => '/local/shared',
+                '/a/hole' => '/local/elsewhere',
+                '/b' => '/local/shared/hole',
+            ]
+        );
+
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/a'));
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/b'));
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/a/file.txt'));
+    }
+
+    public function testRemotePathOwnsSubtreeAcrossContinuousNestedRemap(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a'],
+            [
+                '/a' => '/local/shared',
+                '/a/nested' => '/local/shared/nested',
+            ]
+        );
+
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/a'));
+    }
+
+    public function testRemotePathDoesNotOwnNestedRemapTargetAliasedByParentPlacement(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/a'],
+            [
+                '/a' => '/local/shared',
+                '/a/nested' => '/local/shared/other',
+            ]
+        );
+        $this->assertFalse(
+            $mapper->remote_path_owns_mapped_local_subtree('/a/nested')
+        );
+    }
+
+    public function testRemotePathDoesNotOwnSubtreeAcrossOriginalFollowedPlacementBoundary(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/srv/site'],
+            [],
+            '/local/followed'
+        );
+
+        $this->assertFalse($mapper->remote_path_owns_mapped_local_subtree('/srv'));
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/srv/site'));
+        $this->assertTrue($mapper->remote_path_owns_mapped_local_subtree('/mnt/shared'));
+    }
+
+    public function testRemoteFilesystemRootOwnsOnlyOneContinuousPlacement(): void
+    {
+        $identityMapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/'],
+            [],
+            '/local/followed'
+        );
+        $this->assertTrue(
+            $identityMapper->remote_path_owns_mapped_local_subtree('/')
+        );
+
+        $splitMapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/site'],
+            [],
+            '/local/followed'
+        );
+        $this->assertFalse(
+            $splitMapper->remote_path_owns_mapped_local_subtree('/')
+        );
+    }
+
+    public function testRemotePathDoesNotOwnSubtreeWithForeignPlacementAlias(): void
+    {
+        $mapper = new RemoteToLocalPathMapper(
+            '/local',
+            ['/followed/site'],
+            [],
+            '/local/followed'
+        );
+
+        $this->assertFalse(
+            $mapper->remote_path_owns_mapped_local_subtree('/followed/site')
+        );
+    }
+
     public function testPathBytesDoNotNeedToBeValidUtf8(): void
     {
         $remote_root = "/srv/site-\xff";
@@ -126,6 +314,10 @@ final class RemoteToLocalPathMapperTest extends TestCase
         $this->assertSame(
             $local_content . '/file.txt',
             $mapper->map_path($remote_content . '/file.txt')
+        );
+        $this->assertSame(
+            ["/content-\xfd/file.txt", $remote_content . '/file.txt'],
+            $mapper->remote_paths_mapping_to($local_content . '/file.txt')
         );
     }
 


### PR DESCRIPTION
Files-pull ownership can now be evaluated in local-index coordinates after remaps and followed-symlink placement.

The local scope inverse-maps each candidate through every valid placement, forward-verifies aliases, and requires all owned aliases to permit a change. This leaves remap source holes, protected overlaps, excluded paths, and discontinuous subtrees untouched while allowing another mapping to fill a source hole.

The scope keeps one canonical mapper configuration and preserves disk-backed snapshot lookups, arbitrary-byte paths, and bounded handles. Cleanup and final mirror verification will consume it in follow-up changes.