### PR TITLE
[PHP] Index selected skipped paths without traversing caches

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -16,8 +16,10 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * A filesystem index is a path-sorted list describing a filesystem tree at one
  * point in time. Each index entry records one path, whether that path is a file,
  * link, or directory, its size, its inode change time (ctime), and, for some
- * directories, whether it was empty. Both indexes must use the same path
- * coordinate system; paths may be local relative paths or remote absolute paths.
+ * directories, whether it was empty. A temporary fresh local index may also
+ * use `other` for a selected unsupported local type. Both indexes must use the
+ * same path coordinate system; paths may be local relative paths or remote
+ * absolute paths.
  * Each physical line must decode to one entry. A decoder cannot filter lines;
  * blank or invalid records must throw.
  *
@@ -115,7 +117,7 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * while the processor retains unread entries. The cursor still names only
  * consumed entries and can always be passed to `resume()`.
  *
- * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir'|'other',ctime:int,size:int,empty?:bool}
  * @phpstan-type Cursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -355,6 +355,13 @@ final class FileSyncPatchPlanner
         $patch_base_entry_shape = $patch_base_path_type === null
             ? null
             : $this->index_entry_shape($patch_base_path_type);
+        if ($patch_result_entry_shape === "other") {
+            throw new UnexpectedValueException(
+                "Patch result index contains an unsupported path type at: "
+                . base64_encode($index_path)
+                . "."
+            );
+        }
         $path_to_delete = null;
         $path_to_copy = null;
         $active_deletion_root_byte_offset =
@@ -597,7 +604,7 @@ final class FileSyncPatchPlanner
      *         Base state which an exact `delete` or `replace` removes. Absent
      *         from copy operations and collapsed directory deletions.
      *
-     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type string $type  Expected `file`, `link`, `dir`, or temporary `other` type.
      *         @type int    $size  Expected size.
      *         @type int    $ctime Expected inode change time.
      *     }
@@ -655,7 +662,12 @@ final class FileSyncPatchPlanner
         $this->closed = true;
     }
 
