### PR TITLE
[PHP] Apply local ownership scope while building pull indexes

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-change-scope.php
@@ -102,11 +102,7 @@ final class FileSyncChangeScope
         string $type
     ): bool {
         $this->assert_open();
-        if (!in_array($type, ['file', 'link', 'dir'], true)) {
-            throw new InvalidArgumentException(
-                "Index entry type must be file, link, or dir; got {$type}."
-            );
-        }
+        self::assert_supported_index_entry_type($type);
         if ($this->config['index_path_coordinates'] === 'remote_absolute') {
             return $this->remote_index_entry_change_decision(
                 $index_path,
@@ -140,18 +136,58 @@ final class FileSyncChangeScope
     ): string {
         $this->assert_open();
         self::assert_remote_absolute_path($remote_absolute_path);
+        if (
+            $type !== 'dir'
+            && $this->subtree_intersects_exclusion($remote_absolute_path)
+        ) {
+            return 'block';
+        }
         $current_ownership = $this->snapshots_entry_ownership(
             [$this->config['current_snapshot_id']],
             $remote_absolute_path,
             $type
         );
         if ($current_ownership !== 'unowned') {
-            return $this->entry_is_blocked(
-                $remote_absolute_path,
-                $current_ownership
-            )
-                ? 'block'
-                : 'allow';
+            if (
+                $this->entry_is_blocked(
+                    $remote_absolute_path,
+                    $current_ownership
+                )
+            ) {
+                return 'block';
+            }
+
+            // A current root above the path owns the whole namespace and wins
+            // protected overlap. Exact ownership controls only the link entry,
+            // so it cannot replace a namespace reserved for a descendant.
+            if (
+                $type === 'link'
+                && $this->snapshots_subtree_relation(
+                    [$this->config['current_snapshot_id']],
+                    $remote_absolute_path
+                ) !== 'owns'
+                && (
+                    $this->snapshots_reserve_subtree_namespace(
+                        [$this->config['current_snapshot_id']],
+                        $remote_absolute_path
+                    )
+                    || $this->snapshots_reserve_subtree_namespace(
+                        $this->config['protected_snapshot_ids'],
+                        $remote_absolute_path
+                    )
+                )
+            ) {
+                return 'block';
+            }
+            return 'allow';
+        }
+        if (
+            $this->snapshots_subtree_relation(
+                [$this->config['current_snapshot_id']],
+                $remote_absolute_path
+            ) === 'intersects'
+        ) {
+            return 'block';
         }
         $protected_ownership = $this->snapshots_entry_ownership(
             $this->config['protected_snapshot_ids'],
@@ -159,6 +195,14 @@ final class FileSyncChangeScope
             $type
         );
         if ($protected_ownership !== 'unowned') {
+            return 'block';
+        }
+        if (
+            $this->snapshots_subtree_relation(
+                $this->config['protected_snapshot_ids'],
+                $remote_absolute_path
+            ) !== 'none'
+        ) {
             return 'block';
         }
         $prior_ownership = $this->snapshots_entry_ownership(
@@ -200,10 +244,90 @@ final class FileSyncChangeScope
     public function subtree_may_change(
         string $index_path
     ): bool {
+        return $this->subtree_change_is_allowed(
+            $index_path,
+            null,
+            true
+        );
+    }
+
+    /**
+     * Reports whether this lifecycle may remove a verified empty directory.
+     *
+     * The governing type is the desired type for a replacement and `dir` for
+     * a deletion. The caller confirms emptiness separately, so cache omission
+     * does not block exact removal. Descendant exclusions and ownership
+     * intersections still protect the directory namespace.
+     */
+    public function directory_entry_may_change(
+        string $index_path,
+        string $governing_type
+    ): bool {
+        $this->assert_open();
+        self::assert_supported_index_entry_type($governing_type);
+        if ($this->config['index_path_coordinates'] === 'remote_absolute') {
+            return (
+                $this->remote_index_entry_change_decision(
+                    $index_path,
+                    $governing_type
+                ) === 'allow'
+                && $this->remote_subtree_change_decision(
+                    $index_path,
+                    $governing_type,
+                    false
+                ) === 'allow'
+            );
+        }
+
+        $path_mapper = $this->get_local_path_mapper();
+        $change_is_allowed = false;
+        foreach (
+            $this->remote_paths_mapping_to_local_index_path($index_path)
+            as $remote_absolute_path
+        ) {
+            $entry_decision = $this->remote_index_entry_change_decision(
+                $remote_absolute_path,
+                $governing_type
+            );
+            $subtree_decision = $this->remote_subtree_change_decision(
+                $remote_absolute_path,
+                $governing_type,
+                false
+            );
+            if (
+                $entry_decision === 'block'
+                || $subtree_decision === 'block'
+            ) {
+                return false;
+            }
+            if (
+                $entry_decision === 'allow'
+                && $subtree_decision === 'allow'
+            ) {
+                if (
+                    !$path_mapper->remote_path_owns_mapped_local_subtree(
+                        $remote_absolute_path
+                    )
+                ) {
+                    return false;
+                }
+                $change_is_allowed = true;
+            }
+        }
+        return $change_is_allowed;
+    }
+
+    private function subtree_change_is_allowed(
+        string $index_path,
+        ?string $governing_type,
+        bool $requires_cache_visibility
+    ): bool {
         $this->assert_open();
         if ($this->config['index_path_coordinates'] === 'remote_absolute') {
             return $this->remote_subtree_change_decision(
-                $index_path
+                $index_path,
+                $governing_type,
+                $requires_cache_visibility
             ) === 'allow';
         }
 
@@ -214,7 +338,9 @@ final class FileSyncChangeScope
             as $remote_absolute_path
         ) {
             $decision = $this->remote_subtree_change_decision(
-                $remote_absolute_path
+                $remote_absolute_path,
+                $governing_type,
+                $requires_cache_visibility
             );
             if ($decision === 'block') {
                 return false;
@@ -235,7 +361,9 @@ final class FileSyncChangeScope
 
     /** @return 'allow'|'block'|'unowned' */
     private function remote_subtree_change_decision(
-        string $remote_absolute_path
+        string $remote_absolute_path,
+        ?string $governing_type,
+        bool $requires_cache_visibility
     ): string {
         $this->assert_open();
         self::assert_remote_absolute_path($remote_absolute_path);
@@ -244,13 +372,48 @@ final class FileSyncChangeScope
             $remote_absolute_path
         );
         if ($current_relation === 'owns') {
-            return $this->subtree_is_blocked($remote_absolute_path)
+            return $this->subtree_is_blocked(
+                $remote_absolute_path,
+                $requires_cache_visibility
+            )
+                ? 'block'
+                : 'allow';
+        }
+
+        $current_owns_governing_entry = (
+            $governing_type !== null
+            && $this->snapshots_entry_ownership(
+                [$this->config['current_snapshot_id']],
+                $remote_absolute_path,
+                $governing_type
+            ) === 'owned'
+        );
+        if ($current_owns_governing_entry) {
+            // Exact ownership controls this entry, not descendants. It wins
+            // an exact overlap but not a current or protected reservation.
+            if (
+                $this->snapshots_reserve_subtree_namespace(
+                    [$this->config['current_snapshot_id']],
+                    $remote_absolute_path
+                )
+                || $this->snapshots_reserve_subtree_namespace(
+                    $this->config['protected_snapshot_ids'],
+                    $remote_absolute_path
+                )
+            ) {
+                return 'block';
+            }
+            return $this->subtree_is_blocked(
+                $remote_absolute_path,
+                $requires_cache_visibility
+            )
                 ? 'block'
                 : 'allow';
         }
         if ($current_relation === 'intersects') {
             return 'block';
         }
+
         $protected_relation = $this->snapshots_subtree_relation(
             $this->config['protected_snapshot_ids'],
             $remote_absolute_path
@@ -262,20 +425,76 @@ final class FileSyncChangeScope
             $this->config['prior_snapshot_ids'],
             $remote_absolute_path
         );
-        if ($prior_relation !== 'owns') {
+        $prior_owns_governing_entry = (
+            $governing_type !== null
+            && $this->snapshots_entry_ownership(
+                $this->config['prior_snapshot_ids'],
+                $remote_absolute_path,
+                $governing_type
+            ) === 'owned'
+        );
+        if ($prior_relation !== 'owns' && !$prior_owns_governing_entry) {
             return 'unowned';
         }
-        return $this->subtree_is_blocked($remote_absolute_path)
+        return $this->subtree_is_blocked(
+            $remote_absolute_path,
+            $requires_cache_visibility
+        )
             ? 'block'
             : 'allow';
     }
 
-    private function subtree_is_blocked(string $remote_absolute_path): bool
-    {
+    private function subtree_is_blocked(
+        string $remote_absolute_path,
+        bool $requires_cache_visibility
+    ): bool {
         return (
-            !$this->config['include_caches']
+            (
+                $requires_cache_visibility
+                && !$this->config['include_caches']
+            )
             || $this->subtree_intersects_exclusion($remote_absolute_path)
         );
+    }
+
+    private static function assert_supported_index_entry_type(
+        string $type
+    ): void {
+        if (!in_array($type, ['file', 'link', 'dir'], true)) {
+            throw new InvalidArgumentException(
+                "Index entry type must be file, link, or dir; got {$type}."
+            );
+        }
+    }
+
+    /**
+     * Maps one changeable remote entry into this local-relative index.
+     *
+     * The remote entry must itself be allowed, and no remote alias for its
+     * local path may block the change.
+     *
+     * @return string|null Local path relative to the filesystem root, or null.
+     */
+    public function map_changeable_remote_index_entry_to_local_index_path(
+        string $remote_absolute_path,
+        string $type
+    ): ?string {
+        $this->get_local_path_mapper();
+        if (
+            $this->remote_index_entry_change_decision(
+                $remote_absolute_path,
+                $type
+            ) !== 'allow'
+        ) {
+            return null;
+        }
+        $local_index_path = $this->map_remote_absolute_path_to_index_path(
+            $remote_absolute_path
+        );
+        if (!$this->index_entry_may_change($local_index_path, $type)) {
+            return null;
+        }
+        return $local_index_path;
     }
 
     /**
@@ -560,6 +779,33 @@ final class FileSyncChangeScope
             $remote_absolute_path
         );
         return $intersects ? 'intersects' : 'none';
+    }
+
+    /**
+     * Reports a root or ancestor namespace reservation, excluding exact atoms.
+     *
+     * @param list<string> $snapshot_ids
+     */
+    private function snapshots_reserve_subtree_namespace(
+        array $snapshot_ids,
+        string $remote_absolute_path
+    ): bool {
+        return (
+            $this->deepest_owning_root(
+                $snapshot_ids,
+                $remote_absolute_path
+            ) !== null
+            || $this->snapshots_contain_atom(
+                $snapshot_ids,
+                'root',
+                $remote_absolute_path
+            )
+            || $this->snapshots_contain_atom(
+                $snapshot_ids,
+                'ancestor',
+                $remote_absolute_path
+            )
+        );
     }
 
     /** @param list<string> $snapshot_ids */

--- a/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
+++ b/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
@@ -1,19 +1,18 @@
 <?php
 
-use function Reprint\Importer\file_sync_index_path_may_change;
 use function Reprint\Importer\sort_index_file;
 use function Reprint\Importer\sort_index_file_preserving_duplicate_paths;
 use function Reprint\Importer\write_local_index_entry;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\read_file_index_directory_is_empty;
 use function WordPress\Reprint\Exporter\read_file_index_entry_from_stat;
-use function WordPress\Reprint\Exporter\relative_path_under;
 
 require_once __DIR__ . '/../local-index-update-functions.php';
 require_once __DIR__ . '/../sort-index-file.php';
 require_once __DIR__ . '/../pull/class-remote-index-reader.php';
 require_once __DIR__ . '/../pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/class-file-index-diff-processor.php';
+require_once __DIR__ . '/class-file-sync-change-scope.php';
 require_once __DIR__ . '/class-file-sync-patch-processor.php';
 require_once __DIR__ . '/file-sync-path-functions.php';
 
@@ -57,9 +56,8 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  *         $next_remote_index_file,
  *         $remote_index_file,
  *         $local_index_file,
- *         $path_mapper,
- *         $storage_path,
- *         false
+ *         $change_scope,
+ *         $storage_path
  *     );
  *     do {
  *         $has_next_step = $processor->next_step();
@@ -71,10 +69,9 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  *     }
  *     $processor->close();
  *
- * @phpstan-type MapperConfig array{filesystem_root_b64:string,original_remote_roots_b64:list<string>,resolved_path_mappings:list<array{remote_prefix_b64:string,local_prefix_b64:string}>,local_followed_symlinks_root_b64:string|null}
  * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  * @phpstan-type Position array{phase:'mapping',remote_index_byte_offset?:int,remote_index_diff_cursor?:IndexDiffCursor,mapped_index_byte_offset:int,mapped_index_parents_byte_offset:int}|array{phase:'sorting'|'sorting_parents'|'starting_merge'}|array{phase:'merging',index_diff_cursor:IndexDiffCursor,mapped_index_parent_cursor:IndexDiffCursor,index_byte_offset:int}|array{phase:'verifying',file_sync_patch_processor_cursor:array}|array{phase:'complete'|'restart'}
- * @phpstan-type Cursor array{metadata_source:'remote_recorded'|'locally_observed',next_remote_index_file_b64:string,remote_index_file_b64:string|null,remote_index_exists:bool,retained_local_index_file_b64:string,retained_local_index_exists:bool,mapped_index_file_b64:string,mapped_index_parents_file_b64:string,index_file_b64:string,path_mapper_config:MapperConfig,included_local_index_path_roots_b64:list<string>,excluded_local_index_path_roots_b64:list<string>,verification_storage_path_b64:string,verification_include_caches:bool,position:Position}
+ * @phpstan-type Cursor array{metadata_source:'remote_recorded'|'locally_observed',next_remote_index_file_b64:string,remote_index_file_b64:string|null,remote_index_exists:bool,retained_local_index_file_b64:string,retained_local_index_exists:bool,mapped_index_file_b64:string,mapped_index_parents_file_b64:string,index_file_b64:string,file_sync_change_scope_config:array,verification_storage_path_b64:string,position:Position}
  */
 final class PullLocalIndexProcessor
 {
@@ -86,13 +83,7 @@ final class PullLocalIndexProcessor
     private string $mapped_index_file;
     private string $mapped_index_parents_file;
     private string $index_file;
-    private RemoteToLocalPathMapper $path_mapper;
-
-    /** @var list<string> */
-    private array $included_local_index_path_roots;
-
-    /** @var list<string> */
-    private array $excluded_local_index_path_roots;
+    private FileSyncChangeScope $change_scope;
 
     private ?RemoteIndexReader $remote_index_reader = null;
     private ?FileIndexDiffProcessor $remote_index_diff = null;
@@ -122,28 +113,21 @@ final class PullLocalIndexProcessor
      * @param string                  $work_directory            Existing directory for processor work files.
      * @param string                  $next_remote_index_file Immutable next remote index.
      * @param string                  $retained_local_index_file Retained local index, or a missing path on the first pull.
-     * @param RemoteToLocalPathMapper $path_mapper               Path mapping used by this pull.
-     * @param list<string> $included_local_index_path_roots Local roots which the pull may change.
-     * @param list<string> $excluded_local_index_path_roots Local roots which the pull must not affect.
+     * @param FileSyncChangeScope $change_scope Local-coordinate paths this pull may change.
      */
     public static function start_patch_result(
         string $work_directory,
         string $next_remote_index_file,
         string $retained_local_index_file,
-        RemoteToLocalPathMapper $path_mapper,
-        array $included_local_index_path_roots = [""],
-        array $excluded_local_index_path_roots = []
+        FileSyncChangeScope $change_scope
     ): self {
         return self::start(
             "remote_recorded", $work_directory,
             $next_remote_index_file,
             null,
             $retained_local_index_file,
-            $path_mapper,
-            $included_local_index_path_roots,
-            $excluded_local_index_path_roots,
-            "",
-            false
+            $change_scope,
+            ""
         );
     }
 
@@ -154,33 +138,24 @@ final class PullLocalIndexProcessor
      * @param string                  $next_remote_index_file Immutable next remote index.
      * @param string                  $remote_index_file WAL-applied remote index containing confirmed fetch records, or a missing path for an empty index.
      * @param string                  $retained_local_index_file WAL-applied local index containing confirmed local metadata.
-     * @param RemoteToLocalPathMapper $path_mapper               Path mapping used by this pull.
-     * @param string       $storage_path                    Reprint storage path omitted from final verification.
-     * @param bool         $include_caches                  Whether final verification includes cache paths.
-     * @param list<string> $included_local_index_path_roots Local roots which the pull may change.
-     * @param list<string> $excluded_local_index_path_roots Local roots which the pull must not affect.
+     * @param FileSyncChangeScope $change_scope Local-coordinate paths this pull may change.
+     * @param string              $storage_path Reprint storage path omitted from final verification.
      */
     public static function start_next_local_index(
         string $work_directory,
         string $next_remote_index_file,
         string $remote_index_file,
         string $retained_local_index_file,
-        RemoteToLocalPathMapper $path_mapper,
-        string $storage_path,
-        bool $include_caches,
-        array $included_local_index_path_roots = [""],
-        array $excluded_local_index_path_roots = []
+        FileSyncChangeScope $change_scope,
+        string $storage_path
     ): self {
         return self::start(
             "locally_observed", $work_directory,
             $next_remote_index_file,
             $remote_index_file,
             $retained_local_index_file,
-            $path_mapper,
-            $included_local_index_path_roots,
-            $excluded_local_index_path_roots,
-            $storage_path,
-            $include_caches
+            $change_scope,
+            $storage_path
         );
     }
 
@@ -197,6 +172,14 @@ final class PullLocalIndexProcessor
      */
     public static function resume(array $cursor): self
     {
+        return self::open($cursor);
+    }
+
+    /** @phpstan-param Cursor $cursor */
+    private static function open(
+        array $cursor,
+        ?FileSyncChangeScope $change_scope = null
+    ): self {
         $processor = new self();
         $processor->cursor = $cursor;
         if (
@@ -212,13 +195,8 @@ final class PullLocalIndexProcessor
             $cursor["mapped_index_parents_file_b64"]
         );
         $processor->index_file = self::decode_cursor_path($cursor["index_file_b64"]);
-        $processor->path_mapper = RemoteToLocalPathMapper::from_config($cursor["path_mapper_config"]);
-        $decode_path = [self::class, "decode_cursor_path"];
-        $processor->included_local_index_path_roots = array_map(
-            $decode_path, $cursor["included_local_index_path_roots_b64"]
-        );
-        $processor->excluded_local_index_path_roots = array_map(
-            $decode_path, $cursor["excluded_local_index_path_roots_b64"]
+        $processor->change_scope = $change_scope ?? FileSyncChangeScope::from_config(
+            $cursor["file_sync_change_scope_config"]
         );
         $position = $cursor["position"];
         self::require_file($processor->index_file, "output index");
@@ -376,25 +354,33 @@ final class PullLocalIndexProcessor
                     $this->remote_index_path_selected = true;
                     $remote_absolute_path =
                         $this->remote_index_diff->get_path();
-                    $local_absolute_path = $this->path_mapper->map_path(
-                        $remote_absolute_path
-                    );
-                    $local_relative_path = relative_path_under(
-                        $local_absolute_path,
-                        $this->path_mapper->get_filesystem_root()
-                    );
-                    if ($local_relative_path === null) {
-                        throw new RuntimeException(
-                            "Remote path maps outside the writable local tree: "
-                            . base64_encode($remote_absolute_path)
-                            . "."
+                    $next_remote_path_type =
+                        $this->remote_index_diff
+                            ->get_path_type_in_new_index();
+                    $previous_remote_path_type =
+                        $this->remote_index_diff
+                            ->get_path_type_in_old_index();
+                    $governing_remote_path_type =
+                        $next_remote_path_type ?? $previous_remote_path_type;
+                    if ($governing_remote_path_type === null) {
+                        throw new LogicException(
+                            "Remote index comparison selected a path with no entry."
                         );
                     }
-                    $path_may_change = file_sync_index_path_may_change(
-                        $local_relative_path,
-                        $this->included_local_index_path_roots,
-                        $this->excluded_local_index_path_roots
-                    );
+                    $local_relative_path = $this->change_scope
+                        ->map_changeable_remote_index_entry_to_local_index_path(
+                            $remote_absolute_path,
+                            $governing_remote_path_type
+                        );
+                    $path_may_change = $local_relative_path !== null;
+                    if ($local_relative_path !== null) {
+                        $local_absolute_path = $local_relative_path === ""
+                            ? $this->change_scope->get_filesystem_root()
+                            : wp_join_unix_paths(
+                                $this->change_scope->get_filesystem_root(),
+                                $local_relative_path
+                            );
+                    }
                     if (
                         $path_may_change
                         && $this->remote_index_diff
@@ -402,9 +388,6 @@ final class PullLocalIndexProcessor
                     ) {
                         return $this->restart();
                     }
-                    $next_remote_path_type =
-                        $this->remote_index_diff
-                            ->get_path_type_in_new_index();
                     if ($next_remote_path_type !== null) {
                         $remote_index_entry = [
                             "path" => $remote_absolute_path,
@@ -459,25 +442,20 @@ final class PullLocalIndexProcessor
             }
 
             if ($local_absolute_path === null) {
-                $local_absolute_path = $this->path_mapper->map_path(
-                    $remote_index_entry["path"]
-                );
-                $local_relative_path = relative_path_under(
-                    $local_absolute_path,
-                    $this->path_mapper->get_filesystem_root()
-                );
-                if ($local_relative_path === null) {
-                    throw new RuntimeException(
-                        "Remote path maps outside the writable local tree: "
-                        . base64_encode($remote_index_entry["path"])
-                        . "."
+                $local_relative_path = $this->change_scope
+                    ->map_changeable_remote_index_entry_to_local_index_path(
+                        $remote_index_entry["path"],
+                        $remote_index_entry["type"]
                     );
+                $path_may_change = $local_relative_path !== null;
+                if ($local_relative_path !== null) {
+                    $local_absolute_path = $local_relative_path === ""
+                        ? $this->change_scope->get_filesystem_root()
+                        : wp_join_unix_paths(
+                            $this->change_scope->get_filesystem_root(),
+                            $local_relative_path
+                        );
                 }
-                $path_may_change = file_sync_index_path_may_change(
-                    $local_relative_path,
-                    $this->included_local_index_path_roots,
-                    $this->excluded_local_index_path_roots
-                );
             }
             if ($path_may_change && $local_relative_path !== "") {
                 if (
@@ -599,8 +577,32 @@ final class PullLocalIndexProcessor
         if ($position["phase"] === "verifying") {
             $has_next_verification_step =
                 $this->verification_processor->next_step();
-            if ($this->verification_processor->get_operation() !== null) {
-                return $this->restart();
+            $verification_operation =
+                $this->verification_processor->get_operation();
+            if ($verification_operation !== null) {
+                $governing_entry =
+                    $verification_operation["action"] === "delete"
+                        ? $verification_operation["expected_base"]
+                        : $verification_operation["expected_source"];
+                $base_entry = $verification_operation["expected_base"] ?? null;
+                $verification_change_is_allowed = false;
+                if ($governing_entry["type"] !== "other") {
+                    $verification_change_is_allowed =
+                        is_array($base_entry)
+                        && $base_entry["type"] === "dir"
+                            ? $this->change_scope
+                                ->directory_entry_may_change(
+                                    $verification_operation["path"],
+                                    $governing_entry["type"]
+                                )
+                            : $this->change_scope->index_entry_may_change(
+                                $verification_operation["path"],
+                                $governing_entry["type"]
+                            );
+                }
+                if ($verification_change_is_allowed) {
+                    return $this->restart();
+                }
             }
             if (!$has_next_verification_step) {
                 $this->cursor["position"] = ["phase" => "complete"];
@@ -686,13 +688,30 @@ final class PullLocalIndexProcessor
         }
 
         $write_new_entry = $new_path_type !== null;
+        $old_entry_may_change = $old_path_type === null
+            || ( $old_path_type === "dir"
+                ? $this->change_scope->directory_entry_may_change(
+                    $this->index_diff->get_path(),
+                    $new_path_type ?? "dir"
+                )
+                : $this->change_scope->index_entry_may_change(
+                    $this->index_diff->get_path(),
+                    $old_path_type
+                ) );
         $write_old_entry = $new_path_type === null
             && $old_path_type !== null
-            && !file_sync_index_path_may_change(
-                $this->index_diff->get_path(),
-                $this->included_local_index_path_roots,
-                $this->excluded_local_index_path_roots
-            );
+            && !$old_entry_may_change;
+        if (
+            $write_new_entry
+            && $old_path_type === "dir"
+            && $new_path_type !== "dir"
+            && !$old_entry_may_change
+        ) {
+            // A protected or excluded descendant reserves the retained local
+            // directory even when the new remote entry itself is selected.
+            $write_new_entry = false;
+            $write_old_entry = true;
+        }
         $has_mapped_descendant = false;
         if ($write_new_entry || $write_old_entry) {
             if (!$this->mapped_index_parent_path_selected) {
@@ -875,6 +894,7 @@ final class PullLocalIndexProcessor
             $this->verification_processor->close();
             $this->verification_processor = null;
         }
+        $this->change_scope->close();
         $this->closed = true;
     }
 
@@ -884,11 +904,8 @@ final class PullLocalIndexProcessor
         string $next_remote_index_file,
         ?string $remote_index_file,
         string $retained_local_index_file,
-        RemoteToLocalPathMapper $path_mapper,
-        array $included_local_index_path_roots,
-        array $excluded_local_index_path_roots,
-        string $verification_storage_path,
-        bool $verification_include_caches
+        FileSyncChangeScope $change_scope,
+        string $verification_storage_path
     ): self {
         if (!is_dir($work_directory)) {
             throw new LogicException("Cannot start pull local indexing without its work directory: {$work_directory}.");
@@ -953,7 +970,7 @@ final class PullLocalIndexProcessor
                 "mapped_index_parents_byte_offset" => 0,
             ];
         }
-        return self::resume([
+        return self::open([
             "metadata_source" => $metadata_source,
             "next_remote_index_file_b64" => base64_encode($next_remote_index_file),
             "remote_index_file_b64" =>
@@ -967,14 +984,11 @@ final class PullLocalIndexProcessor
             "mapped_index_parents_file_b64" =>
                 base64_encode($mapped_index_parents_file),
             "index_file_b64" => base64_encode($index_file),
-            "path_mapper_config" => $path_mapper->get_config(),
-            "included_local_index_path_roots_b64" => array_map("base64_encode", $included_local_index_path_roots),
-            "excluded_local_index_path_roots_b64" => array_map("base64_encode", $excluded_local_index_path_roots),
+            "file_sync_change_scope_config" => $change_scope->get_config(),
             "verification_storage_path_b64" =>
                 base64_encode($verification_storage_path),
-            "verification_include_caches" => $verification_include_caches,
             "position" => $position,
-        ]);
+        ], $change_scope);
     }
 
     /** Finishes the patch result or starts final next-index verification. */
@@ -993,18 +1007,31 @@ final class PullLocalIndexProcessor
             return false;
         }
 
-        $this->verification_processor =
-            FileSyncPatchProcessor::start_from_fresh_local_tree(
-                dirname($this->index_file),
-                $this->path_mapper->get_filesystem_root(),
-                $this->index_file,
-                self::decode_cursor_path(
-                    $this->cursor["verification_storage_path_b64"]
-                ),
-                $this->included_local_index_path_roots,
-                $this->excluded_local_index_path_roots,
-                $this->cursor["verification_include_caches"]
-            );
+        $verification_storage_path = self::decode_cursor_path(
+            $this->cursor["verification_storage_path_b64"]
+        );
+        if ($this->change_scope->includes_caches()) {
+            $this->verification_processor =
+                FileSyncPatchProcessor::start_from_fresh_local_tree(
+                    dirname($this->index_file),
+                    $this->change_scope->get_filesystem_root(),
+                    $this->index_file,
+                    $verification_storage_path,
+                    [""],
+                    [],
+                    true
+                );
+        } else {
+            $this->verification_processor =
+                FileSyncPatchProcessor::start_from_fresh_local_tree_with_selected_default_skipped_paths(
+                    dirname($this->index_file),
+                    $this->change_scope->get_filesystem_root(),
+                    $this->index_file,
+                    $verification_storage_path,
+                    $this->change_scope
+                        ->get_selected_default_skipped_index_paths_file()
+                );
+        }
         $this->cursor["position"] = [
             "phase" => "verifying",
             "file_sync_patch_processor_cursor" =>

--- a/tests/Import/FileSyncChangeScopeTest.php
+++ b/tests/Import/FileSyncChangeScopeTest.php
@@ -301,6 +301,140 @@ class FileSyncChangeScopeTest extends TestCase {
         $scope->close();
     }
 
+    public function testDirectoryEntryAuthorityUsesNamespacePrecedence(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/current'],
+            ['kind' => 'exact', 'path' => '/exact-blocked'],
+            ['kind' => 'exact', 'path' => '/exact-overlap'],
+            ['kind' => 'exact', 'path' => '/current-reserved'],
+            ['kind' => 'ancestor', 'path' => '/current-reserved'],
+            ['kind' => 'root', 'path' => '/current-reserved/future'],
+            ['kind' => 'ancestor', 'path' => '/selected/current-boundary'],
+            ['kind' => 'root', 'path' => '/selected/current-boundary/future'],
+        ]);
+        $priorSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/selected'],
+            ['kind' => 'exact', 'path' => '/prior-link'],
+        ]);
+        $protectedSnapshotId = $this->publishSnapshot([
+            ['kind' => 'ancestor', 'path' => '/current/a'],
+            ['kind' => 'root', 'path' => '/current/a/future'],
+            ['kind' => 'ancestor', 'path' => '/exact-blocked'],
+            ['kind' => 'root', 'path' => '/exact-blocked/future'],
+            ['kind' => 'exact', 'path' => '/exact-overlap'],
+            ['kind' => 'exact', 'path' => '/selected/exact-protected'],
+        ]);
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [$priorSnapshotId],
+            [$protectedSnapshotId]
+        );
+
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/current/a', 'dir')
+        );
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/exact-overlap', 'link')
+        );
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/prior-link', 'link')
+        );
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/selected/open', 'dir')
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change('/current-reserved', 'link')
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change('/exact-blocked', 'link')
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change(
+                '/selected/current-boundary',
+                'dir'
+            )
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change(
+                '/selected/exact-protected',
+                'dir'
+            )
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/current/a', 'link')
+        );
+        $this->assertTrue(
+            $scope->index_entry_may_change('/exact-overlap', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/current-reserved', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/exact-blocked', 'link')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change(
+                '/selected/current-boundary',
+                'dir'
+            )
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change(
+                '/selected/exact-protected',
+                'dir'
+            )
+        );
+
+        $scope->close();
+    }
+
+    public function testDirectoryEntryAuthorityIgnoresGlobalCacheVisibility(): void
+    {
+        $currentSnapshotId = $this->publishSnapshot([
+            ['kind' => 'root', 'path' => '/selected'],
+            ['kind' => 'exact', 'path' => '/selected/.git/link'],
+        ]);
+        $scope = $this->scope($currentSnapshotId);
+
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/selected/open', 'dir')
+        );
+        $this->assertTrue(
+            $scope->directory_entry_may_change(
+                '/selected/.git/link',
+                'link'
+            )
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change('/selected', 'dir')
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change(
+                '/selected/.git/directory',
+                'dir'
+            )
+        );
+        $scope->close();
+
+        $scope = $this->scope(
+            $currentSnapshotId,
+            [],
+            [],
+            ['/selected/excluded/future']
+        );
+        $this->assertFalse(
+            $scope->directory_entry_may_change('/selected/excluded', 'dir')
+        );
+        $this->assertFalse(
+            $scope->index_entry_may_change('/selected/excluded', 'link')
+        );
+        $this->assertTrue(
+            $scope->directory_entry_may_change('/selected/open', 'dir')
+        );
+        $scope->close();
+    }
+
     public function testSubtreeRejectsHiddenDefaultSkipsAndExcludedDescendants(): void
     {
         $currentSnapshotId = $this->publishSnapshot([
@@ -416,6 +550,9 @@ class FileSyncChangeScopeTest extends TestCase {
             $this->selectedDefaultSkippedPathsFile
         );
         $this->assertTrue($localScope->subtree_may_change('shared/dir'));
+        $this->assertTrue(
+            $localScope->directory_entry_may_change('shared/dir', 'dir')
+        );
         $localScope->close();
 
         $mapperWithFilledHole = new \RemoteToLocalPathMapper(
@@ -432,6 +569,9 @@ class FileSyncChangeScopeTest extends TestCase {
             $this->selectedDefaultSkippedPathsFile
         );
         $this->assertFalse($localScope->subtree_may_change('shared/dir'));
+        $this->assertFalse(
+            $localScope->directory_entry_may_change('shared/dir', 'dir')
+        );
         $localScope->close();
         $remoteScope->close();
     }

--- a/tests/Import/PullLocalIndexProcessorTest.php
+++ b/tests/Import/PullLocalIndexProcessorTest.php
@@ -7,6 +7,7 @@ use function Reprint\Importer\decode_local_index_entry;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-pull-local-index-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php';
 
 final class PullLocalIndexProcessorTest extends TestCase {
     private string $temporary_directory;
@@ -53,14 +54,14 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->local_entry_from_path('a-local.txt'),
             $this->local_entry_from_path('z-local.txt'),
         ]);
-        $mapper = new RemoteToLocalPathMapper(
+        $change_scope = $this->change_scope(new RemoteToLocalPathMapper(
             $this->filesystem_root,
             ['/remote'],
             [
                 '/remote/a.txt' => $this->filesystem_root . '/z-local.txt',
                 '/remote/z.txt' => $this->filesystem_root . '/a-local.txt',
             ]
-        );
+        ));
 
         $entries = $this->run_to_completion(
             PullLocalIndexProcessor::start_next_local_index(
@@ -68,9 +69,8 @@ final class PullLocalIndexProcessorTest extends TestCase {
                 $this->next_remote_index_file,
                 $this->remote_index_file,
                 $this->retained_local_index_file,
-                $mapper,
-                $this->temporary_directory . '/storage',
-                false
+                $change_scope,
+                $this->temporary_directory . '/storage'
             )
         );
 
@@ -88,6 +88,94 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $this->assertSame( (int) $z_stat['size'], $entries[1]['size']);
     }
 
+    public function testPatchResultIgnoresUnownedRowCollidingWithOwnedAlias(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/owned/file.txt', 'file', 11, 12),
+            $this->remote_entry('/unowned/file.txt', 'file', 21, 22),
+        ]);
+        $this->write_local_index([]);
+        $shared_path = $this->filesystem_root . '/shared/file.txt';
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/owned', '/unowned'],
+                        [
+                            '/owned/file.txt' => $shared_path,
+                            '/unowned/file.txt' => $shared_path,
+                        ]
+                    ),
+                    ['/owned']
+                )
+            )
+        );
+
+        $this->assertSame([
+            [
+                'path' => 'shared/file.txt',
+                'ctime' => 12,
+                'size' => 11,
+                'type' => 'file',
+            ],
+        ], $entries);
+    }
+
+    public function testUnownedCollidingAliasDriftDoesNotRestartConfirmation(): void
+    {
+        $this->write_file('shared/file.txt', 'fetched');
+        $owned_entry = $this->remote_entry('/owned/file.txt', 'file', 7, 10);
+        $this->write_remote_index_file(
+            $this->next_remote_index_file,
+            [
+                $owned_entry,
+                $this->remote_entry('/unowned/file.txt', 'file', 9, 21),
+            ]
+        );
+        $this->write_remote_index_file(
+            $this->remote_index_file,
+            [
+                $owned_entry,
+                $this->remote_entry('/unowned/file.txt', 'file', 8, 20),
+            ]
+        );
+        $this->write_local_index([
+            $this->local_entry_from_path('shared/file.txt'),
+        ]);
+        $shared_path = $this->filesystem_root . '/shared/file.txt';
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/owned', '/unowned'],
+                        [
+                            '/owned/file.txt' => $shared_path,
+                            '/unowned/file.txt' => $shared_path,
+                        ]
+                    ),
+                    ['/owned']
+                ),
+                $this->temporary_directory . '/storage'
+            )
+        );
+
+        $this->assertSame(
+            ['shared/file.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
     public function testPatchResultKeepsRemoteMetadataAndEmptyDirectory(): void
     {
         $this->write_remote_index([
@@ -101,11 +189,11 @@ final class PullLocalIndexProcessorTest extends TestCase {
                 $this->work_directory,
                 $this->next_remote_index_file,
                 $this->retained_local_index_file,
-                new RemoteToLocalPathMapper(
+                $this->change_scope(new RemoteToLocalPathMapper(
                     $this->filesystem_root,
                     ['/remote'],
                     ['/remote' => $this->filesystem_root]
-                )
+                ))
             )
         );
 
@@ -141,11 +229,11 @@ final class PullLocalIndexProcessorTest extends TestCase {
                 $this->work_directory,
                 $this->next_remote_index_file,
                 $this->retained_local_index_file,
-                new RemoteToLocalPathMapper(
+                $this->change_scope(new RemoteToLocalPathMapper(
                     $this->filesystem_root,
                     ['/remote'],
                     ['/remote' => $this->filesystem_root]
-                )
+                ))
             )
         );
 
@@ -162,11 +250,11 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->work_directory,
             $this->next_remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
+            $this->change_scope(new RemoteToLocalPathMapper(
                 $this->filesystem_root,
                 ['/remote'],
                 ['/remote' => $this->filesystem_root]
-            )
+            ))
         );
 
         try {
@@ -249,7 +337,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         ]);
 
         $entries = $this->run_to_completion(
-            $this->start_processor(['parent/child.txt'])
+            $this->start_processor(['parent'])
         );
 
         $this->assertSame(
@@ -279,9 +367,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         ]);
 
         $entries = $this->run_to_completion(
-            $this->start_processor(
-                ['parent-name.txt', 'parent/child.txt']
-            )
+            $this->start_processor()
         );
 
         $this->assertSame(
@@ -302,7 +388,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->work_directory,
             $this->next_remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
+            $this->change_scope(new RemoteToLocalPathMapper(
                 $this->filesystem_root,
                 ['/remote'],
                 [
@@ -312,7 +398,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
                     '/remote/leaf.txt' =>
                         $this->filesystem_root . '/parent/child.txt',
                 ]
-            )
+            ))
         );
 
         $entries = $this->run_to_completion($processor);
