### PR TITLE
[PHP] Materialize selected skipped paths for local sync

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
@@ -30,8 +30,9 @@ use function WordPress\Reprint\Exporter\relative_path_under;
  *
  * @phpstan-type MapperConfig array{filesystem_root_b64:string,original_remote_roots_b64:list<string>,resolved_path_mappings:list<array{remote_prefix_b64:string,local_prefix_b64:string}>,local_followed_symlinks_root_b64:string|null}
  * @phpstan-type RemoteAbsoluteConfig array{index_path_coordinates:'remote_absolute',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool}
- * @phpstan-type LocalRelativeConfig array{index_path_coordinates:'local_relative',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool,remote_to_local_path_mapper_config:MapperConfig}
+ * @phpstan-type LocalRelativeConfig array{index_path_coordinates:'local_relative',ownership_directory_b64:string,current_snapshot_id:string,prior_snapshot_ids:list<string>,protected_snapshot_ids:list<string>,excluded_remote_absolute_path_roots_b64:list<string>,include_caches:bool,remote_to_local_path_mapper_config:MapperConfig,selected_default_skipped_index_paths_file_b64:string}
  * @phpstan-type Config RemoteAbsoluteConfig|LocalRelativeConfig
+ * @phpstan-type SelectedAtomCursor array{selection_fingerprint:string,selected_snapshot_index:int,paths_byte_offset:int}
  */
 final class FileSyncChangeScope
 {
@@ -42,6 +43,7 @@ final class FileSyncChangeScope
     private array $config;
     private string $ownership_directory;
     private ?RemoteToLocalPathMapper $remote_to_local_path_mapper = null;
+    private ?string $selected_default_skipped_index_paths_file = null;
     /** @var list<string> */
     private array $excluded_remote_absolute_path_roots = [];
     private ?string $open_snapshot_id = null;
@@ -310,6 +312,147 @@ final class FileSyncChangeScope
         return $this->config['include_caches'];
     }
 
+    /**
+     * Reports whether root ownership can change any entry in a remote region.
+     *
+     * A full exclusion blocks the region. Current root ownership wins over
+     * another selection, while a protected root blocks prior ownership.
+     */
+    public function root_owned_region_may_change(
+        string $remote_absolute_path
+    ): bool {
+        $this->assert_open();
+        $this->assert_remote_atom_enumeration();
+        self::assert_remote_absolute_path($remote_absolute_path);
+        if ($this->path_is_excluded($remote_absolute_path)) {
+            return false;
+        }
+        if ($this->snapshots_have_root_at_or_above(
+            [$this->config['current_snapshot_id']],
+            $remote_absolute_path
+        )) {
+            return true;
+        }
+        if ($this->snapshots_have_root_at_or_above(
+            $this->config['protected_snapshot_ids'],
+            $remote_absolute_path
+        )) {
+            return false;
+        }
+        return $this->snapshots_have_root_at_or_above(
+            $this->config['prior_snapshot_ids'],
+            $remote_absolute_path
+        );
+    }
+
+    /**
+     * Returns the sorted path-only sidecar for default-skipped local paths.
+     */
+    public function get_selected_default_skipped_index_paths_file(): string
+    {
+        $this->get_local_path_mapper();
+        if ($this->selected_default_skipped_index_paths_file === null) {
+            throw new LogicException(
+                'Local-relative file-sync change scope has no selected default-skipped paths file.'
+            );
+        }
+        return $this->selected_default_skipped_index_paths_file;
+    }
+
+    /** @phpstan-return SelectedAtomCursor */
+    public function initial_selected_ownership_atom_cursor(): array
+    {
+        $this->assert_open();
+        $this->assert_remote_atom_enumeration();
+        return [
+            'selection_fingerprint' => $this->selected_snapshot_fingerprint(),
+            'selected_snapshot_index' => 0,
+            'paths_byte_offset' => 0,
+        ];
+    }
+
+    /** @phpstan-return SelectedAtomCursor */
+    public function completed_selected_ownership_atom_cursor(): array
+    {
+        $cursor = $this->initial_selected_ownership_atom_cursor();
+        $cursor['selected_snapshot_index'] = count(
+            $this->selected_snapshot_ids()
+        );
+        return $cursor;
+    }
+
+    /**
+     * Validates one selected-atom cursor and reports whether it reached EOF.
+     *
+     * @phpstan-param SelectedAtomCursor $cursor
+     */
+    public function selected_ownership_atom_cursor_is_complete(
+        array $cursor
+    ): bool {
+        $this->assert_open();
+        $this->assert_remote_atom_enumeration();
+        $this->assert_selected_atom_cursor($cursor);
+        return $cursor['selected_snapshot_index']
+            === count($this->selected_snapshot_ids());
+    }
+
+    /**
+     * Reads one current-or-prior ownership atom or advances one snapshot.
+     *
+     * Protected snapshots decide whether work is blocked, but never supply
+     * work candidates. Callers retain the returned cursor unchanged between
+     * bounded steps.
+     *
+     * @phpstan-param SelectedAtomCursor $cursor
+     * @return array {
+     *     @type array|null $atom     One ownership atom, or null for a snapshot transition.
+     *     @type array      $cursor   Cursor for the next bounded read.
+     *     @type bool       $complete Whether every selected snapshot is consumed.
+     * }
+     * @phpstan-return array{atom:array{kind:'root'|'exact'|'ancestor',path:string}|null,cursor:SelectedAtomCursor,complete:bool}
+     */
+    public function read_next_selected_ownership_atom(array $cursor): array
+    {
+        $this->assert_open();
+        $this->assert_remote_atom_enumeration();
+        $this->assert_selected_atom_cursor($cursor);
+        $snapshot_ids = $this->selected_snapshot_ids();
+        $snapshot_index = $cursor['selected_snapshot_index'];
+        if ($snapshot_index === count($snapshot_ids)) {
+            return ['atom' => null, 'cursor' => $cursor, 'complete' => true];
+        }
+
+        $snapshot_id = $snapshot_ids[$snapshot_index];
+        $this->open_snapshot($snapshot_id);
+        if ($cursor['paths_byte_offset'] === $this->open_paths_bytes) {
+            ++$cursor['selected_snapshot_index'];
+            $cursor['paths_byte_offset'] = 0;
+            return [
+                'atom' => null,
+                'cursor' => $cursor,
+                'complete' => $cursor['selected_snapshot_index'] === count($snapshot_ids),
+            ];
+        }
+        if ($cursor['paths_byte_offset'] > $this->open_paths_bytes) {
+            throw new UnexpectedValueException(
+                "Ownership snapshot {$snapshot_id} atom cursor exceeds its paths file."
+            );
+        }
+
+        $atom = $this->read_path_atom(
+            $snapshot_id,
+            $cursor['paths_byte_offset']
+        );
+        $next_paths_byte_offset = ftell($this->open_paths_handle);
+        if (!is_int($next_paths_byte_offset)) {
+            throw new RuntimeException(
+                "Ownership snapshot {$snapshot_id} path position cannot be read."
+            );
+        }
+        $cursor['paths_byte_offset'] = $next_paths_byte_offset;
+        return ['atom' => $atom, 'cursor' => $cursor, 'complete' => false];
+    }
+
     public function close(): void
     {
         if ($this->closed) {
@@ -379,7 +522,7 @@ final class FileSyncChangeScope
         }
         if (
             $owning_root !== null
-            && !$this->root_traversal_has_default_skip(
+            && !FileIndexProcessor::path_is_default_skipped_below_root(
                 $owning_root,
                 $remote_absolute_path
             )
@@ -438,6 +581,21 @@ final class FileSyncChangeScope
     }
 
     /** @param list<string> $snapshot_ids */
+    private function snapshots_have_root_at_or_above(
+        array $snapshot_ids,
+        string $remote_absolute_path
+    ): bool {
+        return $this->snapshots_contain_atom(
+            $snapshot_ids,
+            'root',
+            $remote_absolute_path
+        ) || $this->deepest_owning_root(
+            $snapshot_ids,
+            $remote_absolute_path
+        ) !== null;
+    }
+
+    /** @param list<string> $snapshot_ids */
     private function deepest_owning_root(
         array $snapshot_ids,
         string $remote_absolute_path
@@ -454,27 +612,6 @@ final class FileSyncChangeScope
             $ancestor = self::strict_parent($ancestor);
         }
         return null;
-    }
-
-    private function root_traversal_has_default_skip(
-        string $root,
-        string $remote_absolute_path
-    ): bool {
-        // The producer schedules the root without classifying it, then checks
-        // each child using that child's full absolute path.
-        $relative_path = $root === '/'
-            ? substr($remote_absolute_path, 1)
-            : substr($remote_absolute_path, strlen($root) + 1);
-        $prefix = $root;
-        foreach (explode('/', $relative_path) as $component) {
-            $prefix = $prefix === '/'
-                ? '/' . $component
-                : $prefix . '/' . $component;
-            if (FileIndexProcessor::path_is_default_skipped($prefix)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private function snapshot_contains_atom(
@@ -758,6 +895,7 @@ final class FileSyncChangeScope
         ];
         if ($index_path_coordinates === 'local_relative') {
             $expected_keys[] = 'remote_to_local_path_mapper_config';
+            $expected_keys[] = 'selected_default_skipped_index_paths_file_b64';
         }
         $actual_keys = array_keys($config);
         sort($actual_keys, SORT_STRING);
@@ -838,6 +976,11 @@ final class FileSyncChangeScope
                 }
             }
             $this->remote_to_local_path_mapper = $path_mapper;
+            $this->selected_default_skipped_index_paths_file =
+                self::decode_config_path(
+                    $config['selected_default_skipped_index_paths_file_b64'],
+                    'selected default-skipped index paths file'
+                );
         }
         /** @var Config $config */
         $this->config = $config;
@@ -955,6 +1098,84 @@ final class FileSyncChangeScope
         return $last_separator === 0
             ? '/'
             : substr($remote_absolute_path, 0, $last_separator);
+    }
+
+    /** @return list<string> */
+    private function selected_snapshot_ids(): array
+    {
+        return array_values(array_unique(array_merge(
+            [$this->config['current_snapshot_id']],
+            $this->config['prior_snapshot_ids']
+        )));
+    }
+
+    private function selected_snapshot_fingerprint(): string
+    {
+        $framed_selection = pack(
+            'N',
+            strlen($this->ownership_directory)
+        ) . $this->ownership_directory;
+        foreach ($this->selected_snapshot_ids() as $snapshot_id) {
+            $framed_selection .= pack('N', strlen($snapshot_id)) . $snapshot_id;
+        }
+        return hash('sha256', $framed_selection);
+    }
+
+    private function assert_remote_atom_enumeration(): void
+    {
+        if ($this->config['index_path_coordinates'] !== 'remote_absolute') {
+            throw new LogicException(
+                'Selected ownership atoms may be read only from a remote_absolute file-sync change scope.'
+            );
+        }
+    }
+
+    /** @phpstan-param SelectedAtomCursor $cursor */
+    private function assert_selected_atom_cursor(array $cursor): void
+    {
+        $actual_keys = array_keys($cursor);
+        sort($actual_keys, SORT_STRING);
+        $expected_keys = [
+            'selection_fingerprint',
+            'selected_snapshot_index',
+            'paths_byte_offset',
+        ];
+        sort($expected_keys, SORT_STRING);
+        if ($actual_keys !== $expected_keys) {
+            throw new InvalidArgumentException(
+                'Selected ownership-atom cursor fields are invalid.'
+            );
+        }
+        if (
+            !is_string($cursor['selection_fingerprint'])
+            || preg_match(
+                '/^[0-9a-f]{64}$/D',
+                $cursor['selection_fingerprint']
+            ) !== 1
+            || !hash_equals(
+                $this->selected_snapshot_fingerprint(),
+                $cursor['selection_fingerprint']
+            )
+        ) {
+            throw new InvalidArgumentException(
+                'Selected ownership-atom cursor does not match the change scope.'
+            );
+        }
+        if (
+            !is_int($cursor['selected_snapshot_index'])
+            || $cursor['selected_snapshot_index'] < 0
+            || $cursor['selected_snapshot_index'] > count($this->selected_snapshot_ids())
+            || !is_int($cursor['paths_byte_offset'])
+            || $cursor['paths_byte_offset'] < 0
+            || (
+                $cursor['selected_snapshot_index'] === count($this->selected_snapshot_ids())
+                && $cursor['paths_byte_offset'] !== 0
+            )
+        ) {
+            throw new InvalidArgumentException(
+                'Selected ownership-atom cursor positions are invalid.'
+            );
+        }
     }
 
     private function assert_open(): void

