### PR TITLE
[PHP] Make mirror the default files-pull intent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -214,7 +214,7 @@ jobs:
           while { [ "$files_pull_status" -eq 2 ] || [ "$files_pull_status" -eq 124 ]; } \
                 && [ "$files_pull_attempt" -lt "$files_pull_max_attempts" ]; do
             files_pull_attempt=$((files_pull_attempt + 1))
-            files_pull_output="$(timeout 60 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" && files_pull_status=0 || files_pull_status=$?
+            files_pull_output="$(timeout 60 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" --intent=catch-up 2>&1)" && files_pull_status=0 || files_pull_status=$?
             echo "$files_pull_output" | head -50
             files_pull_count="$(find "$FS_ROOT" -type f 2>/dev/null | wc -l | tr -d ' ')"
             if [ "$files_pull_status" -eq 2 ]; then

--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ It can be interrupted and resumed at any time — just re-run the same command:
 php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
+File pulls default to `--intent=mirror`. Mirror makes the selected local tree
+match the selected remote tree, including removing selected local paths which
+are absent remotely. Paths outside the selected scope, including excluded
+paths, remain untouched. Use `--intent=catch-up` when the command should apply
+remote content without removing unrelated local content:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --intent=catch-up
+```
+
+An interrupted pull resumes its saved intent when `--intent` is omitted. The
+intent remains part of the retained files-pull state after completion; run
+with `--abort` before starting a pull with a different intent.
+
 The command returns one of three exit codes:
 
 - 0: sync completed
@@ -246,7 +261,7 @@ By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you ne
 the `--on-fs-root-nonempty` flag controls this behavior. It takes the following values:
 
 - `--on-fs-root-nonempty=error` (default): throw an error and abort.
-- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
+- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content. This requires `--intent=catch-up`.
 
 **Filtering files**
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -87,6 +87,8 @@ require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/index/class-file-index-diff-processor.php';
 require_once __DIR__ . '/lib/index/class-file-sync-change-scope.php';
+require_once __DIR__ . '/lib/index/class-file-sync-cleanup-processor.php';
+require_once __DIR__ . '/lib/index/class-pull-local-index-processor.php';
 require_once __DIR__ . '/lib/index/file-sync-path-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
@@ -111,6 +113,7 @@ require_once __DIR__ . '/lib/pull/class-pull.php';
 // Pull index reader and the WAL for completed files-pull mutations.
 require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
 require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
+require_once __DIR__ . '/lib/pull/class-file-sync-change-scope-mapping-processor.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
 require_once __DIR__ . '/lib/pull/class-remote-index-traversal-journal.php';
 require_once __DIR__ . '/lib/pull/class-files-pull-ownership-processor.php';
@@ -152,6 +155,22 @@ register_shutdown_function(function () {
 class ImportClient
 {
     private const FILES_PULL_OWNERSHIP_CHECKPOINT_STEPS = 200;
+    public const FILES_PULL_INTENTS = ['mirror', 'catch-up'];
+    private const FILES_PULL_MIRROR_PROCESSOR_STAGES = [
+        'local_scope',
+        'patch_result',
+        'cleanup',
+        'next_local_index',
+    ];
+    private const FILES_PULL_POST_DIFF_STAGES = [
+        'diff',
+        'cleanup',
+        'fetch',
+        'recreate_intermediate_symlinks',
+        'next_local_index',
+        'install_local_index',
+        'commit_ownership',
+    ];
     /** Commands executed by ImportClient. */
     public const COMMANDS = [
         "pull",
@@ -256,6 +275,9 @@ class ImportClient
 
     private $files_pull_ownership_directory;
 
+    /** @var string Processor-owned files for a mirror files-pull lifecycle. */
+    private $files_pull_mirror_work_directory;
+
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by comparing the next remote index with the remote index. */
     private $fetch_list_file;
 
@@ -349,6 +371,9 @@ class ImportClient
      * Set via --on-fs-root-nonempty, persisted in state so it survives across invocations.
      */
     private $fs_root_nonempty_behavior = 'error';
+
+    /** @var string Files-pull behavior for this invocation: mirror or catch-up. */
+    private $files_pull_intent = 'mirror';
 
     /**
      * Selects a path-filter preset for files-pull.
@@ -506,6 +531,10 @@ class ImportClient
                 "remote-index-traversals.next.jsonl"
             );
         $this->files_pull_ownership_directory = wp_join_unix_paths($this->pull_state_directory, 'files-pull-ownership');
+        $this->files_pull_mirror_work_directory = wp_join_unix_paths(
+            $this->pull_state_directory,
+            'files-pull-mirror'
+        );
         $this->fetch_list_file =
             wp_join_unix_paths($this->pull_state_directory, "fetch-list.jsonl");
         $this->audit_log_file = wp_join_unix_paths($this->state_dir, "audit.log");
@@ -651,6 +680,78 @@ class ImportClient
             $this->assert_resolved_path_mappings_consistent();
         }
     }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option values are not HTML output.
+
+    /** Rejects a files-pull intent supplied by the CLI or a programmatic caller. */
+    private static function assert_files_pull_intent_value($files_pull_intent): void
+    {
+        if (
+            is_string($files_pull_intent)
+            && in_array($files_pull_intent, self::FILES_PULL_INTENTS, true)
+        ) {
+            return;
+        }
+        $invalid_files_pull_intent = is_string($files_pull_intent)
+            ? $files_pull_intent
+            : gettype($files_pull_intent);
+        throw new InvalidArgumentException(
+            "Invalid --intent value: {$invalid_files_pull_intent}. Valid values: "
+            . implode(', ', self::FILES_PULL_INTENTS)
+        );
+    }
+
+    /** Rejects the one non-empty-root behavior which contradicts mirroring. */
+    private static function assert_files_pull_intent_compatible_with_nonempty_behavior(
+        string $files_pull_intent,
+        string $fs_root_nonempty_behavior
+    ): void {
+        if (
+            $files_pull_intent !== "mirror"
+            || $fs_root_nonempty_behavior !== "preserve-local"
+        ) {
+            return;
+        }
+        throw new InvalidArgumentException(
+            "--intent=mirror cannot be combined with "
+            . "--on-fs-root-nonempty=preserve-local because mirror removes "
+            . "local paths absent from the selected remote tree. Use "
+            . "--intent=catch-up to preserve existing local content."
+        );
+    }
+
+    /** Restores and checks the intent before direct files-pull work begins. */
+    private function assert_files_pull_intent_for_lifecycle(
+        bool $has_progress
+    ): void {
+        if ($has_progress) {
+            $saved_intent = $this->get_state()->files_pull_intent;
+            if (!is_string($saved_intent)) {
+                throw new UnexpectedValueException(
+                    "The active files-pull state has no saved intent. Abort it before starting another files-pull."
+                );
+            }
+            self::assert_files_pull_intent_value($saved_intent);
+            $this->files_pull_intent = $saved_intent;
+        } else {
+            self::assert_files_pull_intent_value($this->files_pull_intent);
+        }
+
+        if (
+            $this->files_pull_intent === "catch-up"
+            && $this->get_state()->files_pull_processor_cursor !== null
+        ) {
+            throw new UnexpectedValueException(
+                "Catch-up files-pull state cannot retain a mirror processor cursor."
+            );
+        }
+        self::assert_files_pull_intent_compatible_with_nonempty_behavior(
+            $this->files_pull_intent,
+            $this->get_state()->fs_root_nonempty_behavior
+        );
+    }
+
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
     /**
      * Log the executed command and full argv to the audit log.
@@ -833,6 +934,11 @@ class ImportClient
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         $this->include_caches = $options["include_caches"] ?? false;
         $this->extra_directory = $options["extra_directory"] ?? null;
+        if (array_key_exists("intent", $options)) {
+            $files_pull_intent = $options["intent"];
+            self::assert_files_pull_intent_value($files_pull_intent);
+            $this->files_pull_intent = $files_pull_intent;
+        }
         if (isset($options["fs_root_nonempty_behavior"])) {
             $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
             if (!in_array($this->fs_root_nonempty_behavior, ['error', 'preserve-local'])) {
@@ -958,6 +1064,7 @@ class ImportClient
                 $active_command->command_name === $file_index_lifecycle_command
                 && $active_command->completion_state !== null
                 && $active_command->completion_state !== "complete";
+            $completed_high_level_file_pull_pipeline = false;
             if (in_array($command, ["pull", "pull-files"], true)) {
                 $pull_pipeline = $this->get_state()->pull_pipeline;
                 $stage_sequence = $pull_pipeline->stage_sequence;
@@ -967,6 +1074,10 @@ class ImportClient
                 $pipeline_is_complete =
                     $last_stage !== null
                     && $pull_pipeline->last_completed_stage === $last_stage;
+                $completed_high_level_file_pull_pipeline =
+                    $pull_pipeline->started_by_command === $command
+                    && $stage_sequence !== []
+                    && $pipeline_is_complete;
                 $is_resuming_file_index_lifecycle =
                     $is_resuming_file_index_lifecycle
                     || (
@@ -974,6 +1085,51 @@ class ImportClient
                         && $stage_sequence !== []
                         && !$pipeline_is_complete
                     );
+            }
+
+            if ($file_index_lifecycle_command === "files-pull") {
+                $intent_was_explicit = array_key_exists("intent", $options);
+                $saved_intent = $this->get_state()->files_pull_intent;
+                $completed_direct_files_pull =
+                    $command === "files-pull"
+                    && $active_command->command_name === "files-pull"
+                    && $active_command->completion_state === "complete";
+                // A completed command keeps its saved intent until abort, so
+                // a no-op or high-level re-pull cannot silently switch modes.
+                if (
+                    (
+                        $is_resuming_file_index_lifecycle
+                        || $completed_direct_files_pull
+                        || $completed_high_level_file_pull_pipeline
+                    )
+                    && !$abort
+                ) {
+                    if (!is_string($saved_intent)) {
+                        throw new UnexpectedValueException(
+                            "The active files-pull state has no saved intent. Abort it before starting another files-pull."
+                        );
+                    }
+                    if (
+                        $intent_was_explicit
+                        && $this->files_pull_intent !== $saved_intent
+                    ) {
+                        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option values are not HTML output.
+                        throw new RuntimeException(
+                            "Cannot change --intent from {$saved_intent} to {$this->files_pull_intent} "
+                            . "while files-pull state is retained. Use the saved intent, or use --abort "
+                                . "before starting another files-pull."
+                        );
+                        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                    }
+                    $this->files_pull_intent = $saved_intent;
+                } elseif (!$intent_was_explicit) {
+                    $this->files_pull_intent = "mirror";
+                }
+                $options["intent"] = $this->files_pull_intent;
+                if (!$abort) {
+                    $this->get_state()->files_pull_intent =
+                        $this->files_pull_intent;
+                }
             }
 
             if (
@@ -1058,6 +1214,17 @@ class ImportClient
             $this->save_state();
         } else {
             $this->follow_symlinks = $this->get_state()->follow_symlinks;
+        }
+
+        $effective_fs_root_nonempty_behavior =
+            array_key_exists("fs_root_nonempty_behavior", $options)
+                ? $this->fs_root_nonempty_behavior
+                : $this->get_state()->fs_root_nonempty_behavior;
+        if ($file_index_lifecycle_command === "files-pull" && !$abort) {
+            self::assert_files_pull_intent_compatible_with_nonempty_behavior(
+                $this->files_pull_intent,
+                $effective_fs_root_nonempty_behavior
+            );
         }
 
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
@@ -2447,7 +2614,11 @@ class ImportClient
                 if (is_string($selection_fingerprint)) {
                     $ownership->abort_active_snapshot(
                         $selection_fingerprint,
-                        in_array($current_stage, ['diff', 'fetch'], true),
+                        in_array(
+                            $current_stage,
+                            self::FILES_PULL_POST_DIFF_STAGES,
+                            true
+                        ),
                         $processor_snapshot_id
                     );
                 }
@@ -2478,10 +2649,17 @@ class ImportClient
             @unlink($this->volatile_files_file);
             $this->audit_log("FILE DELETE | {$this->volatile_files_file}");
         }
+        $this->remove_files_pull_mirror_artifacts();
         $this->remove_next_files_pull_ownership_snapshot();
 
         $this->pull_index_journal->apply_pending_records();
         $this->pull_index_journal->remove_empty_wal();
+    }
+
+    /** Removes processor-owned files from a mirror files-pull attempt. */
+    public function remove_files_pull_mirror_artifacts(): void
+    {
+        self::rmdir_recursive($this->files_pull_mirror_work_directory);
     }
 
     /**
@@ -3084,7 +3262,8 @@ class ImportClient
      * - Prior completed files-pull → delta mode (re-index, diff, fetch changes)
      * - In-progress files-pull → resume from saved state
      *
-     * Both modes share the same pipeline: index → ownership → sort → diff → fetch.
+     * Catch-up keeps unrelated local paths. Mirror additionally plans scoped
+     * local cleanup before fetch and verifies the installed local index after.
      */
     public function run_files_pull(): void
     {
@@ -3100,7 +3279,6 @@ class ImportClient
                 "Finish the unfinished files-push before running files-pull."
             );
         }
-        $this->remove_next_files_pull_ownership_snapshot();
         $active_resumable_command =
             $this->get_state()->active_resumable_command;
         $state_command = $active_resumable_command->command_name ?? null;
@@ -3114,6 +3292,11 @@ class ImportClient
             $current_status !== null &&
             $current_status !== "complete";
 
+        if ($current_status !== "complete") {
+            $this->assert_files_pull_intent_for_lifecycle($has_progress);
+        }
+        $this->remove_next_files_pull_ownership_snapshot();
+
         $resuming_diff =
             $has_progress
             && $active_resumable_command->current_stage === "diff";
@@ -3126,6 +3309,7 @@ class ImportClient
         // Already completed.
         if ($current_status === "complete") {
             $this->pull_index_journal->remove_empty_wal();
+            $this->remove_files_pull_mirror_artifacts();
             $remote_index_entry_count = $this->remote_index_entry_count();
             $this->progress->clear_progress_line();
 
@@ -3196,10 +3380,14 @@ class ImportClient
             // A delta sync ($is_delta) naturally has a non-empty filesystem root
             // because we put those files there during the initial sync.
             if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option guidance is not HTML output.
                 throw new RuntimeException(
                     "Filesystem root is not empty and no cursor found. " .
-                        "Either clear the filesystem root, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
+                        "Either clear the filesystem root, use --abort flag, or combine " .
+                        "--intent=catch-up with --on-fs-root-nonempty=preserve-local " .
+                        "to sync while preserving the existing content.",
                 );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
             }
 
             // The empty WAL blocks files-diff and files-push before the first
@@ -3218,6 +3406,8 @@ class ImportClient
                     $state->extra_directory = $this->extra_directory;
                     $state->files_pull_path_selection_fingerprint =
                         $path_selection_fingerprint;
+                    $state->files_pull_intent = $this->files_pull_intent;
+                    $state->files_pull_processor_cursor = null;
                     $state->diff = new FileDiffProgressState();
                     $state->index = new RemoteFileIndexState();
                     $state->fetch = new FetchListProgressState();
@@ -3267,7 +3457,17 @@ class ImportClient
         $this->save_state();
 
         $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
-        if ($stage !== "diff") {
+        if (in_array(
+            $stage,
+            [
+                "index",
+                "ownership",
+                "sort",
+                "fetch",
+                "recreate_intermediate_symlinks",
+            ],
+            true
+        )) {
             $this->pull_index_journal->open();
         }
 
@@ -3378,7 +3578,10 @@ class ImportClient
 
         if ($stage === "sort") {
             $this->sort_next_remote_index_file();
-            $this->get_state()->active_resumable_command->current_stage = "diff";
+            $next_stage = $this->files_pull_intent === "mirror"
+                ? "local_scope"
+                : "diff";
+            $this->set_files_pull_stage($next_stage, null);
             $this->get_state()->diff = new FileDiffProgressState();
             $this->pull_index_journal->close();
             if (file_exists($this->fetch_list_file)) {
@@ -3387,8 +3590,25 @@ class ImportClient
                     "FILE DELETE | {$this->fetch_list_file} | clearing before diff stage",
                 );
             }
+            if ($next_stage === "local_scope") {
+                $this->get_state()->active_resumable_command
+                    ->completion_state = "partial";
+            }
             $this->save_state();
-            $stage = "diff";
+            $stage = $next_stage;
+            if ($stage === "local_scope") {
+                return;
+            }
+        }
+
+        if ($stage === "local_scope") {
+            $this->take_files_pull_local_scope_step();
+            return;
+        }
+
+        if ($stage === "patch_result") {
+            $this->take_files_pull_patch_result_step();
+            return;
         }
 
         if ($stage === "diff") {
@@ -3402,10 +3622,12 @@ class ImportClient
             $has_files_to_fetch =
                 file_exists($this->fetch_list_file) &&
                 filesize($this->fetch_list_file) > 0;
-            $stage = "fetch";
-            $this->get_state()->active_resumable_command->current_stage = $stage;
-            // Save the fetch stage before applying the WAL. From this stage,
-            // startup applies any pending WAL before it resumes the fetch list.
+            $stage = $this->files_pull_intent === "mirror"
+                ? "cleanup"
+                : "fetch";
+            $this->set_files_pull_stage($stage, null);
+            // Save the post-diff stage before applying the WAL. From this
+            // stage, startup applies any pending WAL before local work resumes.
             $this->save_state();
             $this->pull_index_journal->apply_pending_records();
 
@@ -3432,6 +3654,18 @@ class ImportClient
                     "FILE DELETE | {$this->fetch_list_file} | no files to fetch",
                 );
             }
+
+            if ($this->files_pull_intent === "mirror") {
+                $this->get_state()->active_resumable_command
+                    ->completion_state = "partial";
+                $this->save_state();
+                return;
+            }
+        }
+
+        if ($stage === "cleanup") {
+            $this->take_files_pull_cleanup_step();
+            return;
         }
 
         if ($stage === "fetch") {
@@ -3450,25 +3684,75 @@ class ImportClient
                 );
             }
 
+            if ($this->files_pull_intent === "mirror") {
+                $this->set_files_pull_stage(
+                    "recreate_intermediate_symlinks",
+                    null
+                );
+                $this->get_state()->active_resumable_command
+                    ->completion_state = "partial";
+                $this->save_state();
+                return;
+            }
         }
 
         // Recreate intermediate path symlinks so the full symlink chain
         // works locally.  The server discovers these (e.g. /srv/wordpress
         // -> /wordpress) and includes them in the next remote index.
-        if ($this->follow_symlinks) {
-            $file_sync_change_scope =
-                $this->create_files_pull_remote_change_scope();
-            try {
-                $this->recreate_intermediate_symlinks(
-                    $file_sync_change_scope
-                );
-            } finally {
-                $file_sync_change_scope->close();
+        if (
+            $stage === "fetch"
+            || $stage === "recreate_intermediate_symlinks"
+        ) {
+            if ($this->follow_symlinks) {
+                $file_sync_change_scope =
+                    $this->files_pull_intent === "mirror"
+                        ? $this->open_files_pull_local_change_scope()
+                        : $this->create_files_pull_remote_change_scope();
+                try {
+                    $this->recreate_intermediate_symlinks(
+                        $file_sync_change_scope
+                    );
+                } finally {
+                    $file_sync_change_scope->close();
+                }
             }
+            $this->pull_index_journal->apply_pending_records();
         }
-        $this->pull_index_journal->apply_pending_records();
 
-        $this->ensure_local_index_exists();
+        if (
+            $stage === "recreate_intermediate_symlinks"
+            && $this->files_pull_intent === "mirror"
+        ) {
+            $this->set_files_pull_stage("next_local_index", null);
+            $this->get_state()->active_resumable_command
+                ->completion_state = "partial";
+            $this->save_state();
+            return;
+        }
+
+        if ($stage === "next_local_index") {
+            $this->take_files_pull_next_local_index_step();
+            return;
+        }
+
+        if ($stage === "install_local_index") {
+            $this->install_files_pull_mirror_local_index();
+            $this->set_files_pull_stage("commit_ownership", null);
+            $this->get_state()->active_resumable_command
+                ->completion_state = "partial";
+            $this->save_state();
+            return;
+        }
+
+        if ($this->files_pull_intent === "catch-up") {
+            $this->ensure_local_index_exists();
+        } elseif ($stage !== "commit_ownership") {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Durable stage names are CLI values, never HTML output.
+            throw new UnexpectedValueException(
+                "Mirror files-pull reached an invalid completion stage: {$stage}."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
         $selection_fingerprint = $this->get_state()->files_pull_path_selection_fingerprint;
         if (!is_string($selection_fingerprint)) {
             throw new RuntimeException('Completed files-pull has no path-selection fingerprint.');
@@ -3477,11 +3761,12 @@ class ImportClient
             function () use ($selection_fingerprint): void {
                 $this->get_state()->files_pull_ownership->commit_active_snapshot($selection_fingerprint);
                 $this->get_state()->active_resumable_command->completion_state = "complete";
-                $this->get_state()->active_resumable_command->current_stage = null;
+                $this->set_files_pull_stage(null, null);
             },
             [$this, 'save_state']
         );
         $this->pull_index_journal->remove_empty_wal();
+        $this->remove_files_pull_mirror_artifacts();
 
         $this->progress->clear_progress_line();
         $remote_index_entry_count = $this->remote_index_entry_count();
@@ -3997,6 +4282,10 @@ class ImportClient
         if (!$next_remote_index_file_handle) {
             return;
         }
+        $scope_uses_local_coordinates =
+            $file_sync_change_scope->get_config()[
+                'index_path_coordinates'
+            ] === 'local_relative';
 
         $created = 0;
         while (($next_remote_index_json_line = fgets($next_remote_index_file_handle)) !== false) {
@@ -4036,25 +4325,42 @@ class ImportClient
                 continue;
             }
 
-            if (
-                !$file_sync_change_scope->index_entry_may_change(
-                    $remote_absolute_path,
-                    'link'
-                )
-            ) {
-                continue;
-            }
+            if ($scope_uses_local_coordinates) {
+                $local_relative_path = $file_sync_change_scope
+                    ->map_changeable_remote_index_entry_to_local_index_path(
+                        $remote_absolute_path,
+                        'link'
+                    );
+                if ($local_relative_path === null) {
+                    continue;
+                }
+                $local_absolute_path = $local_relative_path === ""
+                    ? $this->filesystem_root
+                    : wp_join_unix_paths(
+                        $this->filesystem_root,
+                        $local_relative_path
+                    );
+            } else {
+                if (
+                    !$file_sync_change_scope->index_entry_may_change(
+                        $remote_absolute_path,
+                        'link'
+                    )
+                ) {
+                    continue;
+                }
 
-            try {
-                $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
-                    $remote_absolute_path
-                );
-            } catch (RuntimeException $e) {
-                $this->audit_log(
-                    "INTERMEDIATE SYMLINK SKIP: invalid path {$remote_absolute_path}: " . $e->getMessage(),
-                    true,
-                );
-                continue;
+                try {
+                    $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+                        $remote_absolute_path
+                    );
+                } catch (RuntimeException $e) {
+                    $this->audit_log(
+                        "INTERMEDIATE SYMLINK SKIP: invalid path {$remote_absolute_path}: " . $e->getMessage(),
+                        true,
+                    );
+                    continue;
+                }
             }
 
             $preserve_local_skip_reason =
@@ -7633,23 +7939,25 @@ class ImportClient
         }
 
         $file_diff_progress_state = $this->get_state()->diff;
-        $file_sync_change_scope =
-            $this->create_files_pull_remote_change_scope();
+        $file_sync_change_scope = null;
+        $remote_change_scope = null;
         $index_diff = null;
         $fetch_list_file_handle = null;
         try {
+            $file_sync_change_scope = $this->files_pull_intent === "mirror"
+                ? $this->open_files_pull_local_change_scope()
+                : $this->create_files_pull_remote_change_scope();
+            $remote_change_scope = $this->files_pull_intent === "mirror"
+                ? $this->create_files_pull_remote_change_scope()
+                : null;
             $index_diff = FileIndexDiffProcessor::resume(
                 $this->remote_index_file,
                 $this->next_remote_index_file,
                 $file_diff_progress_state->index_diff_cursor,
                 [RemoteIndexReader::class, "decode_index_line"]
             );
-            $remote_to_local_path_mapper = new RemoteToLocalPathMapper(
-                $this->filesystem_root,
-                $this->get_export_directories(),
-                $this->resolved_path_mappings,
-                $this->local_followed_symlinks_root
-            );
+            $remote_to_local_path_mapper =
+                $this->create_files_pull_path_mapper();
             $fetch_list_file_handle = fopen($this->fetch_list_file, "c+b");
             $fetch_list_file_stat = is_resource($fetch_list_file_handle)
                 ? fstat($fetch_list_file_handle)
@@ -7698,7 +8006,44 @@ class ImportClient
 
                     $remote_absolute_path = $index_diff->get_path();
                     $transition = $index_diff->get_path_transition();
-                    if ($transition === "deleted") {
+                    if (
+                        $transition === "deleted"
+                        && $this->files_pull_intent === "mirror"
+                    ) {
+                        $deleted_path_type =
+                            $index_diff->get_path_type_in_old_index();
+                        if ($remote_change_scope === null) {
+                            throw new LogicException(
+                                "Mirror diff requires its remote change scope."
+                            );
+                        }
+                        $deleted_index_entry_may_change =
+                            $remote_change_scope->index_entry_may_change(
+                                $remote_absolute_path,
+                                $deleted_path_type
+                            );
+                        $empty_directory_is_now_implied_by_a_descendant =
+                            $deleted_path_type === "dir"
+                            && file_sync_result_contains_path_or_descendant(
+                                $remote_absolute_path,
+                                $index_diff
+                                    ->get_preceding_path_in_new_index(),
+                                $index_diff
+                                    ->get_following_path_in_new_index()
+                            );
+                        if (
+                            $deleted_index_entry_may_change
+                            || $empty_directory_is_now_implied_by_a_descendant
+                        ) {
+                            // Cleanup owns the local mutation. The WAL only
+                            // removes the confirmed remote entry before that
+                            // bounded processor starts.
+                            $this->pull_index_journal
+                                ->record_remote_invalidation(
+                                    $remote_absolute_path
+                                );
+                        }
+                    } elseif ($transition === "deleted") {
                         $deleted_path_type =
                             $index_diff->get_path_type_in_old_index();
                         $deleted_path_is_empty_directory =
@@ -7821,10 +8166,24 @@ class ImportClient
                             }
                         }
                     } elseif (
-                        $transition !== "unchanged"
-                        && $file_sync_change_scope->index_entry_may_change(
-                            $remote_absolute_path,
-                            $index_diff->get_path_type_in_new_index()
+                        (
+                            $this->files_pull_intent === "mirror"
+                            || $transition !== "unchanged"
+                        )
+                        && (
+                            $this->files_pull_intent === "mirror"
+                                ? $file_sync_change_scope
+                                    ->map_changeable_remote_index_entry_to_local_index_path(
+                                        $remote_absolute_path,
+                                        $index_diff
+                                            ->get_path_type_in_new_index()
+                                    ) !== null
+                                : $file_sync_change_scope
+                                    ->index_entry_may_change(
+                                        $remote_absolute_path,
+                                        $index_diff
+                                            ->get_path_type_in_new_index()
+                                    )
                         )
                     ) {
                         // Preserve-local protects only paths which no earlier
@@ -7889,7 +8248,12 @@ class ImportClient
             if ($index_diff !== null) {
                 $index_diff->close();
             }
-            $file_sync_change_scope->close();
+            if ($file_sync_change_scope !== null) {
+                $file_sync_change_scope->close();
+            }
+            if ($remote_change_scope !== null) {
+                $remote_change_scope->close();
+            }
             if (is_resource($fetch_list_file_handle)) {
                 fclose($fetch_list_file_handle);
             }
@@ -7917,6 +8281,391 @@ class ImportClient
                 $this->get_state()->include_caches
             );
     }
+
+    /** Creates the one remote-to-local mapper used by this files-pull lifecycle. */
+    private function create_files_pull_path_mapper(): RemoteToLocalPathMapper
+    {
+        return new RemoteToLocalPathMapper(
+            $this->filesystem_root,
+            $this->get_export_directories(),
+            $this->resolved_path_mappings,
+            $this->local_followed_symlinks_root
+        );
+    }
+
+    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions contain CLI filesystem paths, never HTML output.
+    /** Stores a files-pull stage and the cursor owned by that stage. */
+    private function set_files_pull_stage(
+        ?string $stage,
+        ?array $processor_cursor
+    ): void {
+        if (
+            $processor_cursor !== null
+            && (
+                $this->files_pull_intent !== "mirror"
+                || !in_array(
+                    $stage,
+                    self::FILES_PULL_MIRROR_PROCESSOR_STAGES,
+                    true
+                )
+            )
+        ) {
+            throw new LogicException(
+                "Only an active mirror processor stage may retain the files-pull processor cursor."
+            );
+        }
+        $this->get_state()->active_resumable_command->current_stage = $stage;
+        $this->get_state()->files_pull_processor_cursor =
+            $processor_cursor;
+    }
+
+    /** Takes one durable selected-path materialization step. */
+    private function take_files_pull_local_scope_step(): void
+    {
+        $remote_change_scope =
+            $this->create_files_pull_remote_change_scope();
+        $path_mapper = $this->create_files_pull_path_mapper();
+        $work_directory = $this->files_pull_mirror_stage_work_directory(
+            'local-scope'
+        );
+        $saved_cursor =
+            $this->get_state()->files_pull_processor_cursor;
+        $processor = null;
+        try {
+            $processor = $saved_cursor === null
+                ? FileSyncChangeScopeMappingProcessor::start(
+                    $remote_change_scope,
+                    $path_mapper,
+                    $work_directory
+                )
+                : FileSyncChangeScopeMappingProcessor::resume(
+                    $remote_change_scope,
+                    $path_mapper,
+                    $work_directory,
+                    $saved_cursor
+                );
+            $has_next_step = $processor->next_step();
+            $processor_cursor = $processor->get_cursor();
+            if ($has_next_step) {
+                $this->set_files_pull_stage(
+                    'local_scope',
+                    $processor_cursor
+                );
+            } else {
+                $this->write_files_pull_local_change_scope_config(
+                    $processor->get_local_change_scope_config()
+                );
+                $this->set_files_pull_stage('patch_result', null);
+            }
+        } finally {
+            if ($processor !== null) {
+                $processor->close();
+            }
+            $remote_change_scope->close();
+        }
+        $this->get_state()->active_resumable_command->completion_state =
+            'partial';
+        $this->save_state();
+    }
+
+    /** Takes one patch-result index processor step. */
+    private function take_files_pull_patch_result_step(): void
+    {
+        $saved_cursor =
+            $this->get_state()->files_pull_processor_cursor;
+        $processor = null;
+        $change_scope = null;
+        try {
+            if ($saved_cursor === null) {
+                $change_scope = $this->open_files_pull_local_change_scope();
+                $processor = PullLocalIndexProcessor::start_patch_result(
+                    $this->files_pull_mirror_stage_work_directory(
+                        'patch-result'
+                    ),
+                    $this->next_remote_index_file,
+                    $this->local_index_file,
+                    $change_scope
+                );
+                $change_scope = null;
+            } else {
+                $processor = PullLocalIndexProcessor::resume($saved_cursor);
+            }
+
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            $processor_cursor = $processor->get_cursor();
+            if ($has_next_step) {
+                $this->set_files_pull_stage(
+                    'patch_result',
+                    $processor_cursor
+                );
+            } elseif ($processor->get_status() === 'restart') {
+                $processor->close();
+                $this->restart_files_pull_mirror();
+                return;
+            } elseif ($processor->get_status() === 'complete') {
+                $this->set_files_pull_stage('diff', null);
+                $this->get_state()->diff = new FileDiffProgressState();
+            } else {
+                throw new LogicException(
+                    'Pull local patch-result processor stopped without a terminal status.'
+                );
+            }
+        } finally {
+            if ($processor !== null) {
+                $processor->close();
+            }
+            if ($change_scope !== null) {
+                $change_scope->close();
+            }
+        }
+        $this->get_state()->active_resumable_command->completion_state =
+            'partial';
+        $this->save_state();
+    }
+
+    /** Takes one ownership-scoped local cleanup step. */
+    private function take_files_pull_cleanup_step(): void
+    {
+        $saved_cursor =
+            $this->get_state()->files_pull_processor_cursor;
+        $processor = $saved_cursor === null
+            ? FileSyncCleanupProcessor::start(
+                $this->files_pull_mirror_stage_work_directory('cleanup'),
+                $this->files_pull_patch_result_index_path(),
+                $this->state_dir,
+                $this->read_files_pull_local_change_scope_config()
+            )
+            : FileSyncCleanupProcessor::resume($saved_cursor);
+        try {
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            $processor_cursor = $processor->get_cursor();
+            if ($has_next_step) {
+                $this->set_files_pull_stage('cleanup', $processor_cursor);
+            } elseif ($processor->get_status() === 'restart') {
+                $processor->close();
+                $this->restart_files_pull_mirror();
+                return;
+            } elseif ($processor->get_status() === 'complete') {
+                $this->set_files_pull_stage('fetch', null);
+            } else {
+                throw new LogicException(
+                    'File sync cleanup processor stopped without a terminal status.'
+                );
+            }
+        } finally {
+            $processor->close();
+        }
+        $this->get_state()->active_resumable_command->completion_state =
+            'partial';
+        $this->save_state();
+    }
+
+    /** Takes one next-local-index mapping or verification step. */
+    private function take_files_pull_next_local_index_step(): void
+    {
+        $saved_cursor =
+            $this->get_state()->files_pull_processor_cursor;
+        $processor = null;
+        $change_scope = null;
+        try {
+            if ($saved_cursor === null) {
+                $change_scope = $this->open_files_pull_local_change_scope();
+                $processor = PullLocalIndexProcessor::start_next_local_index(
+                    $this->files_pull_mirror_stage_work_directory(
+                        'next-local-index'
+                    ),
+                    $this->next_remote_index_file,
+                    $this->remote_index_file,
+                    $this->local_index_file,
+                    $change_scope,
+                    $this->state_dir
+                );
+                $change_scope = null;
+            } else {
+                $processor = PullLocalIndexProcessor::resume($saved_cursor);
+            }
+
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            $processor_cursor = $processor->get_cursor();
+            if ($has_next_step) {
+                $this->set_files_pull_stage(
+                    'next_local_index',
+                    $processor_cursor
+                );
+            } elseif ($processor->get_status() === 'restart') {
+                $processor->close();
+                $this->restart_files_pull_mirror();
+                return;
+            } elseif ($processor->get_status() === 'complete') {
+                $this->set_files_pull_stage('install_local_index', null);
+            } else {
+                throw new LogicException(
+                    'Pull local index processor stopped without a terminal status.'
+                );
+            }
+        } finally {
+            if ($processor !== null) {
+                $processor->close();
+            }
+            if ($change_scope !== null) {
+                $change_scope->close();
+            }
+        }
+        $this->get_state()->active_resumable_command->completion_state =
+            'partial';
+        $this->save_state();
+    }
+
+    /** Atomically installs the verified mirror candidate local index. */
+    private function install_files_pull_mirror_local_index(): void
+    {
+        $candidate_index = $this->files_pull_next_local_index_path();
+        if (!is_file($candidate_index)) {
+            throw new RuntimeException(
+                "Verified next local index not found: {$candidate_index}."
+            );
+        }
+        $swap_index = $this->local_index_file . '.mirror.swap';
+        if (!copy($candidate_index, $swap_index)) {
+            throw new RuntimeException(
+                "Failed to copy the verified next local index: {$swap_index}."
+            );
+        }
+        if (!rename($swap_index, $this->local_index_file)) {
+            @unlink($swap_index);
+            throw new RuntimeException(
+                "Failed to install the verified local index: {$this->local_index_file}."
+            );
+        }
+    }
+
+    /** Restarts mirror planning without publishing its candidate ownership. */
+    private function restart_files_pull_mirror(): void
+    {
+        $saved_follow_symlinks = $this->get_state()->follow_symlinks;
+        $saved_include_caches = $this->get_state()->include_caches;
+        $saved_extra_directory = $this->get_state()->extra_directory;
+        $saved_filter = $this->get_state()->filter;
+        $saved_followed_root_fingerprint =
+            $this->get_state()->local_followed_symlinks_root_fingerprint;
+        $this->clear_files_pull_progress();
+
+        $state = $this->get_state();
+        $state->active_resumable_command->command_name = 'files-pull';
+        $state->active_resumable_command->completion_state = 'partial';
+        $state->active_resumable_command->current_stage = 'index';
+        $state->follow_symlinks = $saved_follow_symlinks;
+        $state->include_caches = $saved_include_caches;
+        $state->extra_directory = $saved_extra_directory;
+        $state->filter = $saved_filter;
+        $state->local_followed_symlinks_root_fingerprint =
+            $saved_followed_root_fingerprint;
+        $state->files_pull_intent = 'mirror';
+        $state->files_pull_processor_cursor = null;
+        $state->files_pull_path_selection_fingerprint =
+            $this->files_pull_path_selection_fingerprint();
+        $this->save_state();
+    }
+
+    /** Opens the completed local-coordinate change scope. */
+    private function open_files_pull_local_change_scope(): FileSyncChangeScope
+    {
+        return FileSyncChangeScope::from_config(
+            $this->read_files_pull_local_change_scope_config()
+        );
+    }
+
+    /** @return array<string,mixed> */
+    private function read_files_pull_local_change_scope_config(): array
+    {
+        $path = $this->files_pull_local_change_scope_config_path();
+        $json = @file_get_contents($path);
+        if (!is_string($json)) {
+            throw new RuntimeException(
+                "Failed to read the files-pull local change scope: {$path}."
+            );
+        }
+        $config = json_decode($json, true);
+        if (!is_array($config)) {
+            throw new UnexpectedValueException(
+                "Files-pull local change scope is not a JSON object: {$path}."
+            );
+        }
+        return $config;
+    }
+
+    /** @param array<string,mixed> $config */
+    private function write_files_pull_local_change_scope_config(
+        array $config
+    ): void {
+        $path = $this->files_pull_local_change_scope_config_path();
+        $temporary_path = $path . '.swap';
+        $json = json_encode(
+            $config,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (file_put_contents($temporary_path, $json) !== strlen($json)) {
+            throw new RuntimeException(
+                "Failed to write the files-pull local change scope: {$temporary_path}."
+            );
+        }
+        if (!rename($temporary_path, $path)) {
+            @unlink($temporary_path);
+            throw new RuntimeException(
+                "Failed to publish the files-pull local change scope: {$path}."
+            );
+        }
+    }
+
+    private function files_pull_local_change_scope_config_path(): string
+    {
+        $this->files_pull_mirror_stage_work_directory('local-scope');
+        return wp_join_unix_paths(
+            $this->files_pull_mirror_work_directory,
+            'local-change-scope.json'
+        );
+    }
+
+    private function files_pull_patch_result_index_path(): string
+    {
+        return wp_join_unix_paths(
+            $this->files_pull_mirror_stage_work_directory('patch-result'),
+            'pull_patch_result_index.jsonl'
+        );
+    }
+
+    private function files_pull_next_local_index_path(): string
+    {
+        return wp_join_unix_paths(
+            $this->files_pull_mirror_stage_work_directory(
+                'next-local-index'
+            ),
+            'next_local_index.jsonl'
+        );
+    }
+
+    private function files_pull_mirror_stage_work_directory(
+        string $directory_name
+    ): string {
+        $work_directory = wp_join_unix_paths(
+            $this->files_pull_mirror_work_directory,
+            $directory_name
+        );
+        if (
+            !is_dir($work_directory)
+            && !mkdir($work_directory, 0755, true)
+            && !is_dir($work_directory)
+        ) {
+            throw new RuntimeException(
+                "Failed to create files-pull mirror work directory: {$work_directory}."
+            );
+        }
+        return $work_directory;
+    }
+    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
     /**
      * Count newlines in a file using buffered reads.  Much faster than
@@ -9706,12 +10455,9 @@ class ImportClient
     private function map_remote_absolute_path_to_local_absolute_path(
         string $remote_absolute_path
     ): string {
-        return ( new RemoteToLocalPathMapper(
-            $this->filesystem_root,
-            $this->get_export_directories(),
-            $this->resolved_path_mappings,
-            $this->local_followed_symlinks_root
-        ) )->map_path($remote_absolute_path);
+        return $this->create_files_pull_path_mapper()->map_path(
+            $remote_absolute_path
+        );
     }
 
 
@@ -12302,6 +13048,15 @@ if (
         ],
 
         // ── files-pull options ───────────────────────────────────
+        [
+            'name' => 'intent',
+            'type' => 'value',
+            'target' => 'intent',
+            'placeholder' => 'MODE',
+            'valid_values' => ImportClient::FILES_PULL_INTENTS,
+            'help' => 'File pull intent: mirror (default) or catch-up',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
+        ],
         [
             'name' => 'filter',
             'type' => 'value',

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -328,7 +328,8 @@ class Pull
                 $stages,
                 !empty($options['follow_symlinks']),
                 !empty($options['include_caches']),
-                $options['extra_directory'] ?? null
+                $options['extra_directory'] ?? null,
+                $options['intent'] ?? 'mirror'
             );
             $file_selection_checkpoint_saved =
                 $command === 'pull' || $command === 'pull-files';
@@ -375,6 +376,8 @@ class Pull
                 $state->fetch = new FetchListProgressState();
                 $state->files_pull_summary = new FilesPullSummaryState();
                 $state->files_pull_path_selection_fingerprint = null;
+                $state->files_pull_intent = $options['intent'] ?? 'mirror';
+                $state->files_pull_processor_cursor = null;
                 $this->client->save_state();
                 foreach ([
                     "{$pull_state_directory}/remote-index.next.jsonl",
@@ -384,6 +387,7 @@ class Pull
                         @unlink($path);
                     }
                 }
+                $this->client->remove_files_pull_mirror_artifacts();
             } elseif ($state_command === 'db-pull' && in_array('db-pull', $stages, true)) {
                 // Discard database dump artifacts from any previous runs.
                 $state = $this->client->get_state();
@@ -419,6 +423,8 @@ class Pull
                     $state->follow_symlinks = !empty($options['follow_symlinks']);
                     $state->include_caches = !empty($options['include_caches']);
                     $state->extra_directory = $options['extra_directory'] ?? null;
+                    $state->files_pull_intent = $options['intent'] ?? 'mirror';
+                    $state->files_pull_processor_cursor = null;
                     $state->pull_pipeline->started_by_command = $command;
                     $state->pull_pipeline->stage_sequence = $stages;
                 },
@@ -869,13 +875,15 @@ class Pull
      * @param bool|null   $follow_symlinks Fresh lifecycle link selection, or null to retain it.
      * @param bool        $include_caches  Fresh lifecycle cache selection.
      * @param string|null $extra_directory Fresh lifecycle additional remote directory.
+     * @param string|null $files_pull_intent Fresh lifecycle intent, or null on abort.
      */
     private function prepare_repull(
         string $command,
         array $stage_sequence = [],
         ?bool $follow_symlinks = null,
         bool $include_caches = false,
-        ?string $extra_directory = null
+        ?string $extra_directory = null,
+        ?string $files_pull_intent = null
     ): void
     {
         $state_dir = $this->client->state_dir;
@@ -909,6 +917,7 @@ class Pull
                 $follow_symlinks,
                 $include_caches,
                 $extra_directory,
+                $files_pull_intent,
                 $reset_file_transfer_state,
                 $reset_file_selection_state,
                 $reset_db_state
@@ -937,6 +946,8 @@ class Pull
                     $state->diff = new FileDiffProgressState();
                     $state->fetch = new FetchListProgressState();
                     $state->files_pull_summary = new FilesPullSummaryState();
+                    $state->files_pull_intent = $files_pull_intent;
+                    $state->files_pull_processor_cursor = null;
                 }
                 if ($reset_file_selection_state) {
                     $state->index = new RemoteFileIndexState();
@@ -968,19 +979,28 @@ class Pull
                 @unlink($path);
             }
         }
+        if ($reset_file_transfer_state) {
+            $this->client->remove_files_pull_mirror_artifacts();
+        }
 
         $this->client->audit_log(strtoupper($command) . " | prepared for delta re-pull", true);
     }
 
     /**
-     * Lower-level commands return with completion_state="partial" when a
-     * server timeout drops the connection. This loop retries automatically,
-     * resetting the completion state to "in_progress" so the handler enters
-     * its resume path on the next call.
+     * Lower-level commands return with completion_state="partial" after a
+     * transient request failure or a bounded mirror processor step. This loop
+     * retries request failures up to the ceiling without charging durable
+     * mirror progress against it.
      */
     private function run_until_complete(string $stage, callable $handler): void
     {
-        for ($attempt = 0; $attempt < 1000; $attempt++) {
+        $transient_retry_attempts = 0;
+        while (true) {
+            $state = $this->client->get_state();
+            $previous_files_pull_stage =
+                $state->active_resumable_command->current_stage;
+            $previous_files_pull_processor_cursor =
+                $state->files_pull_processor_cursor;
             $handler();
             $state = $this->client->get_state();
             if ($state->active_resumable_command->completion_state === 'complete') {
@@ -989,13 +1009,27 @@ class Pull
             if ($state->active_resumable_command->completion_state !== 'partial') {
                 throw new RuntimeException("Stage {$stage} stopped before completing.");
             }
+            $mirror_processor_made_durable_progress =
+                $stage === 'files-pull'
+                && $state->files_pull_intent === 'mirror'
+                && (
+                    $state->active_resumable_command->current_stage
+                        !== $previous_files_pull_stage
+                    || $state->files_pull_processor_cursor
+                        !== $previous_files_pull_processor_cursor
+                );
+            if ($mirror_processor_made_durable_progress) {
+                $transient_retry_attempts = 0;
+            } elseif (++$transient_retry_attempts >= 1000) {
+                throw new RuntimeException(
+                    "Stage {$stage} kept reporting partial progress after 1000 retry attempts; aborting."
+                );
+            }
             $state->active_resumable_command->completion_state = 'in_progress';
             $this->client->save_state();
             $this->client->exit_code = 0;
             $this->progress->tick_spinner();
         }
-
-        throw new RuntimeException("Stage {$stage} kept reporting partial progress after 1000 retry attempts; aborting.");
     }
 
     /**

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -65,6 +65,10 @@ class PullState
     public ?string $resolved_path_mappings_fingerprint = null;
     /** @var string|null Files-pull path-selection fingerprint; guards resume. */
     public ?string $files_pull_path_selection_fingerprint = null;
+    /** @var string|null Active or last completed files-pull intent: mirror or catch-up. */
+    public ?string $files_pull_intent = null;
+    /** @var array|null Opaque cursor for the processor owned by the current files-pull stage. */
+    public ?array $files_pull_processor_cursor = null;
     public FilesPullOwnershipState $files_pull_ownership;
     public FilesPullSummaryState $files_pull_summary;
     public DatabaseTableIndexState $db_index;
@@ -144,6 +148,47 @@ class PullState
         $state->max_allowed_packet = $data['max_allowed_packet'];
         $state->resolved_path_mappings_fingerprint = $data['resolved_path_mappings_fingerprint'];
         $state->files_pull_path_selection_fingerprint = $data['files_pull_path_selection_fingerprint'];
+        if (
+            $data['files_pull_intent'] !== null
+            && !in_array($data['files_pull_intent'], ['mirror', 'catch-up'], true)
+        ) {
+            throw new UnexpectedValueException(
+                'PullState files_pull_intent must be mirror, catch-up, or null.'
+            );
+        }
+        if (
+            $data['files_pull_processor_cursor'] !== null
+            && !is_array($data['files_pull_processor_cursor'])
+        ) {
+            throw new UnexpectedValueException(
+                'PullState files_pull_processor_cursor must be an array or null.'
+            );
+        }
+        $state->files_pull_intent = $data['files_pull_intent'];
+        $state->files_pull_processor_cursor = $data['files_pull_processor_cursor'];
+        if (
+            $state->files_pull_processor_cursor !== null
+            && (
+                $state->files_pull_intent !== 'mirror'
+                || $state->active_resumable_command->command_name !== 'files-pull'
+                || $state->active_resumable_command->completion_state === null
+                || $state->active_resumable_command->completion_state === 'complete'
+                || !in_array(
+                    $state->active_resumable_command->current_stage,
+                    [
+                        'local_scope',
+                        'patch_result',
+                        'cleanup',
+                        'next_local_index',
+                    ],
+                    true
+                )
+            )
+        ) {
+            throw new UnexpectedValueException(
+                'PullState files_pull_processor_cursor requires an active mirror processor stage.'
+            );
+        }
         $state->files_pull_ownership = FilesPullOwnershipState::from_array(
             $data['files_pull_ownership']
         );
@@ -253,6 +298,8 @@ class PullState
             'max_allowed_packet' => $this->max_allowed_packet,
             'resolved_path_mappings_fingerprint' => $this->resolved_path_mappings_fingerprint,
             'files_pull_path_selection_fingerprint' => $this->files_pull_path_selection_fingerprint,
+            'files_pull_intent' => $this->files_pull_intent,
+            'files_pull_processor_cursor' => $this->files_pull_processor_cursor,
             'files_pull_ownership' => $this->files_pull_ownership->to_array(),
             'files_pull_summary' => $this->files_pull_summary->to_array(),
             'db_index' => $this->db_index->to_array(),

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -28,6 +28,19 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--exclude=SOURCE', $output);
     }
 
+    public function testFilePullCommandsDescribeTheirIntentOption(): void
+    {
+        foreach (array('pull', 'pull-files', 'files-pull') as $command) {
+            $output = $this->runHelp($command);
+            $this->assertStringContainsString('--intent=MODE', $output, $command);
+            $this->assertStringContainsString(
+                'mirror (default) or catch-up',
+                $output,
+                $command
+            );
+        }
+    }
+
     public function testFilesIndexHelpNamesTheNextRemoteIndexFile(): void
     {
         $output = $this->runHelp('files-index');

--- a/tests/Import/FileIndexProtocolVersionTest.php
+++ b/tests/Import/FileIndexProtocolVersionTest.php
@@ -71,6 +71,7 @@ final class FileIndexProtocolVersionTest extends TestCase
         $result = $this->runCli([
             'pull-files',
             '--on-fs-root-nonempty=preserve-local',
+            '--intent=catch-up',
         ]);
 
         $this->assertSame(1, $result['exit'], $result['output']);
@@ -94,6 +95,7 @@ final class FileIndexProtocolVersionTest extends TestCase
         $result = $this->runCli([
             'pull-files',
             '--on-fs-root-nonempty=preserve-local',
+            '--intent=catch-up',
         ]);
 
         $this->assertStringNotContainsString(

--- a/tests/Import/FileIndexSelectionLifecycleTest.php
+++ b/tests/Import/FileIndexSelectionLifecycleTest.php
@@ -111,6 +111,7 @@ final class FileIndexSelectionLifecycleTest extends TestCase
                     'current_stage' => 'index',
                     'remote_cursor' => null,
                 ],
+                'files_pull_intent' => 'catch-up',
                 'include_caches' => true,
                 'extra_directory' => $this->extraDirectory,
             ]
@@ -145,6 +146,7 @@ final class FileIndexSelectionLifecycleTest extends TestCase
         $options = [
             'command' => 'pull-files',
             'fs_root_nonempty_behavior' => 'preserve-local',
+            'intent' => 'catch-up',
             'progress' => 'jsonl',
         ];
         if ($includeCaches !== null) {

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -480,11 +480,14 @@ final class FilesPullDiffCheckpointTest extends TestCase
 
     private function newClient(): DiffCheckpointTestClient
     {
-        return new DiffCheckpointTestClient(
+        $client = new DiffCheckpointTestClient(
             $this->remoteReprintApiUrl,
             $this->stateDirectory,
             $this->filesystemRoot
         );
+        ( new \ReflectionProperty(\ImportClient::class, 'files_pull_intent') )
+            ->setValue($client, 'catch-up');
+        return $client;
     }
 
     /** Creates a client whose next files-pull operation starts at diff. */
@@ -515,6 +518,7 @@ final class FilesPullDiffCheckpointTest extends TestCase
             'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
             'fs_root_nonempty_behavior' => 'preserve-local',
+            'files_pull_intent' => 'catch-up',
             'files_pull_path_selection_fingerprint' => hash(
                 'sha256',
                 json_encode([

--- a/tests/Import/FilesPullIntentTest.php
+++ b/tests/Import/FilesPullIntentTest.php
@@ -1,0 +1,684 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound, Generic.Files.OneObjectStructurePerFile.MultipleFound, Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- PHPUnit fixture and test use the repository test namespace and style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/** Records intent checkpoints without replacing production option handling. */
+final class FilesPullIntentFakeClient extends \ImportClient
+{
+    public ?string $intent_at_preflight = null;
+    public ?string $intent_at_files_pull = null;
+    public int $preflight_runs = 0;
+    public int $files_pull_runs = 0;
+    public int $bounded_mirror_steps_remaining = 0;
+    public int $alternating_mirror_steps_remaining = 0;
+    public int $stalled_mirror_steps_remaining = 0;
+    public bool $stop_at_preflight = false;
+
+    public function audit_log(string $message, bool $to_console = true): void
+    {
+    }
+
+    public function output_progress(array $data, bool $force = false): void
+    {
+    }
+
+    public function write_progress_file(?string $error = null): void
+    {
+    }
+
+    public function run_preflight(): void
+    {
+        ++$this->preflight_runs;
+        $this->intent_at_preflight = $this->get_state()->files_pull_intent;
+        if ($this->stop_at_preflight) {
+            throw new \RuntimeException('Stop at preflight.');
+        }
+        $this->get_state()->set_preflight_record([
+            'http_code' => 200,
+            'data' => ['ok' => true],
+        ]);
+        $this->get_state()->remote_protocol_version = PULL_PROTOCOL_VERSION;
+        $this->get_state()->active_resumable_command->completion_state =
+            'complete';
+        $this->save_state();
+    }
+
+    public function run_files_pull(): void
+    {
+        ++$this->files_pull_runs;
+        $this->intent_at_files_pull = $this->get_state()->files_pull_intent;
+        $this->get_state()->active_resumable_command->command_name =
+            'files-pull';
+        if ($this->alternating_mirror_steps_remaining > 0) {
+            --$this->alternating_mirror_steps_remaining;
+            $this->get_state()->active_resumable_command->completion_state =
+                'partial';
+            $this->get_state()->active_resumable_command->current_stage =
+                'local_scope';
+            $this->get_state()->files_pull_processor_cursor = [
+                'step' => intdiv($this->files_pull_runs + 1, 2),
+            ];
+            $this->save_state();
+            return;
+        }
+        if ($this->stalled_mirror_steps_remaining > 0) {
+            --$this->stalled_mirror_steps_remaining;
+            $this->get_state()->active_resumable_command->completion_state =
+                'partial';
+            $this->get_state()->active_resumable_command->current_stage =
+                'local_scope';
+            $this->get_state()->files_pull_processor_cursor = [
+                'step' => 'stalled',
+            ];
+            $this->save_state();
+            return;
+        }
+        if ($this->bounded_mirror_steps_remaining > 0) {
+            --$this->bounded_mirror_steps_remaining;
+            $this->get_state()->active_resumable_command->completion_state =
+                'partial';
+            $this->get_state()->active_resumable_command->current_stage =
+                'local_scope';
+            $this->get_state()->files_pull_processor_cursor = [
+                'step' => $this->files_pull_runs,
+            ];
+            $this->save_state();
+            return;
+        }
+        $this->get_state()->active_resumable_command->completion_state =
+            'complete';
+        $this->get_state()->active_resumable_command->current_stage = null;
+        $this->get_state()->files_pull_processor_cursor = null;
+        $this->save_state();
+    }
+}
+
+final class FilesPullIntentTest extends TestCase
+{
+    private string $temporary_directory;
+    private string $state_directory;
+    private string $filesystem_root;
+    private string $pull_state_file;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temporary_directory = sys_get_temp_dir()
+            . '/files-pull-intent-'
+            . bin2hex(random_bytes(6));
+        $this->state_directory = $this->temporary_directory . '/state';
+        $this->filesystem_root = $this->temporary_directory . '/filesystem';
+        mkdir($this->state_directory, 0755, true);
+        mkdir($this->filesystem_root, 0755, true);
+        $this->pull_state_file = $this->state_directory
+            . '/remotes/'
+            . md5('http://fake.invalid')
+            . '/pull/state.json';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_directory($this->temporary_directory);
+        parent::tearDown();
+    }
+
+    public function testNewHighLevelPullDefaultsToMirrorBeforePreflight(): void
+    {
+        $client = $this->new_client();
+        $client->stop_at_preflight = true;
+
+        try {
+            $client->run([
+                'command' => 'pull-files',
+            ]);
+            $this->fail('Expected the test preflight boundary.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('Stop at preflight.', $exception->getMessage());
+        }
+
+        $this->assertSame('mirror', $client->intent_at_preflight);
+        $this->assertSame('mirror', $this->read_state()['files_pull_intent']);
+        $this->assertSame(0, $client->files_pull_runs);
+    }
+
+    /** @dataProvider filesPullCommandProvider */
+    public function testExplicitCatchUpReachesEveryFilesPullEntryPoint(
+        string $command
+    ): void {
+        $client = $this->new_client();
+        if ($command === 'pull') {
+            $client->stop_at_preflight = true;
+        }
+        if ($command === 'files-pull') {
+            $this->write_state([]);
+        }
+
+        try {
+            $options = [
+                'command' => $command,
+                'intent' => 'catch-up',
+            ];
+            if ($command === 'pull') {
+                $options['runtime'] = 'none';
+            }
+            $client->run($options);
+        } catch (\RuntimeException $exception) {
+            if ($command !== 'pull') {
+                throw $exception;
+            }
+            $this->assertSame('Stop at preflight.', $exception->getMessage());
+        }
+
+        $observed_intent = $command === 'pull'
+            ? $client->intent_at_preflight
+            : $client->intent_at_files_pull;
+        $this->assertSame('catch-up', $observed_intent);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    public static function filesPullCommandProvider(): array
+    {
+        return [
+            'pull' => ['pull'],
+            'pull-files' => ['pull-files'],
+            'files-pull' => ['files-pull'],
+        ];
+    }
+
+    public function testOmittedIntentRestoresTheActiveCatchUpLifecycle(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'partial',
+                'current_stage' => 'index',
+            ],
+        ]);
+        $client = $this->new_client();
+
+        $client->run(['command' => 'files-pull']);
+
+        $this->assertSame('catch-up', $client->intent_at_files_pull);
+    }
+
+    public function testHighLevelRetryCarriesTheSavedCatchUpIntent(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => 'preflight',
+                'completion_state' => 'complete',
+            ],
+            'pull_pipeline' => [
+                'started_by_command' => 'pull-files',
+                'stage_sequence' => ['preflight', 'files-pull'],
+                'last_completed_stage' => 'preflight',
+            ],
+        ]);
+        $client = $this->new_client();
+
+        $client->run(['command' => 'pull-files']);
+
+        $this->assertSame('catch-up', $client->intent_at_files_pull);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    public function testBoundedMirrorProgressDoesNotConsumeTheRetryCeiling(): void
+    {
+        $client = $this->new_client();
+        $client->bounded_mirror_steps_remaining = 1001;
+
+        $client->run(['command' => 'pull-files']);
+
+        $this->assertSame(1002, $client->files_pull_runs);
+        $this->assertSame(
+            'complete',
+            $this->read_state()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testDurableMirrorProgressResetsTheRetryCeiling(): void
+    {
+        $client = $this->new_client();
+        $client->alternating_mirror_steps_remaining = 2001;
+
+        $client->run(['command' => 'pull-files']);
+
+        $this->assertSame(2002, $client->files_pull_runs);
+        $this->assertSame(
+            'complete',
+            $this->read_state()['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testStalledMirrorPartialsStillConsumeTheRetryCeiling(): void
+    {
+        $client = $this->new_client();
+        $client->stalled_mirror_steps_remaining = 1001;
+
+        try {
+            $client->run(['command' => 'pull-files']);
+            $this->fail('Expected stalled partial retries to reach the ceiling.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'after 1000 retry attempts',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(1001, $client->files_pull_runs);
+    }
+
+    public function testCompletedCatchUpRetainsItsIntentWhenOmitted(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'complete',
+                'current_stage' => null,
+            ],
+        ]);
+        $client = $this->new_client();
+
+        $client->run(['command' => 'files-pull']);
+
+        $this->assertSame('catch-up', $client->intent_at_files_pull);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    public function testCompletedCatchUpRejectsExplicitIntentDrift(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'complete',
+                'current_stage' => null,
+            ],
+        ]);
+        $client = $this->new_client();
+
+        try {
+            $client->run([
+                'command' => 'files-pull',
+                'intent' => 'mirror',
+            ]);
+            $this->fail('Expected completed intent drift to be rejected.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --intent from catch-up to mirror',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(0, $client->files_pull_runs);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    /** @dataProvider completedHighLevelPipelineProvider */
+    public function testCompletedHighLevelCatchUpRetainsItsOmittedIntent(
+        string $command,
+        array $options,
+        array $stages
+    ): void {
+        $this->write_completed_high_level_catch_up(
+            $command,
+            $stages
+        );
+        $client = $this->new_client();
+        $client->stop_at_preflight = true;
+
+        try {
+            $client->run($options);
+            $this->fail('Expected the test preflight boundary.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('Stop at preflight.', $exception->getMessage());
+        }
+
+        $this->assertSame('catch-up', $client->intent_at_preflight);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    /** @dataProvider completedHighLevelPipelineProvider */
+    public function testCompletedHighLevelCatchUpRejectsIntentDriftBeforeWrite(
+        string $command,
+        array $options,
+        array $stages
+    ): void {
+        $this->write_completed_high_level_catch_up(
+            $command,
+            $stages
+        );
+        $state_before = file_get_contents($this->pull_state_file);
+        $this->assertIsString($state_before);
+        $client = $this->new_client();
+        $options['intent'] = 'mirror';
+
+        try {
+            $client->run($options);
+            $this->fail('Expected completed intent drift to be rejected.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --intent from catch-up to mirror',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(0, $client->preflight_runs);
+        $this->assertSame(
+            $state_before,
+            file_get_contents($this->pull_state_file)
+        );
+    }
+
+    public static function completedHighLevelPipelineProvider(): array
+    {
+        return [
+            'pull-files' => [
+                'pull-files',
+                ['command' => 'pull-files'],
+                ['preflight', 'files-pull'],
+            ],
+            'pull' => [
+                'pull',
+                ['command' => 'pull', 'runtime' => 'none'],
+                ['preflight', 'files-pull', 'db-pull', 'db-apply'],
+            ],
+        ];
+    }
+
+    public function testExplicitIntentDriftIsRejectedBeforeFilesPullRuns(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'partial',
+                'current_stage' => 'index',
+            ],
+        ]);
+        $client = $this->new_client();
+
+        try {
+            $client->run([
+                'command' => 'files-pull',
+                'intent' => 'mirror',
+            ]);
+            $this->fail('Expected intent drift to be rejected.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --intent from catch-up to mirror',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(0, $client->files_pull_runs);
+        $this->assertSame('catch-up', $this->read_state()['files_pull_intent']);
+    }
+
+    public function testProgrammaticInvalidIntentIsRejectedBeforeStateWrite(): void
+    {
+        $client = $this->new_client();
+
+        try {
+            $client->run([
+                'command' => 'pull-files',
+                'intent' => ['mirror'],
+            ]);
+            $this->fail('Expected an invalid programmatic intent.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Invalid --intent value: array. Valid values: mirror, catch-up',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertFileDoesNotExist($this->pull_state_file);
+        $this->assertSame(0, $client->preflight_runs);
+    }
+
+    public function testMirrorRejectsPreserveLocalBeforePreflight(): void
+    {
+        $client = $this->new_client();
+
+        try {
+            $client->run([
+                'command' => 'pull-files',
+                'intent' => 'mirror',
+                'fs_root_nonempty_behavior' => 'preserve-local',
+            ]);
+            $this->fail('Expected mirror and preserve-local to be rejected.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString(
+                'Use --intent=catch-up to preserve existing local content.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(0, $client->preflight_runs);
+        $this->assertFileDoesNotExist($this->pull_state_file);
+    }
+
+    public function testDirectLifecycleRunnerAlsoRejectsMirrorPreserveLocal(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'mirror',
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'partial',
+                'current_stage' => 'index',
+            ],
+        ]);
+        $client = new \ImportClient(
+            'http://fake.invalid',
+            $this->state_directory,
+            $this->filesystem_root
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client)
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Use --intent=catch-up to preserve existing local content.'
+        );
+
+        $client->run_files_pull();
+    }
+
+    public function testAbortClearsIntentCursorAndMirrorArtifacts(): void
+    {
+        $this->write_state([
+            'files_pull_intent' => 'mirror',
+            'files_pull_processor_cursor' => ['phase' => 'scanning_atoms'],
+            'active_resumable_command' => [
+                'command_name' => 'files-pull',
+                'completion_state' => 'partial',
+                'current_stage' => 'local_scope',
+            ],
+        ]);
+        $mirror_work_directory = dirname($this->pull_state_file)
+            . '/files-pull-mirror/local-scope';
+        mkdir($mirror_work_directory, 0755, true);
+        file_put_contents($mirror_work_directory . '/work', 'transient');
+
+        $this->new_client()->run([
+            'command' => 'files-pull',
+            'abort' => true,
+        ]);
+
+        $state = $this->read_state();
+        $this->assertNull($state['files_pull_intent']);
+        $this->assertNull($state['files_pull_processor_cursor']);
+        $this->assertDirectoryDoesNotExist(
+            dirname($this->pull_state_file) . '/files-pull-mirror'
+        );
+    }
+
+    public function testStateRejectsUnknownIntent(): void
+    {
+        $state = ( new \PullState() )->to_array();
+        $state['files_pull_intent'] = 'merge';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'files_pull_intent must be mirror, catch-up, or null'
+        );
+
+        \PullState::from_array($state);
+    }
+
+    public function testStateRejectsNonArrayProcessorCursor(): void
+    {
+        $state = ( new \PullState() )->to_array();
+        $state['files_pull_processor_cursor'] = 'cursor';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'files_pull_processor_cursor must be an array or null'
+        );
+
+        \PullState::from_array($state);
+    }
+
+    public function testStateRoundTripsAnOpaqueMirrorProcessorCursor(): void
+    {
+        $state = ( new \PullState() )->to_array();
+        $state['files_pull_intent'] = 'mirror';
+        $state['files_pull_processor_cursor'] = [
+            'phase' => 'processor-owned',
+        ];
+        $state['active_resumable_command']['command_name'] = 'files-pull';
+        $state['active_resumable_command']['completion_state'] = 'partial';
+        $state['active_resumable_command']['current_stage'] = 'local_scope';
+
+        $round_trip = \PullState::from_array($state)->to_array();
+
+        $this->assertSame(
+            ['phase' => 'processor-owned'],
+            $round_trip['files_pull_processor_cursor']
+        );
+    }
+
+    /** @dataProvider invalidProcessorCursorOwnerProvider */
+    public function testStateRejectsProcessorCursorOutsideAMirrorProcessorStage(
+        ?string $intent,
+        ?string $command,
+        ?string $stage,
+        string $completion_state = 'partial'
+    ): void {
+        $state = ( new \PullState() )->to_array();
+        $state['files_pull_intent'] = $intent;
+        $state['files_pull_processor_cursor'] = ['phase' => 'processing'];
+        $state['active_resumable_command']['command_name'] = $command;
+        $state['active_resumable_command']['completion_state'] =
+            $completion_state;
+        $state['active_resumable_command']['current_stage'] = $stage;
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'files_pull_processor_cursor requires an active mirror processor stage'
+        );
+
+        \PullState::from_array($state);
+    }
+
+    public static function invalidProcessorCursorOwnerProvider(): array
+    {
+        return [
+            'catch-up' => ['catch-up', 'files-pull', 'local_scope'],
+            'another command' => ['mirror', 'files-index', 'local_scope'],
+            'non-processor stage' => ['mirror', 'files-pull', 'fetch'],
+            'completed lifecycle' => [
+                'mirror',
+                'files-pull',
+                'local_scope',
+                'complete',
+            ],
+        ];
+    }
+
+    private function new_client(): FilesPullIntentFakeClient
+    {
+        return new FilesPullIntentFakeClient(
+            'http://fake.invalid',
+            $this->state_directory,
+            $this->filesystem_root
+        );
+    }
+
+    private function write_completed_high_level_catch_up(
+        string $command,
+        array $stages
+    ): void {
+        $this->write_state([
+            'files_pull_intent' => 'catch-up',
+            'active_resumable_command' => [
+                'command_name' => $stages[count($stages) - 1],
+                'completion_state' => 'complete',
+                'current_stage' => null,
+            ],
+            'pull_pipeline' => [
+                'started_by_command' => $command,
+                'stage_sequence' => $stages,
+                'last_completed_stage' => $stages[count($stages) - 1],
+                'has_completed_once' => true,
+            ],
+        ]);
+    }
+
+    private function write_state(array $changes): void
+    {
+        $defaults = [
+            'preflight' => [
+                'http_code' => 200,
+                'data' => ['ok' => true],
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'fs_root_nonempty_behavior' => 'error',
+        ];
+        \write_current_pull_state(
+            $this->new_client(),
+            array_replace_recursive($defaults, $changes)
+        );
+    }
+
+    private function read_state(): array
+    {
+        $contents = file_get_contents($this->pull_state_file);
+        $this->assertIsString($contents);
+        $state = json_decode($contents, true);
+        $this->assertIsArray($state);
+        return $state;
+    }
+
+    private function remove_directory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (scandir($directory) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->remove_directory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -778,6 +778,7 @@ final class FilesPullLocalIndexTest extends TestCase
             $this->targetUrl,
             '--state-dir=' . $this->stateDirectory,
             '--fs-root=' . $this->rawFileRoot,
+            '--intent=catch-up',
         ]);
         $readyPath = $this->root . '/remote-overrides.json.pause-ready';
         $walPath = $this->pullStateDirectory . '/index.wal';
@@ -851,6 +852,7 @@ final class FilesPullLocalIndexTest extends TestCase
             $this->targetUrl,
             '--state-dir=' . $this->stateDirectory,
             '--fs-root=' . $this->rawFileRoot,
+            '--intent=catch-up',
         ], $extraArguments));
     }
 

--- a/tests/Import/FilesPullRemoteChangeScopeTest.php
+++ b/tests/Import/FilesPullRemoteChangeScopeTest.php
@@ -135,6 +135,156 @@ final class FilesPullRemoteChangeScopeTest extends TestCase {
         $this->assertSame([$linkPath], $this->fetchListPaths());
     }
 
+    public function testMirrorSchedulesAnUnchangedSelectedRemoteEntry(): void
+    {
+        $path = '/site/unchanged.txt';
+        $this->writeIndexes([[$path, 'file']], [[$path, 'file']]);
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/site']],
+            [],
+            [],
+            [],
+            false,
+            false,
+            'mirror'
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertSame([$path], $this->fetchListPaths());
+    }
+
+    public function testMirrorDoesNotFetchCurrentEntryThroughProtectedLocalAlias(): void
+    {
+        $path = '/current/file.txt';
+        $canonicalFilesystemRoot = realpath($this->filesystemRoot);
+        $this->assertIsString($canonicalFilesystemRoot);
+        $this->writeIndexes([[$path, 'file']], [[$path, 'file']]);
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/current']],
+            [],
+            [[['kind' => 'root', 'path' => '/protected']]],
+            [],
+            false,
+            false,
+            'mirror',
+            [
+                '/current' => $canonicalFilesystemRoot . '/shared',
+                '/protected' => $canonicalFilesystemRoot . '/shared',
+            ],
+            ['/current', '/protected']
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertSame([], $this->fetchListPaths());
+    }
+
+    public function testMirrorDoesNotDeleteCurrentEntryThroughProtectedLocalAlias(): void
+    {
+        $path = '/current/file.txt';
+        $canonicalFilesystemRoot = realpath($this->filesystemRoot);
+        $this->assertIsString($canonicalFilesystemRoot);
+        $this->writeIndexes([[$path, 'file']]);
+        $localPath = $this->filesystemRoot . '/shared/file.txt';
+        mkdir(dirname($localPath), 0700, true);
+        file_put_contents($localPath, 'x');
+
+        $client = $this->clientAtDiffStage(
+            [['kind' => 'root', 'path' => '/current']],
+            [],
+            [[['kind' => 'root', 'path' => '/protected']]],
+            [],
+            false,
+            false,
+            'mirror',
+            [
+                '/current' => $canonicalFilesystemRoot . '/shared',
+                '/protected' => $canonicalFilesystemRoot . '/shared',
+            ],
+            ['/current', '/protected']
+        );
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertFileExists($localPath);
+        $this->assertSame([], $this->retainedRemoteIndexPaths());
+    }
+
+    public function testMirrorRecreatesOnlyLocallyAuthorizedIntermediateAlias(): void
+    {
+        $canonicalFilesystemRoot = realpath($this->filesystemRoot);
+        $this->assertIsString($canonicalFilesystemRoot);
+        $this->writeIndexes([]);
+        $client = $this->clientAtDiffStage(
+            [
+                ['kind' => 'exact', 'path' => '/current/blocked'],
+                ['kind' => 'exact', 'path' => '/allowed/link'],
+            ],
+            [],
+            [[['kind' => 'root', 'path' => '/protected']]],
+            [],
+            false,
+            false,
+            'mirror',
+            [
+                '/current' => $canonicalFilesystemRoot . '/shared',
+                '/protected' => $canonicalFilesystemRoot . '/shared',
+                '/allowed' => $canonicalFilesystemRoot . '/allowed',
+            ],
+            ['/current', '/protected', '/allowed']
+        );
+        file_put_contents(
+            $this->pullStateDirectory . '/remote-index.next.jsonl',
+            implode("\n", [
+                json_encode([
+                    'path' => base64_encode('/allowed/link'),
+                    'ctime' => 1,
+                    'size' => 6,
+                    'type' => 'link',
+                    'target' => base64_encode('target'),
+                    'intermediate' => true,
+                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+                json_encode([
+                    'path' => base64_encode('/current/blocked'),
+                    'ctime' => 1,
+                    'size' => 6,
+                    'type' => 'link',
+                    'target' => base64_encode('target'),
+                    'intermediate' => true,
+                ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+            ]) . "\n"
+        );
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $scope = $reflection->getMethod(
+            'open_files_pull_local_change_scope'
+        )->invoke($client);
+        try {
+            $reflection->getMethod('recreate_intermediate_symlinks')->invoke(
+                $client,
+                $scope
+            );
+        } finally {
+            $scope->close();
+        }
+
+        $this->assertTrue(is_link($this->filesystemRoot . '/allowed/link'));
+        $this->assertFalse(is_link($this->filesystemRoot . '/shared/blocked'));
+    }
+
+    public function testCatchUpDoesNotScheduleAnUnchangedRemoteEntry(): void
+    {
+        $path = '/site/unchanged.txt';
+        $this->writeIndexes([[$path, 'file']], [[$path, 'file']]);
+
+        $client = $this->clientAtDiffStage([
+            ['kind' => 'root', 'path' => '/site'],
+        ]);
+        $this->runDiffAndApplyJournal($client);
+
+        $this->assertSame([], $this->fetchListPaths());
+    }
+
     public function testImpliedDirectoryInvalidatesOnlyItsStaleExplicitRow(): void
     {
         $directoryPath = '/site/sparse';
@@ -226,6 +376,8 @@ final class FilesPullRemoteChangeScopeTest extends TestCase {
      * @param list<array{kind:'root'|'exact',path:string}> $priorAtoms
      * @param list<list<array{kind:'root'|'exact',path:string}>> $protectedAtomGroups
      * @param list<string> $excludedRemoteAbsolutePathRoots
+     * @param array<string,string> $resolvedPathMappings
+     * @param list<string> $exportDirectories
      */
     private function clientAtDiffStage(
         array $currentAtoms,
@@ -233,7 +385,10 @@ final class FilesPullRemoteChangeScopeTest extends TestCase {
         array $protectedAtomGroups = [],
         array $excludedRemoteAbsolutePathRoots = [],
         bool $persistedIncludeCaches = false,
-        bool $invocationIncludeCaches = false
+        bool $invocationIncludeCaches = false,
+        string $filesPullIntent = 'catch-up',
+        array $resolvedPathMappings = [],
+        array $exportDirectories = ['/']
     ): \ImportClient {
         $activeSnapshotId = reprint_test_write_ownership_snapshot(
             $this->pullStateDirectory,
@@ -274,14 +429,24 @@ final class FilesPullRemoteChangeScopeTest extends TestCase {
             'preflight' => [
                 'data' => [
                     'ok' => true,
-                    'wp_detect' => ['roots' => [['path' => '/']]],
+                    'wp_detect' => [
+                        'roots' => array_map(
+                            static fn (string $path): array => [
+                                'path' => $path,
+                            ],
+                            $exportDirectories
+                        ),
+                    ],
                 ],
                 'http_code' => 200,
             ],
             'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
             'include_caches' => $persistedIncludeCaches,
-            'fs_root_nonempty_behavior' => 'preserve-local',
+            'fs_root_nonempty_behavior' => $filesPullIntent === 'mirror'
+                ? 'error'
+                : 'preserve-local',
+            'files_pull_intent' => $filesPullIntent,
             'files_pull_path_selection_fingerprint' =>
                 self::CURRENT_SELECTION,
             'files_pull_ownership' => [
@@ -301,16 +466,57 @@ final class FilesPullRemoteChangeScopeTest extends TestCase {
         $reflection->getProperty('is_tty')->setValue($client, false);
         $reflection->getProperty('fs_root_nonempty_behavior')->setValue(
             $client,
-            'preserve-local'
+            $filesPullIntent === 'mirror' ? 'error' : 'preserve-local'
+        );
+        $reflection->getProperty('files_pull_intent')->setValue(
+            $client,
+            $filesPullIntent
         );
         $reflection->getProperty('include_caches')->setValue(
             $client,
             $invocationIncludeCaches
         );
+        $reflection->getProperty('resolved_path_mappings')->setValue(
+            $client,
+            $resolvedPathMappings
+        );
         $reflection->getProperty(
             'pull_excluded_files_with_path_prefixes'
         )->setValue($client, $excludedRemoteAbsolutePathRoots);
+        if ($filesPullIntent === 'mirror') {
+            $this->writeMirrorLocalChangeScope($client, $reflection);
+        }
         return $client;
+    }
+
+    private function writeMirrorLocalChangeScope(
+        \ImportClient $client,
+        \ReflectionClass $reflection
+    ): void {
+        $remoteScope = $reflection
+            ->getMethod('create_files_pull_remote_change_scope')
+            ->invoke($client);
+        $pathMapper = $reflection
+            ->getMethod('create_files_pull_path_mapper')
+            ->invoke($client);
+        $processor = \FileSyncChangeScopeMappingProcessor::start(
+            $remoteScope,
+            $pathMapper,
+            $this->pullStateDirectory . '/files-pull-mirror/local-scope'
+        );
+        try {
+            $hasNextStep = true;
+            while ($hasNextStep) {
+                $hasNextStep = $processor->next_step();
+            }
+            $config = $processor->get_local_change_scope_config();
+        } finally {
+            $processor->close();
+            $remoteScope->close();
+        }
+        $reflection->getMethod(
+            'write_files_pull_local_change_scope_config'
+        )->invoke($client, $config);
     }
 
     private function runDiffAndApplyJournal(\ImportClient $client): void

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -169,6 +169,13 @@ class FilesPullStateTest extends TestCase
 
         $behaviorProp = $reflection->getProperty('fs_root_nonempty_behavior');
         $behaviorProp->setValue($client, 'preserve-local');
+        $savedIntent = $client->get_state()->files_pull_intent;
+        if (is_string($savedIntent)) {
+            $reflection->getProperty('files_pull_intent')->setValue(
+                $client,
+                $savedIntent
+            );
+        }
 
         return [$client, $reflection];
     }
@@ -250,6 +257,10 @@ class FilesPullStateTest extends TestCase
 
         // Step 2: new client, try run_files_pull
         [$client2, $reflection2] = $this->prepareClient();
+        $reflection2->getProperty('files_pull_intent')->setValue(
+            $client2,
+            'catch-up'
+        );
 
         try {
             $reflection2->getMethod('run_files_pull')->invoke($client2);
@@ -456,6 +467,7 @@ class FilesPullStateTest extends TestCase
         ], JSON_UNESCAPED_SLASHES));
         $snapshotId = str_repeat('a', 64);
         $this->writeState([
+            'files_pull_intent' => 'catch-up',
             'active_resumable_command' => [
                 'command_name' => 'files-pull',
                 'completion_state' => 'in_progress',
@@ -519,6 +531,7 @@ class FilesPullStateTest extends TestCase
         file_put_contents($localFile, 'old content');
 
         $this->writeState([
+            "files_pull_intent" => "catch-up",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "in_progress",
@@ -559,6 +572,7 @@ class FilesPullStateTest extends TestCase
         file_put_contents($localFile, 'local drop-in');
 
         $this->writeState([
+            "files_pull_intent" => "catch-up",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "in_progress",

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -153,6 +153,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             "follow_symlinks" => false,
             "include_caches" => false,
             "fs_root_nonempty_behavior" => "preserve-local",
+            "files_pull_intent" => "catch-up",
             "files_pull_path_selection_fingerprint" => $selectionFingerprint,
             "files_pull_ownership" => [
                 "committed_snapshot_ids_by_selection_fingerprint" => [],
@@ -171,6 +172,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
         $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
+        $r->getProperty('files_pull_intent')->setValue($client, 'catch-up');
         $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
         $r->getProperty('pull_excluded_files_with_path_prefixes')->setValue($client, $pull_excluded_files_with_path_prefixes);
         return [$client, $r];

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -131,6 +131,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
             'fs_root_nonempty_behavior' => 'preserve-local',
+            'files_pull_intent' => 'catch-up',
             'filter' => 'none',
         );
 

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -307,6 +307,7 @@ class PullFilterOptionTest extends TestCase
     public function testPullResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
     {
         $this->writeState([
+            "files_pull_intent" => "mirror",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "complete",
@@ -338,6 +339,7 @@ class PullFilterOptionTest extends TestCase
     public function testPullResumesSameUnfinishedPipelineWithoutConflict(): void
     {
         $this->writeState([
+            "files_pull_intent" => "mirror",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "in_progress",
@@ -511,6 +513,7 @@ class PullFilterOptionTest extends TestCase
     public function testPullFilesResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void
     {
         $this->writeState([
+            "files_pull_intent" => "mirror",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "complete",

--- a/tests/Import/RemoteFileIndexConfirmedBatchTest.php
+++ b/tests/Import/RemoteFileIndexConfirmedBatchTest.php
@@ -316,6 +316,10 @@ final class RemoteFileIndexConfirmedBatchTest extends TestCase
         ]);
         $reflection = new \ReflectionClass(\ImportClient::class);
         $reflection->getProperty('follow_symlinks')->setValue($client, true);
+        $reflection->getProperty('files_pull_intent')->setValue(
+            $client,
+            'catch-up'
+        );
 
         $client->run_files_pull();
         $this->assertSame(

--- a/tests/Import/RemoteFileIndexTraversalReplayTest.php
+++ b/tests/Import/RemoteFileIndexTraversalReplayTest.php
@@ -526,6 +526,7 @@ PHP,
                 $client,
                 [
                     'command' => 'files-pull',
+                    'intent' => 'catch-up',
                     'follow_symlinks' => true,
                     'fs_root_nonempty_behavior' => 'preserve-local',
                 ]
@@ -633,6 +634,116 @@ PHP,
                 . '/files-pull-ownership/snapshots/'
                 . $snapshotId . '.lookup'
         );
+    }
+
+    public function testFilesPullIntentReconcilesOnlySelectedLocalPaths(): void
+    {
+        $selectedRemoteDirectory = $this->siteDir . '/selected';
+        mkdir($selectedRemoteDirectory);
+        $selectedRemoteDirectory = realpath($selectedRemoteDirectory);
+        $canonicalSiteDirectory = realpath($this->siteDir);
+        $this->assertIsString($selectedRemoteDirectory);
+        $this->assertIsString($canonicalSiteDirectory);
+        $remoteFile = $selectedRemoteDirectory . '/remote.txt';
+        file_put_contents($remoteFile, 'remote');
+
+        $selectedLocalDirectory = $this->filesystemRoot
+            . $selectedRemoteDirectory;
+        $localFile = $selectedLocalDirectory . '/remote.txt';
+        $localOnlyFile = $selectedLocalDirectory . '/local-only.txt';
+        $outsideLocalFile = $this->filesystemRoot
+            . $canonicalSiteDirectory . '/outside/local-only.txt';
+
+        $this->writeFilesPullState();
+        $options = [
+            'command' => 'files-pull',
+            'include' => [$selectedRemoteDirectory],
+            'follow_symlinks' => false,
+        ];
+        $this->runFilesPullUntilComplete($options);
+        $this->assertSame('remote', file_get_contents($localFile));
+
+        $this->runClient(
+            $this->newClient(),
+            array_merge($options, ['abort' => true])
+        );
+        file_put_contents($localFile, 'local drift');
+        file_put_contents($localOnlyFile, 'local only');
+        mkdir(dirname($outsideLocalFile), 0755, true);
+        file_put_contents($outsideLocalFile, 'outside');
+
+        $this->runFilesPullUntilComplete($options);
+        $this->assertSame('remote', file_get_contents($localFile));
+        $this->assertFileDoesNotExist($localOnlyFile);
+        $this->assertSame('outside', file_get_contents($outsideLocalFile));
+
+        $this->runClient(
+            $this->newClient(),
+            array_merge($options, ['abort' => true])
+        );
+        file_put_contents($localFile, 'local drift');
+        file_put_contents($localOnlyFile, 'local only');
+
+        $this->runFilesPullUntilComplete(
+            array_merge($options, ['intent' => 'catch-up'])
+        );
+        $this->assertSame('local drift', file_get_contents($localFile));
+        $this->assertSame('local only', file_get_contents($localOnlyFile));
+        $this->assertSame('outside', file_get_contents($outsideLocalFile));
+    }
+
+    private function writeFilesPullState(): void
+    {
+        \write_current_pull_state($this->newClient(), [
+            'preflight' => [
+                'data' => [
+                    'ok' => true,
+                    'runtime' => ['document_root' => $this->siteDir],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => $this->siteDir],
+                            ['path' => $this->extraDir],
+                        ],
+                    ],
+                ],
+                'http_code' => 200,
+            ],
+            'remote_protocol_version' => PULL_PROTOCOL_VERSION,
+            'follow_symlinks' => false,
+            'include_caches' => false,
+            'fs_root_nonempty_behavior' => 'error',
+        ]);
+    }
+
+    /**
+     * Runs direct files-pull invocations through completion.
+     *
+     * @param array $options {
+     *     Files-pull command options.
+     *
+     *     @type string       $command         The files-pull command.
+     *     @type list<string> $include         Selected remote roots.
+     *     @type bool         $follow_symlinks Whether to follow symlinks.
+     *     @type string       $intent          Optional files-pull intent.
+     * }
+     */
+    private function runFilesPullUntilComplete(array $options): void
+    {
+        for ($attempt = 0; $attempt < 1000; ++$attempt) {
+            $this->runClient($this->newClient(), $options);
+            $state = $this->readState();
+            if (
+                $state['active_resumable_command']['completion_state']
+                    === 'complete'
+            ) {
+                return;
+            }
+            $this->assertSame(
+                'partial',
+                $state['active_resumable_command']['completion_state']
+            );
+        }
+        $this->fail('files-pull did not complete after 1000 invocations.');
     }
 
     private function newFilesIndexClient(bool $followSymlinks): \ImportClient

--- a/tests/Import/RemoteIndexSortResumeTest.php
+++ b/tests/Import/RemoteIndexSortResumeTest.php
@@ -161,11 +161,15 @@ final class RemoteIndexSortResumeTest extends TestCase
 
     private function runClient(\ImportClient $client, string $command): void
     {
-        $client->run([
+        $options = [
             'command' => $command,
             'follow_symlinks' => false,
             'progress' => 'jsonl',
-        ]);
+        ];
+        if ($command === 'files-pull') {
+            $options['intent'] = 'catch-up';
+        }
+        $client->run($options);
     }
 
     private function writePreflightState(): void

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -312,7 +312,15 @@ export function runImporter(url, outputDir, command, options = {}) {
         }
     }
 
-    const commandExtraArgs = options.extraArgs || [];
+    const commandExtraArgs = [...(options.extraArgs || [])];
+    if (
+        ['pull', 'pull-files', 'files-pull'].includes(command) &&
+        !commandExtraArgs.some(
+            (argument) => argument === '--intent' || argument.startsWith('--intent=')
+        )
+    ) {
+        commandExtraArgs.push('--intent=catch-up');
+    }
     // Wall-clock budget across all resume attempts. Set high enough to cover several
     // WASM PHP invocations (~12s startup each) plus their actual work.
     const wallTimeout = options.wallTimeout || 240000;


### PR DESCRIPTION
`pull`, `pull-files`, and `files-pull` now mirror selected files by default; `--intent=catch-up` preserves local-only changes.

Mirror saves its intent before preflight, reconciles selected local paths through ownership-scoped bounded processors, resumes from durable cursors, and rejects `preserve-local`. Catch-up keeps the existing transition-only behavior. Active and completed lifecycles retain their saved intent until abort, so a rerun cannot silently change semantics.

Tests cover direct and high-level option handling, interruption and restart boundaries, protected remap aliases, selected skipped paths, local drift restoration, selected local-only removal, and explicit catch-up preservation.