@@ -336,7 +422,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->work_directory,
             $this->next_remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
+            $this->change_scope(new RemoteToLocalPathMapper(
                 $this->filesystem_root,
                 ['/remote'],
                 [
@@ -344,7 +430,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
                     '/remote/leaf.txt' =>
                         $this->filesystem_root . '/parent/child.txt',
                 ]
-            )
+            ))
         );
 
         try {
@@ -370,8 +456,8 @@ final class PullLocalIndexProcessorTest extends TestCase {
     public function testRejectsRetainedFileOutsideNarrowSelectionWithMappedDescendant(): void
     {
         $this->write_remote_index([
-            $this->remote_entry('/remote/parent-name.txt', 'file'),
-            $this->remote_entry('/remote/parent/child.txt', 'file'),
+            $this->remote_entry('/remote/source/parent-name.txt', 'file'),
+            $this->remote_entry('/remote/source/parent/child.txt', 'file'),
         ]);
         $this->write_local_index([
             $this->local_entry('parent', 10, 10),
@@ -380,12 +466,16 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->work_directory,
             $this->next_remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
+            $this->change_scope(new RemoteToLocalPathMapper(
                 $this->filesystem_root,
                 ['/remote'],
-                ['/remote' => $this->filesystem_root]
-            ),
-            ['parent-name.txt', 'parent/child.txt']
+                [
+                    '/remote/source/parent-name.txt' =>
+                        $this->filesystem_root . '/parent-name.txt',
+                    '/remote/source/parent/child.txt' =>
+                        $this->filesystem_root . '/parent/child.txt',
+                ]
+            ), ['/remote/source'])
         );
 
         try {
@@ -420,9 +510,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->local_entry_from_path('parent-name.txt'),
             $this->local_entry_from_path('parent/child.txt'),
         ]);
-        $processor = $this->start_processor(
-            ['parent-name.txt', 'parent/child.txt']
-        );
+        $processor = $this->start_processor();
         while ($processor->get_phase() !== 'merging') {
             $this->assertTrue($processor->next_step());
             $processor->flush_pending_output();
@@ -478,6 +566,98 @@ final class PullLocalIndexProcessorTest extends TestCase {
         );
 
         $this->assertSame(['selected/keep.txt'], array_column($entries, 'path'));
+    }
+
+    public function testProtectedDescendantKeepsDirectoryInsteadOfCurrentExactLink(): void
+    {
+        mkdir($this->filesystem_root . '/value', 0700, true);
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value', 'link', 6),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        ['/remote' => $this->filesystem_root]
+                    ),
+                    [],
+                    [],
+                    false,
+                    ['/remote/value/future'],
+                    ['/remote/value']
+                )
+            )
+        );
+
+        $this->assertSame(['value'], array_column($entries, 'path'));
+        $this->assertSame('dir', $entries[0]['type']);
+    }
+
+    public function testExcludedDescendantKeepsDirectoryInsteadOfSelectedLink(): void
+    {
+        mkdir($this->filesystem_root . '/value', 0700, true);
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value', 'link', 6),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('value'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        ['/remote' => $this->filesystem_root]
+                    ),
+                    ['/remote'],
+                    ['/remote/value/future']
+                )
+            )
+        );
+
+        $this->assertSame(['value'], array_column($entries, 'path'));
+        $this->assertSame('dir', $entries[0]['type']);
+    }
+
+    public function testFirstPullDoesNotCreateLeafAboveExcludedDescendant(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value', 'link', 6),
+        ]);
+        $this->write_local_index([]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        ['/remote' => $this->filesystem_root]
+                    ),
+                    ['/remote'],
+                    ['/remote/value/future']
+                )
+            )
+        );
+
+        $this->assertSame([], $entries);
     }
 
     public function testSkipsARemoteParentWhichContainsAnExcludedRoot(): void