--- a/packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php
+++ b/packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php
@@ -630,6 +630,7 @@ final class FileSyncChangeScopeMappingProcessor
             );
         }
         if (!$is_scanning) {
+            clearstatcache(true, $this->unsorted_paths_file);
             $source_stat = @lstat($this->unsorted_paths_file);
             if (
                 !is_array($source_stat)

--- a/packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php
+++ b/packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php
@@ -1,0 +1,645 @@
+<?php
+declare(strict_types=1);
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+
+require_once __DIR__ . '/../class-external-sort-processor.php';
+require_once __DIR__ . '/../index/class-file-sync-change-scope.php';
+require_once __DIR__ . '/class-remote-to-local-path-mapper.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Errors contain private state paths, never HTML.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer processors use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer processors place braces on the following line.
+
+/**
+ * Maps one remote file-sync change scope into local index coordinates.
+ *
+ * Current and prior exact ownership atoms are the only candidates which can
+ * be selected despite the ordinary local indexer's default skips. One scan
+ * step reads one atom, checks one mapping boundary, or appends one candidate.
+ * The path-only sidecar is sorted and deduplicated before atomic publication.
+ * Protected snapshots never supply candidates; the mapped change scope still
+ * consults them before an exact path is retained.
+ *
+ * A root-owned remote region must not gain stricter default skips after path
+ * mapping. Each owned root placement and each reachable explicit remap is
+ * checked separately, so a normal local traversal can still observe every
+ * remote-visible descendant without scanning all default-skipped directories.
+ *
+ * @phpstan-type SelectedAtomCursor array{selection_fingerprint:string,selected_snapshot_index:int,paths_byte_offset:int}
+ * @phpstan-type Cursor array{phase:'scanning_atoms'|'starting_sort'|'sorting_paths'|'complete',configuration_fingerprint:string,selected_atom_cursor:SelectedAtomCursor,pending_root_path_b64:string|null,pending_mapping_index:int,paths_byte_offset:int,sort_cursor:array|null}
+ */
+final class FileSyncChangeScopeMappingProcessor
+{
+    private const MAXIMUM_PATH_ROW_BYTES = 65536;
+    private const CONTEXT_RANKS = [
+        'ordinary' => 0,
+        'wp_content' => 1,
+        'all_descendants' => 2,
+    ];
+
+    private FileSyncChangeScope $remote_change_scope;
+    private FileSyncChangeScope $local_change_scope;
+    private RemoteToLocalPathMapper $remote_to_local_path_mapper;
+    private string $work_directory;
+    private string $unsorted_paths_file;
+    private string $selected_paths_file;
+    private string $configuration_fingerprint;
+    /** @phpstan-var Cursor */
+    private array $cursor;
+    /** @var resource|null */
+    private $paths_handle = null;
+    private ?ExternalSortProcessor $sort_processor = null;
+    private bool $closed = false;
+
+    public static function start(
+        FileSyncChangeScope $remote_change_scope,
+        RemoteToLocalPathMapper $remote_to_local_path_mapper,
+        string $work_directory
+    ): self {
+        $work_directory = self::prepare_work_directory($work_directory);
+        $unsorted_paths_file = $work_directory
+            . '/selected-default-skipped-index-paths.unsorted.jsonl';
+        if (is_link($unsorted_paths_file)) {
+            throw new InvalidArgumentException(
+                'Selected default-skipped paths work file must not be a symbolic link.'
+            );
+        }
+        $paths_handle = @fopen($unsorted_paths_file, 'wb');
+        if (!is_resource($paths_handle) || !fflush($paths_handle)) {
+            if (is_resource($paths_handle)) {
+                fclose($paths_handle);
+            }
+            throw new RuntimeException(
+                "Failed to initialize selected default-skipped paths work file: {$unsorted_paths_file}."
+            );
+        }
+        fclose($paths_handle);
+
+        $phase = $remote_change_scope->includes_caches()
+            ? 'starting_sort'
+            : 'scanning_atoms';
+        return self::resume(
+            $remote_change_scope,
+            $remote_to_local_path_mapper,
+            $work_directory,
+            [
+                'phase' => $phase,
+                'configuration_fingerprint' => self::configuration_fingerprint(
+                    $remote_change_scope,
+                    $remote_to_local_path_mapper,
+                    $work_directory
+                ),
+                'selected_atom_cursor' => $remote_change_scope->includes_caches()
+                    ? $remote_change_scope->completed_selected_ownership_atom_cursor()
+                    : $remote_change_scope->initial_selected_ownership_atom_cursor(),
+                'pending_root_path_b64' => null,
+                'pending_mapping_index' => 0,
+                'paths_byte_offset' => 0,
+                'sort_cursor' => null,
+            ]
+        );
+    }
+
+    /** @phpstan-param Cursor $cursor */
+    public static function resume(
+        FileSyncChangeScope $remote_change_scope,
+        RemoteToLocalPathMapper $remote_to_local_path_mapper,
+        string $work_directory,
+        array $cursor
+    ): self {
+        $work_directory = self::prepare_work_directory($work_directory);
+        $remote_config = $remote_change_scope->get_config();
+        if ($remote_config['index_path_coordinates'] !== 'remote_absolute') {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping requires remote_absolute index paths.'
+            );
+        }
+
+        $processor = new self();
+        $processor->remote_change_scope = $remote_change_scope;
+        $processor->remote_to_local_path_mapper = $remote_to_local_path_mapper;
+        $processor->work_directory = $work_directory;
+        $processor->unsorted_paths_file = $work_directory
+            . '/selected-default-skipped-index-paths.unsorted.jsonl';
+        $processor->selected_paths_file = $work_directory
+            . '/selected-default-skipped-index-paths.jsonl';
+        $processor->configuration_fingerprint = self::configuration_fingerprint(
+            $remote_change_scope,
+            $remote_to_local_path_mapper,
+            $work_directory
+        );
+        $processor->cursor = $cursor;
+        $processor->assert_cursor();
+        if (!hash_equals(
+            $processor->configuration_fingerprint,
+            $cursor['configuration_fingerprint']
+        )) {
+            throw new UnexpectedValueException(
+                'File-sync change-scope mapping configuration changed after start.'
+            );
+        }
+        $processor->local_change_scope =
+            $remote_to_local_path_mapper->map_change_scope_to_local_index(
+                $remote_change_scope,
+                $processor->selected_paths_file
+            );
+        try {
+            $processor->open_phase_resources();
+            if (
+                $cursor['phase'] === 'complete'
+                && !is_file($processor->selected_paths_file)
+            ) {
+                throw new UnexpectedValueException(
+                    'Completed file-sync change-scope selected paths file does not exist.'
+                );
+            }
+        } catch (Throwable $throwable) {
+            $processor->close();
+            throw $throwable;
+        }
+        return $processor;
+    }
+
+    public function next_step(): bool
+    {
+        if ($this->cursor['phase'] === 'complete') {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException(
+                'Cannot take a file-sync change-scope mapping step after close().'
+            );
+        }
+        switch ($this->cursor['phase']) {
+            case 'scanning_atoms':
+                return $this->scan_next_atom_or_mapping();
+            case 'starting_sort':
+                return $this->start_sort();
+            case 'sorting_paths':
+                return $this->sort_next_step();
+        }
+    }
+
+    /** @phpstan-return Cursor */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** @return array<string,mixed> Strict local-relative change-scope config. */
+    public function get_local_change_scope_config(): array
+    {
+        if ($this->cursor['phase'] !== 'complete') {
+            throw new LogicException(
+                'Local file-sync change-scope config is unavailable before mapping completes.'
+            );
+        }
+        return $this->local_change_scope->get_config();
+    }
+
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->closed = true;
+        if (is_resource($this->paths_handle)) {
+            fclose($this->paths_handle);
+        }
+        $this->paths_handle = null;
+        if ($this->sort_processor !== null) {
+            $this->sort_processor->close();
+            $this->sort_processor = null;
+        }
+        $this->local_change_scope->close();
+    }
+
+    private function scan_next_atom_or_mapping(): bool
+    {
+        $this->open_phase_resources();
+        if ($this->cursor['pending_root_path_b64'] !== null) {
+            return $this->validate_next_root_mapping();
+        }
+
+        $result = $this->remote_change_scope->read_next_selected_ownership_atom(
+            $this->cursor['selected_atom_cursor']
+        );
+        if ($result['atom'] === null) {
+            $this->cursor['selected_atom_cursor'] = $result['cursor'];
+            if ($result['complete']) {
+                $this->close_paths_handle();
+                $this->cursor['phase'] = 'starting_sort';
+            }
+            return true;
+        }
+
+        $atom = $result['atom'];
+        if ($atom['kind'] === 'root') {
+            $this->cursor['selected_atom_cursor'] = $result['cursor'];
+            $this->cursor['pending_root_path_b64'] = base64_encode($atom['path']);
+            $this->cursor['pending_mapping_index'] = 0;
+            return true;
+        }
+        if ($atom['kind'] === 'exact') {
+            $this->append_selected_exact_path($atom['path']);
+        }
+        $this->cursor['selected_atom_cursor'] = $result['cursor'];
+        return true;
+    }
+
+    private function validate_next_root_mapping(): bool
+    {
+        $remote_root = base64_decode(
+            $this->cursor['pending_root_path_b64'],
+            true
+        );
+        if (!is_string($remote_root)) {
+            throw new UnexpectedValueException(
+                'File-sync change-scope mapping cursor root path is invalid.'
+            );
+        }
+        $mapping_prefixes =
+            $this->remote_to_local_path_mapper
+                ->get_resolved_remote_mapping_prefixes();
+        $mapping_index = $this->cursor['pending_mapping_index'];
+        if ($mapping_index === 0) {
+            $this->assert_region_mapping_preserves_default_skips($remote_root);
+        } else {
+            $remote_mapping_prefix = $mapping_prefixes[$mapping_index - 1];
+            if (
+                $remote_mapping_prefix !== $remote_root
+                && path_is_same_as_or_descendant_of(
+                    $remote_mapping_prefix,
+                    $remote_root
+                )
+                && !FileIndexProcessor::path_is_default_skipped_below_root(
+                    $remote_root,
+                    $remote_mapping_prefix
+                )
+            ) {
+                $this->assert_region_mapping_preserves_default_skips(
+                    $remote_mapping_prefix
+                );
+            }
+        }
+
+        ++$this->cursor['pending_mapping_index'];
+        if ($this->cursor['pending_mapping_index'] > count($mapping_prefixes)) {
+            $this->cursor['pending_root_path_b64'] = null;
+            $this->cursor['pending_mapping_index'] = 0;
+        }
+        return true;
+    }
+
+    private function assert_region_mapping_preserves_default_skips(
+        string $remote_absolute_path
+    ): void {
+        if (!$this->remote_change_scope->root_owned_region_may_change(
+            $remote_absolute_path
+        )) {
+            return;
+        }
+        $remote_context = FileIndexProcessor::default_skip_descendant_context(
+            $remote_absolute_path
+        );
+        $local_absolute_path =
+            $this->remote_to_local_path_mapper->map_path($remote_absolute_path);
+        $local_context = FileIndexProcessor::path_is_default_skipped_below_root(
+            $this->remote_to_local_path_mapper->get_filesystem_root(),
+            $local_absolute_path
+        )
+            ? 'all_descendants'
+            : FileIndexProcessor::default_skip_descendant_context(
+                $local_absolute_path
+            );
+        if (
+            self::CONTEXT_RANKS[$remote_context]
+                < self::CONTEXT_RANKS[$local_context]
+        ) {
+            throw new InvalidArgumentException(
+                "Remote region {$remote_absolute_path} uses {$remote_context} default-skip context, "
+                . "but it maps to {$local_absolute_path} with stricter {$local_context} context."
+            );
+        }
+    }
+
+    private function append_selected_exact_path(
+        string $remote_absolute_path
+    ): void {
+        $local_relative_path =
+            $this->local_change_scope
+                ->map_remote_absolute_path_to_index_path($remote_absolute_path);
+        if (
+            !$this->local_change_scope->index_entry_may_change(
+                $local_relative_path,
+                'link'
+            )
+        ) {
+            return;
+        }
+        $local_absolute_path =
+            $this->remote_to_local_path_mapper->map_path($remote_absolute_path);
+        if (!FileIndexProcessor::path_is_default_skipped_below_root(
+            $this->remote_to_local_path_mapper->get_filesystem_root(),
+            $local_absolute_path
+        )) {
+            return;
+        }
+
+        $line = json_encode([
+            'path_b64' => base64_encode($local_relative_path),
+        ], JSON_UNESCAPED_SLASHES) . "\n";
+        if (strlen($line) > self::MAXIMUM_PATH_ROW_BYTES) {
+            throw new UnexpectedValueException(
+                'Selected default-skipped index path row exceeds the 65536-byte limit.'
+            );
+        }
+        if (
+            fwrite($this->paths_handle, $line) !== strlen($line)
+            || !fflush($this->paths_handle)
+        ) {
+            throw new RuntimeException(
+                'Failed to append a selected default-skipped index path.'
+            );
+        }
+        $byte_offset = ftell($this->paths_handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException(
+                'Failed to read the selected default-skipped paths byte offset.'
+            );
+        }
+        $this->cursor['paths_byte_offset'] = $byte_offset;
+    }
+
+    private function start_sort(): bool
+    {
+        $this->sort_processor = ExternalSortProcessor::start(
+            $this->unsorted_paths_file,
+            $this->selected_paths_file,
+            $this->work_directory,
+            'selected-default-skipped-paths',
+            self::path_row_key_extractor(),
+            true
+        );
+        $this->cursor['sort_cursor'] = $this->sort_processor->get_cursor();
+        $this->cursor['phase'] = 'sorting_paths';
+        return true;
+    }
+
+    private function sort_next_step(): bool
+    {
+        $this->open_phase_resources();
+        if ($this->sort_processor->next_step()) {
+            $this->cursor['sort_cursor'] = $this->sort_processor->get_cursor();
+            return true;
+        }
+        $this->sort_processor->close();
+        $this->sort_processor = null;
+        $this->cursor['sort_cursor'] = null;
+        $this->cursor['phase'] = 'complete';
+        return false;
+    }
+
+    private function open_phase_resources(): void
+    {
+        if (
+            $this->cursor['phase'] === 'scanning_atoms'
+            && !is_resource($this->paths_handle)
+        ) {
+            if (is_link($this->unsorted_paths_file)) {
+                throw new UnexpectedValueException(
+                    'Selected default-skipped paths work file became a symbolic link.'
+                );
+            }
+            $handle = @fopen($this->unsorted_paths_file, 'c+b');
+            if (!is_resource($handle)) {
+                throw new RuntimeException(
+                    "Failed to open selected default-skipped paths work file: {$this->unsorted_paths_file}."
+                );
+            }
+            $stat = fstat($handle);
+            if (
+                !is_array($stat)
+                || !isset($stat['size'])
+                || !is_int($stat['size'])
+                || $this->cursor['paths_byte_offset'] > $stat['size']
+            ) {
+                fclose($handle);
+                throw new UnexpectedValueException(
+                    'Selected default-skipped paths cursor exceeds its work file.'
+                );
+            }
+            if (
+                !ftruncate($handle, $this->cursor['paths_byte_offset'])
+                || fseek($handle, $this->cursor['paths_byte_offset']) !== 0
+            ) {
+                fclose($handle);
+                throw new RuntimeException(
+                    'Failed to resume the selected default-skipped paths work file.'
+                );
+            }
+            $this->paths_handle = $handle;
+        }
+        if (
+            $this->cursor['phase'] === 'sorting_paths'
+            && $this->sort_processor === null
+        ) {
+            $this->sort_processor = ExternalSortProcessor::resume(
+                $this->unsorted_paths_file,
+                $this->selected_paths_file,
+                $this->work_directory,
+                'selected-default-skipped-paths',
+                self::path_row_key_extractor(),
+                true,
+                $this->cursor['sort_cursor']
+            );
+        }
+    }
+
+    private function close_paths_handle(): void
+    {
+        if (is_resource($this->paths_handle)) {
+            fclose($this->paths_handle);
+        }
+        $this->paths_handle = null;
+    }
+
+    /** @return callable(string):string */
+    private static function path_row_key_extractor(): callable
+    {
+        return static function (string $line): string {
+            $row = json_decode($line, true);
+            if (!is_array($row) || array_keys($row) !== ['path_b64']) {
+                throw new UnexpectedValueException(
+                    'Selected default-skipped path row must contain only path_b64.'
+                );
+            }
+            $path = is_string($row['path_b64'])
+                ? base64_decode($row['path_b64'], true)
+                : false;
+            if (!is_string($path) || base64_encode($path) !== $row['path_b64']) {
+                throw new UnexpectedValueException(
+                    'Selected default-skipped path row contains an invalid path.'
+                );
+            }
+            return $path;
+        };
+    }
+
+    private static function prepare_work_directory(string $work_directory): string
+    {
+        assert_valid_path($work_directory, 'file-sync change-scope mapping work directory');
+        if (
+            !is_dir($work_directory)
+            && !mkdir($work_directory, 0777, true)
+            && !is_dir($work_directory)
+        ) {
+            throw new RuntimeException(
+                "Failed to create file-sync change-scope mapping work directory: {$work_directory}."
+            );
+        }
+        $resolved_work_directory = realpath($work_directory);
+        if (!is_string($resolved_work_directory)) {
+            throw new RuntimeException(
+                "Failed to resolve file-sync change-scope mapping work directory: {$work_directory}."
+            );
+        }
+        return $resolved_work_directory;
+    }
+
+    private static function configuration_fingerprint(
+        FileSyncChangeScope $remote_change_scope,
+        RemoteToLocalPathMapper $remote_to_local_path_mapper,
+        string $work_directory
+    ): string {
+        $configuration = json_encode([
+            'remote_change_scope' => $remote_change_scope->get_config(),
+            'remote_to_local_path_mapper' =>
+                $remote_to_local_path_mapper->get_config(),
+            'work_directory_b64' => base64_encode($work_directory),
+        ], JSON_UNESCAPED_SLASHES);
+        if (!is_string($configuration)) {
+            throw new RuntimeException(
+                'Failed to fingerprint file-sync change-scope mapping configuration.'
+            );
+        }
+        return hash('sha256', $configuration);
+    }
+
+    private function assert_cursor(): void
+    {
+        $actual_keys = array_keys($this->cursor);
+        sort($actual_keys, SORT_STRING);
+        $expected_keys = [
+            'phase',
+            'configuration_fingerprint',
+            'selected_atom_cursor',
+            'pending_root_path_b64',
+            'pending_mapping_index',
+            'paths_byte_offset',
+            'sort_cursor',
+        ];
+        sort($expected_keys, SORT_STRING);
+        if ($actual_keys !== $expected_keys) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping cursor fields are invalid.'
+            );
+        }
+        if (!in_array($this->cursor['phase'], [
+            'scanning_atoms', 'starting_sort', 'sorting_paths', 'complete',
+        ], true)) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping cursor phase is invalid.'
+            );
+        }
+        if (
+            !is_string($this->cursor['configuration_fingerprint'])
+            || preg_match(
+                '/^[0-9a-f]{64}$/D',
+                $this->cursor['configuration_fingerprint']
+            ) !== 1
+            || !is_array($this->cursor['selected_atom_cursor'])
+            || !is_int($this->cursor['pending_mapping_index'])
+            || $this->cursor['pending_mapping_index'] < 0
+            || !is_int($this->cursor['paths_byte_offset'])
+            || $this->cursor['paths_byte_offset'] < 0
+            || (
+                $this->cursor['sort_cursor'] !== null
+                && !is_array($this->cursor['sort_cursor'])
+            )
+        ) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping cursor values are invalid.'
+            );
+        }
+
+        $selected_atoms_complete = $this->remote_change_scope
+            ->selected_ownership_atom_cursor_is_complete(
+                $this->cursor['selected_atom_cursor']
+            );
+        $is_scanning = $this->cursor['phase'] === 'scanning_atoms';
+        if ($is_scanning === $selected_atoms_complete) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping cursor phase disagrees with its selected-atom cursor.'
+            );
+        }
+
+        if ($this->cursor['pending_root_path_b64'] !== null) {
+            $pending_root = is_string($this->cursor['pending_root_path_b64'])
+                ? base64_decode($this->cursor['pending_root_path_b64'], true)
+                : false;
+            if (
+                !$is_scanning
+                || !is_string($pending_root)
+                || base64_encode($pending_root)
+                    !== $this->cursor['pending_root_path_b64']
+            ) {
+                throw new InvalidArgumentException(
+                    'File-sync change-scope mapping cursor root path is invalid.'
+                );
+            }
+            assert_valid_path(
+                $pending_root,
+                'file-sync change-scope mapping cursor root'
+            );
+            if (
+                $this->cursor['pending_mapping_index']
+                    > count(
+                        $this->remote_to_local_path_mapper
+                            ->get_resolved_remote_mapping_prefixes()
+                    )
+            ) {
+                throw new InvalidArgumentException(
+                    'File-sync change-scope mapping cursor mapping index is invalid.'
+                );
+            }
+        } elseif ($this->cursor['pending_mapping_index'] !== 0) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping cursor has no root for its mapping index.'
+            );
+        }
+
+        $has_sort_cursor = is_array($this->cursor['sort_cursor']);
+        if (
+            ( $this->cursor['phase'] === 'sorting_paths' ) !== $has_sort_cursor
+        ) {
+            throw new InvalidArgumentException(
+                'File-sync change-scope mapping sort cursor is inconsistent with its phase.'
+            );
+        }
+        if (!$is_scanning) {
+            $source_stat = @lstat($this->unsorted_paths_file);
+            if (
+                !is_array($source_stat)
+                || ( $source_stat['mode'] & 0170000 ) !== 0100000
+                || $source_stat['size'] !== $this->cursor['paths_byte_offset']
+            ) {
+                throw new UnexpectedValueException(
+                    'File-sync change-scope mapping source does not match its completed scan boundary.'
+                );
+            }
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -147,7 +147,8 @@ final class RemoteToLocalPathMapper
      * Re-expresses a remote-absolute change scope in local-index coordinates.
      */
     public function map_change_scope_to_local_index(
-        FileSyncChangeScope $remote_change_scope
+        FileSyncChangeScope $remote_change_scope,
+        string $selected_default_skipped_index_paths_file
     ): FileSyncChangeScope {
         $config = $remote_change_scope->get_config();
         if ($config["index_path_coordinates"] !== "remote_absolute") {
@@ -157,7 +158,17 @@ final class RemoteToLocalPathMapper
         }
         $config["index_path_coordinates"] = "local_relative";
         $config["remote_to_local_path_mapper_config"] = $this->get_config();
+        $config["selected_default_skipped_index_paths_file_b64"] =
+            base64_encode($selected_default_skipped_index_paths_file);
         return FileSyncChangeScope::from_config($config);
+    }
+
+    /** @return list<string> Byte-sorted explicit remote mapping prefixes. */
+    public function get_resolved_remote_mapping_prefixes(): array
+    {
+        $remote_prefixes = array_keys($this->resolved_path_mappings);
+        sort($remote_prefixes, SORT_STRING);
+        return $remote_prefixes;
     }
 
     /** Returns the local filesystem root used by map_path(). */

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -541,6 +541,108 @@ final class FileIndexProcessor {
      */
     public static function path_is_default_skipped(string $path): bool
     {
+        if (self::path_has_persistent_default_skip($path)) {
+            return true;
+        }
+
+        // Operating-system metadata matches only the basename.
+        $basename = basename($path);
+        static $skipped_basenames = [
+            ".DS_Store", "._.DS_Store",
+            "Thumbs.db", "desktop.ini", "ehthumbs.db",
+        ];
+        if (in_array($basename, $skipped_basenames, true)) {
+            return true;
+        }
+        // Editor and merge scratch files: Emacs locks and autosaves, trailing
+        // tildes, Vim swaps, backups, and conflict leftovers.
+        if ($basename !== "" && $basename[0] === "." && isset($basename[1]) && $basename[1] === "#") {
+            return true;
+        }
+        if (strlen($basename) >= 3 && $basename[0] === "#" && substr($basename, -1) === "#") {
+            return true;
+        }
+        if (preg_match("/(?:~|\\.(?:swp|swo|swn|bak|orig|rej))$/", $basename) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Reports whether ordinary traversal skips a candidate below its scheduled root.
+     *
+     * The scheduled root itself bypasses default-skip classification. Every
+     * strict prefix through a descendant is classified exactly as it is when
+     * directory traversal reaches that path.
+     *
+     * @param string $scheduled_root Scheduled traversal root.
+     * @param string $candidate      Same path or one descendant to classify.
+     * @return bool Whether ordinary traversal omits the candidate.
+     */
+    public static function path_is_default_skipped_below_root(
+        string $scheduled_root,
+        string $candidate
+    ): bool {
+        if ($candidate === $scheduled_root) {
+            return false;
+        }
+        $descendant_prefix = $scheduled_root === "/"
+            ? "/"
+            : $scheduled_root . "/";
+        if (strncmp($candidate, $descendant_prefix, strlen($descendant_prefix)) !== 0) {
+            throw new InvalidArgumentException(
+                "Default-skip candidate {$candidate} is outside scheduled root {$scheduled_root}."
+            );
+        }
+
+        $relative_path = substr($candidate, strlen($descendant_prefix));
+        $prefix = $scheduled_root;
+        foreach (explode("/", $relative_path) as $component) {
+            if ($component === "") {
+                throw new InvalidArgumentException(
+                    "Default-skip candidate {$candidate} contains an empty path component."
+                );
+            }
+            $prefix = wp_join_unix_paths($prefix, $component);
+            if (self::path_is_default_skipped($prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Classifies which default skips may apply below a path already reached.
+     *
+     * The scheduled traversal root is reached without classifying its own
+     * basename. Once a persistent skipped component or wp-content cache
+     * directory has been reached, every suffix remains skipped. An exact
+     * wp-content basename has a narrower rule for its direct descendants.
+     * Basename and editor-file skips do not persist into a suffix.
+     *
+     * @param string $path Filesystem path whose possible descendants are classified.
+     * @return string One of ordinary, wp_content, or all_descendants.
+     */
+    public static function default_skip_descendant_context(string $path): string
+    {
+        if (self::path_has_persistent_default_skip($path)) {
+            return "all_descendants";
+        }
+        if (basename($path) === "wp-content") {
+            return "wp_content";
+        }
+        return "ordinary";
+    }
+
+    /**
+     * Reports whether one reached path places every descendant in the skip set.
+     *
+     * @param string $path Filesystem path to classify.
+     * @return bool Whether every suffix stays default-skipped.
+     */
+    private static function path_has_persistent_default_skip(string $path): bool
+    {
         // Sentinel slashes make component matches independent of whether the
         // component appears at the beginning, middle, or end of the path.
         $path_with_boundaries = "/" . trim($path, "/") . "/";
@@ -575,28 +677,6 @@ final class FileIndexProcessor {
                 return true;
             }
         }
-
-        // Operating-system metadata matches only the basename.
-        $basename = basename($path);
-        static $skipped_basenames = [
-            ".DS_Store", "._.DS_Store",
-            "Thumbs.db", "desktop.ini", "ehthumbs.db",
-        ];
-        if (in_array($basename, $skipped_basenames, true)) {
-            return true;
-        }
-        // Editor and merge scratch files: Emacs locks and autosaves, trailing
-        // tildes, Vim swaps, backups, and conflict leftovers.
-        if ($basename !== "" && $basename[0] === "." && isset($basename[1]) && $basename[1] === "#") {
-            return true;
-        }
-        if (strlen($basename) >= 3 && $basename[0] === "#" && substr($basename, -1) === "#") {
-            return true;
-        }
-        if (preg_match("/(?:~|\\.(?:swp|swo|swn|bak|orig|rej))$/", $basename) === 1) {
-            return true;
-        }
-
         return false;
     }
 

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -161,6 +161,81 @@ final class FileIndexSkipDefaultsTest extends TestCase
         ];
     }
 
+    public function testDescendantContextUsesTheSamePersistentSkipGrammar(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-server/src/export.php';
+
+        $this->assertSame(
+            'ordinary',
+            FileIndexProcessor::default_skip_descendant_context(
+                '/srv/wp-content/plugins'
+            )
+        );
+        $this->assertSame(
+            'wp_content',
+            FileIndexProcessor::default_skip_descendant_context(
+                '/srv/wp-content'
+            )
+        );
+        $this->assertSame(
+            'all_descendants',
+            FileIndexProcessor::default_skip_descendant_context(
+                '/srv/wp-content/cache'
+            )
+        );
+        $this->assertSame(
+            'all_descendants',
+            FileIndexProcessor::default_skip_descendant_context('/srv/.git')
+        );
+        $this->assertSame(
+            'ordinary',
+            FileIndexProcessor::default_skip_descendant_context('/srv/.gitmodules')
+        );
+        $this->assertSame(
+            'ordinary',
+            FileIndexProcessor::default_skip_descendant_context('/srv/file.php~')
+        );
+    }
+
+    public function testDefaultSkipBelowRootPreservesTheScheduledBoundary(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-server/src/export.php';
+
+        $this->assertFalse(
+            FileIndexProcessor::path_is_default_skipped_below_root('/', '/')
+        );
+        $this->assertTrue(
+            FileIndexProcessor::path_is_default_skipped_below_root(
+                '/',
+                '/.DS_Store/child'
+            )
+        );
+        $this->assertFalse(
+            FileIndexProcessor::path_is_default_skipped_below_root(
+                '/scratch~',
+                '/scratch~/child'
+            )
+        );
+        $this->assertTrue(
+            FileIndexProcessor::path_is_default_skipped_below_root(
+                '/site',
+                '/site/wp-content/cache/file'
+            )
+        );
+        $this->assertTrue(
+            FileIndexProcessor::path_is_default_skipped_below_root(
+                '/site',
+                "/site/.DS_Store/child-\xFF"
+            )
+        );
+        $this->assertFalse(
+            FileIndexProcessor::path_is_default_skipped_below_root(
+                '/site',
+                "/site/\xFF.gitmodules/child"
+            )
+        );
+    }
+
     // ------------------------------------------------------------------
     // Integration tests — endpoint_file_index() over the fixture
     // ------------------------------------------------------------------

--- a/tests/Import/FileSyncChangeScopeMappingProcessorTest.php
+++ b/tests/Import/FileSyncChangeScopeMappingProcessorTest.php
@@ -1,0 +1,787 @@
+<?php
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Import tests place class braces on the following line.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Tests share this namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php';
+
+final class FileSyncChangeScopeMappingProcessorTest extends TestCase
+{
+    private string $temporaryDirectory;
+    private string $ownershipDirectory;
+    private string $filesystemRoot;
+    private int $nextSnapshotNumber = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporaryDirectory = sys_get_temp_dir()
+            . '/change-scope-mapping-' . uniqid('', true);
+        $this->ownershipDirectory = $this->temporaryDirectory . '/ownership';
+        $this->filesystemRoot = $this->temporaryDirectory . '/local';
+        mkdir($this->ownershipDirectory . '/snapshots', 0777, true);
+        mkdir($this->filesystemRoot, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+        parent::tearDown();
+    }
+
+    public function testMaterializesOnlySelectedCurrentAndPriorSkippedExactPaths(): void
+    {
+        $arbitraryBytePath = "/site/.DS_Store/child-\xFF";
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+            ['kind' => 'exact', 'path' => '/site/.git/current-link'],
+            ['kind' => 'exact', 'path' => $arbitraryBytePath],
+            ['kind' => 'exact', 'path' => '/site/ordinary-link'],
+            ['kind' => 'exact', 'path' => '/alias-a/.cache/shared-link'],
+            ['kind' => 'exact', 'path' => '/excluded/.git/link'],
+        ]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/old/node_modules/prior-link'],
+            ['kind' => 'exact', 'path' => '/alias-b/.cache/shared-link'],
+            ['kind' => 'exact', 'path' => '/protected/.git/link'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/protected/.git/link'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId],
+            ['/excluded']
+        );
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->filesystemRoot,
+            ['/site'],
+            [
+                '/alias-a' => $this->filesystemRoot . '/shared',
+                '/alias-b' => $this->filesystemRoot . '/shared',
+            ]
+        );
+
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $this->temporaryDirectory . '/work'
+        );
+        $this->finish($processor);
+        $config = $processor->get_local_change_scope_config();
+        $localScope = \FileSyncChangeScope::from_config($config);
+
+        $this->assertSame(
+            [
+                "old/node_modules/prior-link",
+                "shared/.cache/shared-link",
+                "site/.DS_Store/child-\xFF",
+                'site/.git/current-link',
+            ],
+            $this->readSelectedPaths(
+                $localScope->get_selected_default_skipped_index_paths_file()
+            )
+        );
+        $this->assertFalse(
+            $localScope->index_entry_may_change(
+                'protected/.git/link',
+                'link'
+            )
+        );
+        $this->assertSame(
+            $mapper->get_config(),
+            $config['remote_to_local_path_mapper_config']
+        );
+        $this->assertSame(
+            base64_encode(
+                realpath($this->temporaryDirectory . '/work')
+                    . '/selected-default-skipped-index-paths.jsonl'
+            ),
+            $config['selected_default_skipped_index_paths_file_b64']
+        );
+        try {
+            $localScope->initial_selected_ownership_atom_cursor();
+            $this->fail('Local-coordinate scope exposed remote ownership atoms.');
+        } catch (\LogicException $exception) {
+            $this->assertStringContainsString(
+                'remote_absolute',
+                $exception->getMessage()
+            );
+        }
+
+        $localScope->close();
+        $completedCursor = $processor->get_cursor();
+        $processor->close();
+        $processor = \FileSyncChangeScopeMappingProcessor::resume(
+            $remoteScope,
+            $mapper,
+            $this->temporaryDirectory . '/work',
+            $completedCursor
+        );
+        $this->assertSame($config, $processor->get_local_change_scope_config());
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    public function testSelectedAtomCursorIsBoundToItsOwnershipDirectory(): void
+    {
+        $snapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/site/.git/link'],
+        ]);
+        $firstScope = $this->scope($snapshotId);
+        $cursor = $firstScope->initial_selected_ownership_atom_cursor();
+
+        $otherOwnershipDirectory = $this->temporaryDirectory
+            . '/other-ownership';
+        mkdir($otherOwnershipDirectory . '/snapshots', 0777, true);
+        foreach (['paths.jsonl', 'lookup'] as $suffix) {
+            copy(
+                $this->ownershipDirectory . '/snapshots/'
+                    . $snapshotId . '.' . $suffix,
+                $otherOwnershipDirectory . '/snapshots/'
+                    . $snapshotId . '.' . $suffix
+            );
+        }
+        $otherScope = \FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode(
+                $otherOwnershipDirectory
+            ),
+            'current_snapshot_id' => $snapshotId,
+            'prior_snapshot_ids' => [],
+            'protected_snapshot_ids' => [],
+            'excluded_remote_absolute_path_roots_b64' => [],
+            'include_caches' => false,
+        ]);
+
+        try {
+            $otherScope->read_next_selected_ownership_atom($cursor);
+            $this->fail('Ownership cursor resumed against another artifact directory.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'does not match',
+                $exception->getMessage()
+            );
+        }
+
+        $otherScope->close();
+        $firstScope->close();
+    }
+
+    public function testIncludeCachesPublishesAnEmptySidecarWithoutReadingAtoms(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+            ['kind' => 'exact', 'path' => '/site/.git/link'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            [],
+            true
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            new \RemoteToLocalPathMapper(
+                $this->filesystemRoot,
+                ['/site'],
+                ['/site' => $this->filesystemRoot . '/.git']
+            ),
+            $this->temporaryDirectory . '/include-caches-work'
+        );
+
+        $this->finish($processor);
+        $scope = \FileSyncChangeScope::from_config(
+            $processor->get_local_change_scope_config()
+        );
+        $this->assertSame(
+            '',
+            file_get_contents(
+                $scope->get_selected_default_skipped_index_paths_file()
+            )
+        );
+
+        $scope->close();
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    public function testResumeTruncatesOutputAndReplaysOuterSortBoundaries(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/site/.git/z-link'],
+            ['kind' => 'exact', 'path' => '/site/.git/a-link'],
+        ]);
+        $remoteScope = $this->scope($currentSnapshotId);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->filesystemRoot,
+            ['/site']
+        );
+        $workDirectory = $this->temporaryDirectory . '/resume-work';
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $workDirectory
+        );
+
+        while ($processor->get_cursor()['paths_byte_offset'] === 0) {
+            $this->assertTrue($processor->next_step());
+        }
+        $durableCursor = $processor->get_cursor();
+        $this->assertTrue($processor->next_step());
+        $processor->close();
+        file_put_contents(
+            $workDirectory
+                . '/selected-default-skipped-index-paths.unsorted.jsonl',
+            "corrupt-tail\n",
+            FILE_APPEND
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::resume(
+            $remoteScope,
+            $mapper,
+            $workDirectory,
+            $durableCursor
+        );
+        while ($processor->get_cursor()['phase'] === 'scanning_atoms') {
+            $this->assertTrue($processor->next_step());
+        }
+
+        $startingSortCursor = $processor->get_cursor();
+        $this->assertSame('starting_sort', $startingSortCursor['phase']);
+        $this->assertTrue($processor->next_step());
+        $processor->close();
+        $processor = \FileSyncChangeScopeMappingProcessor::resume(
+            $remoteScope,
+            $mapper,
+            $workDirectory,
+            $startingSortCursor
+        );
+
+        $replayedPublish = false;
+        $replayedCompletion = false;
+        while ($processor->get_cursor()['phase'] !== 'complete') {
+            $beforeStep = $processor->get_cursor();
+            $processor->next_step();
+            if (
+                !$replayedPublish
+                && $beforeStep['phase'] === 'sorting_paths'
+                && $beforeStep['sort_cursor']['phase'] === 'publishing_output'
+            ) {
+                $processor->close();
+                $processor = \FileSyncChangeScopeMappingProcessor::resume(
+                    $remoteScope,
+                    $mapper,
+                    $workDirectory,
+                    $beforeStep
+                );
+                $replayedPublish = true;
+            } elseif (
+                !$replayedCompletion
+                && $beforeStep['phase'] === 'sorting_paths'
+                && $beforeStep['sort_cursor']['phase'] === 'cleaning_work_files'
+                && $beforeStep['sort_cursor']['next_cleanup_slot'] === 2
+            ) {
+                $processor->close();
+                $processor = \FileSyncChangeScopeMappingProcessor::resume(
+                    $remoteScope,
+                    $mapper,
+                    $workDirectory,
+                    $beforeStep
+                );
+                $replayedCompletion = true;
+            }
+        }
+        $this->assertTrue($replayedPublish);
+        $this->assertTrue($replayedCompletion);
+        $this->assertSame(
+            ['site/.git/a-link', 'site/.git/z-link'],
+            $this->readSelectedPaths(
+                base64_decode(
+                    $processor->get_local_change_scope_config()[
+                        'selected_default_skipped_index_paths_file_b64'
+                    ],
+                    true
+                )
+            )
+        );
+
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    public function testRejectsCursorStateThatCouldSkipSelectedWork(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'exact', 'path' => '/site/.git/link'],
+        ]);
+        $remoteScope = $this->scope($currentSnapshotId);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->filesystemRoot,
+            ['/site']
+        );
+        $workDirectory = $this->temporaryDirectory . '/strict-cursor-work';
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $workDirectory
+        );
+        $this->finish($processor);
+        $completeCursor = $processor->get_cursor();
+        $processor->close();
+
+        $invalidNestedCursor = $completeCursor;
+        $invalidNestedCursor['selected_atom_cursor'] = [];
+        $this->assertMappingResumeRejected(
+            $remoteScope,
+            $mapper,
+            $workDirectory,
+            $invalidNestedCursor
+        );
+
+        $pendingRootCursor = $completeCursor;
+        $pendingRootCursor['pending_root_path_b64'] = base64_encode('/site');
+        $this->assertMappingResumeRejected(
+            $remoteScope,
+            $mapper,
+            $workDirectory,
+            $pendingRootCursor
+        );
+
+        $wrongSourceOffsetCursor = $completeCursor;
+        ++$wrongSourceOffsetCursor['paths_byte_offset'];
+        $this->assertMappingResumeRejected(
+            $remoteScope,
+            $mapper,
+            $workDirectory,
+            $wrongSourceOffsetCursor
+        );
+
+        $startingSortWorkDirectory = $this->temporaryDirectory
+            . '/strict-starting-sort-work';
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $startingSortWorkDirectory
+        );
+        while ($processor->get_cursor()['phase'] === 'scanning_atoms') {
+            $this->assertTrue($processor->next_step());
+        }
+        $startingSortCursor = $processor->get_cursor();
+        $processor->close();
+        $startingSortCursor['selected_atom_cursor'] =
+            $remoteScope->initial_selected_ownership_atom_cursor();
+        $this->assertMappingResumeRejected(
+            $remoteScope,
+            $mapper,
+            $startingSortWorkDirectory,
+            $startingSortCursor
+        );
+
+        $remoteScope->close();
+    }
+
+    /**
+     * @dataProvider mappingContextCases
+     * @param list<string> $remoteRoots
+     * @param array<string,string> $resolvedMappings Local values are suffixes below the test filesystem root.
+     */
+    public function testRejectsOnlyMappingsWithStricterLocalSkipContext(
+        array $remoteRoots,
+        array $resolvedMappings,
+        ?string $followedRootSuffix,
+        bool $expectRejection
+    ): void {
+        $atoms = array_map(
+            static function (string $remoteRoot): array {
+                return ['kind' => 'root', 'path' => $remoteRoot];
+            },
+            $remoteRoots
+        );
+        $currentSnapshotId = $this->publishSnapshot($atoms);
+        $remoteScope = $this->scope($currentSnapshotId);
+        $localMappings = [];
+        foreach ($resolvedMappings as $remotePrefix => $localSuffix) {
+            $localMappings[$remotePrefix] = $this->filesystemRoot
+                . ( $localSuffix === '' ? '' : '/' . $localSuffix );
+        }
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->filesystemRoot,
+            ['/site'],
+            $localMappings,
+            $followedRootSuffix === null
+                ? null
+                : $this->filesystemRoot . '/' . $followedRootSuffix
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $this->temporaryDirectory . '/mapping-' . $this->nextSnapshotNumber
+        );
+
+        try {
+            $this->finish($processor);
+            $this->assertFalse(
+                $expectRejection,
+                'Expected stricter mapped default-skip context to be rejected.'
+            );
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertTrue(
+                $expectRejection,
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString(
+                'stricter',
+                $exception->getMessage()
+            );
+        } finally {
+            $processor->close();
+            $remoteScope->close();
+        }
+    }
+
+    /** @return array<string,array{0:list<string>,1:array<string,string>,2:string|null,3:bool}> */
+    public static function mappingContextCases(): array
+    {
+        return [
+            'ordinary root into git' => [
+                ['/site'], ['/site' => '.git'], null, true,
+            ],
+            'wp-content root into ordinary' => [
+                ['/site/wp-content'], ['/site/wp-content' => 'content'], null, false,
+            ],
+            'wp-content root into git' => [
+                ['/site/wp-content'], ['/site/wp-content' => '.git'], null, true,
+            ],
+            'ordinary plugins region into local wp-content' => [
+                ['/site/wp-content/plugins'],
+                ['/site/wp-content/plugins' => 'wp-content'],
+                null,
+                true,
+            ],
+            'reachable nested remap into git' => [
+                ['/site'], ['/site/nested' => '.git'], null, true,
+            ],
+            'unreachable scratch remap is not inherited' => [
+                ['/site'], ['/site/foo~' => '.git'], null, false,
+            ],
+            'separately scheduled scratch root is checked' => [
+                ['/site', '/site/foo~'], ['/site/foo~' => '.git'], null, true,
+            ],
+            'followed placement into skipped component' => [
+                ['/outside'], [], '.git', true,
+            ],
+            'near-miss names remain ordinary' => [
+                ["/site/\xFF.gitmodules"],
+                ["/site/\xFF.gitmodules" => 'cache-control'],
+                null,
+                false,
+            ],
+        ];
+    }
+
+    public function testFullyExcludedUnsafeRegionNeedsNoLocalTraversal(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/site'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            ['/site']
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            new \RemoteToLocalPathMapper(
+                $this->filesystemRoot,
+                ['/site'],
+                ['/site' => $this->filesystemRoot . '/.git']
+            ),
+            $this->temporaryDirectory . '/excluded-region-work'
+        );
+
+        $this->finish($processor);
+        $this->assertSame('complete', $processor->get_cursor()['phase']);
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    public function testProtectedPriorRegionNeedsNoLocalTraversal(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            new \RemoteToLocalPathMapper(
+                $this->filesystemRoot,
+                ['/old'],
+                ['/old' => $this->filesystemRoot . '/.git']
+            ),
+            $this->temporaryDirectory . '/protected-region-work'
+        );
+
+        $this->finish($processor);
+        $this->assertSame('complete', $processor->get_cursor()['phase']);
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    public function testNestedProtectedHoleDoesNotHideAllowedUnsafeRemainder(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old/protected'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            new \RemoteToLocalPathMapper(
+                $this->filesystemRoot,
+                ['/old'],
+                ['/old' => $this->filesystemRoot . '/.git']
+            ),
+            $this->temporaryDirectory . '/protected-hole-work'
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        try {
+            $this->finish($processor);
+        } finally {
+            $processor->close();
+            $remoteScope->close();
+        }
+    }
+
+    public function testCurrentNestedRootIsCheckedInsideProtectedPriorRegion(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old/current'],
+        ]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/old'],
+        ]);
+        $remoteScope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            new \RemoteToLocalPathMapper(
+                $this->filesystemRoot,
+                ['/old'],
+                ['/old/current' => $this->filesystemRoot . '/.git']
+            ),
+            $this->temporaryDirectory . '/current-nested-work'
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        try {
+            $this->finish($processor);
+        } finally {
+            $processor->close();
+            $remoteScope->close();
+        }
+    }
+
+    public function testScheduledScratchRootIsSafeOnlyWhenMappedToFilesystemRoot(): void
+    {
+        $scratchFilesystemRoot = $this->temporaryDirectory . '/local~';
+        mkdir($scratchFilesystemRoot);
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/foo~'],
+        ]);
+        $remoteScope = $this->scope($currentSnapshotId);
+        $mapper = new \RemoteToLocalPathMapper(
+            $scratchFilesystemRoot,
+            ['/foo~'],
+            ['/foo~' => $scratchFilesystemRoot]
+        );
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $mapper,
+            $this->temporaryDirectory . '/scratch-root-work'
+        );
+
+        $this->finish($processor);
+        $this->assertSame('complete', $processor->get_cursor()['phase']);
+        $this->assertSame(
+            '',
+            file_get_contents(base64_decode(
+                $processor->get_local_change_scope_config()[
+                    'selected_default_skipped_index_paths_file_b64'
+                ],
+                true
+            ))
+        );
+        $processor->close();
+        $remoteScope->close();
+    }
+
+    /**
+     * @param list<string> $priorSnapshotIds
+     * @param list<string> $protectedSnapshotIds
+     * @param list<string> $excludedRemoteAbsolutePathRoots
+     */
+    private function scope(
+        string $currentSnapshotId,
+        array $priorSnapshotIds = [],
+        array $protectedSnapshotIds = [],
+        array $excludedRemoteAbsolutePathRoots = [],
+        bool $includeCaches = false
+    ): \FileSyncChangeScope {
+        return \FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode(
+                $this->ownershipDirectory
+            ),
+            'current_snapshot_id' => $currentSnapshotId,
+            'prior_snapshot_ids' => $priorSnapshotIds,
+            'protected_snapshot_ids' => $protectedSnapshotIds,
+            'excluded_remote_absolute_path_roots_b64' => array_map(
+                'base64_encode',
+                $excludedRemoteAbsolutePathRoots
+            ),
+            'include_caches' => $includeCaches,
+        ]);
+    }
+
+    /** @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $atoms */
+    private function publishSnapshot(array $atoms): string
+    {
+        usort(
+            $atoms,
+            static function (array $left, array $right): int {
+                return strcmp(
+                    $left['path'] . "\0" . $left['kind'],
+                    $right['path'] . "\0" . $right['kind']
+                );
+            }
+        );
+        ++$this->nextSnapshotNumber;
+        $snapshotId = str_pad(
+            dechex($this->nextSnapshotNumber),
+            64,
+            '0',
+            STR_PAD_LEFT
+        );
+        $pathsFile = $this->ownershipDirectory . '/snapshots/'
+            . $snapshotId . '.paths.jsonl';
+        $pathsHandle = fopen($pathsFile, 'wb');
+        $lookupRows = [];
+        foreach ($atoms as $atom) {
+            $pathsByteOffset = ftell($pathsHandle);
+            fwrite($pathsHandle, json_encode([
+                'kind' => $atom['kind'],
+                'path_b64' => base64_encode($atom['path']),
+            ], JSON_UNESCAPED_SLASHES) . "\n");
+            $lookupRows[] = hash(
+                'sha256',
+                $atom['kind'] . "\0" . $atom['path']
+            ) . ' ' . sprintf('%016x', $pathsByteOffset) . "\n";
+        }
+        fclose($pathsHandle);
+        sort($lookupRows, SORT_STRING);
+        file_put_contents(
+            $this->ownershipDirectory . '/snapshots/'
+                . $snapshotId . '.lookup',
+            implode('', $lookupRows)
+        );
+        return $snapshotId;
+    }
+
+    private function finish(\FileSyncChangeScopeMappingProcessor $processor): void
+    {
+        $steps = 0;
+        while ($processor->next_step()) {
+            ++$steps;
+            if ($steps > 10000) {
+                $this->fail('File-sync change-scope mapping did not complete.');
+            }
+        }
+    }
+
+    /** @param array<string,mixed> $cursor */
+    private function assertMappingResumeRejected(
+        \FileSyncChangeScope $remoteScope,
+        \RemoteToLocalPathMapper $mapper,
+        string $workDirectory,
+        array $cursor
+    ): void {
+        try {
+            $resumed = \FileSyncChangeScopeMappingProcessor::resume(
+                $remoteScope,
+                $mapper,
+                $workDirectory,
+                $cursor
+            );
+            $resumed->close();
+            $this->fail('Invalid mapping cursor resumed successfully.');
+        } catch (\InvalidArgumentException | \UnexpectedValueException $exception) {
+            $this->assertNotSame('', $exception->getMessage());
+        }
+    }
+
+    /** @return list<string> */
+    private function readSelectedPaths(string $pathsFile): array
+    {
+        $paths = [];
+        $handle = fopen($pathsFile, 'rb');
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $paths[] = base64_decode($row['path_b64'], true);
+        }
+        fclose($handle);
+        return $paths;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory) || is_link($directory)) {
+            return;
+        }
+        foreach (scandir($directory) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/FileSyncChangeScopeTest.php
+++ b/tests/Import/FileSyncChangeScopeTest.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-
 class FileSyncChangeScopeTest extends TestCase {
     private string $temporaryDirectory;
     private string $ownershipDirectory;
+    private string $selectedDefaultSkippedPathsFile;
     private int $nextSnapshotNumber = 0;
 
     protected function setUp(): void
@@ -23,6 +24,9 @@ class FileSyncChangeScopeTest extends TestCase {
         $this->ownershipDirectory = $this->temporaryDirectory
             . "/ownership-\nname";
         mkdir($this->ownershipDirectory . '/snapshots', 0777, true);
+        $this->selectedDefaultSkippedPathsFile = $this->temporaryDirectory
+            . '/selected-default-skipped-paths.jsonl';
+        file_put_contents($this->selectedDefaultSkippedPathsFile, '');
     }
 
     protected function tearDown(): void
@@ -361,7 +365,10 @@ class FileSyncChangeScopeTest extends TestCase {
                 '/protected' => '/local/shared',
             ]
         );
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         $this->assertFalse(
             $localScope->index_entry_may_change('shared/file.php', 'file')
         );
@@ -372,7 +379,10 @@ class FileSyncChangeScopeTest extends TestCase {
             ['/current'],
             ['/current' => '/local/shared']
         );
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         $this->assertTrue(
             $localScope->index_entry_may_change('shared/file.php', 'file')
         );
@@ -402,7 +412,8 @@ class FileSyncChangeScopeTest extends TestCase {
             ['/a' => '/local/shared']
         );
         $localScope = $continuousMapper->map_change_scope_to_local_index(
-            $remoteScope
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
         );
         $this->assertTrue($localScope->subtree_may_change('shared/dir'));
         $localScope->close();
@@ -417,7 +428,8 @@ class FileSyncChangeScopeTest extends TestCase {
             ]
         );
         $localScope = $mapperWithFilledHole->map_change_scope_to_local_index(
-            $remoteScope
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
         );
         $this->assertFalse($localScope->subtree_may_change('shared/dir'));
         $localScope->close();
