### PR TITLE
[PHP] Restrict file-sync cleanup to selected local paths

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
@@ -1,7 +1,6 @@
 <?php
 
 use function Reprint\Importer\append_file_sync_path_stack_entry;
-use function Reprint\Importer\file_sync_index_path_may_change;
 use function Reprint\Importer\read_file_sync_path_stack_entry;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\assert_valid_relative_path;
@@ -11,6 +10,8 @@ use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
 require_once __DIR__ . '/class-file-sync-patch-processor.php';
+require_once __DIR__ . '/../pull/class-remote-to-local-path-mapper.php';
+require_once __DIR__ . '/class-file-sync-change-scope.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths and files are CLI values, never HTML output.
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
@@ -35,11 +36,9 @@ require_once __DIR__ . '/class-file-sync-patch-processor.php';
  *
  *     $cleanup = FileSyncCleanupProcessor::start(
  *         $work_directory,
- *         $filesystem_root,
  *         $patch_result_index,
  *         $storage_path,
- *         ['wp-content'],
- *         ['wp-content/uploads/keep']
+ *         $local_change_scope_config
  *     );
  *     do {
  *         $has_next_step = $cleanup->next_step();
@@ -55,10 +54,10 @@ require_once __DIR__ . '/class-file-sync-patch-processor.php';
  * @phpstan-type PatchCursor array<string,mixed>
  * @phpstan-type PlanningPosition array{phase:'planning',file_sync_patch_processor_cursor:PatchCursor}
  * @phpstan-type ExpectedBase array{type:string,size:int,ctime:int}
- * @phpstan-type RemovingPosition array{phase:'removing',path_b64:string,expected_base:ExpectedBase,file_sync_patch_processor_cursor:PatchCursor}
+ * @phpstan-type RemovingPosition array{phase:'removing',path_b64:string,governing_type:string,expected_base:ExpectedBase,file_sync_patch_processor_cursor:PatchCursor}
  * @phpstan-type PruningPosition array{phase:'pruning'}
  * @phpstan-type Position PlanningPosition|RemovingPosition|PruningPosition|array{phase:'complete'|'restart'}
- * @phpstan-type Cursor array{filesystem_root_b64:string,empty_parent_paths_file_b64:string,empty_parent_paths_file_byte_offset:int,empty_parent_path_stack_top_byte_offset:int|null,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,position:Position}
+ * @phpstan-type Cursor array{file_sync_change_scope_config:array<string,mixed>,empty_parent_paths_file_b64:string,empty_parent_paths_file_byte_offset:int,empty_parent_path_stack_top_byte_offset:int|null,position:Position}
  * @phpstan-type EmptyParentPath array{path:string,previous_byte_offset:int|null,expected_ctime:int|null}
  */
 final class FileSyncCleanupProcessor
@@ -69,11 +68,8 @@ final class FileSyncCleanupProcessor
     /** Canonical filesystem root decoded from the cursor. */
     private string $filesystem_root;
 
-    /** @var list<string> Roots whose descendants may be removed. */
-    private array $included_index_path_roots;
-
-    /** @var list<string> Roots which cleanup must not affect. */
-    private array $excluded_index_path_roots;
+    /** Selection authority in local-relative index coordinates. */
+    private FileSyncChangeScope $change_scope;
 
     /** Patch planning retained while the cursor is planning or removing. */
     private FileSyncPatchProcessor $patch_processor;
@@ -97,22 +93,34 @@ final class FileSyncCleanupProcessor
      * The patch result index describes the local paths which the caller wants
      * to write after cleanup.
      *
-     * @param string       $work_directory             Existing directory for cleanup state.
-     * @param string       $filesystem_root            Filesystem root scanned and changed by cleanup.
-     * @param string       $patch_result_index_file    Index which the later file sync must produce.
-     * @param string       $storage_path               Reprint storage path omitted from the local scan.
-     * @param list<string> $included_index_path_roots  Roots whose descendants cleanup may remove.
-     * @param list<string> $excluded_index_path_roots  Roots which cleanup must not affect.
-     * @param bool         $include_caches             Whether the local scan includes cache directories.
+     * @param string $work_directory          Existing directory for cleanup state.
+     * @param string $patch_result_index_file Index which the later file sync must produce.
+     * @param string $storage_path            Reprint storage path omitted from the local scan.
+     * @param array  $change_scope_config { Local-relative change-scope config.
+     *     @type string       $index_path_coordinates                    Must be `local_relative`.
+     *     @type string       $ownership_directory_b64                   Base64-encoded ownership directory.
+     *     @type string       $current_snapshot_id                       Snapshot which owns paths selected by this pull.
+     *     @type list<string> $prior_snapshot_ids                        Earlier snapshots for this selection.
+     *     @type list<string> $protected_snapshot_ids                    Snapshots owned by other selections.
+     *     @type list<string> $excluded_remote_absolute_path_roots_b64   Base64-encoded excluded remote roots.
+     *     @type bool         $include_caches                            Whether ordinary producer traversal included default-skipped paths.
+     *     @type string       $selected_default_skipped_index_paths_file_b64 Base64-encoded immutable sorted selected-path sidecar.
+     *     @type array        $remote_to_local_path_mapper_config {      Saved remote-to-local placement.
+     *         @type string       $filesystem_root_b64                   Base64-encoded local filesystem root.
+     *         @type list<string> $original_remote_roots_b64             Base64-encoded roots selected before following links.
+     *         @type list<array>  $resolved_path_mappings {              Resolved remote and local prefix pairs.
+     *             @type string $remote_prefix_b64                       Base64-encoded remote prefix.
+     *             @type string $local_prefix_b64                        Base64-encoded local prefix.
+     *         }
+     *         @type string|null  $local_followed_symlinks_root_b64      Base64-encoded placement for followed targets.
+     *     }
+     * }
      */
     public static function start(
         string $work_directory,
-        string $filesystem_root,
         string $patch_result_index_file,
         string $storage_path,
-        array $included_index_path_roots = [""],
-        array $excluded_index_path_roots = [],
-        bool $include_caches = false
+        array $change_scope_config
     ): self {
         if (!is_dir($work_directory)) {
             throw new LogicException(
@@ -121,16 +129,49 @@ final class FileSyncCleanupProcessor
         }
         $work_directory = trim_right_slash($work_directory);
         $processor = new self();
-        $processor->patch_processor =
-            FileSyncPatchProcessor::start_from_fresh_local_tree(
-                $work_directory,
-                $filesystem_root,
-                $patch_result_index_file,
-                $storage_path,
-                $included_index_path_roots,
-                $excluded_index_path_roots,
-                $include_caches
+        if (
+            ( $change_scope_config['index_path_coordinates'] ?? null )
+                !== 'local_relative'
+        ) {
+            throw new InvalidArgumentException(
+                'File sync cleanup requires a local_relative change-scope config.'
             );
+        }
+        $processor->change_scope = FileSyncChangeScope::from_config(
+            $change_scope_config
+        );
+        try {
+            $filesystem_root = $processor->change_scope->get_filesystem_root();
+            if ($processor->change_scope->includes_caches()) {
+                // The selected-path sidecar is empty when ordinary traversal
+                // includes caches, so that traversal must scan them itself.
+                $processor->patch_processor =
+                    FileSyncPatchProcessor::start_from_fresh_local_tree(
+                        $work_directory,
+                        $filesystem_root,
+                        $patch_result_index_file,
+                        $storage_path,
+                        [""],
+                        [],
+                        true
+                    );
+            } else {
+                $processor->patch_processor =
+                    FileSyncPatchProcessor::start_from_fresh_local_tree_with_selected_default_skipped_paths(
+                        $work_directory,
+                        $filesystem_root,
+                        $patch_result_index_file,
+                        $storage_path,
+                        $processor->change_scope
+                            ->get_selected_default_skipped_index_paths_file(),
+                        [""],
+                        []
+                    );
+            }
+        } catch (Throwable $start_failure) {
+            $processor->change_scope->close();
+            throw $start_failure;
+        }
         $patch_cursor = $processor->patch_processor->get_cursor();
         $canonical_filesystem_root = self::decode_cursor_path(
             $patch_cursor["position"]["fresh_local_index_cursor"][
@@ -148,30 +189,20 @@ final class FileSyncCleanupProcessor
         );
         if (!is_resource($processor->empty_parent_paths_handle)) {
             $processor->patch_processor->close();
+            $processor->change_scope->close();
             throw new RuntimeException(
                 "Failed to initialize the empty parent paths file: {$empty_parent_paths_file}"
             );
         }
         $processor->filesystem_root = $canonical_filesystem_root;
-        $processor->included_index_path_roots = $included_index_path_roots;
-        $processor->excluded_index_path_roots = $excluded_index_path_roots;
         $processor->cursor = [
-            "filesystem_root_b64" => base64_encode(
-                $canonical_filesystem_root
-            ),
+            "file_sync_change_scope_config" =>
+                $processor->change_scope->get_config(),
             "empty_parent_paths_file_b64" => base64_encode(
                 $empty_parent_paths_file
             ),
             "empty_parent_paths_file_byte_offset" => 0,
             "empty_parent_path_stack_top_byte_offset" => null,
-            "included_index_path_roots_b64" => array_map(
-                "base64_encode",
-                $included_index_path_roots
-            ),
-            "excluded_index_path_roots_b64" => array_map(
-                "base64_encode",
-                $excluded_index_path_roots
-            ),
             "position" => [
                 "phase" => "planning",
                 "file_sync_patch_processor_cursor" => $patch_cursor,
@@ -190,12 +221,10 @@ final class FileSyncCleanupProcessor
      * @param array $cursor {
      *     Cursor returned by get_cursor().
      *
-     *     @type string       $filesystem_root_b64                         Base64-encoded canonical filesystem root.
+     *     @type array        $file_sync_change_scope_config               Local-relative selection authority.
      *     @type string       $empty_parent_paths_file_b64                 Base64-encoded path to the parent-path stack.
      *     @type int          $empty_parent_paths_file_byte_offset         Confirmed byte offset in the parent-path stack.
      *     @type int|null     $empty_parent_path_stack_top_byte_offset     Byte offset of the current stack entry.
-     *     @type list<string> $included_index_path_roots_b64               Base64-encoded roots whose contents may be removed.
-     *     @type list<string> $excluded_index_path_roots_b64               Base64-encoded roots cleanup must not affect.
      *     @type array        $position                                    Current planning, removing, pruning, complete, or restart phase.
      * }
      * @phpstan-param Cursor $cursor
@@ -204,50 +233,43 @@ final class FileSyncCleanupProcessor
     {
         $processor = new self();
         $processor->cursor = $cursor;
-        $processor->filesystem_root = self::decode_cursor_path(
-            $cursor["filesystem_root_b64"],
-            "filesystem root"
+        $processor->change_scope = FileSyncChangeScope::from_config(
+            $cursor["file_sync_change_scope_config"]
         );
-        $resolved_filesystem_root = realpath($processor->filesystem_root);
-        if (
-            $resolved_filesystem_root === false
-            || $resolved_filesystem_root !== $processor->filesystem_root
-            || !is_dir($processor->filesystem_root)
-            || is_link($processor->filesystem_root)
-        ) {
-            throw new RuntimeException(
-                "The file sync cleanup filesystem root no longer resolves to its saved path."
-            );
-        }
-        $processor->included_index_path_roots = self::decode_path_roots(
-            $cursor["included_index_path_roots_b64"],
-            "included"
-        );
-        $processor->excluded_index_path_roots = self::decode_path_roots(
-            $cursor["excluded_index_path_roots_b64"],
-            "excluded"
-        );
-        $position = $cursor["position"];
-        if (
-            $position["phase"] === "complete"
-            || $position["phase"] === "restart"
-        ) {
-            return $processor;
-        }
-        $empty_parent_paths_file = self::decode_cursor_path(
-            $cursor["empty_parent_paths_file_b64"],
-            "empty parent paths file"
-        );
-        $processor->empty_parent_paths_handle = fopen(
-            $empty_parent_paths_file,
-            "r+b"
-        );
-        if (!is_resource($processor->empty_parent_paths_handle)) {
-            throw new RuntimeException(
-                "Failed to reopen the empty parent paths file: {$empty_parent_paths_file}"
-            );
-        }
         try {
+            $processor->filesystem_root =
+                $processor->change_scope->get_filesystem_root();
+            $resolved_filesystem_root = realpath($processor->filesystem_root);
+            if (
+                $resolved_filesystem_root === false
+                || $resolved_filesystem_root !== $processor->filesystem_root
+                || !is_dir($processor->filesystem_root)
+                || is_link($processor->filesystem_root)
+            ) {
+                throw new RuntimeException(
+                    "The file sync cleanup filesystem root no longer resolves to its saved path."
+                );
+            }
+            $position = $cursor["position"];
+            if (
+                $position["phase"] === "complete"
+                || $position["phase"] === "restart"
+            ) {
+                return $processor;
+            }
+            $empty_parent_paths_file = self::decode_cursor_path(
+                $cursor["empty_parent_paths_file_b64"],
+                "empty parent paths file"
+            );
+            $processor->empty_parent_paths_handle = fopen(
+                $empty_parent_paths_file,
+                "r+b"
+            );
+            if (!is_resource($processor->empty_parent_paths_handle)) {
+                throw new RuntimeException(
+                    "Failed to reopen the empty parent paths file: {$empty_parent_paths_file}"
+                );
+            }
             if (
                 !ftruncate(
                     $processor->empty_parent_paths_handle,
@@ -287,12 +309,18 @@ final class FileSyncCleanupProcessor
                     $position["file_sync_patch_processor_cursor"]
                 );
             }
+            return $processor;
         } catch (Throwable $resume_failure) {
-            fclose($processor->empty_parent_paths_handle);
+            if (isset($processor->patch_processor)) {
+                $processor->patch_processor->close();
+            }
+            if (is_resource($processor->empty_parent_paths_handle)) {
+                fclose($processor->empty_parent_paths_handle);
+            }
             $processor->empty_parent_paths_handle = null;
+            $processor->change_scope->close();
             throw $resume_failure;
         }
-        return $processor;
     }
 
     /**
@@ -322,32 +350,59 @@ final class FileSyncCleanupProcessor
             $has_next_patch_step = $this->patch_processor->next_step();
             $patch_cursor = $this->patch_processor->get_cursor();
             $operation = $this->patch_processor->get_operation();
-            // A selected root marks where traversal begins, not a result
-            // entry. Keep that boundary when its contents are empty.
+            // A root atom marks the traversal boundary but does not own
+            // that entry. Ask the scope with the operation's governing type.
             if (
                 $operation !== null
                 && (
-                    $operation["action"] === "delete"
-                    || $operation["action"] === "replace"
-                )
-                && !in_array(
-                    $operation["path"],
-                    $this->included_index_path_roots,
-                    true
+                    $operation['action'] === 'delete'
+                    || $operation['action'] === 'replace'
                 )
             ) {
-                if (!isset($operation["expected_base"])) {
+                $governing_entry = $operation['action'] === 'delete'
+                    ? ( $operation['expected_base'] ?? null )
+                    : ( $operation['expected_source'] ?? null );
+                if (!is_array($governing_entry)) {
                     throw new LogicException(
-                        "Exact file sync cleanup removal has no patch-base entry."
+                        'File sync cleanup operation has no governing index entry.'
                     );
                 }
-                $this->cursor["position"] = [
-                    "phase" => "removing",
-                    "path_b64" => base64_encode($operation["path"]),
-                    "expected_base" => $operation["expected_base"],
-                    "file_sync_patch_processor_cursor" => $patch_cursor,
-                ];
-                return true;
+                if (!isset($operation['expected_base'])) {
+                    throw new LogicException(
+                        'Exact file sync cleanup removal has no patch-base entry.'
+                    );
+                }
+                // The supplemental local scan labels selected unsupported
+                // paths `other`. A deletion has no owned index-entry type,
+                // while a replacement uses its supported desired type.
+                if (
+                    !(
+                        $operation['action'] === 'delete'
+                        && $governing_entry['type'] === 'other'
+                    )
+                ) {
+                    $removal_is_allowed =
+                        $operation['expected_base']['type'] === 'dir'
+                            ? $this->change_scope
+                                ->directory_entry_may_change(
+                                    $operation['path'],
+                                    $governing_entry['type']
+                                )
+                            : $this->change_scope->index_entry_may_change(
+                                $operation['path'],
+                                $governing_entry['type']
+                            );
+                    if ($removal_is_allowed) {
+                        $this->cursor['position'] = [
+                            'phase' => 'removing',
+                            'path_b64' => base64_encode($operation['path']),
+                            'governing_type' => $governing_entry['type'],
+                            'expected_base' => $operation['expected_base'],
+                            'file_sync_patch_processor_cursor' => $patch_cursor,
+                        ];
+                        return true;
+                    }
+                }
             }
             if (!$has_next_patch_step) {
                 $this->patch_processor->close();
@@ -370,6 +425,19 @@ final class FileSyncCleanupProcessor
                 $position["path_b64"],
                 "pending cleanup path"
             );
+            $removal_is_allowed =
+                $position['expected_base']['type'] === 'dir'
+                    ? $this->change_scope->directory_entry_may_change(
+                        $index_path,
+                        $position['governing_type']
+                    )
+                    : $this->change_scope->index_entry_may_change(
+                        $index_path,
+                        $position['governing_type']
+                    );
+            if (!$removal_is_allowed) {
+                return $this->finish_removal_step($position);
+            }
             $absolute_path = $this->absolute_selected_path($index_path);
             $path_stat = @lstat($absolute_path);
             $path_removed = !is_array($path_stat);
@@ -390,6 +458,8 @@ final class FileSyncCleanupProcessor
                     $this->cursor["position"] = ["phase" => "restart"];
                     return false;
                 }
+            }
+            if (is_array($path_stat)) {
                 if ($path_type === "dir") {
                     $path_removed = @rmdir($absolute_path);
                     if (!$path_removed) {
@@ -438,23 +508,7 @@ final class FileSyncCleanupProcessor
             if ($path_removed) {
                 $this->schedule_parent_path($index_path);
             }
-            $patch_cursor = $position[
-                "file_sync_patch_processor_cursor"
-            ];
-            if ($patch_cursor["position"]["phase"] === "complete") {
-                $this->patch_processor->close();
-                if ($this->empty_parent_path === null) {
-                    $this->cursor["position"] = ["phase" => "complete"];
-                    return false;
-                }
-                $this->cursor["position"] = ["phase" => "pruning"];
-                return true;
-            }
-            $this->cursor["position"] = [
-                "phase" => "planning",
-                "file_sync_patch_processor_cursor" => $patch_cursor,
-            ];
-            return true;
+            return $this->finish_removal_step($position);
         }
 
         if ($this->empty_parent_path === null) {
@@ -474,7 +528,10 @@ final class FileSyncCleanupProcessor
             && $this->empty_parent_path["expected_ctime"] !== null
             && (int) $path_stat["ctime"]
                 === $this->empty_parent_path["expected_ctime"];
-        if ($parent_is_unchanged_directory) {
+        if (
+            $parent_is_unchanged_directory
+            && $this->change_scope->subtree_may_change($index_path)
+        ) {
             $removed = @rmdir($absolute_path);
             if (!$removed) {
                 clearstatcache(true, $absolute_path);
@@ -522,15 +579,39 @@ final class FileSyncCleanupProcessor
     }
 
     /**
+     * Continues after a planned removal was applied or became unauthorized.
+     *
+     * @phpstan-param RemovingPosition $position
+     */
+    private function finish_removal_step(array $position): bool
+    {
+        $patch_cursor = $position[
+            'file_sync_patch_processor_cursor'
+        ];
+        if ($patch_cursor['position']['phase'] === 'complete') {
+            $this->patch_processor->close();
+            if ($this->empty_parent_path === null) {
+                $this->cursor['position'] = ['phase' => 'complete'];
+                return false;
+            }
+            $this->cursor['position'] = ['phase' => 'pruning'];
+            return true;
+        }
+        $this->cursor['position'] = [
+            'phase' => 'planning',
+            'file_sync_patch_processor_cursor' => $patch_cursor,
+        ];
+        return true;
+    }
+
+    /**
      * Returns everything needed to resume after the latest completed step.
      *
      * @return array {
-     *     @type string       $filesystem_root_b64                         Base64-encoded canonical filesystem root.
+     *     @type array        $file_sync_change_scope_config               Local-relative selection authority.
      *     @type string       $empty_parent_paths_file_b64                 Base64-encoded path to the parent-path stack.
      *     @type int          $empty_parent_paths_file_byte_offset         Confirmed byte offset in the parent-path stack.
      *     @type int|null     $empty_parent_path_stack_top_byte_offset     Byte offset of the current stack entry.
-     *     @type list<string> $included_index_path_roots_b64               Base64-encoded roots whose contents may be removed.
-     *     @type list<string> $excluded_index_path_roots_b64               Base64-encoded roots cleanup must not affect.
      *     @type array        $position                                    Current planning, removing, pruning, complete, or restart phase.
      * }
      * @phpstan-return Cursor
@@ -588,6 +669,7 @@ final class FileSyncCleanupProcessor
         if (isset($this->patch_processor)) {
             $this->patch_processor->close();
         }
+        $this->change_scope->close();
         if (is_resource($this->empty_parent_paths_handle)) {
             fclose($this->empty_parent_paths_handle);
         }
@@ -599,18 +681,6 @@ final class FileSyncCleanupProcessor
     private function absolute_selected_path(string $index_path): string
     {
         assert_valid_relative_path($index_path, "File sync cleanup path");
-        if (
-            !file_sync_index_path_may_change(
-                $index_path,
-                $this->included_index_path_roots,
-                $this->excluded_index_path_roots
-            )
-        ) {
-            throw new RuntimeException(
-                "File sync cleanup cursor selected a path outside its allowed roots: "
-                . base64_encode($index_path)
-            );
-        }
         $absolute_path = wp_join_unix_paths(
             $this->filesystem_root,
             $index_path
@@ -641,14 +711,7 @@ final class FileSyncCleanupProcessor
             return;
         }
         $parent_path = substr($index_path, 0, $separator);
-        if (
-            in_array($parent_path, $this->included_index_path_roots, true)
-            || !file_sync_index_path_may_change(
-                $parent_path,
-                $this->included_index_path_roots,
-                $this->excluded_index_path_roots
-            )
-        ) {
+        if (!$this->change_scope->subtree_may_change($parent_path)) {
             return;
         }
         $parent_absolute_path = $this->absolute_selected_path($parent_path);
@@ -711,21 +774,6 @@ final class FileSyncCleanupProcessor
         } finally {
             closedir($directory_handle);
         }
-    }
-
-    /** Decodes arbitrary-byte path roots stored in the JSON cursor. */
-    private static function decode_path_roots(
-        array $path_roots_b64,
-        string $field_name
-    ): array {
-        $path_roots = [];
-        foreach ($path_roots_b64 as $path_root_b64) {
-            $path_roots[] = self::decode_cursor_path(
-                $path_root_b64,
-                $field_name . " path root"
-            );
-        }
-        return $path_roots;
     }
 
     /** Decodes one arbitrary-byte path stored in the JSON cursor. */

--- a/tests/Import/FileSyncCleanupProcessorTest.php
+++ b/tests/Import/FileSyncCleanupProcessorTest.php
@@ -7,10 +7,12 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-server/src/utils.php';
 require_once __DIR__ . '/../../packages/reprint-server/src/class-file-index-processor.php';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-file-sync-change-scope-mapping-processor.php';
 
 final class FileSyncCleanupProcessorTest extends TestCase {
     private string $temporary_directory;
     private string $filesystem_root;
+    private string $last_ownership_directory;
 
     protected function setUp(): void
     {
@@ -21,6 +23,9 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $this->filesystem_root =
             $this->temporary_directory . '/filesystem-root';
         mkdir($this->filesystem_root, 0755, true);
+        $canonical_filesystem_root = realpath($this->filesystem_root);
+        $this->assertIsString($canonical_filesystem_root);
+        $this->filesystem_root = $canonical_filesystem_root;
     }
 
     protected function tearDown(): void
@@ -41,12 +46,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'leaf'
         );
         $work_directory = $this->work_directory('remove-tree');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('empty.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
 
         $phases = $this->run_to_completion($processor);
@@ -82,7 +89,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         mkdir($storage_path);
         file_put_contents($storage_path . '/keep.txt', 'state');
         $work_directory = $this->work_directory('keep-skipped');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('keep-skipped-result.jsonl', []),
@@ -105,6 +112,100 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $this->assertFileExists($storage_path . '/keep.txt');
     }
 
+    public function testIncludeCachesRemovesStaleDotGitEntryOwnedByCurrentRoot(): void
+    {
+        mkdir($this->filesystem_root . '/.git', 0755, true);
+        $stale_path = $this->filesystem_root . '/.git/stale.txt';
+        file_put_contents($stale_path, 'stale');
+        $work_directory = $this->work_directory('include-caches-dot-git');
+        $processor = $this->startCleanup(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('include-caches-dot-git-result.jsonl', []),
+            $work_directory,
+            [''],
+            [],
+            true
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist($stale_path);
+    }
+
+    public function testRemovesAnExactLinkInsideDotGit(): void
+    {
+        mkdir($this->filesystem_root . '/site/.git', 0755, true);
+        $path = $this->filesystem_root . '/site/.git/stale-link';
+        symlink('missing-target', $path);
+        $work_directory = $this->work_directory('exact-dot-git-link');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('exact-dot-git-link-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig([
+                ['kind' => 'exact', 'path' => '/site/.git/stale-link'],
+            ], [], [], [], ['/site'])
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFalse(is_link($path));
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/site/.git'
+        );
+    }
+
+    public function testPriorExactTombstoneKeepsALocalFifo(): void
+    {
+        if (!function_exists('posix_mkfifo')) {
+            $this->markTestSkipped('This PHP build cannot create a FIFO.');
+        }
+        mkdir($this->filesystem_root . '/site/.git', 0755, true);
+        $fifo_path = $this->filesystem_root . '/site/.git/stale.pipe';
+        posix_mkfifo($fifo_path, 0600);
+        $work_directory = $this->work_directory('prior-exact-local-fifo');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('prior-exact-local-fifo-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [],
+                [[
+                    'kind' => 'exact',
+                    'path' => '/site/.git/stale.pipe',
+                ]],
+                [],
+                [],
+                ['/site']
+            )
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertIsArray(lstat($fifo_path));
+        unlink($fifo_path);
+    }
+
+    public function testKeepsOrdinaryDefaultSkippedDrift(): void
+    {
+        mkdir($this->filesystem_root . '/site/.git', 0755, true);
+        $path = $this->filesystem_root . '/site/.git/ordinary.txt';
+        file_put_contents($path, 'ordinary drift');
+        $work_directory = $this->work_directory('ordinary-dot-git-drift');
+        $processor = $this->startCleanup(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('ordinary-dot-git-result.jsonl', []),
+            $work_directory,
+            ['site']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertSame('ordinary drift', file_get_contents($path));
+    }
+
     public function testKeepsAnExplicitlyExcludedChild(): void
     {
         mkdir($this->filesystem_root . '/selected/tree/keep', 0755, true);
@@ -117,7 +218,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'keep'
         );
         $work_directory = $this->work_directory('keep-excluded');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('keep-excluded-result.jsonl', []),
@@ -140,7 +241,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
     {
         mkdir($this->filesystem_root . '/selected');
         $work_directory = $this->work_directory('keep-included-root');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('keep-included-root-result.jsonl', []),
@@ -172,7 +273,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $work_directory = $this->work_directory(
             'replace-' . $local_type . '-' . $result_type
         );
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('replace-result.jsonl', [
@@ -217,7 +318,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'indexed'
         );
         $work_directory = $this->work_directory('result-parent');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('result-parent.jsonl', [
@@ -245,7 +346,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
     {
         file_put_contents($this->filesystem_root . '/delete.txt', 'delete');
         $work_directory = $this->work_directory('pending-removal');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('pending-result.jsonl', []),
@@ -275,16 +376,29 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         );
     }
 
-    public function testCopyLeavesThePathForTheCallerToWrite(): void
+    public function testCopyDoesNotReadATamperedOwnershipSnapshot(): void
     {
         $work_directory = $this->work_directory('copy-restart');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('copy-restart-result.jsonl', [
                 $this->entry('remote.txt', 'file'),
             ]),
             $work_directory
+        );
+        $change_scope_config = $processor->get_cursor()[
+            'file_sync_change_scope_config'
+        ];
+        $ownership_directory = base64_decode(
+            $change_scope_config['ownership_directory_b64'],
+            true
+        );
+        $this->assertIsString($ownership_directory);
+        unlink(
+            $ownership_directory . '/snapshots/'
+                . $change_scope_config['current_snapshot_id']
+                . '.paths.jsonl'
         );
 
         $this->run_to_completion($processor);
@@ -300,7 +414,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $path = $this->filesystem_root . '/delete.txt';
         file_put_contents($path, 'old');
         $work_directory = $this->work_directory('changed-removal');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('changed-removal-result.jsonl', []),
@@ -336,7 +450,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $path = $this->filesystem_root . '/entry';
         file_put_contents($path, 'old');
         $work_directory = $this->work_directory('changed-replacement');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('changed-replacement-result.jsonl', [
@@ -361,7 +475,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $path = $this->filesystem_root . '/entry';
         mkdir($path);
         $work_directory = $this->work_directory('changed-empty-directory');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('changed-empty-directory-result.jsonl', [
@@ -392,7 +506,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         mkdir($outside_directory);
         file_put_contents($outside_directory . '/delete.txt', 'outside');
         $work_directory = $this->work_directory('moved-parent');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('moved-parent-result.jsonl', []),
@@ -440,12 +554,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'delete'
         );
         $work_directory = $this->work_directory('parent-stack');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('parent-stack-result.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
         do {
             $processor->next_step();
@@ -477,12 +593,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'second'
         );
         $work_directory = $this->work_directory('discard-stack-tail');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('discard-stack-tail-result.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
         do {
             $processor->next_step();
@@ -525,12 +643,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'delete'
         );
         $work_directory = $this->work_directory('corrupt-parent-stack');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('corrupt-parent-stack-result.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
         do {
             $processor->next_step();
@@ -573,12 +693,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'delete'
         );
         $work_directory = $this->work_directory('repeat-prune');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('repeat-prune-result.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
         do {
             $processor->next_step();
@@ -608,12 +730,14 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             'delete'
         );
         $work_directory = $this->work_directory('changed-parent');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('changed-parent-result.jsonl', []),
             $work_directory,
-            ['selected']
+            ['selected'],
+            [],
+            true
         );
         do {
             $processor->next_step();
@@ -635,6 +759,406 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $this->assertSame('complete', $processor->get_status());
     }
 
+    public function testPriorOwnershipRemovesOnlyUnprotectedLocalPaths(): void
+    {
+        mkdir(
+            $this->filesystem_root . '/selected/protected/current',
+            0755,
+            true
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/stale.txt',
+            'stale'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/selected/protected/keep.txt',
+            'protected'
+        );
+        file_put_contents(
+            $this->filesystem_root
+                . '/selected/protected/current/remove.txt',
+            'current'
+        );
+        file_put_contents($this->filesystem_root . '/outside.txt', 'outside');
+        $work_directory = $this->work_directory('ownership-precedence');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('ownership-precedence-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [[
+                    'kind' => 'root',
+                    'path' => '/selected/protected/current',
+                ]],
+                [['kind' => 'root', 'path' => '/selected']],
+                [['kind' => 'root', 'path' => '/selected/protected']]
+            )
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/stale.txt'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root . '/selected/protected/keep.txt'
+        );
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root
+                . '/selected/protected/current/remove.txt'
+        );
+        $this->assertFileExists($this->filesystem_root . '/outside.txt');
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/protected/current'
+        );
+    }
+
+    public function testRemapSourceHoleKeepsTheLocalPath(): void
+    {
+        mkdir($this->filesystem_root . '/mapped/hole', 0755, true);
+        mkdir($this->filesystem_root . '/elsewhere', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/mapped/remove.txt',
+            'remove'
+        );
+        file_put_contents(
+            $this->filesystem_root . '/mapped/hole/keep.txt',
+            'keep'
+        );
+        $work_directory = $this->work_directory('remap-source-hole');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('remap-source-hole-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [['kind' => 'root', 'path' => '/site']],
+                [],
+                [],
+                [],
+                ['/site'],
+                [
+                    '/site' => $this->filesystem_root . '/mapped',
+                    '/site/hole' => $this->filesystem_root . '/elsewhere',
+                ]
+            )
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/mapped/remove.txt'
+        );
+        $this->assertFileExists(
+            $this->filesystem_root . '/mapped/hole/keep.txt'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/mapped/hole'
+        );
+    }
+
+    public function testReplacementUsesTheResultLinkTypeAsAuthority(): void
+    {
+        mkdir($this->filesystem_root . '/selected', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/entry',
+            'old file'
+        );
+        $work_directory = $this->work_directory('governing-link-type');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('governing-link-result.jsonl', [
+                $this->entry('selected/entry', 'link'),
+            ]),
+            $work_directory,
+            $this->localScopeConfig([
+                ['kind' => 'exact', 'path' => '/selected/entry'],
+            ], [], [], [], ['/selected'])
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $this->assertSame('link', $cursor['position']['governing_type']);
+        $this->assertSame(
+            'file',
+            $cursor['position']['expected_base']['type']
+        );
+        $this->run_to_completion($processor);
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/entry'
+        );
+    }
+
+    public function testEmptyDirectoryKeepsAnAbsentProtectedDescendant(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a', 0755, true);
+        $work_directory = $this->work_directory(
+            'empty-protected-descendant'
+        );
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('empty-protected-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [['kind' => 'root', 'path' => '/current']],
+                [['kind' => 'root', 'path' => '/selected']],
+                [
+                    ['kind' => 'ancestor', 'path' => '/selected/a'],
+                    [
+                        'kind' => 'root',
+                        'path' => '/selected/a/future',
+                    ],
+                ],
+                [],
+                ['/'],
+                [],
+                true
+            )
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/a'
+        );
+    }
+
+    public function testCachesOmittedStillRemoveVerifiedEmptyDirectory(): void
+    {
+        mkdir($this->filesystem_root . '/selected/empty', 0755, true);
+        $work_directory = $this->work_directory(
+            'empty-with-caches-omitted'
+        );
+        $processor = $this->startCleanup(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('empty-caches-omitted-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertDirectoryDoesNotExist(
+            $this->filesystem_root . '/selected/empty'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected'
+        );
+    }
+
+    public function testCurrentAndPriorExactLinksMayReplaceEmptyDirectories(): void
+    {
+        foreach (['current', 'prior'] as $ownership) {
+            $index_path = 'selected/' . $ownership;
+            mkdir($this->filesystem_root . '/' . $index_path, 0755, true);
+            $work_directory = $this->work_directory(
+                'exact-link-over-empty-directory-' . $ownership
+            );
+            $exact_atom = [[
+                'kind' => 'exact',
+                'path' => '/' . $index_path,
+            ]];
+            $processor = FileSyncCleanupProcessor::start(
+                $work_directory,
+                $this->write_index(
+                    'exact-link-over-empty-directory-' . $ownership
+                        . '-result.jsonl',
+                    [$this->entry($index_path, 'link')]
+                ),
+                $work_directory,
+                $this->localScopeConfig(
+                    $ownership === 'current' ? $exact_atom : [],
+                    $ownership === 'prior' ? $exact_atom : [],
+                    [],
+                    [],
+                    ['/selected']
+                )
+            );
+
+            $this->run_to_completion($processor);
+
+            $this->assertDirectoryDoesNotExist(
+                $this->filesystem_root . '/' . $index_path
+            );
+        }
+    }
+
+    public function testParentPruningKeepsTheScopeTraversalRoot(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/stale.txt',
+            'stale'
+        );
+        $work_directory = $this->work_directory('scope-prune-boundary');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('scope-prune-boundary-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig([
+                ['kind' => 'root', 'path' => '/selected/a'],
+            ], [], [], [], ['/'], [], true)
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a/b'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/a'
+        );
+    }
+
+    public function testParentPruningKeepsAnAbsentProtectedDescendant(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/stale.txt',
+            'stale'
+        );
+        $work_directory = $this->work_directory('protected-prune-boundary');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('protected-prune-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [['kind' => 'root', 'path' => '/current']],
+                [['kind' => 'root', 'path' => '/selected']],
+                [
+                    ['kind' => 'ancestor', 'path' => '/selected/a'],
+                    [
+                        'kind' => 'root',
+                        'path' => '/selected/a/future',
+                    ],
+                ],
+                [],
+                ['/'],
+                [],
+                true
+            )
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a/b'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/a'
+        );
+    }
+
+    public function testParentPruningStopsWhenCachesWereOmitted(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a/b', 0755, true);
+        file_put_contents(
+            $this->filesystem_root . '/selected/a/b/stale.txt',
+            'stale'
+        );
+        $work_directory = $this->work_directory('cache-prune-boundary');
+        $processor = $this->startCleanup(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('cache-prune-result.jsonl', []),
+            $work_directory,
+            ['selected']
+        );
+
+        $this->run_to_completion($processor);
+
+        $this->assertFileDoesNotExist(
+            $this->filesystem_root . '/selected/a/b/stale.txt'
+        );
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/a/b'
+        );
+    }
+
+    public function testTamperedRemovalCursorRechecksEmptyDirectoryNamespace(): void
+    {
+        mkdir($this->filesystem_root . '/selected/a', 0755, true);
+        $work_directory = $this->work_directory(
+            'tampered-empty-directory-scope'
+        );
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('tampered-empty-directory-result.jsonl', []),
+            $work_directory,
+            $this->localScopeConfig(
+                [['kind' => 'root', 'path' => '/selected']],
+                [],
+                [],
+                [],
+                ['/'],
+                [],
+                true
+            )
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->flush_pending_output();
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $processor->close();
+
+        $cursor['file_sync_change_scope_config'] = $this->localScopeConfig(
+            [['kind' => 'root', 'path' => '/current']],
+            [['kind' => 'root', 'path' => '/selected']],
+            [
+                ['kind' => 'ancestor', 'path' => '/selected/a'],
+                ['kind' => 'root', 'path' => '/selected/a/future'],
+            ],
+            [],
+            ['/'],
+            [],
+            true
+        );
+        $resumed = FileSyncCleanupProcessor::resume($cursor);
+        $this->run_to_completion($resumed);
+
+        $this->assertDirectoryExists(
+            $this->filesystem_root . '/selected/a'
+        );
+    }
+
+    public function testTamperedOutOfScopeRemovalCursorIgnoresPhysicalDrift(): void
+    {
+        mkdir($this->filesystem_root . '/selected', 0755, true);
+        $path = $this->filesystem_root . '/selected/entry';
+        file_put_contents($path, 'old file');
+        $work_directory = $this->work_directory('out-of-scope-drift');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->write_index('out-of-scope-drift-result.jsonl', [
+                $this->entry('selected/entry', 'link'),
+            ]),
+            $work_directory,
+            $this->localScopeConfig([
+                ['kind' => 'exact', 'path' => '/selected/entry'],
+            ], [], [], [], ['/selected'])
+        );
+        do {
+            $processor->next_step();
+        } while ($processor->get_phase() !== 'removing');
+        $processor->flush_pending_output();
+        $cursor = $this->stored_cursor($processor->get_cursor());
+        $processor->close();
+
+        // An exact link atom does not authorize changing a file at that path.
+        $cursor['position']['governing_type'] = 'file';
+        file_put_contents($path, 'new file state');
+        clearstatcache(true, $path);
+        $resumed = FileSyncCleanupProcessor::resume($cursor);
+
+        $this->assertFalse($resumed->next_step());
+        $this->assertSame('complete', $resumed->get_status());
+        $this->assertSame('new file state', file_get_contents($path));
+        $resumed->close();
+    }
+
     public function testCursorStoresArbitraryBytePathsAsBase64(): void
     {
         $included_root = "selected-\xff";
@@ -646,7 +1170,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         }
         file_put_contents($this->filesystem_root . '/' . $path, 'delete');
         $work_directory = $this->work_directory("arbitrary-\xfd");
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('arbitrary-result.jsonl', []),
@@ -662,9 +1186,15 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             base64_encode($path),
             $cursor['position']['path_b64']
         );
+        $this->assertArrayNotHasKey(
+            'included_index_path_roots_b64',
+            $cursor
+        );
         $this->assertSame(
-            [base64_encode($included_root)],
-            $cursor['included_index_path_roots_b64']
+            'local_relative',
+            $cursor['file_sync_change_scope_config'][
+                'index_path_coordinates'
+            ]
         );
         $processor->flush_pending_output();
         $processor->close();
@@ -677,7 +1207,7 @@ final class FileSyncCleanupProcessorTest extends TestCase {
     public function testCompleteAndCloseAreStable(): void
     {
         $work_directory = $this->work_directory('complete');
-        $processor = FileSyncCleanupProcessor::start(
+        $processor = $this->startCleanup(
             $work_directory,
             $this->filesystem_root,
             $this->write_index('complete-result.jsonl', []),
@@ -696,6 +1226,190 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $this->assertFalse($resumed->next_step());
         $this->assertSame('complete', $resumed->get_status());
         $resumed->close();
+    }
+
+    /**
+     * Starts cleanup through a local-coordinate selection scope.
+     *
+     * @param list<string> $included_index_path_roots
+     * @param list<string> $excluded_index_path_roots
+     */
+    private function startCleanup(
+        string $work_directory,
+        string $filesystem_root,
+        string $patch_result_index_file,
+        string $storage_path,
+        array $included_index_path_roots = [''],
+        array $excluded_index_path_roots = [],
+        bool $include_caches = false
+    ): FileSyncCleanupProcessor {
+        $remote_roots = array_map(
+            static fn (string $path): string => $path === ''
+                ? '/'
+                : '/' . $path,
+            $included_index_path_roots
+        );
+        return FileSyncCleanupProcessor::start(
+            $work_directory,
+            $patch_result_index_file,
+            $storage_path,
+            $this->localScopeConfig(
+                array_map(
+                    static fn (string $path): array => [
+                        'kind' => 'root',
+                        'path' => $path,
+                    ],
+                    $remote_roots
+                ),
+                [],
+                [],
+                array_map(
+                    static fn (string $path): string => $path === ''
+                        ? '/'
+                        : '/' . $path,
+                    $excluded_index_path_roots
+                ),
+                $remote_roots,
+                [],
+                $include_caches
+            )
+        );
+    }
+
+    /**
+     * @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $current_atoms
+     * @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $prior_atoms
+     * @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $protected_atoms
+     * @param list<string> $excluded_remote_roots
+     * @param list<string> $original_remote_roots
+     * @param array<string,string> $resolved_path_mappings
+     * @return array<string,mixed>
+     */
+    private function localScopeConfig(
+        array $current_atoms,
+        array $prior_atoms = [],
+        array $protected_atoms = [],
+        array $excluded_remote_roots = [],
+        array $original_remote_roots = ['/'],
+        array $resolved_path_mappings = [],
+        bool $include_caches = false
+    ): array {
+        $current_snapshot_id = $this->publishOwnershipSnapshot(
+            $current_atoms
+        );
+        $ownership_directory = $this->last_ownership_directory;
+        $prior_snapshot_ids = $prior_atoms === []
+            ? []
+            : [$this->publishOwnershipSnapshot(
+                $prior_atoms,
+                $ownership_directory
+            )];
+        $protected_snapshot_ids = $protected_atoms === []
+            ? []
+            : [$this->publishOwnershipSnapshot(
+                $protected_atoms,
+                $ownership_directory
+            )];
+        sort($prior_snapshot_ids, SORT_STRING);
+        sort($protected_snapshot_ids, SORT_STRING);
+        sort($excluded_remote_roots, SORT_STRING);
+        $mapper = new RemoteToLocalPathMapper(
+            $this->filesystem_root,
+            $original_remote_roots,
+            $resolved_path_mappings
+        );
+        $remote_scope = FileSyncChangeScope::from_config([
+            'index_path_coordinates' => 'remote_absolute',
+            'ownership_directory_b64' => base64_encode($ownership_directory),
+            'current_snapshot_id' => $current_snapshot_id,
+            'prior_snapshot_ids' => $prior_snapshot_ids,
+            'protected_snapshot_ids' => $protected_snapshot_ids,
+            'excluded_remote_absolute_path_roots_b64' => array_map(
+                'base64_encode',
+                $excluded_remote_roots
+            ),
+            'include_caches' => $include_caches,
+        ]);
+        $mapping_work_directory = $this->temporary_directory
+            . '/scope-mapping-' . bin2hex(random_bytes(4));
+        mkdir($mapping_work_directory, 0755, true);
+        $mapping_processor = FileSyncChangeScopeMappingProcessor::start(
+            $remote_scope,
+            $mapper,
+            $mapping_work_directory
+        );
+        do {
+            $has_next_mapping_step = $mapping_processor->next_step();
+        } while ($has_next_mapping_step);
+        $local_scope_config =
+            $mapping_processor->get_local_change_scope_config();
+        $mapping_processor->close();
+        $remote_scope->close();
+        return $local_scope_config;
+    }
+
+    /**
+     * @param list<array{kind:'root'|'exact'|'ancestor',path:string}> $atoms
+     */
+    private function publishOwnershipSnapshot(
+        array $atoms,
+        ?string $ownership_directory = null
+    ): string
+    {
+        if ($ownership_directory === null) {
+            $ownership_directory = $this->temporary_directory . '/ownership-'
+                . bin2hex(random_bytes(4));
+            $this->last_ownership_directory = $ownership_directory;
+            mkdir($ownership_directory . '/snapshots', 0755, true);
+        }
+        usort(
+            $atoms,
+            static fn (array $left, array $right): int => strcmp(
+                $left['path'] . "\0" . $left['kind'],
+                $right['path'] . "\0" . $right['kind']
+            )
+        );
+        $snapshot_id = hash('sha256', random_bytes(16));
+        $paths_path = $this->ownershipSnapshotPath(
+            $snapshot_id,
+            'paths.jsonl',
+            $ownership_directory
+        );
+        $paths_handle = fopen($paths_path, 'wb');
+        $this->assertIsResource($paths_handle);
+        $lookup_rows = [];
+        foreach ($atoms as $atom) {
+            $paths_byte_offset = ftell($paths_handle);
+            $this->assertIsInt($paths_byte_offset);
+            fwrite($paths_handle, json_encode([
+                'kind' => $atom['kind'],
+                'path_b64' => base64_encode($atom['path']),
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n");
+            $lookup_rows[] = hash(
+                'sha256',
+                $atom['kind'] . "\0" . $atom['path']
+            ) . ' ' . sprintf('%016x', $paths_byte_offset) . "\n";
+        }
+        fclose($paths_handle);
+        sort($lookup_rows, SORT_STRING);
+        file_put_contents(
+            $this->ownershipSnapshotPath(
+                $snapshot_id,
+                'lookup',
+                $ownership_directory
+            ),
+            implode('', $lookup_rows)
+        );
+        return $snapshot_id;
+    }
+
+    private function ownershipSnapshotPath(
+        string $snapshot_id,
+        string $extension,
+        string $ownership_directory
+    ): string {
+        return $ownership_directory . '/snapshots/'
+            . $snapshot_id . '.' . $extension;
     }
 
     /** @return list<string> */


### PR DESCRIPTION
File-sync cleanup now derives all removal authority from one local change scope. Deletes use the prior entry type, replacements use the desired entry type, and parent pruning requires subtree authority, so exclusions, protected aliases, and mapping holes stop destructive cleanup.

The initial local scan supplements only selected skipped paths instead of traversing every cache tree. Exact selected links can be removed or replaced while unrelated skipped FIFOs and unreadable directories remain untouched.