@@ -559,7 +739,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         ]);
 
         $entries = $this->run_to_completion(
-            $this->start_processor(['parent/child'])
+            $this->start_processor(['parent'])
         );
 
         $this->assertSame([], $entries);
@@ -605,16 +785,15 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->next_remote_index_file,
             $this->remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
+            $this->change_scope(new RemoteToLocalPathMapper(
                 $this->filesystem_root,
                 ['/remote'],
                 [
                     '/remote/a.txt' => $local_path,
                     '/remote/b.txt' => $local_path,
                 ]
-            ),
-            $this->temporary_directory . '/storage',
-            false
+            )),
+            $this->temporary_directory . '/storage'
         );
 
         try {
@@ -724,6 +903,356 @@ final class PullLocalIndexProcessorTest extends TestCase {
 
         $this->assertSame('restart', $processor->get_status());
         $processor->close();
+    }
+
+    public function testUnchangedExactGitLinkCompletesFinalVerification(): void
+    {
+        mkdir($this->filesystem_root . '/.git', 0700, true);
+        $path = $this->filesystem_root . '/.git/link';
+        symlink('target', $path);
+        $this->write_remote_index([
+            $this->remote_entry('/remote/.git/link', 'link', 6),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('.git/link'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        ['/remote' => $this->filesystem_root]
+                    ),
+                    [],
+                    [],
+                    false,
+                    [],
+                    ['/remote/.git/link']
+                ),
+                $this->temporary_directory . '/storage'
+            )
+        );
+
+        $this->assertSame(['.git/link'], array_column($entries, 'path'));
+    }
+
+    public function testOrdinaryUnownedCacheDriftCompletesFinalVerification(): void
+    {
+        $this->write_file('value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file'),
+        ]);
+        $this->write_local_index([$this->local_entry_from_path('value.txt')]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $this->write_file('.git/unowned.txt', 'cache drift');
+
+        $entries = $this->run_to_completion($processor);
+
+        $this->assertSame(['value.txt'], array_column($entries, 'path'));
+    }
+
+    public function testSelectedCacheDriftRestartsWhenCachesAreIncluded(): void
+    {
+        $this->write_file('value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file'),
+        ]);
+        $this->write_local_index([$this->local_entry_from_path('value.txt')]);
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                ),
+                ['/remote'],
+                [],
+                true
+            ),
+            $this->temporary_directory . '/storage'
+        );
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $this->write_file('.git/selected.txt', 'cache drift');
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testFinalVerificationIgnoresOutsideAndProtectedAdditions(): void
+    {
+        $this->write_file('selected/value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/selected/value.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('selected/value.txt'),
+        ]);
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                ),
+                ['/remote/selected'],
+                [],
+                false,
+                ['/remote/protected']
+            ),
+            $this->temporary_directory . '/storage'
+        );
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        $this->write_file('outside.txt', 'outside');
+        $this->write_file('protected/new.txt', 'protected');
+
+        $entries = $this->run_to_completion($processor);
+
+        $this->assertSame(['selected/value.txt'], array_column($entries, 'path'));
+    }
+
+    public function testFinalVerificationSelectedDeletionReturnsRestart(): void
+    {
+        $this->write_file('value.txt', 'fetched');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value.txt', 'file'),
+        ]);
+        $this->write_local_index([$this->local_entry_from_path('value.txt')]);
+        $processor = $this->start_processor();
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        unlink($this->filesystem_root . '/value.txt');
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testFinalVerificationUsesReplaceSourceTypeForExactLink(): void
+    {
+        $path = $this->filesystem_root . '/value';
+        symlink('target', $path);
+        $this->write_remote_index([
+            $this->remote_entry('/remote/value', 'link', 6),
+        ]);
+        $this->write_local_index([$this->local_entry_from_path('value')]);
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                ),
+                [],
+                [],
+                false,
+                [],
+                ['/remote/value']
+            ),
+            $this->temporary_directory . '/storage'
+        );
+        while ($processor->get_phase() !== 'verifying') {
+            $this->assertTrue($processor->next_step());
+            $processor->flush_pending_output();
+        }
+        unlink($path);
+        file_put_contents($path, 'file');
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testFinalVerificationUsesDeleteBaseTypeForExactLink(): void
+    {
+        $path = $this->filesystem_root . '/obsolete-link';
+        symlink('target', $path);
+        $this->write_remote_index([]);
+        $this->write_local_index([
+            $this->local_entry_from_path('obsolete-link'),
+        ]);
+        $processor = PullLocalIndexProcessor::start_next_local_index(
+            $this->work_directory,
+            $this->next_remote_index_file,
+            $this->remote_index_file,
+            $this->retained_local_index_file,
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                ),
+                [],
+                [],
+                false,
+                [],
+                ['/remote/obsolete-link']
+            ),
+            $this->temporary_directory . '/storage'
+        );
+
+        $this->run_to_completion_without_closing($processor);
+
+        $this->assertSame('restart', $processor->get_status());
+        $processor->close();
+    }
+
+    public function testFinalVerificationPreservesFifoAtPriorExactTombstone(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build cannot create a FIFO.');
+        }
+        mkdir($this->filesystem_root . '/.git');
+        $fifo_path = $this->filesystem_root . '/.git/obsolete';
+        $this->assertTrue(posix_mkfifo($fifo_path, 0600));
+        $this->write_remote_index([]);
+        $this->write_local_index([
+            [
+                'path' => '.git/obsolete',
+                'ctime' => 1,
+                'size' => 6,
+                'type' => 'link',
+            ],
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        ['/remote' => $this->filesystem_root]
+                    ),
+                    [],
+                    [],
+                    false,
+                    [],
+                    [],
+                    ['/remote/.git/obsolete']
+                ),
+                $this->temporary_directory . '/storage'
+            )
+        );
+
+        $this->assertSame([], $entries);
+        clearstatcache(true, $fifo_path);
+        $this->assertSame('fifo', filetype($fifo_path));
+        unlink($fifo_path);
+    }
+
+    public function testCandidateRetainsProtectedRemapSourceHole(): void
+    {
+        $this->write_file('shared/kept.txt', 'kept');
+        $this->write_file('shared/hole/protected.txt', 'protected');
+        $this->write_remote_index([
+            $this->remote_entry('/a/kept.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('shared/kept.txt'),
+            $this->local_entry_from_path('shared/hole/protected.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/a', '/b'],
+                        [
+                            '/a' => $this->filesystem_root . '/shared',
+                            '/a/hole' => $this->filesystem_root . '/elsewhere',
+                            '/b' => $this->filesystem_root . '/shared/hole',
+                        ]
+                    ),
+                    ['/a'],
+                    [],
+                    false,
+                    ['/b']
+                ),
+                $this->temporary_directory . '/storage'
+            )
+        );
+
+        $this->assertSame(
+            ['shared/hole/protected.txt', 'shared/kept.txt'],
+            array_column($entries, 'path')
+        );
+    }
+
+    public function testCandidateMapsFollowedTarget(): void
+    {
+        $this->write_file('followed/outside/file.txt', 'followed');
+        $this->write_remote_index([
+            $this->remote_entry('/outside/file.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('followed/outside/file.txt'),
+        ]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_next_local_index(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                $this->change_scope(
+                    new RemoteToLocalPathMapper(
+                        $this->filesystem_root,
+                        ['/remote'],
+                        [],
+                        $this->filesystem_root . '/followed'
+                    ),
+                    ['/outside']
+                ),
+                $this->temporary_directory . '/storage'
+            )
+        );
+
+        $this->assertSame(
+            ['followed/outside/file.txt'],
+            array_column($entries, 'path')
+        );
     }
 
     public function testNextRemoteEntryMissingFromRemoteIndexReturnsRestart(): void
@@ -872,17 +1401,25 @@ final class PullLocalIndexProcessorTest extends TestCase {
             $this->next_remote_index_file,
             $this->remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
-                $this->filesystem_root,
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    [$remote_root],
+                    [$remote_root . "/file-\xff.txt" => $local_path]
+                ),
                 [$remote_root],
-                [$remote_root . "/file-\xff.txt" => $local_path]
+                [$remote_root . "/excluded-\xfc"]
             ),