@@ -444,7 +456,10 @@ class FileSyncChangeScopeTest extends TestCase {
             [],
             [$protectedSnapshotId]
         );
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         $this->assertFalse(
             $localScope->index_entry_may_change(
                 'followed/outside/file.php',
@@ -455,7 +470,10 @@ class FileSyncChangeScopeTest extends TestCase {
         $remoteScope->close();
 
         $remoteScope = $this->scope($currentSnapshotId);
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         $this->assertTrue(
             $localScope->index_entry_may_change(
                 'followed/outside/file.php',
@@ -487,7 +505,10 @@ class FileSyncChangeScopeTest extends TestCase {
             [$remoteRoot],
             [$remoteRoot => $localPrefix]
         );
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         $localRelativeLink = "mapped-\xFE/link-\xFC";
 
         $this->assertTrue(
@@ -502,6 +523,10 @@ class FileSyncChangeScopeTest extends TestCase {
         );
         $this->assertSame($filesystemRoot, $localScope->get_filesystem_root());
         $this->assertTrue($localScope->includes_caches());
+        $this->assertSame(
+            $this->selectedDefaultSkippedPathsFile,
+            $localScope->get_selected_default_skipped_index_paths_file()
+        );
 
         $config = $localScope->get_config();
         $this->assertSame('local_relative', $config['index_path_coordinates']);
@@ -542,6 +567,15 @@ class FileSyncChangeScopeTest extends TestCase {
                 $exception->getMessage()
             );
         }
+        try {
+            $remoteScope->get_selected_default_skipped_index_paths_file();
+            $this->fail('Remote-coordinate scope exposed a local selected-path file.');
+        } catch (\LogicException $exception) {
+            $this->assertStringContainsString(
+                'uses remote_absolute index paths',
+                $exception->getMessage()
+            );
+        }
 
         $mapper = new \RemoteToLocalPathMapper('/local', ['/site']);
         $config = $remoteScope->get_config();
@@ -556,9 +590,15 @@ class FileSyncChangeScopeTest extends TestCase {
             );
         }
 
-        $localScope = $mapper->map_change_scope_to_local_index($remoteScope);
+        $localScope = $mapper->map_change_scope_to_local_index(
+            $remoteScope,
+            $this->selectedDefaultSkippedPathsFile
+        );
         try {
-            $mapper->map_change_scope_to_local_index($localScope);
+            $mapper->map_change_scope_to_local_index(
+                $localScope,
+                $this->selectedDefaultSkippedPathsFile
+            );
             $this->fail('A local-relative scope was mapped a second time.');
         } catch (\InvalidArgumentException $exception) {
             $this->assertStringContainsString(


### PR DESCRIPTION
Mirror reconciliation must inspect selected paths that ordinary cache-skipping traversal omits. This change materializes those paths in a bounded, resumable processor and binds the published list to the local change scope.

It also centralizes the scheduled-root traversal-skip predicate so remote selection, local mapping, and later supplemental indexing share one rule. Unsafe cache-skipping mappings fail before local mutation unless exclusions or protected ownership make the entire mapped region unreachable.