-    /** Returns the logical entry kind used by the plan transition table. */
+    /**
+     * Returns the logical entry kind used by the plan transition table.
+     *
+     * @return string `file`, `symlink`, `empty_directory`, or `other`.
+     * @phpstan-return 'file'|'symlink'|'empty_directory'|'other'
+     */
     private function index_entry_shape(string $path_type): string
     {
         if ($path_type === "file") {
@@ -664,7 +676,15 @@ final class FileSyncPatchPlanner
         if ($path_type === "link") {
             return "symlink";
         }
-        return "empty_directory";
+        if ($path_type === "dir") {
+            return "empty_directory";
+        }
+        if ($path_type === "other") {
+            return "other";
+        }
+        throw new UnexpectedValueException(
+            "File sync patch index has an invalid path type: {$path_type}."
+        );
     }
 
     /** Reports whether the active deletion root contains the index path. */

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
@@ -23,6 +23,9 @@ require_once __DIR__ . '/class-fresh-local-index-processor.php';
  * current local tree is the result. start_from_fresh_local_tree() reverses
  * that direction: the current local tree is the patch base and the supplied
  * index is the result.
+ * start_from_fresh_local_tree_with_selected_default_skipped_paths() uses the
+ * same direction after adding the named path-only sidecar to the caches-off
+ * fresh scan.
  *
  * The supplied index must describe the same filesystem root on the same
  * machine. File and symlink changes use ctime, which cannot be compared across
@@ -46,11 +49,13 @@ require_once __DIR__ . '/class-fresh-local-index-processor.php';
  *     $processor->close();
  *
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
- * @phpstan-type FreshIndexPosition array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}|array{phase:'sorting'}|array{phase:'complete'}
- * @phpstan-type FreshIndexCursor array{fresh_local_index_file_b64:string,filesystem_root_b64:string,storage_path_b64:string,include_caches:bool,position:FreshIndexPosition}
+ * @phpstan-type FreshSelectedPathsConfig array{mode:'ordinary'}|array{mode:'selected_default_skipped_paths',file_b64:string}
+ * @phpstan-type FreshIndexPosition array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}|array{phase:'supplementing',selected_paths_byte_offset:int,preceding_selected_path_b64:string|null,fresh_local_index_byte_offset:int}|array{phase:'sorting'}|array{phase:'complete'}
+ * @phpstan-type FreshIndexCursor array{fresh_local_index_file_b64:string,filesystem_root_b64:string,storage_path_b64:string,include_caches:bool,selected_paths:FreshSelectedPathsConfig,position:FreshIndexPosition}
+ * @phpstan-type FreshIndexSelection array{mode:'ordinary',include_caches:bool}|array{mode:'selected_default_skipped_paths',file:string}
  * @phpstan-type PlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  * @phpstan-type PlannerCursor array{patch_base_index_file_b64:string,patch_result_index_file_b64:string,active_deletion_roots_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',index_diff_cursor:PlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
- * @phpstan-type FreshTreePosition array{phase:'indexing'|'sorting'|'starting_patch',patch_base_index_file_b64:string,patch_result_index_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',fresh_local_index_cursor:FreshIndexCursor}
+ * @phpstan-type FreshTreePosition array{phase:'indexing'|'supplementing'|'sorting'|'starting_patch',patch_base_index_file_b64:string,patch_result_index_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',fresh_local_index_cursor:FreshIndexCursor}
  * @phpstan-type Position FreshTreePosition|array{phase:'planning',file_sync_patch_planner_cursor:PlannerCursor}|array{phase:'complete'}
  * @phpstan-type Cursor array{fresh_local_index_file_b64:string,position:Position}
  * @phpstan-type SyncOperation array{action:'copy'|'delete'|'replace',path:string,expected_source?:array{type:string,size:int,ctime:int},expected_base?:array{type:string,size:int,ctime:int}}
@@ -100,7 +105,10 @@ final class FileSyncPatchProcessor {
             $storage_path,
             $included_index_path_roots,
             $excluded_index_path_roots,
-            $include_caches,
+            [
+                "mode" => "ordinary",
+                "include_caches" => $include_caches,
+            ],
             "collapsed"
         );
     }
@@ -139,7 +147,47 @@ final class FileSyncPatchProcessor {
             $storage_path,
             $included_index_path_roots,
             $excluded_index_path_roots,
-            $include_caches,
+            [
+                "mode" => "ordinary",
+                "include_caches" => $include_caches,
+            ],
+            "exact"
+        );
+    }
+
+    /**
+     * Plans from a fresh tree including selected default-skipped paths.
+     *
+     * @param string       $work_directory                             Existing directory for processor state.
+     * @param string       $filesystem_root                            Filesystem root scanned for the fresh index.
+     * @param string       $patch_result_index_file                    Tree which the patch must produce.
+     * @param string       $storage_path                               Reprint storage path omitted from the fresh index.
+     * @param string       $selected_default_skipped_index_paths_file  Immutable sorted path-only JSONL file.
+     * @param list<string> $included_index_path_roots                  Roots within which changes may be planned.
+     * @param list<string> $excluded_index_path_roots                  Roots which changes must not affect.
+     */
+    public static function start_from_fresh_local_tree_with_selected_default_skipped_paths(
+        string $work_directory,
+        string $filesystem_root,
+        string $patch_result_index_file,
+        string $storage_path,
+        string $selected_default_skipped_index_paths_file,
+        array $included_index_path_roots = [""],
+        array $excluded_index_path_roots = []
+    ): self {
+        $work_directory = trim_right_slash($work_directory);
+        return self::create(
+            $work_directory,
+            $filesystem_root,
+            wp_join_unix_paths($work_directory, "fresh_local_index.jsonl"),
+            $patch_result_index_file,
+            $storage_path,
+            $included_index_path_roots,
+            $excluded_index_path_roots,
+            [
+                "mode" => "selected_default_skipped_paths",
+                "file" => $selected_default_skipped_index_paths_file,
+            ],
             "exact"
         );
     }
@@ -156,6 +204,7 @@ final class FileSyncPatchProcessor {
         $position = $cursor["position"];
         if (
             $position["phase"] === "indexing"
+            || $position["phase"] === "supplementing"
             || $position["phase"] === "sorting"
             || $position["phase"] === "starting_patch"
         ) {
@@ -195,6 +244,7 @@ final class FileSyncPatchProcessor {
 
         if (
             $position["phase"] === "indexing"
+            || $position["phase"] === "supplementing"
             || $position["phase"] === "sorting"
         ) {
             $this->fresh_local_index_processor->next_step();
@@ -326,7 +376,7 @@ final class FileSyncPatchProcessor {
      *     @type array  $expected_base {
      *         Base index entry removed by an exact `delete` or `replace`.
      *
-     *         @type string $type  Expected `file`, `link`, or `dir` type.
+     *         @type string $type  Expected `file`, `link`, `dir`, or temporary `other` type.
      *         @type int    $size  Expected size.
      *         @type int    $ctime Expected inode change time.
      *     }
@@ -344,7 +394,10 @@ final class FileSyncPatchProcessor {
         return $this->cursor;
     }
 
-    /** Returns `indexing`, `sorting`, `starting_patch`, `planning`, or `complete`. */
+    /**
+     * Returns `indexing`, `supplementing`, `sorting`, `starting_patch`,
+     * `planning`, or `complete`.
+     */
     public function get_phase(): string
     {
         return $this->cursor["position"]["phase"];
@@ -439,6 +492,7 @@ final class FileSyncPatchProcessor {
         $this->closed = true;
     }
 
+    /** @phpstan-param FreshIndexSelection $fresh_index_selection */
     private static function create(
         string $work_directory,
         string $filesystem_root,
@@ -447,7 +501,7 @@ final class FileSyncPatchProcessor {
         string $storage_path,
         array $included_index_path_roots,
         array $excluded_index_path_roots,
-        bool $include_caches,
+        array $fresh_index_selection,
         string $deletion_policy
     ): self {
         if (!is_dir($work_directory)) {
@@ -461,13 +515,22 @@ final class FileSyncPatchProcessor {
             "fresh_local_index.jsonl"
         );
         $processor->fresh_local_index_file = $fresh_local_index_file;
-        $processor->fresh_local_index_processor =
-            FreshLocalIndexProcessor::start(
+        if ($fresh_index_selection["mode"] === "ordinary") {
+            $processor->fresh_local_index_processor = FreshLocalIndexProcessor::start(
                 $fresh_local_index_file,
                 $filesystem_root,
                 $storage_path,
-                $include_caches
+                $fresh_index_selection["include_caches"]
             );
+        } else {
+            $processor->fresh_local_index_processor =
+                FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+                    $fresh_local_index_file,
+                    $filesystem_root,
+                    $storage_path,
+                    $fresh_index_selection["file"]
+                );
+        }
         $processor->cursor = [
             "fresh_local_index_file_b64" => base64_encode(
                 $fresh_local_index_file

--- a/packages/reprint-client/src/lib/index/class-fresh-local-index-processor.php
+++ b/packages/reprint-client/src/lib/index/class-fresh-local-index-processor.php
@@ -2,6 +2,11 @@
 
 use function Reprint\Importer\sort_index_file;
 use function Reprint\Importer\write_local_index_entry;
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_relative_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\read_file_index_directory_is_empty;
+use function WordPress\Reprint\Exporter\read_file_index_entry_from_stat;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
@@ -24,8 +29,9 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * offset before continuing the filesystem traversal. Bytes written by a step
  * whose cursor was not stored are written again from the same traversal point.
  *
- * Each next_step() call performs one filesystem traversal event or sorts the
- * completed index. False means the index is complete and remains false.
+ * Each next_step() call performs one filesystem traversal event, inspects one
+ * explicitly selected default-skipped path, or sorts the completed index.
+ * False means the index is complete and remains false.
  *
  *     $processor = FreshLocalIndexProcessor::start(
  *         $fresh_local_index_file,
@@ -42,15 +48,26 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * A later process continues with
  * `FreshLocalIndexProcessor::resume($saved_cursor)`.
  *
+ * The selected-path form is for a sorted, deduplicated JSONL file containing
+ * `{"path_b64":"..."}` rows. Ordinary traversal still omits generated caches
+ * and development files. After that traversal, the processor inspects only
+ * the selected paths, without descending into their directories.
+ *
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
+ * @phpstan-type SelectedPathsNone array{mode:'ordinary'}
+ * @phpstan-type SelectedPathsFile array{mode:'selected_default_skipped_paths',file_b64:string}
+ * @phpstan-type SelectedPathsConfig SelectedPathsNone|SelectedPathsFile
  * @phpstan-type IndexingPosition array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
+ * @phpstan-type SupplementingPosition array{phase:'supplementing',selected_paths_byte_offset:int,preceding_selected_path_b64:string|null,fresh_local_index_byte_offset:int}
  * @phpstan-type SortingPosition array{phase:'sorting'}
  * @phpstan-type CompletePosition array{phase:'complete'}
- * @phpstan-type Position IndexingPosition|SortingPosition|CompletePosition
- * @phpstan-type Cursor array{fresh_local_index_file_b64:string,filesystem_root_b64:string,storage_path_b64:string,include_caches:bool,position:Position}
+ * @phpstan-type Position IndexingPosition|SupplementingPosition|SortingPosition|CompletePosition
+ * @phpstan-type Cursor array{fresh_local_index_file_b64:string,filesystem_root_b64:string,storage_path_b64:string,include_caches:bool,selected_paths:SelectedPathsConfig,position:Position}
  */
 final class FreshLocalIndexProcessor
 {
+    private const MAX_SELECTED_PATH_ROW_BYTES = 64 * 1024;
+
     /** @var Cursor Current cursor returned to the caller. */
     private array $cursor;
 
@@ -60,11 +77,17 @@ final class FreshLocalIndexProcessor
     /** Filesystem root decoded from the cursor. */
     private string $filesystem_root;
 
+    /** Canonical Reprint storage path omitted from the index, or an empty string. */
+    private string $storage_path;
+
     /** Filesystem traversal retained during indexing. */
     private FileIndexProcessor $file_index_processor;
 
-    /** @var resource|null Fresh local index retained during indexing. */
+    /** @var resource|null Fresh local index retained during indexing and supplementation. */
     private $fresh_local_index_handle = null;
+
+    /** @var resource|null Selected default-skipped paths retained during supplementation. */
+    private $selected_paths_handle = null;
 
     /** Whether close() released this processor's handles. */
     private bool $closed = false;
@@ -86,10 +109,82 @@ final class FreshLocalIndexProcessor
         string $storage_path,
         bool $include_caches = false
     ): self {
+        return self::create(
+            $fresh_local_index_file,
+            $filesystem_root,
+            $storage_path,
+            $include_caches,
+            ["mode" => "ordinary"]
+        );
+    }
+
+    /**
+     * Starts a caches-off scan followed by selected default-skipped paths.
+     *
+     * The selected-path file must remain immutable for this lifecycle. It is
+     * sorted and deduplicated by decoded local-relative path bytes. Each row
+     * has exactly one canonical-base64 `path_b64` field.
+     *
+     * @param string $fresh_local_index_file                    Output JSONL file.
+     * @param string $filesystem_root                           Filesystem root represented by the index.
+     * @param string $storage_path                              Reprint storage path omitted from the index.
+     * @param string $selected_default_skipped_index_paths_file Immutable path-only JSONL file.
+     */
+    public static function start_with_selected_default_skipped_paths(
+        string $fresh_local_index_file,
+        string $filesystem_root,
+        string $storage_path,
+        string $selected_default_skipped_index_paths_file
+    ): self {
+        $selected_paths_handle = self::open_selected_paths_at_offset(
+            $selected_default_skipped_index_paths_file,
+            0
+        );
+        $selected_paths_stat = fstat($selected_paths_handle);
+        $fresh_local_index_stat = @stat($fresh_local_index_file);
+        if (
+            $selected_paths_stat !== false
+            && $fresh_local_index_stat !== false
+            && $selected_paths_stat["dev"] === $fresh_local_index_stat["dev"]
+            && $selected_paths_stat["ino"] === $fresh_local_index_stat["ino"]
+        ) {
+            fclose($selected_paths_handle);
+            throw new InvalidArgumentException(
+                "The selected-path input and fresh local index must be different files."
+            );
+        }
+        fclose($selected_paths_handle);
+        return self::create(
+            $fresh_local_index_file,
+            $filesystem_root,
+            $storage_path,
+            false,
+            [
+                "mode" => "selected_default_skipped_paths",
+                "file_b64" => base64_encode(
+                    $selected_default_skipped_index_paths_file
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Starts a fresh local index with one explicit path-selection mode.
+     *
+     * @phpstan-param SelectedPathsConfig $selected_paths
+     */
+    private static function create(
+        string $fresh_local_index_file,
+        string $filesystem_root,
+        string $storage_path,
+        bool $include_caches,
+        array $selected_paths
+    ): self {
         $processor = new self();
         $filesystem_root = $processor->resolve_filesystem_root($filesystem_root);
         $processor->fresh_local_index_file = $fresh_local_index_file;
         $processor->filesystem_root = $filesystem_root;
+        $processor->storage_path = self::canonical_storage_path($storage_path);
         $processor->fresh_local_index_handle = fopen(
             $fresh_local_index_file,
             "w+b"
@@ -113,6 +208,7 @@ final class FreshLocalIndexProcessor
             "filesystem_root_b64" => base64_encode($filesystem_root),
             "storage_path_b64" => base64_encode($storage_path),
             "include_caches" => $include_caches,
+            "selected_paths" => $selected_paths,
             "position" => [
                 "phase" => "indexing",
                 "file_index_cursor" =>
@@ -128,6 +224,8 @@ final class FreshLocalIndexProcessor
      *
      * During indexing, bytes after the saved output offset are discarded and
      * FileIndexProcessor resumes from the traversal cursor stored with it.
+     * During supplementation, the output is truncated to its saved boundary
+     * and the immutable selected-path input seeks to its saved byte offset.
      * Sorting starts again from the complete unsorted file. A complete cursor
      * opens no files.
      *
@@ -149,8 +247,22 @@ final class FreshLocalIndexProcessor
             $cursor["storage_path_b64"],
             "storage path"
         );
+        $processor->storage_path = self::canonical_storage_path($storage_path);
+        self::assert_selected_paths_config($cursor["selected_paths"]);
+        if (
+            $cursor["selected_paths"]["mode"]
+                === "selected_default_skipped_paths"
+            && $cursor["include_caches"]
+        ) {
+            throw new InvalidArgumentException(
+                "Selected default-skipped paths require a caches-off local traversal."
+            );
+        }
         $position = $cursor["position"];
-        if ($position["phase"] !== "indexing") {
+        if (
+            $position["phase"] !== "indexing"
+            && $position["phase"] !== "supplementing"
+        ) {
             return $processor;
         }
 
@@ -162,33 +274,16 @@ final class FreshLocalIndexProcessor
                 "The fresh local index filesystem root no longer resolves to its saved path."
             );
         }
-        $processor->fresh_local_index_handle = fopen(
+        $processor->fresh_local_index_handle = self::open_output_at_offset(
             $processor->fresh_local_index_file,
-            "r+b"
+            $position["fresh_local_index_byte_offset"]
         );
-        if (!is_resource($processor->fresh_local_index_handle)) {
-            throw new RuntimeException(
-                "Failed to reopen the fresh local index: "
-                . $processor->fresh_local_index_file
+        if ($position["phase"] === "supplementing") {
+            $processor->selected_paths_handle = self::open_selected_paths_at_offset(
+                self::selected_paths_file($cursor["selected_paths"]),
+                $position["selected_paths_byte_offset"]
             );
-        }
-        if (
-            !ftruncate(
-                $processor->fresh_local_index_handle,
-                $position["fresh_local_index_byte_offset"]
-            )
-            || fseek(
-                $processor->fresh_local_index_handle,
-                $position["fresh_local_index_byte_offset"]
-            ) !== 0
-        ) {
-            fclose($processor->fresh_local_index_handle);
-            $processor->fresh_local_index_handle = null;
-            throw new RuntimeException(
-                "Failed to truncate and seek the fresh local index to byte "
-                . $position["fresh_local_index_byte_offset"]
-                . "."
-            );
+            return $processor;
         }
         $processor->file_index_processor = FileIndexProcessor::resume(
             [$filesystem_root],
@@ -204,7 +299,7 @@ final class FreshLocalIndexProcessor
     }
 
     /**
-     * Performs one filesystem traversal event or sorts the completed index.
+     * Performs one traversal event, selected-path inspection, or index sort.
      *
      * True means another step may be performed. False means the fresh local
      * index is complete.
@@ -232,6 +327,10 @@ final class FreshLocalIndexProcessor
             return false;
         }
 
+        if ($position["phase"] === "supplementing") {
+            return $this->supplement_next_selected_path($position);
+        }
+
         if (!$this->file_index_processor->next_index_step()) {
             if (!fflush($this->fresh_local_index_handle)) {
                 throw new RuntimeException(
@@ -239,8 +338,27 @@ final class FreshLocalIndexProcessor
                 );
             }
             $this->file_index_processor->close();
-            $this->close_fresh_local_index_handle();
-            $this->cursor["position"] = ["phase" => "sorting"];
+            if (
+                $this->cursor["selected_paths"]["mode"]
+                    === "selected_default_skipped_paths"
+            ) {
+                $this->selected_paths_handle = self::open_selected_paths_at_offset(
+                    self::selected_paths_file(
+                        $this->cursor["selected_paths"]
+                    ),
+                    0
+                );
+                $this->cursor["position"] = [
+                    "phase" => "supplementing",
+                    "selected_paths_byte_offset" => 0,
+                    "preceding_selected_path_b64" => null,
+                    "fresh_local_index_byte_offset" =>
+                        $this->fresh_local_index_byte_offset(),
+                ];
+            } else {
+                $this->close_fresh_local_index_handle();
+                $this->cursor["position"] = ["phase" => "sorting"];
+            }
             return true;
         }
 
@@ -317,20 +435,12 @@ final class FreshLocalIndexProcessor
                 break;
         }
 
-        $fresh_local_index_byte_offset = ftell(
-            $this->fresh_local_index_handle
-        );
-        if (!is_int($fresh_local_index_byte_offset)) {
-            throw new RuntimeException(
-                "Failed to determine the fresh local index byte offset."
-            );
-        }
         $this->cursor["position"] = [
             "phase" => "indexing",
             "file_index_cursor" =>
                 $this->file_index_processor->get_cursor(),
             "fresh_local_index_byte_offset" =>
-                $fresh_local_index_byte_offset,
+                $this->fresh_local_index_byte_offset(),
         ];
         return true;
     }
@@ -367,8 +477,264 @@ final class FreshLocalIndexProcessor
         if (isset($this->file_index_processor)) {
             $this->file_index_processor->close();
         }
+        $this->close_selected_paths_handle();
         $this->close_fresh_local_index_handle();
         $this->closed = true;
+    }
+
+    /**
+     * Reads and inspects at most one selected default-skipped path.
+     *
+     * @phpstan-param SupplementingPosition $position
+     */
+    private function supplement_next_selected_path(array $position): bool
+    {
+        $row = self::read_bounded_selected_path_row(
+            $this->selected_paths_handle
+        );
+        if ($row === false) {
+            if (!fflush($this->fresh_local_index_handle)) {
+                throw new RuntimeException(
+                    "Failed to flush the fresh local index."
+                );
+            }
+            $this->close_selected_paths_handle();
+            $this->close_fresh_local_index_handle();
+            $this->cursor["position"] = ["phase" => "sorting"];
+            return true;
+        }
+
+        $selected_path = self::decode_selected_path_row($row);
+        $preceding_selected_path = $position[
+            "preceding_selected_path_b64"
+        ] === null
+            ? null
+            : self::decode_canonical_base64_path(
+                $position["preceding_selected_path_b64"],
+                "preceding selected path"
+            );
+        if (
+            $preceding_selected_path !== null
+            && strcmp($selected_path, $preceding_selected_path) <= 0
+        ) {
+            throw new UnexpectedValueException(
+                "Selected default-skipped paths must be sorted and deduplicated; "
+                . base64_encode($selected_path)
+                . " follows "
+                . base64_encode($preceding_selected_path)
+                . "."
+            );
+        }
+        $absolute_path = wp_join_unix_paths(
+            $this->filesystem_root,
+            $selected_path
+        );
+        if (
+            !FileIndexProcessor::path_is_default_skipped_below_root(
+                $this->filesystem_root,
+                $absolute_path
+            )
+        ) {
+            throw new UnexpectedValueException(
+                "Selected path is not omitted by the default local traversal: "
+                . base64_encode($selected_path)
+                . "."
+            );
+        }
+
+        if ($this->path_is_in_storage($absolute_path)) {
+            return $this->settle_selected_path($selected_path);
+        }
+        $resolved_parent = $this->resolve_selected_path_parent(
+            $selected_path
+        );
+        if ($resolved_parent === null) {
+            return $this->settle_selected_path($selected_path);
+        }
+        $resolved_absolute_path = wp_join_unix_paths(
+            $resolved_parent,
+            basename($absolute_path)
+        );
+        if (!$this->path_is_in_storage($resolved_absolute_path)) {
+            clearstatcache(true, $absolute_path);
+            $path_stat = @lstat($absolute_path);
+            if ($path_stat !== false) {
+                $this->append_selected_path_entry(
+                    $selected_path,
+                    $absolute_path,
+                    $path_stat
+                );
+            }
+        }
+
+        return $this->settle_selected_path($selected_path);
+    }
+
+    /**
+     * Resolves a selected path's parent through bounded lexical prefixes.
+     *
+     * is_executable() checks directory search permission for the current PHP
+     * user on POSIX. A false lstat() for the next component under a confirmed
+     * searchable directory is treated as a missing tail. Existing prefixes
+     * must resolve to searchable directories inside the filesystem root. This
+     * walks at most the path's parent components and never scans a directory.
+     *
+     * @return string|null Resolved immediate parent, or null for a missing tail.
+     */
+    private function resolve_selected_path_parent(
+        string $selected_path
+    ): ?string {
+        $lexical_prefix = $this->filesystem_root;
+        $resolved_prefix = $this->filesystem_root;
+        $parent_components = explode("/", $selected_path);
+        array_pop($parent_components);
+
+        foreach ($parent_components as $parent_component) {
+            $this->assert_searchable_selected_path_parent_prefix(
+                $resolved_prefix
+            );
+            $lexical_prefix = wp_join_unix_paths(
+                $lexical_prefix,
+                $parent_component
+            );
+            clearstatcache(true, $lexical_prefix);
+            $prefix_stat = @lstat($lexical_prefix);
+            if ($prefix_stat === false) {
+                return null;
+            }
+            $prefix_entry = read_file_index_entry_from_stat(
+                $lexical_prefix,
+                $prefix_stat
+            );
+            if (
+                $prefix_entry["type"] !== "dir"
+                && $prefix_entry["type"] !== "link"
+            ) {
+                throw new RuntimeException(
+                    "Selected path parent prefix is not a directory: "
+                    . base64_encode($lexical_prefix)
+                    . "."
+                );
+            }
+            $next_resolved_prefix = realpath($lexical_prefix);
+            if ($next_resolved_prefix === false) {
+                throw new RuntimeException(
+                    "Selected path parent prefix does not resolve to a directory: "
+                    . base64_encode($lexical_prefix)
+                    . "."
+                );
+            }
+            if (
+                !path_is_same_as_or_descendant_of(
+                    $next_resolved_prefix,
+                    $this->filesystem_root
+                )
+            ) {
+                throw new RuntimeException(
+                    "Selected path parent prefix resolves outside the filesystem root: "
+                    . base64_encode($lexical_prefix)
+                    . " resolved to "
+                    . base64_encode($next_resolved_prefix)
+                    . "."
+                );
+            }
+            $resolved_prefix = $next_resolved_prefix;
+        }
+
+        $this->assert_searchable_selected_path_parent_prefix(
+            $resolved_prefix
+        );
+        return $resolved_prefix;
+    }
+
+    /** Requires one resolved parent prefix to be a searchable directory. */
+    private function assert_searchable_selected_path_parent_prefix(
+        string $resolved_prefix
+    ): void {
+        clearstatcache(true, $resolved_prefix);
+        if (!is_dir($resolved_prefix) || !is_executable($resolved_prefix)) {
+            throw new RuntimeException(
+                "Selected path parent prefix is not a searchable directory: "
+                . base64_encode($resolved_prefix)
+                . "."
+            );
+        }
+    }
+
+    /** Stores the input and output boundaries after one selected path. */
+    private function settle_selected_path(string $selected_path): bool
+    {
+        $selected_paths_byte_offset = ftell($this->selected_paths_handle);
+        if (!is_int($selected_paths_byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the selected-path byte offset."
+            );
+        }
+        $this->cursor["position"] = [
+            "phase" => "supplementing",
+            "selected_paths_byte_offset" => $selected_paths_byte_offset,
+            "preceding_selected_path_b64" => base64_encode($selected_path),
+            "fresh_local_index_byte_offset" =>
+                $this->fresh_local_index_byte_offset(),
+        ];
+        return true;
+    }
+
+    /**
+     * Appends the actual state of one selected path without descending.
+     *
+     * @param array{mode:int,ctime?:int,size?:int} $path_stat One lstat() result.
+     */
+    private function append_selected_path_entry(
+        string $selected_path,
+        string $absolute_path,
+        array $path_stat
+    ): void {
+        $entry = read_file_index_entry_from_stat($absolute_path, $path_stat);
+        // A selected unsupported type stays in this temporary index so exact
+        // planning can replace it. Ordinary traversal rejects it above.
+        $local_entry = [
+            "path" => $selected_path,
+            "ctime" => $entry["ctime"],
+            "size" => $entry["size"],
+            "type" => $entry["type"],
+        ];
+        if ($entry["type"] === "dir") {
+            $directory_is_empty = read_file_index_directory_is_empty(
+                $absolute_path
+            );
+            if ($directory_is_empty === null) {
+                throw new RuntimeException(
+                    "Could not inspect the selected local directory: "
+                    . base64_encode($selected_path)
+                    . "."
+                );
+            }
+            $local_entry["empty"] = $directory_is_empty;
+        }
+        write_local_index_entry(
+            $this->fresh_local_index_handle,
+            $local_entry
+        );
+    }
+
+    /** Reports whether a physical or lexical path belongs to Reprint storage. */
+    private function path_is_in_storage(string $path): bool
+    {
+        return $this->storage_path !== ""
+            && path_is_same_as_or_descendant_of($path, $this->storage_path);
+    }
+
+    /** Returns the fresh-index byte offset after the latest completed write. */
+    private function fresh_local_index_byte_offset(): int
+    {
+        $byte_offset = ftell($this->fresh_local_index_handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the fresh local index byte offset."
+            );
+        }
+        return $byte_offset;
     }
 
     /** Returns the resolved real directory represented by the index. */
@@ -388,6 +754,178 @@ final class FreshLocalIndexProcessor
         return trim_right_slash($resolved_filesystem_root);
     }
 
+    /** Returns the same canonical storage path used by FileIndexProcessor. */
+    private static function canonical_storage_path(string $storage_path): string
+    {
+        $storage_path = rtrim($storage_path, "/");
+        if ($storage_path === "") {
+            return "";
+        }
+        $canonical_storage_path = realpath($storage_path);
+        return $canonical_storage_path !== false
+            ? $canonical_storage_path
+            : $storage_path;
+    }
+
+    /** Validates one cursor-selected path source. */
+    private static function assert_selected_paths_config(array $config): void
+    {
+        if (
+            $config === ["mode" => "ordinary"]
+        ) {
+            return;
+        }
+        if (
+            array_keys($config) !== ["mode", "file_b64"]
+            || $config["mode"] !== "selected_default_skipped_paths"
+            || !is_string($config["file_b64"])
+        ) {
+            throw new InvalidArgumentException(
+                "Fresh local index cursor has an invalid selected-path config."
+            );
+        }
+        self::decode_canonical_base64_path(
+            $config["file_b64"],
+            "selected-path file"
+        );
+    }
+
+    /** @phpstan-param SelectedPathsConfig $config */
+    private static function selected_paths_file(array $config): string
+    {
+        if ($config["mode"] !== "selected_default_skipped_paths") {
+            throw new LogicException(
+                "Ordinary local indexing has no selected-path file."
+            );
+        }
+        return self::decode_canonical_base64_path(
+            $config["file_b64"],
+            "selected-path file"
+        );
+    }
+
+    /**
+     * Reads one complete bounded selected-path row.
+     *
+     * @param resource $handle Open selected-path file.
+     * @return string|false One row including LF, or false at EOF.
+     */
+    private static function read_bounded_selected_path_row($handle)
+    {
+        $byte_offset = ftell($handle);
+        if (!is_int($byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the selected-path row offset."
+            );
+        }
+        $row = fgets($handle, self::MAX_SELECTED_PATH_ROW_BYTES + 1);
+        if ($row === false) {
+            if (feof($handle)) {
+                return false;
+            }
+            throw new RuntimeException(
+                "Failed to read the selected-path row at byte offset {$byte_offset}."
+            );
+        }
+        if (substr($row, -1) !== "\n") {
+            $row_bytes = strlen($row);
+            if (feof($handle)) {
+                throw new UnexpectedValueException(
+                    "The selected-path row at byte offset {$byte_offset} is unterminated after {$row_bytes} bytes."
+                );
+            }
+            throw new UnexpectedValueException(
+                "The selected-path row at byte offset {$byte_offset} exceeds the maximum of "
+                . self::MAX_SELECTED_PATH_ROW_BYTES
+                . " bytes; read {$row_bytes} bytes without LF."
+            );
+        }
+        return $row;
+    }
+
+    /** Decodes one strict path-only JSONL row. */
+    private static function decode_selected_path_row(string $row): string
+    {
+        $record = json_decode(substr($row, 0, -1), true);
+        if (
+            !is_array($record)
+            || array_keys($record) !== ["path_b64"]
+            || !is_string($record["path_b64"])
+        ) {
+            throw new UnexpectedValueException(
+                "Selected default-skipped path file contains an invalid row."
+            );
+        }
+        $path = self::decode_canonical_base64_path(
+            $record["path_b64"],
+            "selected path"
+        );
+        assert_valid_relative_path($path, "Selected default-skipped path");
+        return $path;
+    }
+
+    /** Decodes one canonical-base64 path. */
+    private static function decode_canonical_base64_path(
+        string $encoded_path,
+        string $field_name
+    ): string {
+        $path = base64_decode($encoded_path, true);
+        if ($path === false || base64_encode($path) !== $encoded_path) {
+            throw new InvalidArgumentException(
+                "Fresh local index {$field_name} has invalid canonical base64."
+            );
+        }
+        return $path;
+    }
+
+    /** @return resource Open selected-path input positioned at its cursor. */
+    private static function open_selected_paths_at_offset(
+        string $path,
+        int $byte_offset
+    ) {
+        $handle = @fopen($path, "rb");
+        $stat = is_resource($handle) ? fstat($handle) : false;
+        if (
+            $stat === false
+            || ( $stat["mode"] & 0170000 ) !== 0100000
+            || $byte_offset < 0
+            || $byte_offset > $stat["size"]
+            || fseek($handle, $byte_offset) !== 0
+        ) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            throw new RuntimeException(
+                "Failed to open the immutable selected-path file at byte {$byte_offset}: {$path}"
+            );
+        }
+        return $handle;
+    }
+
+    /** @return resource Open fresh index truncated to its durable boundary. */
+    private static function open_output_at_offset(
+        string $path,
+        int $byte_offset
+    ) {
+        $handle = @fopen($path, "r+b");
+        $stat = is_resource($handle) ? fstat($handle) : false;
+        if (
+            $stat === false
+            || $byte_offset < 0
+            || $byte_offset > $stat["size"]
+            || !ftruncate($handle, $byte_offset)
+            || fseek($handle, $byte_offset) !== 0
+        ) {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            throw new RuntimeException(
+                "Failed to resume the fresh local index at byte {$byte_offset}: {$path}"
+            );
+        }
+        return $handle;
+    }
+
     /** Decodes one arbitrary-byte path stored in the JSON cursor. */
     private static function decode_cursor_path(
         string $encoded_path,
@@ -402,7 +940,16 @@ final class FreshLocalIndexProcessor
         return $path;
     }
 
-    /** Closes the fresh local index retained during filesystem traversal. */
+    /** Closes the selected-path input retained during supplementation. */
+    private function close_selected_paths_handle(): void
+    {
+        if (is_resource($this->selected_paths_handle)) {
+            fclose($this->selected_paths_handle);
+        }
+        $this->selected_paths_handle = null;
+    }
+
+    /** Closes the fresh local index retained during indexing or supplementation. */
     private function close_fresh_local_index_handle(): void
     {
         if (is_resource($this->fresh_local_index_handle)) {

--- a/packages/reprint-client/src/lib/local-index-update-functions.php
+++ b/packages/reprint-client/src/lib/local-index-update-functions.php
@@ -214,14 +214,14 @@ function merge_local_index_mutations(
  * @type string $path Decoded filesystem path.
  * @type int $ctime Indexed change timestamp.
  * @type int $size Indexed size.
- * @type string $type `file`, `link`, or `dir`.
+ * @type string $type `file`, `link`, `dir`, or temporary `other`.
  * @type bool $empty Whether a directory has no descendant entries in
  *                         this index.
  * }
- * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}
+ * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir'|'other',empty?:bool}
  */
 function decode_local_index_entry( string $local_index_json_line ): array {
-	/** @var array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool} $encoded_local_index_entry */
+	/** @var array{path:string,ctime:int,size:int,type:'file'|'link'|'dir'|'other',empty?:bool} $encoded_local_index_entry */
 	$encoded_local_index_entry = json_decode(
 		$local_index_json_line,
 		true,
@@ -251,7 +251,7 @@ function decode_local_index_entry( string $local_index_json_line ): array {
  *
  * @param  resource|null  $local_index_handle  Open index, or null when no index exists.
  *
- * @return \Generator<int,array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool},mixed,void>
+ * @return \Generator<int,array{path:string,ctime:int,size:int,type:'file'|'link'|'dir'|'other',empty?:bool},mixed,void>
  */
 function read_local_index_entries( $local_index_handle ): \Generator {
 	if ( ! is_resource( $local_index_handle ) ) {
@@ -333,7 +333,7 @@ function read_local_index_updates( $sorted_local_index_updates_handle ): \Genera
  * @type string $path Path bytes.
  * @type int $ctime Entry ctime.
  * @type int $size Entry size.
- * @type string $type `file`, `link`, or `dir`.
+ * @type string $type `file`, `link`, `dir`, or temporary `other`.
  * @type bool $empty Whether a directory has no descendant entries in
  *                         this index.
  * }

--- a/tests/Import/FileSyncPatchProcessorTest.php
+++ b/tests/Import/FileSyncPatchProcessorTest.php
@@ -453,6 +453,135 @@ final class FileSyncPatchProcessorTest extends TestCase {
         );
     }
 
+    public function testSelectedDefaultSkippedPathsSurvivePatchProcessorResume(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        symlink('target.txt', $this->filesystem_root . '/.git/link');
+        $link_stat = lstat($this->filesystem_root . '/.git/link');
+        $this->assertIsArray($link_stat);
+        $patch_result_index = $this->write_index(
+            'selected-result.jsonl',
+            [
+                [
+                    'path' => '.git/link',
+                    'ctime' => (int) $link_stat['ctime'],
+                    'size' => (int) $link_stat['size'],
+                    'type' => 'link',
+                ],
+                [
+                    'path' => '.git/missing',
+                    'ctime' => 1,
+                    'size' => 10,
+                    'type' => 'link',
+                ],
+            ]
+        );
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/link',
+            '.git/missing',
+        ]);
+        $work_directory = $this->work_directory('selected-path-resume');
+        $processor = FileSyncPatchProcessor::start_from_fresh_local_tree_with_selected_default_skipped_paths(
+            $work_directory,
+            $this->filesystem_root,
+            $patch_result_index,
+            $work_directory,
+            $selected_paths_file
+        );
+        $this->assertSame(
+            [
+                'mode' => 'selected_default_skipped_paths',
+                'file_b64' => base64_encode($selected_paths_file),
+            ],
+            $processor->get_cursor()['position'][
+                'fresh_local_index_cursor'
+            ]['selected_paths']
+        );
+        for ($step = 0; $step < 100; ++$step) {
+            if ($processor->get_phase() === 'supplementing') {
+                break;
+            }
+            $this->assertTrue($processor->next_step());
+        }
+        $this->assertSame('supplementing', $processor->get_phase());
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_outputs();
+        $cursor = $this->serialize_cursor($processor->get_cursor());
+        $processor->close();
+
+        $resumed = FileSyncPatchProcessor::resume($cursor);
+        $this->assertSame(
+            [
+                [
+                    'action' => 'copy',
+                    'path' => '.git/missing',
+                    'expected_source' => [
+                        'type' => 'link',
+                        'size' => 10,
+                        'ctime' => 1,
+                    ],
+                ],
+            ],
+            $this->run_to_completion($resumed)
+        );
+    }
+
+    public function testSelectedLinkReplacesAnUnsupportedLocalPath(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build cannot create a FIFO.');
+        }
+        mkdir($this->filesystem_root . '/.git');
+        $selected_path = '.git/link';
+        $absolute_selected_path = $this->filesystem_root
+            . '/' . $selected_path;
+        posix_mkfifo($absolute_selected_path, 0600);
+        $fifo_stat = lstat($absolute_selected_path);
+        $this->assertIsArray($fifo_stat);
+        $patch_result_index = $this->write_index(
+            'selected-link-result.jsonl',
+            [
+                [
+                    'path' => $selected_path,
+                    'ctime' => 1,
+                    'size' => 6,
+                    'type' => 'link',
+                ],
+            ]
+        );
+        $selected_paths_file = $this->write_selected_paths([
+            $selected_path,
+        ]);
+        $work_directory = $this->work_directory('selected-link-over-fifo');
+        $processor = FileSyncPatchProcessor::start_from_fresh_local_tree_with_selected_default_skipped_paths(
+            $work_directory,
+            $this->filesystem_root,
+            $patch_result_index,
+            $work_directory,
+            $selected_paths_file
+        );
+
+        $this->assertSame(
+            [
+                [
+                    'action' => 'replace',
+                    'path' => $selected_path,
+                    'expected_source' => [
+                        'type' => 'link',
+                        'size' => 6,
+                        'ctime' => 1,
+                    ],
+                    'expected_base' => [
+                        'type' => 'other',
+                        'size' => 0,
+                        'ctime' => (int) $fifo_stat['ctime'],
+                    ],
+                ],
+            ],
+            $this->run_to_completion($processor)
+        );
+    }
+
     /** @return list<array<string,mixed>> */
     private function run_to_completion(
         FileSyncPatchProcessor $processor
@@ -520,6 +649,26 @@ final class FileSyncPatchProcessorTest extends TestCase {
         return $path;
     }
 
+    /** @param list<string> $paths */
+    private function write_selected_paths(array $paths): string
+    {
+        $lines = array_map(
+            static function (string $path): string {
+                return json_encode(
+                    ['path_b64' => base64_encode($path)],
+                    JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                );
+            },
+            $paths
+        );
+        $path = $this->temporary_directory . '/selected-paths.jsonl';
+        file_put_contents(
+            $path,
+            empty($lines) ? '' : implode("\n", $lines) . "\n"
+        );
+        return $path;
+    }
+
     /** @return array{path:string,ctime:int,size:int,type:string} */
     private function entry(string $path, int $size): array
     {
@@ -566,7 +715,11 @@ final class FileSyncPatchProcessorTest extends TestCase {
 
     private function remove_path(string $path): void
     {
-        if (is_link($path) || is_file($path)) {
+        if (
+            is_link($path)
+            || is_file($path)
+            || ( @lstat($path) !== false && !is_dir($path) )
+        ) {
             unlink($path);
             return;
         }

--- a/tests/Import/FreshLocalIndexProcessorTest.php
+++ b/tests/Import/FreshLocalIndexProcessorTest.php
@@ -141,6 +141,571 @@ final class FreshLocalIndexProcessorTest extends TestCase {
         );
     }
 
+    public function testSelectedDefaultSkippedPathsAddPresentEntriesAndOmitMissingPaths(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        mkdir($this->filesystem_root . '/.git/present');
+        symlink('target.txt', $this->filesystem_root . '/.git/link');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/link',
+            '.git/missing',
+            '.git/no-parent/value',
+            '.git/present/missing/deeper/value',
+        ]);
+
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->run_to_completion($processor);
+
+        $entries = $this->read_index_entries();
+        $this->assertSame(['.git/link'], array_column($entries, 'decoded_path'));
+        $this->assertSame('link', $entries[0]['type']);
+    }
+
+    public function testSelectedFilesAndDirectoriesAreIndexedWithoutDescent(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        mkdir($this->filesystem_root . '/.git/empty');
+        file_put_contents($this->filesystem_root . '/.git/file.txt', 'file');
+        mkdir($this->filesystem_root . '/.git/full');
+        file_put_contents(
+            $this->filesystem_root . '/.git/full/unselected.txt',
+            'child'
+        );
+        mkdir($this->filesystem_root . '/.DS_Store');
+        file_put_contents(
+            $this->filesystem_root . '/.DS_Store/selected.txt',
+            'selected'
+        );
+        $selected_paths_file = $this->write_selected_paths([
+            '.DS_Store/selected.txt',
+            '.git/empty',
+            '.git/file.txt',
+            '.git/full',
+        ]);
+
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->run_to_completion($processor);
+
+        $entries = $this->read_index_entries();
+        $this->assertSame(
+            [
+                '.DS_Store/selected.txt',
+                '.git/empty',
+                '.git/file.txt',
+                '.git/full',
+            ],
+            array_column($entries, 'decoded_path')
+        );
+        $this->assertSame('file', $entries[0]['type']);
+        $this->assertTrue($entries[1]['empty']);
+        $this->assertSame('file', $entries[2]['type']);
+        $this->assertFalse($entries[3]['empty']);
+        $this->assertNotContains(
+            '.git/full/unselected.txt',
+            array_column($entries, 'decoded_path')
+        );
+    }
+
+    public function testOnlySelectedUnsupportedPathsAreIndexed(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build cannot create a FIFO.');
+        }
+        mkdir($this->filesystem_root . '/.git');
+        posix_mkfifo($this->filesystem_root . '/.git/unowned.pipe', 0600);
+        $empty_selected_paths_file = $this->write_selected_paths([]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $empty_selected_paths_file
+        );
+        $this->run_to_completion($processor);
+        $this->assertSame([], $this->read_index_entries());
+
+        posix_mkfifo($this->filesystem_root . '/.git/selected.pipe', 0600);
+        $selected_paths_file = $this->write_selected_paths(
+            ['.git/selected.pipe'],
+            'selected-fifo.jsonl'
+        );
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->run_to_completion($processor);
+        $entries = $this->read_index_entries();
+        $this->assertSame(
+            ['.git/selected.pipe'],
+            array_column($entries, 'decoded_path')
+        );
+        $this->assertSame('other', $entries[0]['type']);
+    }
+
+    public function testOrdinaryTraversalStillRejectsUnsupportedPaths(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build cannot create a FIFO.');
+        }
+        $fifo_path = $this->filesystem_root . '/ordinary.pipe';
+        posix_mkfifo($fifo_path, 0600);
+        $processor = FreshLocalIndexProcessor::start(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path
+        );
+        try {
+            $this->expectException(RuntimeException::class);
+            $canonical_fifo_path = realpath($this->filesystem_root)
+                . '/ordinary.pipe';
+            $this->expectExceptionMessage(
+                'Cannot index the unsupported local path: '
+                . base64_encode($canonical_fifo_path)
+                . '.'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testSelectedPathParentMayResolveWithinButNotOutsideTheRoot(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        mkdir($this->filesystem_root . '/.git/target');
+        file_put_contents(
+            $this->filesystem_root . '/.git/target/value.txt',
+            'inside'
+        );
+        symlink('target', $this->filesystem_root . '/.git/inside');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/inside/value.txt',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->run_to_completion($processor);
+        $this->assertSame(
+            ['.git/inside/value.txt'],
+            array_column($this->read_index_entries(), 'decoded_path')
+        );
+
+        $outside_directory = $this->temporary_directory . '/outside';
+        mkdir($outside_directory);
+        file_put_contents($outside_directory . '/value.txt', 'outside');
+        symlink($outside_directory, $this->filesystem_root . '/.git/outside');
+        $selected_paths_file = $this->write_selected_paths(
+            ['.git/outside/value.txt'],
+            'outside-parent.jsonl'
+        );
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Selected path parent prefix resolves outside the filesystem root:'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testSelectedPathRejectsAnUnresolvableExistingParent(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        symlink(
+            $this->temporary_directory . '/missing-target',
+            $this->filesystem_root . '/.git/broken'
+        );
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/broken/value.txt',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Selected path parent prefix does not resolve to a directory:'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    public function testSelectedPathRejectsANonDirectoryParentPrefix(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        file_put_contents($this->filesystem_root . '/.git/file.txt', 'file');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/file.txt/child.txt',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Selected path parent prefix is not a directory:'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    /**
+     * @dataProvider unsearchableSelectedPathParents
+     */
+    public function testSelectedPathRejectsAnUnsearchableParentPrefix(
+        string $locked_parent,
+        string $selected_path
+    ): void {
+        $absolute_locked_parent = $this->filesystem_root
+            . '/' . $locked_parent;
+        mkdir($absolute_locked_parent, 0755, true);
+        $remaining_parent = dirname($selected_path);
+        if ($remaining_parent !== $locked_parent) {
+            mkdir(
+                $this->filesystem_root . '/' . $remaining_parent,
+                0755,
+                true
+            );
+        }
+        chmod($absolute_locked_parent, 0000);
+        $selected_paths_file = $this->write_selected_paths([$selected_path]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Selected path parent prefix is not a searchable directory: '
+                . base64_encode(realpath($absolute_locked_parent))
+                . '.'
+            );
+            $this->run_to_completion($processor);
+        } finally {
+            chmod($absolute_locked_parent, 0700);
+            $processor->close();
+        }
+    }
+
+    /** @return array<string,array{string,string}> */
+    public static function unsearchableSelectedPathParents(): array
+    {
+        return [
+            'immediate parent' => [
+                '.git/locked',
+                '.git/locked/value.txt',
+            ],
+            'deeper parent' => [
+                '.git/locked',
+                '.git/locked/deeper/value.txt',
+            ],
+        ];
+    }
+
+    public function testSelectedPathsStillOmitTheStorageSubtree(): void
+    {
+        $storage_path = $this->filesystem_root . '/.git/reprint-state';
+        mkdir($storage_path, 0755, true);
+        file_put_contents($storage_path . '/state.json', 'state');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/reprint-state/state.json',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $storage_path,
+            $selected_paths_file
+        );
+        $this->run_to_completion($processor);
+
+        $this->assertSame([], $this->read_index_entries());
+    }
+
+    public function testSelectedPathsResumeFromBothDurableOffsets(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        file_put_contents($this->filesystem_root . '/.git/a.txt', 'a');
+        file_put_contents($this->filesystem_root . '/.git/b.txt', 'b');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/a.txt',
+            '.git/b.txt',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->advance_to_phase($processor, 'supplementing');
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $saved_cursor = $this->serialize_cursor($processor->get_cursor());
+        $saved_output_offset = $saved_cursor['position'][
+            'fresh_local_index_byte_offset'
+        ];
+        $saved_input_offset = $saved_cursor['position'][
+            'selected_paths_byte_offset'
+        ];
+        $this->assertGreaterThan(0, $saved_output_offset);
+        $this->assertGreaterThan(0, $saved_input_offset);
+
+        $this->assertTrue($processor->next_step());
+        $processor->flush_pending_output();
+        $this->assertGreaterThan(
+            $saved_output_offset,
+            filesize($this->fresh_local_index_file)
+        );
+        $processor->close();
+
+        $resumed = FreshLocalIndexProcessor::resume($saved_cursor);
+        $this->assertSame('supplementing', $resumed->get_phase());
+        $this->run_to_completion($resumed);
+        $this->assertSame(
+            ['.git/a.txt', '.git/b.txt'],
+            array_column($this->read_index_entries(), 'decoded_path')
+        );
+    }
+
+    public function testResumeReplaysBothSelectedPathPhaseTransitions(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        file_put_contents($this->filesystem_root . '/.git/value.txt', 'value');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/value.txt',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+
+        $cursor_before_supplementing = null;
+        for ($step = 0; $step < 100; ++$step) {
+            $processor->flush_pending_output();
+            $cursor_before_step = $this->serialize_cursor(
+                $processor->get_cursor()
+            );
+            $this->assertTrue($processor->next_step());
+            if ($processor->get_phase() === 'supplementing') {
+                $cursor_before_supplementing = $cursor_before_step;
+                break;
+            }
+        }
+        $this->assertIsArray($cursor_before_supplementing);
+        $processor->close();
+
+        $resumed = FreshLocalIndexProcessor::resume(
+            $cursor_before_supplementing
+        );
+        $this->assertTrue($resumed->next_step());
+        $this->assertSame('supplementing', $resumed->get_phase());
+        $this->assertTrue($resumed->next_step());
+        $resumed->flush_pending_output();
+        $cursor_before_sorting = $this->serialize_cursor(
+            $resumed->get_cursor()
+        );
+        $this->assertTrue($resumed->next_step());
+        $this->assertSame('sorting', $resumed->get_phase());
+        $resumed->close();
+
+        $resumed = FreshLocalIndexProcessor::resume($cursor_before_sorting);
+        $this->assertTrue($resumed->next_step());
+        $this->assertSame('sorting', $resumed->get_phase());
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('complete', $resumed->get_phase());
+        $resumed->close();
+        $this->assertSame(
+            ['.git/value.txt'],
+            array_column($this->read_index_entries(), 'decoded_path')
+        );
+    }
+
+    public function testSupplementalResumeRequiresItsImmutableInput(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        $selected_paths_file = $this->write_selected_paths([
+            '.git/missing',
+        ]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->advance_to_phase($processor, 'supplementing');
+        $processor->flush_pending_output();
+        $cursor = $this->serialize_cursor($processor->get_cursor());
+        $processor->close();
+        unlink($selected_paths_file);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Failed to open the immutable selected-path file at byte 0'
+        );
+        FreshLocalIndexProcessor::resume($cursor);
+    }
+
+    public function testSelectedPathInputCannotBeTheFreshIndexOutput(): void
+    {
+        $row = json_encode(
+            ['path_b64' => base64_encode('.git/value.txt')],
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        file_put_contents($this->fresh_local_index_file, $row);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The selected-path input and fresh local index must be different files.'
+        );
+        try {
+            FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+                $this->fresh_local_index_file,
+                $this->filesystem_root,
+                $this->storage_path,
+                $this->fresh_local_index_file
+            );
+        } finally {
+            $this->assertSame($row, file_get_contents($this->fresh_local_index_file));
+        }
+    }
+
+    public function testSelectedPathCursorSupportsArbitraryBytes(): void
+    {
+        mkdir($this->filesystem_root . '/.git');
+        $selected_path = ".git/value-\xff";
+        if (@file_put_contents(
+            $this->filesystem_root . '/' . $selected_path,
+            'value'
+        ) === false) {
+            $this->markTestSkipped(
+                'This filesystem does not accept non-UTF-8 path components.'
+            );
+        }
+        $selected_paths_file = $this->write_selected_paths([$selected_path]);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        $this->advance_to_phase($processor, 'supplementing');
+        $processor->flush_pending_output();
+        $cursor = $this->serialize_cursor($processor->get_cursor());
+        $processor->close();
+
+        $resumed = FreshLocalIndexProcessor::resume($cursor);
+        $this->run_to_completion($resumed);
+        $this->assertSame(
+            [$selected_path],
+            array_column($this->read_index_entries(), 'decoded_path')
+        );
+    }
+
+    /**
+     * @dataProvider invalidSelectedPathRows
+     */
+    public function testRejectsInvalidSelectedPathRows(
+        string $contents,
+        string $message
+    ): void {
+        $selected_paths_file = $this->temporary_directory
+            . '/invalid-selected-paths.jsonl';
+        file_put_contents($selected_paths_file, $contents);
+        $processor = FreshLocalIndexProcessor::start_with_selected_default_skipped_paths(
+            $this->fresh_local_index_file,
+            $this->filesystem_root,
+            $this->storage_path,
+            $selected_paths_file
+        );
+        try {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage($message);
+            $this->run_to_completion($processor);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    /** @return array<string,array{string,string}> */
+    public static function invalidSelectedPathRows(): array
+    {
+        $row = static function (string $path): string {
+            return json_encode(
+                ['path_b64' => base64_encode($path)],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
+        };
+        return [
+            'malformed JSON' => ["not-json\n", 'contains an invalid row'],
+            'extra field' => [
+                '{"path_b64":"LmdpdC9h","extra":true}' . "\n",
+                'contains an invalid row',
+            ],
+            'noncanonical base64' => [
+                '{"path_b64":"LmdpdC9hYg"}' . "\n",
+                'invalid canonical base64',
+            ],
+            'absolute path' => [
+                $row('/.git/value'),
+                'must not be absolute',
+            ],
+            'ordinary path' => [
+                $row('ordinary.txt'),
+                'is not omitted by the default local traversal',
+            ],
+            'duplicate path' => [
+                $row('.git/a') . $row('.git/a'),
+                'must be sorted and deduplicated',
+            ],
+            'descending path' => [
+                $row('.git/b') . $row('.git/a'),
+                'must be sorted and deduplicated',
+            ],
+            'unterminated row' => [
+                rtrim($row('.git/a'), "\n"),
+                'is unterminated',
+            ],
+            'oversized row' => [
+                '{"path_b64":"' . str_repeat('A', 70 * 1024) . '"}' . "\n",
+                'exceeds the maximum',
+            ],
+        ];
+    }
+
     public function testCursorSerializesAndResumesEveryPhaseWithArbitraryBytePaths(): void
     {
         $arbitrary_byte_directory =
@@ -215,6 +780,19 @@ final class FreshLocalIndexProcessorTest extends TestCase {
         $this->fail('Fresh local index did not complete within 100 steps.');
     }
 
+    private function advance_to_phase(
+        FreshLocalIndexProcessor $processor,
+        string $phase
+    ): void {
+        for ($step = 0; $step < 100; ++$step) {
+            if ($processor->get_phase() === $phase) {
+                return;
+            }
+            $this->assertTrue($processor->next_step());
+        }
+        $this->fail("Fresh local index did not reach {$phase} within 100 steps.");
+    }
+
     /**
      * @param array<string,mixed> $cursor
      * @return array<string,mixed>
@@ -257,9 +835,35 @@ final class FreshLocalIndexProcessorTest extends TestCase {
         return $entries;
     }
 
+    /** @param list<string> $paths */
+    private function write_selected_paths(
+        array $paths,
+        string $filename = 'selected-paths.jsonl'
+    ): string {
+        $lines = array_map(
+            static function (string $path): string {
+                return json_encode(
+                    ['path_b64' => base64_encode($path)],
+                    JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                );
+            },
+            $paths
+        );
+        $selected_paths_file = $this->temporary_directory . '/' . $filename;
+        file_put_contents(
+            $selected_paths_file,
+            empty($lines) ? '' : implode("\n", $lines) . "\n"
+        );
+        return $selected_paths_file;
+    }
+
     private function remove_path(string $path): void
     {
-        if (is_link($path) || is_file($path)) {
+        if (
+            is_link($path)
+            || is_file($path)
+            || ( @lstat($path) !== false && !is_dir($path) )
+        ) {
             unlink($path);
             return;
         }


### PR DESCRIPTION
Fresh local indexing must observe selected paths that ordinary cache-skipping traversal omits without entering unrelated skipped trees. This change adds a bounded supplemental phase that reads the materialized path list and stats only those exact paths.

Unsupported selected path types remain visible to patch planning so an owned desired link can replace a local FIFO or socket, while inaccessible or escaping parents fail before an incorrect absence is recorded.