-            $this->temporary_directory . '/storage',
-            false,
-            ['selected'],
-            ["selected/excluded-\xfc"]
+            $this->temporary_directory . '/storage'
         );
         $cursor = $processor->get_cursor();
+        $this->assertArrayHasKey('file_sync_change_scope_config', $cursor);
+        $this->assertArrayNotHasKey('path_mapper_config', $cursor);
+        $this->assertArrayNotHasKey(
+            'included_local_index_path_roots_b64',
+            $cursor
+        );
+        $this->assertArrayNotHasKey('verification_include_caches', $cursor);
         $this->assertIsString(json_encode($cursor, JSON_THROW_ON_ERROR));
         $processor->close();
 
@@ -1213,6 +1750,134 @@ final class PullLocalIndexProcessorTest extends TestCase {
     }
 
     /**
+     * @param list<string> $remote_roots
+     * @param list<string> $excluded_remote_roots
+     * @param list<string> $protected_remote_roots
+     * @param list<string> $current_exact_remote_paths
+     * @param list<string> $prior_exact_remote_paths
+     */
+    private function change_scope(
+        RemoteToLocalPathMapper $path_mapper,
+        array $remote_roots = ['/remote'],
+        array $excluded_remote_roots = [],
+        bool $include_caches = false,
+        array $protected_remote_roots = [],
+        array $current_exact_remote_paths = [],
+        array $prior_exact_remote_paths = []
+    ): FileSyncChangeScope {
+        $current_atoms = array_map(
+            static fn (string $path): array => [
+                'kind' => 'root',
+                'path' => $path,
+            ],
+            $remote_roots
+        );
+        foreach ($current_exact_remote_paths as $path) {
+            $current_atoms[] = ['kind' => 'exact', 'path' => $path];
+        }
+        $snapshot_id = $this->publish_ownership_snapshot($current_atoms);
+        $protected_snapshot_ids = [];
+        if ($protected_remote_roots !== []) {
+            $protected_snapshot_ids[] = $this->publish_ownership_snapshot(
+                array_map(
+                    static fn (string $path): array => [
+                        'kind' => 'root',
+                        'path' => $path,
+                    ],
+                    $protected_remote_roots
+                )
+            );
+        }
+        $prior_snapshot_ids = [];
+        if ($prior_exact_remote_paths !== []) {
+            $prior_snapshot_ids[] = $this->publish_ownership_snapshot(
+                array_map(
+                    static fn (string $path): array => [
+                        'kind' => 'exact',
+                        'path' => $path,
+                    ],
+                    $prior_exact_remote_paths
+                )
+            );
+        }
+        $ownership_directory = $this->temporary_directory
+            . '/pull-state/files-pull-ownership';
+        $remote_scope = FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode($ownership_directory),
+            'current_snapshot_id' => $snapshot_id,
+            'prior_snapshot_ids' => $prior_snapshot_ids,
+            'protected_snapshot_ids' => $protected_snapshot_ids,
+            'excluded_remote_absolute_path_roots_b64' => array_map(
+                'base64_encode',
+                $excluded_remote_roots
+            ),
+            'include_caches' => $include_caches,
+        ]);
+        try {
+            $mapping_processor = FileSyncChangeScopeMappingProcessor::start(
+                $remote_scope,
+                $path_mapper,
+                $this->temporary_directory
+                    . '/scope-mapping-'
+                    . bin2hex(random_bytes(6))
+            );
+            try {
+                do {
+                    $has_next_step = $mapping_processor->next_step();
+                } while ($has_next_step);
+                $local_config =
+                    $mapping_processor->get_local_change_scope_config();
+            } finally {
+                $mapping_processor->close();
+            }
+            return FileSyncChangeScope::from_config($local_config);
+        } finally {
+            $remote_scope->close();
+        }
+    }
+
+    /** @param list<array{kind:'root'|'exact',path:string}> $atoms */
+    private function publish_ownership_snapshot(array $atoms): string
+    {
+        $snapshots_directory = $this->temporary_directory
+            . '/pull-state/files-pull-ownership/snapshots';
+        if (!is_dir($snapshots_directory)) {
+            mkdir($snapshots_directory, 0777, true);
+        }
+        $expanded_atoms = [];
+        foreach ($atoms as $atom) {
+            $expanded_atoms[$atom['kind'] . "\0" . $atom['path']] = $atom;
+            if ($atom['kind'] !== 'root') {
+                continue;
+            }
+            $ancestor = $atom['path'];
+            while ($ancestor !== '/') {
+                $ancestor = dirname($ancestor);
+                $expanded_atoms['ancestor' . "\0" . $ancestor] = [
+                    'kind' => 'ancestor',
+                    'path' => $ancestor,
+                ];
+            }
+        }
+        $paths = '';
+        $lookup_rows = [];
+        foreach ($expanded_atoms as $atom) {
+            $lookup_rows[] = hash('sha256', $atom['kind'] . "\0" . $atom['path'])
+                . ' ' . sprintf('%016x', strlen($paths)) . "\n";
+            $paths .= json_encode([
+                'kind' => $atom['kind'],
+                'path_b64' => base64_encode($atom['path']),
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        }
+        sort($lookup_rows, SORT_STRING);
+        $snapshot_id = bin2hex(random_bytes(32));
+        file_put_contents($snapshots_directory . '/' . $snapshot_id . '.paths.jsonl', $paths);
+        file_put_contents($snapshots_directory . '/' . $snapshot_id . '.lookup', implode('', $lookup_rows));
+        return $snapshot_id;
+    }
+
+    /**
      * @param list<string> $included_local_index_path_roots
      * @param list<string> $excluded_local_index_path_roots
      */
@@ -1221,20 +1886,30 @@ final class PullLocalIndexProcessorTest extends TestCase {
         array $excluded_local_index_path_roots = []
     ): PullLocalIndexProcessor
     {
+        $remote_roots = array_map(
+            static fn (string $path): string =>
+                $path === '' ? '/remote' : '/remote/' . $path,
+            $included_local_index_path_roots
+        );
+        $excluded_remote_roots = array_map(
+            static fn (string $path): string => '/remote/' . $path,
+            $excluded_local_index_path_roots
+        );
         return PullLocalIndexProcessor::start_next_local_index(
             $this->work_directory,
             $this->next_remote_index_file,
             $this->remote_index_file,
             $this->retained_local_index_file,
-            new RemoteToLocalPathMapper(
-                $this->filesystem_root,
-                ['/remote'],
-                ['/remote' => $this->filesystem_root]
+            $this->change_scope(
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                ),
+                $remote_roots,
+                $excluded_remote_roots
             ),
-            $this->temporary_directory . '/storage',
-            false,
-            $included_local_index_path_roots,
-            $excluded_local_index_path_roots
+            $this->temporary_directory . '/storage'
         );
     }
 


### PR DESCRIPTION
PullLocal now maps and confirms only remote rows owned by the active selection and allowed by every local alias. This prevents an unowned remote alias from borrowing authority from another path which maps to the same local destination.

Final verification uses the selected skipped-path list instead of traversing every skipped tree, so exact owned links remain observable without touching unrelated FIFOs, sockets, or unreadable cache directories.