### PR TITLE
[PHP] Retain pulled default-skipped local index rows

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -59,8 +59,8 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  *     }
  *
  * No local type, size, or ctime is needed because the local path is already
- * gone. A skipped path or a path outside the filesystem root also has no local
- * fields.
+ * gone. A path outside the filesystem root, or the root itself, also has no
+ * local fields.
  *
  * Applying the `+` record above writes these index entries:
  *
@@ -271,7 +271,7 @@ class PullIndexJournal
      * files-diff and PushPlan compare the path with the old local index and
      * treat the pulled path as a new local change.
      *
-     * A null local path, a path outside the filesystem root, or a skipped path
+     * A null local path, a path outside the filesystem root, or the root itself
      * updates only the remote index.
      *
      * @param string      $remote_absolute_path Source absolute path.
@@ -336,8 +336,7 @@ class PullIndexJournal
      * Adds a `-` record after files-pull removes a local path.
      *
      * The record always removes the remote index entry. If the local path is
-     * under the filesystem root and is not skipped, it removes the local index
-     * entry too.
+     * below the filesystem root, it removes the local index entry too.
      *
      * @param string $remote_absolute_path Deleted source absolute path.
      * @param string $local_absolute_path  Local path already removed.
@@ -711,7 +710,7 @@ class PullIndexJournal
      * Returns the path used by the local index.
      *
      * The path is relative to the filesystem root. This method returns null
-     * for the root itself, a path outside it, or a skipped path.
+     * for the root itself or a path outside it.
      *
      * @param string $local_absolute_path Absolute local path.
      * @return string|null Relative path, or null when the local index must not
@@ -730,11 +729,7 @@ class PullIndexJournal
         ) {
             return null;
         }
-        return FileIndexProcessor::path_is_default_skipped(
-            $local_relative_path
-        )
-            ? null
-            : $local_relative_path;
+        return $local_relative_path;
     }
 
     /**

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -73,6 +73,70 @@ final class PullIndexWalTest extends TestCase
         $this->assertFileDoesNotExist($pullIndexWalPath);
     }
 
+    public function testAppliedBatchRetainsDefaultSkippedLocalUpsert(): void
+    {
+        $localRelativePath = 'wp-content/cache/pulled.txt';
+        $this->assertTrue(
+            \FileIndexProcessor::path_is_default_skipped($localRelativePath)
+        );
+        $filesystemRoot = realpath($this->fileRoot);
+        $this->assertIsString($filesystemRoot);
+        $localAbsolutePath = $filesystemRoot . '/' . $localRelativePath;
+        mkdir(dirname($localAbsolutePath), 0700, true);
+        file_put_contents($localAbsolutePath, 'changed cache');
+        $localPathStat = lstat($localAbsolutePath);
+        $this->assertIsArray($localPathStat);
+
+        $journal = $this->journal($this->client());
+        $journal->record_remote_upsert(
+            '/site/wp-content/cache/pulled.txt',
+            42,
+            13,
+            'file',
+            $localAbsolutePath
+        );
+        $journal->apply_pending_records();
+
+        $localIndexEntries = $this->readLocalIndex();
+        $this->assertArrayHasKey($localRelativePath, $localIndexEntries);
+        $this->assertSame(
+            (int) $localPathStat['ctime'],
+            $localIndexEntries[$localRelativePath]['ctime']
+        );
+        $this->assertSame(13, $localIndexEntries[$localRelativePath]['size']);
+        $this->assertSame('file', $localIndexEntries[$localRelativePath]['type']);
+    }
+
+    public function testAppliedBatchAppliesDefaultSkippedLocalDeletionWithArbitraryPathBytes(): void
+    {
+        $arbitraryByte = chr(255);
+        $localRelativePath = 'site/node_modules/generated-' . $arbitraryByte . '.js';
+        $this->assertTrue(
+            \FileIndexProcessor::path_is_default_skipped($localRelativePath)
+        );
+        $filesystemRoot = realpath($this->fileRoot);
+        $this->assertIsString($filesystemRoot);
+        $localAbsolutePath = $filesystemRoot . '/' . $localRelativePath;
+        file_put_contents(
+            dirname($this->pullStateDirectory) . '/local_index.jsonl',
+            json_encode([
+                'path' => base64_encode($localRelativePath),
+                'ctime' => 10,
+                'size' => 7,
+                'type' => 'file',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
+        );
+
+        $journal = $this->journal($this->client());
+        $journal->record_successful_deletion(
+            '/site/node_modules/generated-' . $arbitraryByte . '.js',
+            $localAbsolutePath
+        );
+        $journal->apply_pending_records();
+
+        $this->assertSame([], $this->readLocalIndex());
+    }
+
     public function testRecordedMutationsUsePlusAndMinusOperations(): void
     {
         $journal = $this->journal($this->client());


### PR DESCRIPTION
Files-pull now retains local-index metadata for every selected path it actually changes, including paths that normally match cache or development skips.

The pull journal already receives only successful mutations. Removing its second default-skip filter keeps local upserts and deletions aligned with their remote records while paths outside the filesystem root and the root itself remain excluded. This preserves arbitrary-byte paths and gives later cleanup and verification an accurate baseline for selected intermediate links.
