### PR TITLE
[PHP] Resume interrupted pull-db downloads and database applies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,9 @@ The `WpcloudHostAnalyzer` auto-detects WP Cloud production infrastructure that w
 
 Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic plugin deactivation: at the end of `db-apply`, while the target database connection is still open, the importer instantiates the host analyzer, extracts plugin directory names from `paths_to_remove`, and removes matching entries from the `active_plugins` option. This prevents "plugin file does not exist" warnings in wp-admin. The deactivation is derived from `paths_to_remove` — there is no separate manifest field for it. We skip WordPress's `deactivate_plugins()` because the plugin files will already be gone from disk by the time WordPress boots, so firing deactivation hooks into absent code is pointless.
 
-### SQL Streaming Crash Recovery
+### SQL Streaming Source Retries
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `<remote-state-directory>/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+When one SQL response ends in the middle of a statement, the importer requests the next response in the same process. File and MySQL output can continue downloading in a new process from the last file size and source position Reprint saved. MySQL is not changed until the download finishes. If applying the SQL stops, the next process starts `db.sql` from the beginning on a new connection, which runs the dump header again. Stdout cannot continue in another process because Reprint cannot tell how much SQL the receiving program or file got. Reset that program or file before running `db-pull --abort`.
 
 ### Progress Tracking
 

--- a/README.md
+++ b/README.md
@@ -346,15 +346,15 @@ By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
 php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
-You can also pipe the SQL directly to stdout or stream it into a MySQL server
-without writing a file to disk. Use `--sql-output` to choose the mode:
+You can also pipe the SQL directly to stdout or download and apply it to a
+MySQL server in one command. Use `--sql-output` to choose the mode:
 
 ```bash
 # Pipe to stdout — useful for feeding into mysql CLI or another tool
 php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=stdout | mysql -u root my_database
 
-# Stream directly into MySQL — no intermediate file, no pipe
+# Download all of db.sql, then apply it to MySQL
 php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=mysql --mysql-database=my_database --mysql-host=127.0.0.1 --mysql-user=root --mysql-password=secret
 ```
@@ -365,14 +365,16 @@ The three modes:
 |------|-------------|-------------|
 | `file` (default) | Writes SQL to `$STATE_DIR/db.sql` | `db.sql` |
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
-| `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
+| `mysql` | Writes `db.sql`, confirms it is complete, then applies it through `db-apply` | `db.sql` |
 
-All three modes recover from server crashes mid-stream (PHP fatal errors,
-OOM kills, `max_execution_time` expiry). When the server dies before sending
-a completion chunk, the importer detects the transport failure, saves its
-cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/sql-buffer`
-so the next run reloads it and continues.
+File and MySQL modes save the size of `db.sql` with the source position. After
+a stopped process, they remove any later bytes and continue the download. MySQL
+is not changed until the download finishes. If applying the SQL stops, the next
+process opens a new target connection and starts `db.sql` from the beginning.
+This runs its SQL mode, foreign-key, unique-check, and autocommit settings again.
+Stdout cannot continue in another process because Reprint cannot tell how much
+SQL the receiving program or file got. Reset that program or file before
+aborting the stdout pull.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -384,7 +386,7 @@ The command returns one of three exit codes:
 
 - 0: sync completed
 - 1: failure
-- 2: partial completion, needs re-running
+- 2: partial completion; re-run the same command when its output is resumable
 
 #### Step 4 — Download files delta.
 
@@ -552,9 +554,9 @@ created by your environment. We won't need them. Furthermore, they may
 not get deleted during the database import if the site doesn't use
 the same table prefix as your environment.
 
-If you used `--sql-output=mysql`, the SQL was already executed — there's
-no `db.sql` to import. For `--sql-output=stdout`, the SQL was piped to
-whatever tool was reading stdout (typically `mysql` CLI).
+If you used `--sql-output=mysql`, the SQL was already applied and the complete
+`db.sql` remains in the state directory. For `--sql-output=stdout`, the SQL was
+piped to whatever tool was reading stdout (typically `mysql` CLI).
 
 ### State and progress files
 
@@ -670,9 +672,10 @@ are absent while the plan is still being built.
 #### `<remote-state-directory>/pull/state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it
-back periodically and on shutdown. It stores everything needed to resume after
-a crash or interruption: the current command, cursor position, AIMD tuning
-state, and per-phase bookmarks.
+back periodically and on shutdown. It stores command, cursor, AIMD tuning, and
+phase state. Some commands also need the file they were writing or the last
+position the other server confirmed. This state file alone cannot continue
+direct SQL output.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to
@@ -724,7 +727,7 @@ fresh.
   "current_file": "wp-content/uploads/photo.jpg",
   "current_file_bytes": 1048576,  // expected size after last complete write
   "sql_bytes": 524288,            // expected db.sql size
-  "sql_output": "file",           // "file" | "stdout" | "mysql"
+  "sql_output": "file",           // "file" | "stdout"; MySQL uses "file"
 
   "tuning": {
     "config": { ... },            // AIMD parameters
@@ -803,7 +806,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
-* `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
+* `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` to stream it, or `--sql-output=mysql` to download and apply it through the database-only pull pipeline.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `<remote-state-directory>/pull/domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
@@ -811,4 +814,4 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from the pull state selected by the remote Reprint API URL. No network calls are made. See [Step 6](#step-6--generate-runtime-configuration).
 
-All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the remote index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
+All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the remote index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. File downloads resume from the last saved cursor. After direct stdout output stops, reset or restore the receiving program or file before aborting that pull. After an interrupted `db-apply`, Reprint starts `db.sql` from the beginning. This runs the SQL header again on the new connection and does not assume that earlier, uncommitted queries were saved.

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -193,8 +193,7 @@ their parent directories.
         │   ├── fetch-list.jsonl
         │   ├── volatile-files.json
         │   ├── domains.json
-        │   ├── sql-stats.json
-        │   └── sql-buffer
+        │   └── sql-stats.json
         └── push/
 ```
 
@@ -214,7 +213,6 @@ Use these path names:
 | Volatile files file | `$volatile_files_file` |
 | Domains file | `$domains_file` |
 | SQL statistics file | `$sql_stats_file` |
-| SQL buffer file | `$sql_buffer_file` |
 | Audit log file | `$audit_log_file` |
 | Progress file | `$progress_file` |
 | Reprint process lock path | `$process_lock_path` |

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -173,6 +173,10 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const DATABASE_DUMP_INTENT_FILE = 'database-dump.intent';
+    private const DATABASE_DUMP_RECORD_FILE = 'database-dump.json';
+    private const DATABASE_APPLY_ATTEMPT_FILE = 'database-apply.json';
+    private const DATABASE_STDOUT_STATUS_FILE = 'database-stdout-output.json';
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -280,6 +284,9 @@ class ImportClient
 
     /** @var bool Set to true by SIGTERM/SIGINT handler to finish the current chunk and exit cleanly. */
     private $shutdown_requested = false;
+
+    /** @var string|null Top-level command whose signal policy is restored after a scoped stage. */
+    private $signal_handling_command;
 
     /** @var int|null First signal asking files-push to stop after its active sender step. */
     private $files_push_stop_signal = null;
@@ -422,23 +429,8 @@ class ImportClient
     /** @var string Path to progress.json — machine-readable progress for external readers. */
     private $progress_file;
 
-    /** @var string SQL output mode: 'file' (default), 'stdout', or 'mysql'. */
+    /** @var string SQL download mode: 'file' (default) or 'stdout'. */
     private $sql_output_mode = 'file';
-
-    /** @var string|null MySQL host for --sql-output=mysql. */
-    private $mysql_host;
-
-    /** @var int|null MySQL port for --sql-output=mysql. */
-    private $mysql_port;
-
-    /** @var string|null MySQL user for --sql-output=mysql. */
-    private $mysql_user;
-
-    /** @var string|null MySQL password for --sql-output=mysql. */
-    private $mysql_password;
-
-    /** @var string|null MySQL database for --sql-output=mysql. */
-    private $mysql_database;
 
     /** @var resource File descriptor for progress output — STDOUT normally, STDERR in stdout mode. */
     private $progress_fd;
@@ -458,20 +450,8 @@ class ImportClient
     {
         // Register the command's signal behavior before constructor work can
         // create state or receive a signal under another command's policy.
-        if (function_exists("pcntl_signal")) {
-            // Enable async signals (PHP 7.1+) so signals work during blocking operations
-            if (function_exists("pcntl_async_signals")) {
-                pcntl_async_signals(true);
-            }
-            if ($signal_handling_command === 'files-push') {
-                $this->enable_files_push_signal_handling();
-            } elseif ($signal_handling_command !== 'files-diff') {
-                // files-diff must not save the pull command's state from a
-                // shutdown handler; default signal behavior ends the report.
-                pcntl_signal(SIGINT, [$this, "handle_shutdown"]);
-                pcntl_signal(SIGTERM, [$this, "handle_shutdown"]);
-            }
-        }
+        $this->signal_handling_command = $signal_handling_command;
+        $this->install_signal_handling_for_command($signal_handling_command);
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
         $this->state_dir = trim_right_slash($state_dir);
@@ -854,6 +834,46 @@ class ImportClient
             );
         }
 
+        // Keep --sql-output=mysql as the db-pull spelling for the database-only
+        // pull pipeline. Reprint downloads all of db.sql before db-apply opens
+        // the target, so a later process can continue either stage safely.
+        if ($command === 'db-pull' && ( $options['sql_output'] ?? null ) === 'mysql') {
+            if (empty($options['mysql_database'])) {
+                throw new InvalidArgumentException(
+                    '--mysql-database is required when using --sql-output=mysql',
+                );
+            }
+
+            $target_host = $options['mysql_host'] ?? '127.0.0.1';
+            $target_port = isset($options['mysql_port']) ? (int) $options['mysql_port'] : 3306;
+            if (strpos($target_host, ':') !== false) {
+                list($host, $port_or_socket) = explode(':', $target_host, 2);
+                if ($port_or_socket !== '' && $port_or_socket[0] !== '/') {
+                    $target_host = $host;
+                    if (!isset($options['mysql_port'])) {
+                        $target_port = (int) $port_or_socket;
+                    }
+                }
+            }
+
+            $options['sql_output'] = 'file';
+            $options['target_engine'] = 'mysql';
+            $options['target_host'] = $target_host;
+            $options['target_port'] = $target_port;
+            $options['target_user'] = $options['mysql_user'] ?? 'root';
+            $options['target_pass'] = $options['mysql_password']
+                ?? ( getenv('MYSQL_PASSWORD') !== false ? getenv('MYSQL_PASSWORD') : '' );
+            $options['target_db'] = $options['mysql_database'];
+            unset(
+                $options['mysql_host'],
+                $options['mysql_port'],
+                $options['mysql_user'],
+                $options['mysql_password'],
+                $options['mysql_database'],
+            );
+            $command = 'pull-db';
+        }
+
         $progress_output_mode = $options['progress'] ?? 'auto';
         if (
             !is_string($progress_output_mode)
@@ -911,6 +931,31 @@ class ImportClient
         }
 
         $this->state = $this->load_state();
+
+        $stdout_status_file = wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_STDOUT_STATUS_FILE,
+        );
+        $stdout_status = $this->read_json_file($stdout_status_file);
+        $has_unfinished_stdout_output =
+            is_file($stdout_status_file)
+            && ( $stdout_status['status'] ?? null ) !== 'complete';
+        $saved_command = $this->get_state()->active_resumable_command;
+        $has_unfinished_db_pull =
+            $saved_command->command_name === 'db-pull'
+            && in_array($saved_command->completion_state, ['in_progress', 'partial'], true);
+        if (
+            !$abort
+            && in_array($command, ['db-pull', 'pull', 'pull-db'], true)
+            && $has_unfinished_stdout_output
+        ) {
+            throw new RuntimeException(
+                'db-pull stopped while writing SQL to stdout. Reprint does not know how ' .
+                'much SQL the receiving program or file got. Reset that program or file, ' .
+                'then run db-pull --abort. Start again with --sql-output=file and apply ' .
+                'db.sql with db-apply.',
+            );
+        }
 
         if ($command === "pull-metadata") {
             $this->run_pull_metadata();
@@ -1012,6 +1057,19 @@ class ImportClient
                     "Invalid --sql-output mode: {$mode}. Valid modes: file, stdout, mysql",
                 );
             }
+            $saved_sql_output = $this->get_state()->sql_output;
+            if (
+                !$abort
+                && $has_unfinished_db_pull
+                && $saved_sql_output !== null
+                && $saved_sql_output !== $mode
+            ) {
+                throw new RuntimeException(
+                    "Cannot change --sql-output from {$saved_sql_output}" .
+                    " to {$mode} while db-pull is unfinished. Resume with the original mode " .
+                    'or run db-pull --abort.',
+                );
+            }
             $this->sql_output_mode = $mode;
             $this->get_state()->sql_output = $mode;
         } elseif (isset($this->get_state()->sql_output)) {
@@ -1027,50 +1085,7 @@ class ImportClient
             $this->progress->set_terminal_output_enabled($this->uses_terminal_progress());
         }
 
-        // MySQL connection parameters for --sql-output=mysql.
-        if (isset($options["mysql_host"])) {
-            $this->mysql_host = $options["mysql_host"];
-            $this->get_state()->mysql_host = $this->mysql_host;
-        } elseif (isset($this->get_state()->mysql_host)) {
-            $this->mysql_host = $this->get_state()->mysql_host;
-        }
-
-        if (isset($options["mysql_port"])) {
-            $this->mysql_port = (int) $options["mysql_port"];
-            $this->get_state()->mysql_port = $this->mysql_port;
-        } elseif (isset($this->get_state()->mysql_port)) {
-            $this->mysql_port = (int) $this->get_state()->mysql_port;
-        }
-
-        if (isset($options["mysql_user"])) {
-            $this->mysql_user = $options["mysql_user"];
-            $this->get_state()->mysql_user = $this->mysql_user;
-        } elseif (isset($this->get_state()->mysql_user)) {
-            $this->mysql_user = $this->get_state()->mysql_user;
-        }
-
-        if (isset($options["mysql_database"])) {
-            $this->mysql_database = $options["mysql_database"];
-            $this->get_state()->mysql_database = $this->mysql_database;
-        } elseif (isset($this->get_state()->mysql_database)) {
-            $this->mysql_database = $this->get_state()->mysql_database;
-        }
-
         $this->save_state();
-
-        // Password is never persisted — must be supplied each run or via env.
-        if (isset($options["mysql_password"])) {
-            $this->mysql_password = $options["mysql_password"];
-        } elseif (getenv("MYSQL_PASSWORD") !== false) {
-            $this->mysql_password = getenv("MYSQL_PASSWORD");
-        }
-
-        // Validate mysql mode requirements.
-        if ($this->sql_output_mode === "mysql" && empty($this->mysql_database)) {
-            throw new InvalidArgumentException(
-                "--mysql-database is required when using --sql-output=mysql",
-            );
-        }
 
         $this->initialize_tuner($options);
 
@@ -2169,6 +2184,78 @@ class ImportClient
         die("\nForced exit.\n");
     }
 
+    /** Stops db-apply before it reads another SQL file chunk. */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- PHP passes the signal number to handlers.
+    public function handle_database_apply_shutdown(int $signal): void
+    {
+        if (!$this->shutdown_requested) {
+            $this->shutdown_requested = true;
+            return;
+        }
+        if (function_exists('posix_kill') && function_exists('posix_getpid')) {
+            posix_kill(posix_getpid(), SIGKILL);
+        }
+        die("\nForced exit.\n");
+    }
+
+    /** Installs the deferred signal policy for a db-apply stage. */
+    public function enable_database_apply_signal_handling(): void
+    {
+        $this->install_signal_handling_for_command('db-apply');
+    }
+
+    /** Restores the signal policy selected by the top-level command. */
+    public function restore_command_signal_handling(): void
+    {
+        $this->install_signal_handling_for_command($this->signal_handling_command);
+    }
+
+    /** Installs one command's handlers, async mode, and SIGINT/SIGTERM mask. */
+    private function install_signal_handling_for_command(?string $command): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+        if (function_exists('pcntl_sigprocmask')) {
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+        }
+        if (function_exists('pcntl_async_signals')) {
+            pcntl_async_signals(false);
+        }
+
+        if ($command === 'files-push') {
+            $this->enable_files_push_signal_handling();
+        } elseif ($command === 'db-apply') {
+            // PDO drivers and the SQLite compatibility layer are not safe to
+            // interrupt inside an executing SQL file chunk. The apply loop
+            // explicitly dispatches a pending signal between chunks.
+            pcntl_signal(SIGINT, [$this, 'handle_database_apply_shutdown']);
+            pcntl_signal(SIGTERM, [$this, 'handle_database_apply_shutdown']);
+            // pcntl_signal() unblocks the signal whose handler it installs.
+            if (function_exists('pcntl_sigprocmask')) {
+                pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            }
+            return;
+        } elseif ($command === 'files-diff') {
+            // files-diff must not save the pull command's state from a
+            // shutdown handler; default signal behavior ends the report.
+            pcntl_signal(SIGINT, SIG_DFL);
+            pcntl_signal(SIGTERM, SIG_DFL);
+        } else {
+            // Enable the generic command shutdown handler outside scoped stages.
+            pcntl_signal(SIGINT, [$this, 'handle_shutdown']);
+            pcntl_signal(SIGTERM, [$this, 'handle_shutdown']);
+        }
+
+        // Enable async signals (PHP 7.1+) so signals work during blocking operations
+        if (function_exists('pcntl_async_signals')) {
+            pcntl_async_signals(true);
+        }
+        if (function_exists('pcntl_sigprocmask')) {
+            pcntl_sigprocmask(SIG_UNBLOCK, [SIGINT, SIGTERM]);
+        }
+    }
+
     /** Installs the files-push first-signal stop behavior when PCNTL exists. */
     public function enable_files_push_signal_handling(): void
     {
@@ -2224,32 +2311,29 @@ class ImportClient
                     "RESTART | Clearing db-pull state",
                     true,
                 );
-                $this->reset_state();
-                $this->save_state();
-
-                if ($this->sql_output_mode === "file") {
-                    $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
-                    if (file_exists($sql_file)) {
-                        unlink($sql_file);
-                        $this->audit_log(
-                            "FILE DELETE | {$sql_file} | abort db-pull",
-                        );
+                foreach ([
+                    wp_join_unix_paths($this->state_dir, "db.sql"),
+                    wp_join_unix_paths($this->state_dir, "db-tables.jsonl"),
+                    wp_join_unix_paths($this->pull_state_directory, "domains.json"),
+                    wp_join_unix_paths($this->pull_state_directory, "sql-stats.json"),
+                ] as $path) {
+                    if (file_exists($path)) {
+                        if (!unlink($path)) {
+                            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The path belongs to the caller-selected state directory.
+                            throw new RuntimeException(
+                                "Reprint could not delete db-pull file: {$path}. " .
+                                "Check its permissions, then run db-pull --abort again.",
+                            );
+                        }
+                        $this->audit_log("FILE DELETE | {$path} | abort db-pull");
                     }
                 }
-                $tables_file = wp_join_unix_paths($this->state_dir, "db-tables.jsonl");
-                if (file_exists($tables_file)) {
-                    unlink($tables_file);
-                    $this->audit_log(
-                        "FILE DELETE | {$tables_file} | abort db-pull",
-                    );
-                }
-                $domains_file = wp_join_unix_paths($this->pull_state_directory, "domains.json");
-                if (file_exists($domains_file)) {
-                    unlink($domains_file);
-                    $this->audit_log(
-                        "FILE DELETE | {$domains_file} | abort db-pull",
-                    );
-                }
+                $this->reset_state();
+                $this->save_state();
+                // Clear the status files only after state no longer says the
+                // pull is running. If abort stops here, running --abort again
+                // finishes the cleanup instead of resuming direct output.
+                $this->clear_database_pull_records();
                 break;
 
             case "db-index":
@@ -2276,6 +2360,13 @@ class ImportClient
                 );
                 $this->reset_state();
                 $this->save_state();
+                $apply_attempt_file = wp_join_unix_paths(
+                    $this->pull_state_directory,
+                    self::DATABASE_APPLY_ATTEMPT_FILE,
+                );
+                if (file_exists($apply_attempt_file) && !unlink($apply_attempt_file)) {
+                    throw new RuntimeException('Reprint could not delete the saved db-apply information.');
+                }
                 break;
         }
 
@@ -3731,8 +3822,8 @@ class ImportClient
      * Command: db-pull
      *
      * Rules:
-     * - Stream next portion of SQL from last saved cursor
-     * - If already completed and db.sql exists: require --abort flag
+     * - File output continues from a saved cursor; direct output retries only in this process
+     * - If already completed and db.sql exists: report the saved result
      * - If db.sql missing but state says complete: warn and require --abort flag
      * - Otherwise: error
      */
@@ -3740,36 +3831,41 @@ class ImportClient
     {
         $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
         $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
+        $dump_intent_file = wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_DUMP_INTENT_FILE,
+        );
 
         $has_progress =
             $state_command === "db-pull" &&
-            ($this->get_state()->active_resumable_command->completion_state ?? null) === "in_progress";
+            in_array(
+                $this->get_state()->active_resumable_command->completion_state ?? null,
+                ["in_progress", "partial"],
+                true,
+            );
         $current_status =
             $state_command === "db-pull"
                 ? $this->get_state()->active_resumable_command->completion_state ?? null
                 : null;
 
-        // Check if already completed
+        // A repeated command reports the saved result. --abort remains the
+        // explicit way to discard it and download a new dump.
         if ($current_status === "complete") {
             if ($this->sql_output_mode === "file") {
-                $sql_exists = file_exists($sql_file);
-                if ($sql_exists) {
-                    throw new RuntimeException(
-                        "db-pull already completed and db.sql exists. Use --abort flag to start over.",
-                    );
-                } else {
+                if (!file_exists($sql_file)) {
                     throw new RuntimeException(
                         "db-pull marked complete but db.sql is missing. Use --abort flag to re-sync.",
                     );
                 }
-            } else {
-                throw new RuntimeException(
-                    "db-pull already completed. Use --abort flag to start over.",
-                );
             }
+            $this->audit_log('SKIP db-pull | already complete', true);
+            $this->progress->show_lifecycle_line("db-pull already complete\n");
+            return;
         }
 
         if ($has_progress) {
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->save_state();
             $stage = $this->get_state()->active_resumable_command->current_stage ?? "db-index";
             $this->audit_log(
                 sprintf(
@@ -3798,6 +3894,25 @@ class ImportClient
             $this->get_state()->active_resumable_command->current_stage = "db-index";
             $this->get_state()->diff = new FileDiffProgressState();
             $this->get_state()->db_index = new DatabaseTableIndexState();
+            $this->get_state()->sql_bytes = null;
+            $this->get_state()->sql_output = $this->sql_output_mode;
+            if ($this->sql_output_mode === 'file') {
+                // Remove the old db.sql before removing the information which marks it
+                // complete. If the process stops here, either both still exist or db.sql is gone.
+                if (file_exists($sql_file)) {
+                    if (!unlink($sql_file)) {
+                        throw new RuntimeException(
+                            "Reprint could not remove the old db.sql: {$sql_file}. " .
+                            "Check its permissions, then start db-pull again.",
+                        );
+                    }
+                    $this->audit_log("FILE DELETE | {$sql_file} | start db-pull");
+                }
+                $this->clear_database_pull_records();
+                $this->write_json_file($dump_intent_file, [
+                    'create_table_query' => true,
+                ]);
+            }
             $this->save_state();
 
             $this->audit_log("START db-pull", true);
@@ -3838,6 +3953,17 @@ class ImportClient
             // Transition to sql stage
             $this->get_state()->active_resumable_command->current_stage = "sql";
             $this->get_state()->active_resumable_command->remote_cursor = null;
+            if ($this->sql_output_mode === 'stdout') {
+                $this->write_json_file(
+                    wp_join_unix_paths(
+                        $this->pull_state_directory,
+                        self::DATABASE_STDOUT_STATUS_FILE,
+                    ),
+                    [
+                        'status' => 'in_progress',
+                    ],
+                );
+            }
             $this->save_state();
         }
 
@@ -3855,9 +3981,59 @@ class ImportClient
             return;
         }
 
-        // Mark as complete
+        if ($this->sql_output_mode === 'file') {
+            $dump_intent = $this->read_json_file($dump_intent_file);
+            $dump_hash = hash_file('sha256', $sql_file);
+            if (
+                ( $dump_intent['create_table_query'] ?? false ) !== true
+                || !is_string($dump_hash)
+            ) {
+                throw new RuntimeException(
+                    'Reprint could not confirm that db.sql finished downloading.',
+                );
+            }
+            $this->write_json_file(
+                wp_join_unix_paths(
+                    $this->pull_state_directory,
+                    self::DATABASE_DUMP_RECORD_FILE,
+                ),
+                [
+                    'sha256' => $dump_hash,
+                    'create_table_query' => true,
+                ],
+            );
+            $apply_attempt_file = wp_join_unix_paths(
+                $this->pull_state_directory,
+                self::DATABASE_APPLY_ATTEMPT_FILE,
+            );
+            if (file_exists($apply_attempt_file) && !unlink($apply_attempt_file)) {
+                throw new RuntimeException(
+                    'Reprint could not clear the saved db-apply information for the previous db.sql.',
+                );
+            }
+        }
+
+        // Mark the completed bytes before removing the download intent. If
+        // the process stops between these writes, the matching dump record
+        // still classifies db.sql and the leftover intent is harmless.
+        $this->get_state()->sql_bytes = null;
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->save_state();
+        if ($this->sql_output_mode === 'file') {
+            if (file_exists($dump_intent_file)) {
+                @unlink($dump_intent_file);
+            }
+        } else {
+            $this->write_json_file(
+                wp_join_unix_paths(
+                    $this->pull_state_directory,
+                    self::DATABASE_STDOUT_STATUS_FILE,
+                ),
+                [
+                    'status' => 'complete',
+                ],
+            );
+        }
 
         $this->audit_log("db-pull complete", true);
 
@@ -3866,8 +4042,6 @@ class ImportClient
             $this->progress->show_lifecycle_line("SQL file: {$sql_file}\n");
         } elseif ($this->sql_output_mode === "stdout") {
             $this->progress->show_lifecycle_line("SQL written to stdout\n");
-        } elseif ($this->sql_output_mode === "mysql") {
-            $this->progress->show_lifecycle_line("SQL applied to {$this->mysql_database}\n");
         }
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log_file}\n");
         $db_sync_complete = [
@@ -3888,13 +4062,6 @@ class ImportClient
     // db-apply: Apply SQL dump to a target MySQL database with URL rewriting
     // =========================================================================
 
-    /**
-     * Command: db-apply
-     *
-     * Reads db.sql, optionally rewrites URLs, and executes statements against
-     * a target MySQL database. Supports resumption via statement count tracking.
-     *
-     */
     private function run_db_domains(): void
     {
         $domains_file = wp_join_unix_paths($this->pull_state_directory, "domains.json");
@@ -3915,7 +4082,7 @@ class ImportClient
 
             $sql_handle = fopen($sql_file, "r");
             if (!$sql_handle) {
-                throw new RuntimeException("Cannot open SQL file: {$sql_file}");
+                throw new RuntimeException("Reprint could not open db.sql for reading: {$sql_file}");
             }
 
             try {
@@ -5535,108 +5702,48 @@ class ImportClient
         return $pdo;
     }
 
-    private function create_target_db_apply_connection(array $options): array
-    {
-        $target_engine = strtolower((string) ($options["target_engine"] ?? "mysql"));
-        if (!in_array($target_engine, ["mysql", "sqlite"], true)) {
-            throw new InvalidArgumentException(
-                "Invalid --target-engine value: {$target_engine}. Valid engines: mysql, sqlite.",
-            );
-        }
-
-        if ($target_engine === "sqlite") {
-            $target_path = $options["target_sqlite_path"] ?? null;
-            $target_db = $options["target_db"] ?? "sqlite_database";
-
-            if (!$target_path) {
-                $content_dir = $this->clean_preflight_path(
-                    $this->get_state()->get(
-                        'preflight.database.wp.paths_urls.content_dir'
-                    ),
-                );
-                if ($content_dir === null) {
-                    throw new InvalidArgumentException(
-                        "--target-sqlite-path option is required but was missing.",
-                    );
-                }
-                $target_path = wp_join_unix_paths(
-                    $this->filesystem_root,
-                    $content_dir,
-                    'database',
-                    '.ht.sqlite'
-                );
-                $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
-                $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
-            }
-
-            // Persist target database configuration for apply-runtime.
-            $this->get_state()->apply->target_engine = "sqlite";
-            $this->get_state()->apply->target_db = $target_db;
-            $this->get_state()->apply->target_sqlite_path = $target_path;
-
-            return [
-                $this->create_sqlite_target_pdo($target_path, $target_db),
-                sprintf(
-                    "engine=sqlite path=%s db=%s",
-                    $target_path,
-                    $target_db,
-                ),
-            ];
-        }
-
-        $target_host = $options["target_host"] ?? "127.0.0.1";
-        $target_port = (int) ($options["target_port"] ?? 3306);
-        $target_user = $options["target_user"] ?? null;
-        $target_pass = $options["target_pass"] ?? "";
-        $target_db = $options["target_db"] ?? null;
-
-        if (!$target_user || !$target_db) {
-            throw new InvalidArgumentException(
-                "db-apply with --target-engine=mysql requires --target-user and --target-db.",
-            );
-        }
-
-        // Persist target database configuration for apply-runtime.
-        $this->get_state()->apply->target_engine = "mysql";
-        $this->get_state()->apply->target_db = $target_db;
-        $this->get_state()->apply->target_host = $target_host;
-        $this->get_state()->apply->target_port = $target_port;
-        $this->get_state()->apply->target_user = $target_user;
-        $this->get_state()->apply->target_pass = $target_pass;
-
-        $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
-        try {
-            $pdo = new PDO($dsn, $target_user, $target_pass, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                PDO::MYSQL_ATTR_LOCAL_INFILE => false,
-            ]);
-        } catch (PDOException $e) {
-            throw new RuntimeException(
-                "Cannot connect to target MySQL database: " . $e->getMessage(),
-                0,
-                $e,
-            );
-        }
-
-        return [
-            $pdo,
-            sprintf(
-                "engine=mysql host=%s port=%d db=%s user=%s",
-                $target_host,
-                $target_port,
-                $target_db,
-                $target_user,
-            ),
-        ];
-    }
-
+    /**
+     * Reads db.sql, optionally rewrites URLs, and executes statements against
+     * the target database. A complete db-pull output starts again at the
+     * beginning after interruption, so the new connection runs the SQL header
+     * and does not skip queries which may not have committed. Other SQL files
+     * cannot start again safely.
+     */
     public function run_db_apply(array $options): void
     {
         $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
         if (!file_exists($sql_file)) {
             throw new RuntimeException(
                 "db.sql not found in {$this->state_dir}. Run db-pull first.",
+            );
+        }
+        $sql_hash = hash_file('sha256', $sql_file);
+        if (!is_string($sql_hash)) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The path is the caller-selected CLI state directory.
+            throw new RuntimeException("Reprint could not read db.sql: {$sql_file}");
+        }
+        $dump_record = $this->read_json_file(wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_DUMP_RECORD_FILE,
+        ));
+        $is_confirmed_replacement_dump =
+            ( $dump_record['create_table_query'] ?? false ) === true
+            && hash_equals((string) ( $dump_record['sha256'] ?? '' ), $sql_hash);
+        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
+        $current_status =
+            $state_command === 'db-apply'
+                ? $this->get_state()->active_resumable_command->completion_state ?? null
+                : null;
+        $has_unconfirmed_download_intent =
+            is_file(wp_join_unix_paths(
+                $this->pull_state_directory,
+                self::DATABASE_DUMP_INTENT_FILE,
+            ))
+            && !$is_confirmed_replacement_dump;
+        if ($has_unconfirmed_download_intent) {
+            throw new RuntimeException(
+                'db.sql is still downloading. Finish db-pull or run db-pull --abort ' .
+                'before db-apply.',
             );
         }
 
@@ -5679,64 +5786,118 @@ class ImportClient
             }
         }
 
-        // Check state for resume
-        $state_command = $this->get_state()->active_resumable_command->command_name ?? null;
-        $current_status = $state_command === "db-apply" ? ($this->get_state()->active_resumable_command->completion_state ?? null) : null;
-
-        if ($current_status === "complete") {
+        $apply_state = $this->get_state()->apply;
+        if (empty($url_mapping) && !empty($apply_state->rewrite_url)) {
+            $url_mapping = $apply_state->rewrite_url;
+        } elseif (
+            !empty($url_mapping)
+            && !empty($apply_state->rewrite_url)
+            && $url_mapping !== $apply_state->rewrite_url
+            && in_array($current_status, ["in_progress", "partial"], true)
+        ) {
             throw new RuntimeException(
-                "db-apply already completed. Use --abort flag to re-run.",
+                'db-apply has not finished. Use the same --rewrite-url values as before, ' .
+                'or restore or reset the target database, run db-apply --abort, and start again.',
             );
         }
-
-        $apply_state = $this->get_state()->apply;
-        $statements_executed = $apply_state->statements_executed;
-        $bytes_read = $apply_state->bytes_read;
-        $is_resume = $current_status === "in_progress" && $statements_executed > 0;
-
-        if ($is_resume) {
+        $target = $this->resolve_database_apply_target($options);
+        $target_identity = $target;
+        unset($target_identity['pass']);
+        $apply_behavior = [
+            'target' => $target_identity,
+            'rewrite_url' => $url_mapping,
+            'new_site_url' => (string) ( $options['new_site_url'] ?? '' ),
+            'table_prefix' => $this->get_state()->get(
+                'preflight.database.wp.table_prefix'
+            ),
+            'host_plugin_directories' => $this->host_plugin_directories(),
+        ];
+        $behavior_json = json_encode($apply_behavior, JSON_UNESCAPED_SLASHES);
+        if ($behavior_json === false) {
+            throw new RuntimeException('Reprint could not save the db-apply settings.');
+        }
+        $behavior_hash = hash('sha256', $behavior_json);
+        $attempt_file = wp_join_unix_paths(
+            $this->pull_state_directory,
+            self::DATABASE_APPLY_ATTEMPT_FILE,
+        );
+        $attempt = $this->read_json_file($attempt_file);
+        $attempt_status = $attempt['status'] ?? null;
+        if ($attempt_status === 'complete') {
+            $matches_completed_attempt =
+                hash_equals((string) ( $attempt['sql_sha256'] ?? '' ), $sql_hash)
+                && hash_equals(
+                    (string) ( $attempt['behavior_sha256'] ?? '' ),
+                    $behavior_hash,
+                );
+            if (!$matches_completed_attempt) {
+                throw new RuntimeException(
+                    'db-apply already finished, but db.sql, the target database, or the apply ' .
+                    'options are different now. Run db-apply --abort before applying this SQL again.',
+                );
+            }
+            if ($current_status !== 'complete') {
+                $this->get_state()->active_resumable_command->command_name = 'db-apply';
+                $this->get_state()->active_resumable_command->completion_state = 'complete';
+                $this->record_database_apply_target($target);
+                $this->get_state()->apply->statements_executed =
+                    (int) ( $attempt['statements_executed'] ?? 0 );
+                $this->get_state()->apply->bytes_read = (int) ( $attempt['bytes_read'] ?? 0 );
+                if (!empty($url_mapping)) {
+                    $this->get_state()->apply->rewrite_url = $url_mapping;
+                }
+                $this->save_state();
+                $this->audit_log('RECOVER db-apply | target work was already complete', true);
+                return;
+            }
+            $this->audit_log('SKIP db-apply | already complete', true);
+            $this->progress->show_lifecycle_line("db-apply already complete\n");
+            return;
+        }
+        $is_restart = $attempt_status === 'in_progress';
+        if ($is_restart) {
+            $can_restart =
+                $attempt_status === 'in_progress'
+                && $is_confirmed_replacement_dump
+                && hash_equals( (string) ( $attempt['sql_sha256'] ?? '' ), $sql_hash )
+                && hash_equals( (string) ( $attempt['behavior_sha256'] ?? '' ), $behavior_hash );
+            if (!$can_restart) {
+                throw new RuntimeException(
+                    'db-apply stopped after it may have changed the target database. Reprint ' .
+                    'cannot safely run this SQL again because db.sql, the target database, or ' .
+                    'the apply options changed. Restore or reset the target database, then run ' .
+                    'db-apply --abort and start again.',
+                );
+            }
             $this->audit_log(
                 sprintf(
-                    "RESUME db-apply | statements=%d | bytes_read=%d",
-                    $statements_executed,
-                    $bytes_read,
+                    "RESTART db-apply | prior_statements=%d | prior_bytes_read=%d",
+                    $apply_state->statements_executed,
+                    $apply_state->bytes_read,
                 ),
                 true,
             );
-            $this->progress->show_lifecycle_line("Resuming db-apply (executed: {$statements_executed} statements)\n");
-            $this->output_progress([
-                "type" => "lifecycle",
-                "event" => "resuming",
-                "command" => "db-apply",
-                "statements_executed" => $statements_executed,
-                "bytes_read" => $bytes_read,
-                "message" => "Resuming db-apply (executed: {$statements_executed} statements)",
-            ], true);
-        } else {
             $this->get_state()->active_resumable_command->command_name = "db-apply";
             $this->get_state()->active_resumable_command->completion_state = "in_progress";
             $this->get_state()->apply = new DatabaseApplyCommandState();
+            $this->record_database_apply_target($target);
             if (!empty($url_mapping)) {
                 $this->get_state()->apply->rewrite_url = $url_mapping;
             }
             $this->save_state();
-            $statements_executed = 0;
-            $bytes_read = 0;
-
-            $this->audit_log("START db-apply", true);
-            $this->progress->show_lifecycle_line("Starting db-apply\n");
-            $this->output_progress([
-                "type" => "lifecycle",
-                "event" => "starting",
-                "command" => "db-apply",
-                "message" => "Starting db-apply",
-            ], true);
         }
+        $statements_executed = 0;
 
-        // On resume, use the persisted URL mapping if none provided on CLI
-        if (empty($url_mapping) && !empty($apply_state->rewrite_url)) {
-            $url_mapping = $apply_state->rewrite_url;
-        }
+        $event = $is_restart ? "restarting" : "starting";
+        $verb = $is_restart ? "Restarting" : "Starting";
+        $this->audit_log( ( $is_restart ? "RESTART" : "START" ) . " db-apply", true );
+        $this->progress->show_lifecycle_line("{$verb} db-apply\n");
+        $this->output_progress([
+            "type" => "lifecycle",
+            "event" => $event,
+            "command" => "db-apply",
+            "message" => "{$verb} db-apply",
+        ], true);
 
         // Set up SQL statement rewriter if we have URL mappings
         $stmt_rewriter = null;
@@ -5760,12 +5921,12 @@ class ImportClient
             );
         }
 
-        [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
+        [$pdo, $connection_label] = $this->create_target_db_apply_connection($target);
         $sqlite_prepared_pdo = null;
         $sqlite_prepared_statement_cache = [];
         $sqlite_prepared_statement_cache_order = [];
         if (
-            strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
+            $target['engine'] === 'sqlite'
             && method_exists($pdo, 'get_connection')
         ) {
             $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
@@ -5810,7 +5971,25 @@ class ImportClient
         });
         $sql_handle = fopen($sql_file, "r");
         if (!$sql_handle) {
-            throw new RuntimeException("Cannot open SQL file: {$sql_file}");
+            throw new RuntimeException("Reprint could not open db.sql for reading: {$sql_file}");
+        }
+        $mysql_apply_lock_name = null;
+        if ($target['engine'] === 'mysql') {
+            $mysql_apply_lock_name =
+                'reprint-db-apply:' . substr(hash('sha256', $target['db']), 0, 47);
+            $lock_statement = $pdo->prepare('SELECT GET_LOCK(?, 30)');
+            if (
+                !$lock_statement
+                || !$lock_statement->execute([$mysql_apply_lock_name])
+                || (int) $lock_statement->fetchColumn() !== 1
+            ) {
+                fclose($sql_handle);
+                throw new RuntimeException(
+                    'Another db-apply is still using the target database. Wait for it to finish, ' .
+                    'then try again.',
+                );
+            }
+            $this->audit_log("DB-APPLY LOCK | acquired {$mysql_apply_lock_name}", false);
         }
 
         $sql_file_size = filesize($sql_file);
@@ -5829,21 +6008,6 @@ class ImportClient
             }
         }
 
-        // If resuming, seek to saved position. bytes_read is the byte offset
-        // right after the last successfully executed query (tracked via
-        // query_stream->get_bytes_consumed()), so no statement skipping is
-        // needed after seeking — we're exactly at the next un-executed query.
-        $seek_offset = 0;
-        $stmts_to_skip = 0;
-        if ($bytes_read > 0 && $bytes_read < $sql_file_size) {
-            fseek($sql_handle, $bytes_read);
-            $total_bytes_read = $bytes_read;
-            $seek_offset = $bytes_read;
-        } elseif ($statements_executed > 0) {
-            // Can't seek — need to scan from beginning and skip statements
-            $stmts_to_skip = $statements_executed;
-        }
-
         $this->output_progress([
             "status" => "starting",
             "phase" => "db-apply",
@@ -5852,16 +6016,39 @@ class ImportClient
         ]);
 
         try {
+            // Save restart information only after the target connection, SQL file,
+            // and MySQL lock are ready, but before reading the first SQL statement.
+            if (!$is_restart) {
+                $this->write_json_file($attempt_file, [
+                    'status' => 'in_progress',
+                    'sql_sha256' => $sql_hash,
+                    'behavior_sha256' => $behavior_hash,
+                ]);
+                $this->get_state()->active_resumable_command->command_name = "db-apply";
+                $this->get_state()->active_resumable_command->completion_state = "in_progress";
+                $this->get_state()->apply = new DatabaseApplyCommandState();
+                $this->record_database_apply_target($target);
+                if (!empty($url_mapping)) {
+                    $this->get_state()->apply->rewrite_url = $url_mapping;
+                }
+                $this->save_state();
+            }
+
             $chunk_size = 64 * 1024; // 64KB read chunks
 
             while (!feof($sql_handle)) {
-                // Check shutdown
-                if ($this->shutdown_requested) {
-                    $this->audit_log("SHUTDOWN REQUESTED | saving state", true);
-                    break;
+                if (function_exists('pcntl_sigprocmask')) {
+                    pcntl_sigprocmask(SIG_UNBLOCK, [SIGINT, SIGTERM]);
                 }
                 if (function_exists("pcntl_signal_dispatch")) {
                     pcntl_signal_dispatch();
+                }
+                if (function_exists('pcntl_sigprocmask')) {
+                    pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+                }
+                if ($this->shutdown_requested) {
+                    $this->audit_log("SHUTDOWN REQUESTED | saving state", true);
+                    break;
                 }
 
                 $data = fread($sql_handle, $chunk_size);
@@ -5874,12 +6061,6 @@ class ImportClient
                 while ($query_stream->next_query()) {
                     $query = $query_stream->get_query();
                     $stmt_count++;
-
-                    // Skip already-executed statements on resume
-                    if ($stmts_to_skip > 0) {
-                        $stmts_to_skip--;
-                        continue;
-                    }
 
                     // Execute against target database
                     $executed_query = $query;
@@ -5912,14 +6093,13 @@ class ImportClient
                     $statements_executed++;
                     $stmts_since_save++;
 
-                    // Save state periodically. bytes_read is the file offset
-                    // right after the last extracted query — NOT total_bytes_read,
-                    // which includes bytes buffered in the query stream that haven't
-                    // formed a complete query yet. This ensures resumption starts at
-                    // the exact boundary between executed and un-executed queries.
+                    // Save diagnostic counters periodically. bytes_read is the
+                    // file offset after the last extracted query, not
+                    // total_bytes_read, which includes an incomplete query in
+                    // the parser. An unfinished apply still restarts the dump.
                     if ($stmts_since_save >= $save_every) {
                         $this->get_state()->apply->statements_executed = $statements_executed;
-                        $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                        $this->get_state()->apply->bytes_read = $query_stream->get_bytes_consumed();
                         $this->save_state();
                         $stmts_since_save = 0;
 
@@ -5951,16 +6131,15 @@ class ImportClient
                 }
             }
 
-            // Drain any remaining buffered query
-            $query_stream->mark_input_complete();
-            while ($query_stream->next_query()) {
+            // Only EOF makes the buffered tail a complete query. An orderly
+            // stop leaves a partial statement unexecuted; the next process
+            // starts reading db.sql again from the beginning.
+            if (!$this->shutdown_requested) {
+                $query_stream->mark_input_complete();
+            }
+            while (!$this->shutdown_requested && $query_stream->next_query()) {
                 $query = $query_stream->get_query();
                 $stmt_count++;
-
-                if ($stmts_to_skip > 0) {
-                    $stmts_to_skip--;
-                    continue;
-                }
 
                 $executed_query = $query;
                 try {
@@ -5995,7 +6174,7 @@ class ImportClient
             if ($this->shutdown_requested) {
                 // Save partial progress
                 $this->get_state()->apply->statements_executed = $statements_executed;
-                $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->get_state()->apply->bytes_read = $query_stream->get_bytes_consumed();
                 $this->get_state()->active_resumable_command->completion_state = "partial";
                 $this->save_state();
                 $this->audit_log(
@@ -6038,9 +6217,20 @@ class ImportClient
                     $this->audit_log("DB-APPLY | deactivated plugin {$basename} (path-incompatible siteurl)");
                 }
 
-                // Mark complete
+                $completed_bytes = $query_stream->get_bytes_consumed();
+                $this->write_json_file($attempt_file, [
+                    'status' => 'complete',
+                    'sql_sha256' => $sql_hash,
+                    'behavior_sha256' => $behavior_hash,
+                    'statements_executed' => $statements_executed,
+                    'bytes_read' => $completed_bytes,
+                ]);
+
+                // The sidecar reaches complete first. If state persistence is
+                // interrupted, the next invocation repairs state without
+                // executing the target SQL again.
                 $this->get_state()->apply->statements_executed = $statements_executed;
-                $this->get_state()->apply->bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->get_state()->apply->bytes_read = $completed_bytes;
                 $this->get_state()->active_resumable_command->completion_state = "complete";
                 $this->save_state();
 
@@ -6068,7 +6258,224 @@ class ImportClient
             }
         } finally {
             fclose($sql_handle);
+            if ($mysql_apply_lock_name !== null) {
+                try {
+                    $release_statement = $pdo->prepare('SELECT RELEASE_LOCK(?)');
+                    if ($release_statement) {
+                        $release_statement->execute([$mysql_apply_lock_name]);
+                    }
+                } catch (Throwable $release_error) {
+                    $this->audit_log(
+                        'DB-APPLY LOCK | release failed: ' . $release_error->getMessage(),
+                        true,
+                    );
+                }
+            }
         }
+    }
+
+    /**
+     * Resolves the effective db-apply target without opening a connection.
+     *
+     * @param array $options {
+     *     db-apply target options.
+     *
+     *     @type string $target_engine      mysql or sqlite.
+     *     @type string $target_host        MySQL host.
+     *     @type int    $target_port        MySQL port.
+     *     @type string $target_user        MySQL user.
+     *     @type string $target_pass        MySQL password.
+     *     @type string $target_db          Target database name.
+     *     @type string $target_sqlite_path SQLite file path.
+     * }
+     * @return array {
+     *     Resolved target fields.
+     *
+     *     @type string $engine      mysql or sqlite.
+     *     @type string $db          Target database name.
+     *     @type string $sqlite_path SQLite file path. Present only for SQLite.
+     *     @type string $host        MySQL host. Present only for MySQL.
+     *     @type int    $port        MySQL port. Present only for MySQL.
+     *     @type string $user        MySQL user. Present only for MySQL.
+     *     @type string $pass        MySQL password. Present only for MySQL.
+     * }
+     */
+    private function resolve_database_apply_target(array $options): array
+    {
+        $target_engine = strtolower( (string) ( $options['target_engine'] ?? 'mysql' ) );
+        if (!in_array($target_engine, ['mysql', 'sqlite'], true)) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The message reports the caller's CLI value.
+            throw new InvalidArgumentException(
+                "Invalid --target-engine value: {$target_engine}. Valid engines: mysql, sqlite.",
+            );
+        }
+
+        if ($target_engine === 'sqlite') {
+            $target_path = $options['target_sqlite_path'] ?? null;
+            $target_db = $options['target_db'] ?? 'sqlite_database';
+            if (!$target_path) {
+                $content_dir = $this->clean_preflight_path(
+                    $this->get_state()->get(
+                        'preflight.database.wp.paths_urls.content_dir'
+                    ),
+                );
+                if ($content_dir === null) {
+                    throw new InvalidArgumentException(
+                        '--target-sqlite-path option is required but was missing.',
+                    );
+                }
+                $target_path = wp_join_unix_paths(
+                    $this->filesystem_root,
+                    $content_dir,
+                    'database',
+                    '.ht.sqlite'
+                );
+                $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
+                $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
+            }
+            if ($target_path !== ':memory:' && strpos($target_path, '/') !== 0) {
+                $working_directory = getcwd();
+                if ($working_directory === false) {
+                    throw new RuntimeException(
+                        'Cannot resolve the current working directory for --target-sqlite-path.',
+                    );
+                }
+                $target_path = wp_join_unix_paths($working_directory, $target_path);
+            }
+            if ($target_path !== ':memory:') {
+                $target_path = realpath_with_missing_tail($target_path);
+            }
+            return [
+                'engine' => 'sqlite',
+                'db' => $target_db,
+                'sqlite_path' => $target_path,
+            ];
+        }
+
+        $target_user = $options['target_user'] ?? null;
+        $target_db = $options['target_db'] ?? null;
+        if (!$target_user || !$target_db) {
+            throw new InvalidArgumentException(
+                'db-apply with --target-engine=mysql requires --target-user and --target-db.',
+            );
+        }
+        return [
+            'engine' => 'mysql',
+            'host' => $options['target_host'] ?? '127.0.0.1',
+            'port' => (int) ( $options['target_port'] ?? 3306 ),
+            'user' => $target_user,
+            'pass' => $options['target_pass'] ?? '',
+            'db' => $target_db,
+        ];
+    }
+
+    /**
+     * Opens the resolved db-apply target.
+     *
+     * @param array $target {
+     *     Resolved target from resolve_database_apply_target().
+     *
+     *     @type string $engine      mysql or sqlite.
+     *     @type string $db          Target database name.
+     *     @type string $sqlite_path SQLite file path for a SQLite target.
+     *     @type string $host        MySQL host for a MySQL target.
+     *     @type int    $port        MySQL port for a MySQL target.
+     *     @type string $user        MySQL user for a MySQL target.
+     *     @type string $pass        MySQL password for a MySQL target.
+     * }
+     * @return array {
+     *     Open target connection and diagnostic label.
+     *
+     *     @type PDO    $0 Target connection.
+     *     @type string $1 Target label.
+     * }
+     */
+    private function create_target_db_apply_connection(array $target): array
+    {
+        if ($target['engine'] === 'sqlite') {
+            $target_path = $target['sqlite_path'];
+            $target_db = $target['db'];
+
+            return [
+                $this->create_sqlite_target_pdo($target_path, $target_db),
+                sprintf(
+                    "engine=sqlite path=%s db=%s",
+                    $target_path,
+                    $target_db,
+                ),
+            ];
+        }
+
+        $target_host = $target['host'];
+        $target_port = $target['port'];
+        $target_user = $target['user'];
+        $target_pass = $target['pass'];
+        $target_db = $target['db'];
+
+        $target_socket = null;
+        if (strpos($target_host, ':') !== false) {
+            list($host, $port_or_socket) = explode(':', $target_host, 2);
+            if ($port_or_socket !== '' && $port_or_socket[0] === '/') {
+                $target_host = $host;
+                $target_socket = $port_or_socket;
+            }
+        }
+        $dsn = $target_socket === null
+            ? "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4"
+            : "mysql:unix_socket={$target_socket};dbname={$target_db};charset=utf8mb4";
+        try {
+            $pdo = new PDO($dsn, $target_user, $target_pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::MYSQL_ATTR_LOCAL_INFILE => false,
+            ]);
+        } catch (PDOException $e) {
+            throw new RuntimeException(
+                "Cannot connect to target MySQL database: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        return [
+            $pdo,
+            sprintf(
+                "engine=mysql host=%s port=%d%s db=%s user=%s",
+                $target_host,
+                $target_port,
+                $target_socket === null ? '' : " socket={$target_socket}",
+                $target_db,
+                $target_user,
+            ),
+        ];
+    }
+
+    /**
+     * Records the resolved target needed by apply-runtime before target SQL begins.
+     *
+     * @param array $target {
+     *     Resolved target from resolve_database_apply_target().
+     *
+     *     @type string $engine      mysql or sqlite.
+     *     @type string $db          Target database name.
+     *     @type string $sqlite_path SQLite file path for a SQLite target.
+     *     @type string $host        MySQL host for a MySQL target.
+     *     @type int    $port        MySQL port for a MySQL target.
+     *     @type string $user        MySQL user for a MySQL target.
+     *     @type string $pass        MySQL password for a MySQL target.
+     * }
+     */
+    private function record_database_apply_target(array $target): void
+    {
+        $apply = $this->get_state()->apply;
+        $apply->target_engine = $target['engine'];
+        $apply->target_db = $target['db'];
+        $apply->target_host = $target['engine'] === 'mysql' ? $target['host'] : null;
+        $apply->target_port = $target['engine'] === 'mysql' ? $target['port'] : null;
+        $apply->target_user = $target['engine'] === 'mysql' ? $target['user'] : null;
+        $apply->target_pass = $target['engine'] === 'mysql' ? $target['pass'] : null;
+        $apply->target_sqlite_path =
+            $target['engine'] === 'sqlite' ? $target['sqlite_path'] : null;
     }
 
     private function execute_db_apply_query(
@@ -6142,6 +6549,20 @@ class ImportClient
      */
     private function deactivate_host_plugins(PDO $pdo): array
     {
+        return $this->deactivate_plugins_by_dir(
+            $pdo,
+            $this->host_plugin_directories(),
+            "host-specific",
+        );
+    }
+
+    /**
+     * Returns plugin directories removed by the current source-host analysis.
+     *
+     * @return string[] Plugin directory names.
+     */
+    private function host_plugin_directories(): array
+    {
         $webhost = $this->get_state()->webhost ?? "other";
         $analyzer = host_analyzer_for($webhost);
         $preflight_data = $this->get_state()->preflight_record()["data"] ?? [];
@@ -6153,8 +6574,7 @@ class ImportClient
                 $plugin_dirs[] = $m[1];
             }
         }
-
-        return $this->deactivate_plugins_by_dir($pdo, $plugin_dirs, "host-specific");
+        return $plugin_dirs;
     }
 
     /**
@@ -6257,8 +6677,8 @@ class ImportClient
         $pdo->exec(
             "UPDATE {$options_table} SET option_value = FROM_BASE64('{$encoded_value}') WHERE option_name = 'active_plugins'"
         );
-        // The SQL dump runs with AUTOCOMMIT=0 and issues a final COMMIT,
-        // but autocommit stays off. Our UPDATE needs an explicit COMMIT.
+        // The managed MySQL dump leaves AUTOCOMMIT=0 after its final COMMIT.
+        // Our UPDATE needs an explicit COMMIT.
         $pdo->exec('COMMIT');
 
         $this->audit_log(
@@ -7530,98 +7950,73 @@ class ImportClient
         // ── Set up write strategy based on output mode ──────────────
 
         $sql_handle = null;
-        $mysql_conn = null;
-        $sql_buffer_handle = null;
         $sql_bytes_written = 0;
-        $sql_buffer = "";
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
 
-            // Crash recovery: if SQL file is larger than expected, truncate it.
-            // This happens if we crashed after writing but before saving the new cursor.
+            // Remove bytes written after the last saved source position before
+            // appending the next part of the dump.
             $tracked_bytes = $this->get_state()->sql_bytes ?? null;
-            if ($tracked_bytes !== null && file_exists($sql_file)) {
+            if ($cursor !== null) {
+                if (!is_int($tracked_bytes) || $tracked_bytes < 0 || !file_exists($sql_file)) {
+                    throw new RuntimeException(
+                        'db-pull cannot continue because db.sql is missing or Reprint did not save ' .
+                        'its size. Run db-pull --abort, then start db-pull again.',
+                    );
+                }
                 $actual_size = filesize($sql_file);
+                if ($actual_size === false || $actual_size < $tracked_bytes) {
+                    throw new RuntimeException(
+                        sprintf(
+                            'db-pull cannot continue because db.sql has %d bytes, but Reprint had saved ' .
+                            'a size of %d bytes. Run db-pull --abort, then start db-pull again.',
+                            $actual_size === false ? 0 : $actual_size,
+                            $tracked_bytes,
+                        ),
+                    );
+                }
                 if ($actual_size > $tracked_bytes) {
                     $this->audit_log(
                         sprintf(
-                            "CRASH RECOVERY | Truncating db.sql from %d to %d bytes",
+                            "RESUME | Truncating db.sql from %d to %d bytes",
                             $actual_size,
                             $tracked_bytes,
                         ),
                         true,
                     );
                     $handle = fopen($sql_file, "r+");
-                    if ($handle) {
-                        ftruncate($handle, $tracked_bytes);
-                        fclose($handle);
+                    if (!$handle || !ftruncate($handle, $tracked_bytes)) {
+                        if ($handle) {
+                            fclose($handle);
+                        }
+                        throw new RuntimeException(
+                            'Reprint could not remove unfinished bytes from db.sql. ' .
+                            'Run db-pull --abort, then start db-pull again.',
+                        );
                     }
+                    fclose($handle);
                 }
             }
 
-            $sql_bytes_written = file_exists($sql_file) ? filesize($sql_file) : 0;
+            if ($cursor === null) {
+                $sql_bytes_written = 0;
+            } else {
+                $existing_size = filesize($sql_file);
+                if ($existing_size === false) {
+                    throw new RuntimeException("Reprint could not read the size of db.sql: {$sql_file}");
+                }
+                $sql_bytes_written = $existing_size;
+            }
 
             // Open in write mode if no cursor (starting fresh), append mode if resuming
             $sql_handle = fopen($sql_file, $cursor ? "a" : "w");
             if (!$sql_handle) {
-                throw new RuntimeException("Cannot open SQL file: {$sql_file}");
+                throw new RuntimeException("Reprint could not open db.sql for writing: {$sql_file}");
             }
 
         } elseif ($mode === "stdout") {
             $sql_bytes_written = $this->get_state()->sql_bytes ?? 0;
-
-        } elseif ($mode === "mysql") {
-            $sql_bytes_written = $this->get_state()->sql_bytes ?? 0;
-
-            $host = $this->mysql_host ?? "127.0.0.1";
-            $user = $this->mysql_user ?? "root";
-            $pass = $this->mysql_password ?? "";
-            $name = $this->mysql_database;
-
-            // Parse host for port/socket (same format as WordPress DB_HOST).
-            // An explicit --mysql-port takes precedence over a port embedded
-            // in the host string.
-            $port = $this->mysql_port ?? 3306;
-            $socket = null;
-            if (strpos($host, ":") !== false) {
-                list($host, $port_or_socket) = explode(":", $host, 2);
-                if ($port_or_socket[0] === "/") {
-                    $socket = $port_or_socket;
-                } elseif ($this->mysql_port === null) {
-                    $port = (int) $port_or_socket;
-                }
-            }
-
-            $mysql_conn = new \mysqli($host, $user, $pass, $name, $port, $socket);
-            if ($mysql_conn->connect_error) {
-                throw new RuntimeException("MySQL connection failed: " . $mysql_conn->connect_error);
-            }
-            $mysql_conn->set_charset("utf8mb4");
-
-            $this->audit_log(
-                "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
-                true,
-            );
-
-            // Open a persistent buffer file so partial queries survive crashes.
-            // Each SQL chunk is appended to this file as it arrives; when the
-            // query completes and executes, the file is truncated. If the process
-            // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-            if (file_exists($sql_buffer_file)) {
-                $sql_buffer = file_get_contents($sql_buffer_file);
-                $this->audit_log(
-                    sprintf("CRASH RECOVERY | Restored %d bytes from pull/sql-buffer", strlen($sql_buffer)),
-                    true,
-                );
-            }
-            // Open in write mode (truncate) if we loaded nothing, append if we
-            // have a partial query to continue accumulating into.
-            $sql_buffer_handle = fopen($sql_buffer_file, $sql_buffer !== "" ? "a" : "w");
-            if (!$sql_buffer_handle) {
-                throw new RuntimeException("Cannot open SQL buffer file: {$sql_buffer_file}");
-            }
         }
 
         // Domain discovery and statement counting: scan SQL for URLs during download
@@ -7669,12 +8064,15 @@ class ImportClient
             false,
         );
 
-        $caught_exception = null;
-        $buffer_not_flushed = "";
         $chunks_since_save = 0;
         try {
             while (!$complete) {
                 $params = $this->get_tuned_params("sql_chunk");
+                // db-apply may read a completed db.sql again from the beginning only
+                // when every dumped base table replaces its target table.
+                if ($mode === 'file') {
+                    $params['create_table_query'] = true;
+                }
                 $url = $this->build_url("sql_chunk", $cursor, $params);
 
                 $context = new StreamingContext();
@@ -7683,9 +8081,6 @@ class ImportClient
                     &$cursor,
                     &$complete,
                     &$sql_handle,
-                    $mysql_conn,
-                    &$sql_buffer_handle,
-                    &$sql_buffer,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -7704,45 +8099,11 @@ class ImportClient
                         pcntl_signal_dispatch();
                     }
 
-                    $cursor = $chunk["headers"]["x-cursor"] ?? $cursor;
-
-                    // Save cursor periodically (every 50 chunks).
-                    // Skip saving when there's buffered SQL waiting for a
-                    // complete statement — crash recovery would replay the
-                    // cursor but miss the buffered bytes.
-                    $chunks_since_save++;
-                    if (
-                        $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS
-                        && $sql_buffer === ""
-                    ) {
-                        if ($sql_handle) {
-                            fflush($sql_handle);
-                        }
-                        $this->get_state()->active_resumable_command->remote_cursor = $cursor;
-                        $this->get_state()->sql_bytes = $sql_bytes_written;
-                        $this->get_state()->sql_statements_counted = $sql_statements_counted;
-                        $this->save_state();
-                        $chunks_since_save = 0;
-
-                        // Also persist discovered domains so they survive crashes.
-                        // On resume, the SQL download picks up from the cursor,
-                        // skipping already-downloaded data — so domains from that
-                        // earlier data would be lost without periodic saves.
-                        if ($domain_collector) {
-                            $domains = $domain_collector->get_domains();
-                            if (!empty($domains)) {
-                                file_put_contents(
-                                    $domains_file,
-                                    json_encode($domains, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
-                                );
-                            }
-                        }
-                    }
+                    $chunk_cursor = $chunk["headers"]["x-cursor"] ?? $cursor;
 
                     $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                     if ($chunk_type === "sql") {
-                        $query_complete = ($chunk["headers"]["x-query-complete"] ?? "1") === "1";
                         $data = $chunk["body"];
 
                         switch ($mode) {
@@ -7759,48 +8120,19 @@ class ImportClient
 
                             case "stdout":
                                 $bytes = @fwrite(STDOUT, $data);
-                                if ($bytes === false) {
-                                    // Broken pipe — save state and exit cleanly so the
-                                    // pipe reader (e.g. `mysql`) can finish on its own.
-                                    $this->save_state();
-                                    exit(0);
+                                if ($bytes === false || $bytes !== strlen($data)) {
+                                    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI stream byte counts are not HTML.
+                                    throw new RuntimeException(
+                                        'SQL stdout write failed after ' .
+                                        ( $bytes === false ? '0' : $bytes ) . '/' . strlen($data) .
+                                        ' bytes. The program reading stdout may have received only part ' .
+                                        'of the SQL. Reset it before trying again.',
+                                    );
+                                    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
                                 }
                                 $sql_bytes_written += $bytes;
                                 break;
 
-                            case "mysql":
-                                // Append to disk immediately so the buffer survives
-                                // even if the process is killed mid-chunk.
-                                if ($sql_buffer_handle) {
-                                    fwrite($sql_buffer_handle, $data);
-                                    fflush($sql_buffer_handle);
-                                }
-
-                                $sql_buffer .= $data;
-                                $sql_bytes_written += strlen($data);
-
-                                if ($query_complete) {
-                                    if (!$mysql_conn->multi_query($sql_buffer)) {
-                                        throw new RuntimeException("MySQL execution failed: " . $mysql_conn->error);
-                                    }
-                                    // Drain all result sets from multi_query before sending the
-                                    // next chunk — mysqli requires this.
-                                    do {
-                                        $result = $mysql_conn->store_result();
-                                        if ($result) { $result->free(); }
-                                        if ($mysql_conn->errno) {
-                                            throw new RuntimeException("MySQL statement error: " . $mysql_conn->error);
-                                        }
-                                    } while ($mysql_conn->more_results() && $mysql_conn->next_result());
-
-                                    // Query executed — truncate the buffer file and reset.
-                                    if ($sql_buffer_handle) {
-                                        ftruncate($sql_buffer_handle, 0);
-                                        rewind($sql_buffer_handle);
-                                    }
-                                    $sql_buffer = "";
-                                }
-                                break;
                         }
 
                         // Feed data to query stream for domain discovery and statement counting
@@ -7870,6 +8202,38 @@ class ImportClient
                     } elseif ($chunk_type === "error") {
                         $this->handle_error_chunk($chunk, "sql", $context);
                     }
+
+                    // The cursor names the part just processed. Only file output
+                    // persists it after flushing the matching bytes. Direct output
+                    // retains it in memory for source retries in this process.
+                    $cursor = $chunk_cursor;
+                    $chunks_since_save++;
+                    if (
+                        $mode === 'file'
+                        && $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS
+                    ) {
+                        if ($sql_handle) {
+                            if (!fflush($sql_handle)) {
+                                throw new RuntimeException('Reprint could not finish writing db.sql before saving progress.');
+                            }
+                        }
+                        // Persist discovered domains before the cursor because
+                        // resume skips SQL from before that cursor.
+                        if ($domain_collector) {
+                            $domains = $domain_collector->get_domains();
+                            if (!empty($domains)) {
+                                file_put_contents(
+                                    $domains_file,
+                                    json_encode($domains, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+                                );
+                            }
+                        }
+                        $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                        $this->get_state()->sql_bytes = $sql_bytes_written;
+                        $this->get_state()->sql_statements_counted = $sql_statements_counted;
+                        $this->save_state();
+                        $chunks_since_save = 0;
+                    }
                 };
 
                 $cursor_before = $cursor;
@@ -7887,11 +8251,10 @@ class ImportClient
                         $cursor,
                         $e,
                     );
-                    $retry_log = "SQL RETRY | resuming source request | mode={$mode}";
-                    if ($sql_buffer !== "") {
-                        $retry_log .= " | buffered_sql=" . strlen($sql_buffer) . " bytes";
-                    }
-                    $this->audit_log($retry_log, true);
+                    $this->audit_log(
+                        "SQL RETRY | resuming source request | mode={$mode}",
+                        true,
+                    );
                     continue;
                 }
                 $this->get_state()->consecutive_interrupted_responses = 0;
@@ -7902,15 +8265,17 @@ class ImportClient
                     $context->response_stats ?? [],
                 );
 
-                // Save cursor for resumption (keep it even when complete for reference)
+                // Save the file size and source position together.
                 if ($sql_handle) {
-                    fflush($sql_handle);
+                    if (!fflush($sql_handle)) {
+                        throw new RuntimeException('Reprint could not finish writing db.sql before saving progress.');
+                    }
+                    $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                    // Keep the final file size until run_db_sync records overall
+                    // completion; that last state write may itself be interrupted.
+                    $this->get_state()->sql_bytes = $sql_bytes_written;
+                    $this->save_state();
                 }
-
-                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
-                // Clear sql_bytes when complete, otherwise save current position
-                $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
-                $this->save_state();
             }
 
             // Drain any remaining statements after download completes
@@ -7953,51 +8318,11 @@ class ImportClient
                     );
                 }
             }
-        } catch (\Throwable $e) {
-            $caught_exception = $e;
-            throw $e;
         } finally {
             if ($sql_handle) {
                 fclose($sql_handle);
             }
-            if ($sql_buffer_handle) {
-                fclose($sql_buffer_handle);
-                $sql_buffer_handle = null;
-            }
-            if ($mysql_conn) {
-                $pending = $sql_buffer;
-                $mysql_conn->close();
-                $mysql_conn = null;
-                // Clean up buffer file — if we got here with an empty buffer,
-                // all queries were executed successfully.
-                $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-                if ($pending === "" && file_exists($sql_buffer_file)) {
-                    unlink($sql_buffer_file);
-                }
-                if ($pending !== "") {
-                    if ($caught_exception !== null) {
-                        // An exception is already in flight (e.g. curl error,
-                        // MySQL error). Don't mask it by throwing about the
-                        // buffer — the buffer data is safely persisted in
-                        // pull/sql-buffer and will be recovered on the next run.
-                        $this->audit_log(
-                            "BUFFER NOT FLUSHED | " . strlen($pending) .
-                            " bytes in SQL buffer during exception unwind" .
-                            " (original error: " . $caught_exception->getMessage() . ")",
-                            true,
-                        );
-                    } else {
-                        $buffer_not_flushed = $pending;
-                    }
-                }
-            }
-        }
 
-        if ($buffer_not_flushed !== "") {
-            throw new RuntimeException(
-                "Buffered SQL was never executed (" . strlen($buffer_not_flushed) .
-                " bytes) — incomplete export?"
-            );
         }
     }
 
@@ -10160,13 +10485,13 @@ class ImportClient
      * Track consecutive interrupted responses and decide whether to resume.
      *
      * Compares the cursor before and after the request. A cursor advance means
-     * the request produced another durable part, so the counter resets. If the
+     * the request handler accepted another complete part, so the counter resets. If the
      * cursor did not move, the counter increments. After
      * MAX_CONSECUTIVE_INTERRUPTED_RESPONSES with no progress, the runner stops.
      *
      * @param string                           $phase         Human-readable phase name.
      * @param ?string                          $cursor_before Cursor at request start.
-     * @param ?string                          $cursor_after  Last durable cursor.
+     * @param ?string                          $cursor_after  Last accepted cursor in this process.
      * @param TransientInterruptionException   $exception     Response failure.
      */
     protected function assert_can_resume_after_interrupted_response(
@@ -10862,6 +11187,71 @@ class ImportClient
         $this->state->pull_pipeline = $previous_state->pull_pipeline;
     }
 
+    /** Removes the files that describe a database pull. */
+    public function clear_database_pull_records(): void
+    {
+        foreach ([
+            self::DATABASE_DUMP_INTENT_FILE,
+            self::DATABASE_DUMP_RECORD_FILE,
+            self::DATABASE_STDOUT_STATUS_FILE,
+        ] as $filename) {
+            $path = wp_join_unix_paths($this->pull_state_directory, $filename);
+            if (file_exists($path) && !unlink($path)) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- basename is one of the fixed record names above.
+                throw new RuntimeException('Cannot delete saved database pull file: ' . basename($path));
+            }
+        }
+    }
+
+    /**
+     * Reads a JSON object, returning an empty array when it is absent or invalid.
+     *
+     * @return array<string,mixed> Decoded JSON object.
+     */
+    private function read_json_file(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return [];
+        }
+        $value = json_decode($contents, true);
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * Writes a JSON object without exposing a partly written file.
+     *
+     * @param array<string,mixed> $value JSON object fields.
+     */
+    private function write_json_file(string $path, array $value): void
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These CLI errors name the state file and its directory.
+        $json = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new RuntimeException(
+                'Reprint could not encode ' . basename($path) . ' as JSON: ' . json_last_error_msg(),
+            );
+        }
+        $contents = $json . "\n";
+        $temporary_path = $path . '.tmp';
+        if (file_put_contents($temporary_path, $contents) !== strlen($contents)) {
+            throw new RuntimeException(
+                'Reprint could not save ' . basename($path) . '. Check that ' . dirname($path) .
+                ' is writable and has free space.',
+            );
+        }
+        if (!rename($temporary_path, $path)) {
+            throw new RuntimeException(
+                'Reprint could not finish saving ' . basename($path) .
+                '. Check the state directory permissions.',
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+    }
+
     /** Return the in-process pull state. */
     public function get_state(): PullState
     {
@@ -11146,19 +11536,7 @@ class ImportClient
         }
         $state = $this->encode_state_paths($state);
 
-        // Write to temp file first, then atomic rename
-        $json = json_encode($state, JSON_PRETTY_PRINT);
-        if ($json === false) {
-            throw new RuntimeException("Failed to encode state: " . json_last_error_msg());
-        }
-        $tmp_file = $this->pull_state_file . '.tmp';
-        $bytes = file_put_contents($tmp_file, $json);
-        if ($bytes === false) {
-            throw new RuntimeException("Failed to write state file: $tmp_file (disk full?)");
-        }
-        if (!rename($tmp_file, $this->pull_state_file)) {
-            throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->pull_state_file}");
-        }
+        $this->write_json_file($this->pull_state_file, $state);
 
         $remote_index_entry_count = $this->remote_index_entry_count();
         $files_pulled = $this->files_pulled; // Completed in this run
@@ -11616,7 +11994,7 @@ if (
             'type' => 'value',
             'target' => 'sql_output',
             'placeholder' => 'MODE',
-            'help' => 'Output mode: file (default), stdout, mysql',
+            'help' => 'Output mode: file (default), stdout, mysql (download then apply)',
             'commands' => ['db-pull'],
         ],
         [
@@ -11624,7 +12002,7 @@ if (
             'type' => 'value',
             'target' => 'mysql_host',
             'placeholder' => 'HOST',
-            'help' => 'MySQL host (default: 127.0.0.1, for --sql-output=mysql)',
+            'help' => 'Target MySQL host (default: 127.0.0.1, for --sql-output=mysql)',
             'commands' => ['db-pull'],
         ],
         [
@@ -11632,7 +12010,7 @@ if (
             'type' => 'value',
             'target' => 'mysql_port',
             'placeholder' => 'PORT',
-            'help' => 'MySQL port (default: 3306, for --sql-output=mysql)',
+            'help' => 'Target MySQL port (default: 3306, for --sql-output=mysql)',
             'commands' => ['db-pull'],
         ],
         [
@@ -11640,7 +12018,7 @@ if (
             'type' => 'value',
             'target' => 'mysql_user',
             'placeholder' => 'USER',
-            'help' => 'MySQL user (default: root, for --sql-output=mysql)',
+            'help' => 'Target MySQL user (default: root, for --sql-output=mysql)',
             'commands' => ['db-pull'],
         ],
         [
@@ -11648,7 +12026,7 @@ if (
             'type' => 'value',
             'target' => 'mysql_password',
             'placeholder' => 'PASS',
-            'help' => 'MySQL password (or set MYSQL_PASSWORD env)',
+            'help' => 'Target MySQL password (or set MYSQL_PASSWORD env)',
             'commands' => ['db-pull'],
         ],
         [
@@ -11656,7 +12034,7 @@ if (
             'type' => 'value',
             'target' => 'mysql_database',
             'placeholder' => 'DB',
-            'help' => 'MySQL database (required for --sql-output=mysql)',
+            'help' => 'Target MySQL database (required for --sql-output=mysql)',
             'commands' => ['db-pull'],
         ],
 
@@ -12505,14 +12883,18 @@ if (
             "short" => "Pull the database as a SQL dump (index + download)",
             "description" =>
                 "Indexes remote tables, then streams the full SQL dump into\n" .
-                "--state-dir/db.sql (default), to stdout, or directly into a\n" .
-                "MySQL connection. Resumes from the last cursor if interrupted.\n" .
+                "--state-dir/db.sql (default) or to stdout. With --sql-output=mysql,\n" .
+                "it downloads db.sql completely before applying it to MySQL. File\n" .
+                "downloads continue from the last saved source position. An interrupted\n" .
+                "MySQL apply starts db.sql from the beginning on a new connection.\n" .
+                "If stdout stops, reset the receiving program or file, then abort and\n" .
+                "restart as file output.\n" .
                 "Discovered domains are cached for later use by db-apply.\n",
             "extra" =>
                 "Output modes:\n" .
                 "  file    Write to --state-dir/db.sql (default)\n" .
                 "  stdout  Write raw SQL to stdout; progress goes to stderr\n" .
-                "  mysql   Stream directly into a MySQL connection\n",
+                "  mysql   Download db.sql, then apply it to MySQL\n",
         ],
         "db-index" => [
             "level" => "low",
@@ -12544,7 +12926,7 @@ if (
             "short" => "Print local pull metadata for host integrations as JSON",
             "usage" => "reprint pull-metadata <remote-reprint-api-url> --state-dir=DIR",
             "description" =>
-                "Prints pull lifecycle, artifact availability, and source-site\n" .
+                "Prints pull progress, available downloads, and source-site\n" .
                 "metadata for host integrations. The remote Reprint API URL selects\n" .
                 "the state; no network calls are made.\n",
             "extra" =>
@@ -12556,7 +12938,8 @@ if (
             "short" => "Apply the SQL dump to a local MySQL or SQLite database",
             "description" =>
                 "Reads db.sql from --state-dir, optionally rewrites URLs, and executes\n" .
-                "all statements against a target database. Resumable. Saves target\n" .
+                "all statements against a target database. After an interruption, a complete\n" .
+                "db-pull output starts again at the beginning and reruns its SQL header. Saves target\n" .
                 "database credentials to state for use by apply-runtime.\n",
             "extra" =>
                 "MySQL example:\n" .

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -123,7 +123,7 @@ class Pull
      * Handle --abort for high-level pull commands.
      *
      * File pipelines keep downloaded site files in place. The database
-     * pipeline removes stale database artifacts so the next pull-db fetches
+     * pipeline removes old database files so the next pull-db fetches
      * and applies a fresh dump.
      */
     public function abort(string $command = 'pull'): void
@@ -142,7 +142,7 @@ class Pull
         $label = $command === 'pull' ? 'Pull' : $command;
         $message = "{$label} state cleared.";
         $message .= $command === 'pull-db'
-            ? " Database artifacts will be downloaded again."
+            ? " Database files will be downloaded again."
             : " Downloaded files are preserved.";
         $this->progress->show_lifecycle_line("{$message}\n");
         $this->client->output_progress([
@@ -312,7 +312,7 @@ class Pull
                     }
                 }
             } elseif ($state_command === 'db-pull' && in_array('db-pull', $stages, true)) {
-                // Discard database dump artifacts from any previous runs.
+                // Discard database files from previous runs.
                 $state = $this->client->get_state();
                 $state->active_resumable_command->command_name = null;
                 $state->active_resumable_command->completion_state = null;
@@ -321,16 +321,27 @@ class Pull
                 $state->consecutive_interrupted_responses = 0;
                 $state->sql_bytes = null;
                 $state->db_index = new DatabaseTableIndexState();
-                $this->client->save_state();
                 foreach ([
                     "{$state_dir}/db.sql",
                     "{$state_dir}/db-tables.jsonl",
                     "{$pull_state_directory}/domains.json",
+                    "{$pull_state_directory}/sql-stats.json",
                 ] as $path) {
                     if (file_exists($path)) {
-                        @unlink($path);
+                        if (!unlink($path)) {
+                            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The path belongs to the caller-selected state directory.
+                            throw new RuntimeException(
+                                "Reprint could not delete pull file: {$path}. " .
+                                "Check its permissions, then try again.",
+                            );
+                            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                        }
                     }
                 }
+                $this->client->save_state();
+                // Remove the status files only after the saved command no
+                // longer says this database pull is running.
+                $this->client->clear_database_pull_records();
             }
         }
 
@@ -373,10 +384,14 @@ class Pull
             $this->print_stage_header($stage);
 
             try {
-                $this->run_stage($stage, $options, $step, $total);
+                $stage_completed = $this->run_stage($stage, $options, $step, $total);
             } catch (\Exception $e) {
                 $this->report_failure($command, $stage, $stages, $i, $e);
                 throw new PullFailureReportedException($e->getMessage(), 0, $e);
+            }
+
+            if (!$stage_completed) {
+                return;
             }
 
             $this->client->mark_pull_stage_complete($stage, $command, $stages);
@@ -405,11 +420,11 @@ class Pull
      * Runs one pipeline stage and prints its completion summary.
      *
      * Stages that delegate to lower-level commands rely on those commands for
-     * their own resume state. The pipeline checkpoint is saved by the caller
-     * after this method returns, so a thrown exception leaves the stage
-     * unfinished at the orchestration level.
+     * their own resume state. True lets the caller save the pipeline checkpoint;
+     * false leaves a partial stage unfinished and returns control to the process.
+     * A thrown exception also leaves the stage unfinished.
      */
-    private function run_stage(string $stage, array $options, int $step, int $total): void
+    private function run_stage(string $stage, array $options, int $step, int $total): bool
     {
         switch ($stage) {
             case 'preflight':
@@ -486,9 +501,18 @@ class Pull
                     $state->active_resumable_command->command_name !== 'db-apply' ||
                     $state->active_resumable_command->completion_state !== 'complete'
                 ) {
-                    $this->run_until_complete('db-apply', function () use ($options) {
+                    $this->client->enable_database_apply_signal_handling();
+                    try {
                         $this->client->run_db_apply($options);
-                    });
+                    } finally {
+                        $this->client->restore_command_signal_handling();
+                    }
+                    $completion_state =
+                        $this->client->get_state()->active_resumable_command->completion_state;
+                    if ($completion_state === 'partial') {
+                        $this->client->exit_code = 2;
+                        return false;
+                    }
                 }
                 $stmts = $state->apply->statements_executed;
                 $this->print_done($stage, $stmts > 0 ? number_format($stmts) . " statements" : null);
@@ -508,6 +532,7 @@ class Pull
                 $this->start_server($options);
                 break;
         }
+        return true;
     }
 
     /**
@@ -821,8 +846,6 @@ class Pull
             $state->apply = new DatabaseApplyCommandState();
             $state->sql_output = null;
         }
-        $this->client->save_state();
-
         $paths = [];
         if ($reset_file_transfer_state) {
             $paths[] = wp_join_unix_paths($pull_state_directory, 'remote-index.next.jsonl');
@@ -832,12 +855,26 @@ class Pull
             $paths[] = wp_join_unix_paths($state_dir, 'db.sql');
             $paths[] = wp_join_unix_paths($state_dir, 'db-tables.jsonl');
             $paths[] = wp_join_unix_paths($pull_state_directory, 'domains.json');
+            $paths[] = wp_join_unix_paths($pull_state_directory, 'sql-stats.json');
         }
 
         foreach ($paths as $path) {
             if (file_exists($path)) {
-                @unlink($path);
+                if (!unlink($path)) {
+                    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The path belongs to the caller-selected state directory.
+                    throw new RuntimeException(
+                        "Reprint could not delete pull file: {$path}. " .
+                        "Check its permissions, then try again.",
+                    );
+                    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                }
             }
+        }
+        $this->client->save_state();
+        if ($reset_db_state) {
+            // If cleanup stops after this save, the next --abort can remove
+            // the leftover status files without resuming database output.
+            $this->client->clear_database_pull_records();
         }
 
         $this->client->audit_log(strtoupper($command) . " | prepared for delta re-pull", true);

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -74,19 +74,15 @@ class PullState
     /** @var int SQL statements counted while streaming db.sql. */
     public int $sql_statements_counted = 0;
     public DatabaseApplyCommandState $apply;
-    /** @var string|null SQL output mode persisted for resume: file, stdout, or mysql. */
+    /** @var string|null SQL download mode persisted for resume: file or stdout. */
     public ?string $sql_output = null;
-    /**
-     * @var string|null MySQL host persisted for resume.
-     *
-     * The password is deliberately excluded from pull state.
-     */
+    /** @var string|null Unused direct-output host field retained in the state shape. */
     public ?string $mysql_host = null;
-    /** @var int|null MySQL port persisted for resume. */
+    /** @var int|null Unused direct-output port field retained in the state shape. */
     public ?int $mysql_port = null;
-    /** @var string|null MySQL user persisted for resume. */
+    /** @var string|null Unused direct-output user field retained in the state shape. */
     public ?string $mysql_user = null;
-    /** @var string|null MySQL database persisted for resume. */
+    /** @var string|null Unused direct-output database field retained in the state shape. */
     public ?string $mysql_database = null;
     /** Number of consecutive interrupted responses without cursor progress. */
     public int $consecutive_interrupted_responses = 0;

--- a/tests/Import/DatabaseCommandRestartTest.php
+++ b/tests/Import/DatabaseCommandRestartTest.php
@@ -1,0 +1,1432 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+class DatabaseCommandRestartTest extends TestCase
+{
+    private string $root;
+    /** @var int[] */
+    private array $childPids = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/reprint-database-restart-' . uniqid('', true);
+        mkdir($this->root . '/state', 0755, true);
+        mkdir($this->root . '/files', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->childPids as $childPid) {
+            $waitResult = pcntl_waitpid($childPid, $status, WNOHANG);
+            if ($waitResult === 0 && function_exists('posix_kill') && defined('SIGKILL')) {
+                posix_kill($childPid, SIGKILL);
+                pcntl_waitpid($childPid, $status);
+            }
+        }
+        $this->removeTree($this->root);
+        parent::tearDown();
+    }
+
+    public function testDbPullContinuesAfterExitCodeTwo(): void
+    {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('The local streaming endpoint requires pcntl.');
+        }
+
+        $sql = "SELECT 2;\n";
+        [$remoteUrl, $serverPid] = $this->startOneResponseServer(function (array $query) use ($sql): string {
+            $this->assertSame('sql_chunk', $query['endpoint'] ?? null);
+            $this->assertSame('saved-sql-cursor', base64_decode($query['cursor'] ?? '', true));
+            return $this->multipartResponse([
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'sql',
+                        'X-Query-Complete' => '1',
+                        'X-Cursor' => base64_encode('final-sql-cursor'),
+                    ],
+                    'body' => $sql,
+                ],
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'completion',
+                        'X-Status' => 'complete',
+                    ],
+                    'body' => '',
+                ],
+            ]);
+        });
+
+        $client = $this->newClient($remoteUrl);
+        $this->writeReplacementDumpIntent($client);
+        $state = $client->get_state();
+        $state->active_resumable_command->command_name = 'db-pull';
+        $state->active_resumable_command->completion_state = 'partial';
+        $state->active_resumable_command->current_stage = 'sql';
+        $state->active_resumable_command->remote_cursor = base64_encode('saved-sql-cursor');
+        $state->sql_bytes = strlen("SELECT 1;\n");
+        $state->sql_output = 'file';
+        $client->save_state();
+        file_put_contents($this->root . '/state/db.sql', "SELECT 1;\n");
+
+        try {
+            $result = $this->runCli([
+                'db-pull',
+                $remoteUrl,
+                '--state-dir=' . $this->root . '/state',
+                '--fs-root=' . $this->root . '/files',
+                '--progress=jsonl',
+            ]);
+        } finally {
+            pcntl_waitpid($serverPid, $serverStatus);
+        }
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('"event":"resuming"', $result['output']);
+        $this->assertSame("SELECT 1;\nSELECT 2;\n", file_get_contents($this->root . '/state/db.sql'));
+        $dumpRecord = json_decode(
+            (string) file_get_contents($client->pull_state_directory . '/database-dump.json'),
+            true,
+        );
+        $this->assertIsArray($dumpRecord);
+        $this->assertSame(
+            hash_file('sha256', $this->root . '/state/db.sql'),
+            $dumpRecord['sha256'] ?? null,
+        );
+        $this->assertTrue($dumpRecord['create_table_query'] ?? false);
+        $this->assertTrue(pcntl_wifexited($serverStatus));
+        $this->assertSame(0, pcntl_wexitstatus($serverStatus));
+
+        $alreadyComplete = $this->runCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ]);
+
+        $this->assertSame(0, $alreadyComplete['exit'], $alreadyComplete['output']);
+        $this->assertSame(
+            "SELECT 1;\nSELECT 2;\n",
+            file_get_contents($this->root . '/state/db.sql'),
+        );
+    }
+
+    public function testDbPullCrashKeepsThePartNamedByItsSavedCursor(): void
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill') || !defined('SIGKILL')) {
+            $this->markTestSkipped('The process-death test requires pcntl and posix signals.');
+        }
+
+        $readyPath = $this->root . '/sql-stream-ready';
+        $releasePath = $this->root . '/sql-stream-release';
+        [$remoteUrl, $serverPid] = $this->startTwoResponseSqlServer($readyPath, $releasePath);
+        $client = $this->newClient($remoteUrl);
+        $this->writeReplacementDumpIntent($client);
+        $state = $client->get_state();
+        $state->active_resumable_command->command_name = 'db-pull';
+        $state->active_resumable_command->completion_state = 'in_progress';
+        $state->active_resumable_command->current_stage = 'sql';
+        $state->sql_output = 'file';
+        $client->save_state();
+
+        [$process] = $this->startCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ], true);
+
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+        $expectedFirstResponse = $this->sqlStatements(1, 50);
+        $this->waitUntil(function () use ($readyPath, $pullStatePath, $expectedFirstResponse): bool {
+            if (!is_file($readyPath) || !is_file($pullStatePath)) {
+                return false;
+            }
+            $state = json_decode( (string) file_get_contents($pullStatePath), true );
+            return base64_decode($state['active_resumable_command']['remote_cursor'] ?? '', true) === 'cursor-50'
+                && is_file($this->root . '/state/db.sql')
+                && filesize($this->root . '/state/db.sql') === strlen($expectedFirstResponse);
+        }, 'The first process did not store the cursor for SQL part 50.');
+
+        $status = proc_get_status($process);
+        $this->assertTrue($status['running']);
+        $this->assertTrue(posix_kill($status['pid'], SIGKILL));
+        proc_close($process);
+        file_put_contents($releasePath, '');
+
+        $result = $this->runCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ]);
+        pcntl_waitpid($serverPid, $serverStatus);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame($this->sqlStatements(1, 60), file_get_contents($this->root . '/state/db.sql'));
+        $this->assertTrue(pcntl_wifexited($serverStatus));
+        $this->assertSame(0, pcntl_wexitstatus($serverStatus));
+    }
+
+    public function testDbPullDropsCursorlessBytesBeforeSavingItsFirstBoundary(): void
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill') || !defined('SIGKILL')) {
+            $this->markTestSkipped('The process-death test requires pcntl and posix signals.');
+        }
+
+        $firstReadyPath = $this->root . '/first-sql-stream-ready';
+        $firstReleasePath = $this->root . '/first-sql-stream-release';
+        $secondReadyPath = $this->root . '/second-sql-stream-ready';
+        $secondReleasePath = $this->root . '/second-sql-stream-release';
+        [$remoteUrl, $serverPid] = $this->startThreeResponseSqlServer(
+            $firstReadyPath,
+            $firstReleasePath,
+            $secondReadyPath,
+            $secondReleasePath,
+        );
+        $client = $this->newClient($remoteUrl);
+        $this->writeReplacementDumpIntent($client);
+        $state = $client->get_state();
+        $state->active_resumable_command->command_name = 'db-pull';
+        $state->active_resumable_command->completion_state = 'in_progress';
+        $state->active_resumable_command->current_stage = 'sql';
+        $state->sql_output = 'file';
+        $client->save_state();
+
+        [$firstProcess] = $this->startCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ], true);
+
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+        $firstUnconfirmedBytes = $this->sqlStatements(1, 10);
+        $this->waitUntil(function () use ($firstReadyPath, $pullStatePath, $firstUnconfirmedBytes): bool {
+            if (!is_file($firstReadyPath) || !is_file($pullStatePath)) {
+                return false;
+            }
+            $state = json_decode( (string) file_get_contents($pullStatePath), true );
+            return empty($state['active_resumable_command']['remote_cursor'])
+                && is_file($this->root . '/state/db.sql')
+                && filesize($this->root . '/state/db.sql') === strlen($firstUnconfirmedBytes);
+        }, 'The first process did not write bytes before its first saved cursor.');
+
+        $firstStatus = proc_get_status($firstProcess);
+        $this->assertTrue($firstStatus['running']);
+        $this->assertTrue(posix_kill($firstStatus['pid'], SIGKILL));
+        proc_close($firstProcess);
+        file_put_contents($firstReleasePath, '');
+
+        [$secondProcess] = $this->startCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ], true);
+
+        $secondCheckpointState = null;
+        $this->waitUntil(function () use (
+            $secondProcess,
+            $secondReadyPath,
+            $pullStatePath,
+            &$secondCheckpointState
+        ): bool {
+            if (!is_file($secondReadyPath) || !is_file($pullStatePath)) {
+                return false;
+            }
+            if (!proc_get_status($secondProcess)['running']) {
+                return false;
+            }
+            $state = json_decode( (string) file_get_contents($pullStatePath), true );
+            if (base64_decode($state['active_resumable_command']['remote_cursor'] ?? '', true) !== 'cursor-50') {
+                return false;
+            }
+            $secondCheckpointState = $state;
+            return true;
+        }, 'The second process did not save its first SQL cursor.');
+
+        $secondStatus = proc_get_status($secondProcess);
+        $this->assertTrue($secondStatus['running']);
+        $this->assertTrue(posix_kill($secondStatus['pid'], SIGKILL));
+        proc_close($secondProcess);
+        file_put_contents($secondReleasePath, '');
+
+        $expectedCheckpointBytes = $this->sqlStatements(1, 50);
+        $this->assertSame(strlen($expectedCheckpointBytes), $secondCheckpointState['sql_bytes']);
+        $this->assertSame(strlen($expectedCheckpointBytes), filesize($this->root . '/state/db.sql'));
+
+        $result = $this->runCli([
+            'db-pull',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--progress=jsonl',
+        ]);
+        pcntl_waitpid($serverPid, $serverStatus);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertSame($this->sqlStatements(1, 60), file_get_contents($this->root . '/state/db.sql'));
+        $this->assertTrue(pcntl_wifexited($serverStatus));
+        $this->assertSame(0, pcntl_wexitstatus($serverStatus));
+    }
+
+    public function testStandaloneDbApplyDefersSignalsBetweenSqlChunks(): void
+    {
+        if (
+            !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_signal')
+            || !function_exists('pcntl_signal_get_handler')
+            || !function_exists('pcntl_sigprocmask')
+        ) {
+            $this->markTestSkipped('The signal policy test requires PCNTL signal APIs.');
+        }
+
+        $originalAsyncSignals = pcntl_async_signals();
+        $originalSigintHandler = pcntl_signal_get_handler(SIGINT);
+        $originalSigtermHandler = pcntl_signal_get_handler(SIGTERM);
+        pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $originalSignalMask);
+        pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+
+        try {
+            $client = new \ImportClient(
+                'http://standalone-db-apply-signals.test/export',
+                $this->root . '/state',
+                $this->root . '/files',
+                'db-apply',
+            );
+
+            $this->assertFalse(pcntl_async_signals());
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $databaseApplySignalMask);
+            pcntl_sigprocmask(SIG_SETMASK, $databaseApplySignalMask);
+            $this->assertContains(SIGINT, $databaseApplySignalMask);
+            $this->assertContains(SIGTERM, $databaseApplySignalMask);
+
+            $sigintHandler = pcntl_signal_get_handler(SIGINT);
+            $sigtermHandler = pcntl_signal_get_handler(SIGTERM);
+            $this->assertIsArray($sigintHandler);
+            $this->assertSame($client, $sigintHandler[0]);
+            $this->assertSame('handle_database_apply_shutdown', $sigintHandler[1]);
+            $this->assertIsArray($sigtermHandler);
+            $this->assertSame($client, $sigtermHandler[0]);
+            $this->assertSame('handle_database_apply_shutdown', $sigtermHandler[1]);
+        } finally {
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals(false);
+            pcntl_signal(SIGINT, $originalSigintHandler);
+            pcntl_signal(SIGTERM, $originalSigtermHandler);
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals($originalAsyncSignals);
+            pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+        }
+    }
+
+    public function testDbApplyContinuesAfterExitCodeTwo(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGTERM') || !defined('SIGSTOP') || !defined('SIGCONT')) {
+            $this->markTestSkipped('The orderly interruption test requires posix signals.');
+        }
+
+        $remoteUrl = 'http://db-apply-partial.test/export';
+        $sqlitePath = $this->root . '/partial.sqlite';
+        $client = $this->newClient($remoteUrl);
+        $this->writeItemDump(5000);
+        $this->writeReplacementDumpRecord($client);
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+
+        [$process, $pipes] = $this->startCli([
+            'db-apply',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . $sqlitePath,
+            '--target-db=wordpress',
+            '--progress=jsonl',
+        ]);
+        $this->waitUntil(function () use ($process, $pullStatePath): bool {
+            $processStatus = proc_get_status($process);
+            if (!$processStatus['running']) {
+                return false;
+            }
+            $state = json_decode( (string) @file_get_contents($pullStatePath), true );
+            return (int) ( $state['apply']['statements_executed'] ?? 0 ) >= 100;
+        }, 'db-apply completed before the test could request an orderly stop.');
+
+        $status = proc_get_status($process);
+        $this->assertTrue(posix_kill($status['pid'], SIGSTOP));
+        $this->assertTrue(posix_kill($status['pid'], SIGTERM));
+        $this->assertTrue(posix_kill($status['pid'], SIGCONT));
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $this->assertSame(2, proc_close($process), (string) $stdout . (string) $stderr);
+
+        $partialState = json_decode( (string) file_get_contents($pullStatePath), true );
+        $this->assertSame('partial', $partialState['active_resumable_command']['completion_state']);
+        $this->assertGreaterThan(0, $partialState['apply']['statements_executed']);
+        $this->assertLessThan(5002, $partialState['apply']['statements_executed']);
+
+        $result = $this->runCli([
+            'db-apply',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . $sqlitePath,
+            '--target-db=wordpress',
+            '--progress=jsonl',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('"event":"restarting"', $result['output']);
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        $this->assertSame(5000, (int) $pdo->query('SELECT COUNT(*) FROM items')->fetchColumn());
+    }
+
+    public function testDbApplyRestartsTheDumpAfterProcessDeath(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGKILL') || !defined('SIGSTOP') || !defined('SIGCONT')) {
+            $this->markTestSkipped('The process-death test requires posix signals.');
+        }
+
+        $remoteUrl = 'http://db-apply-crash.test/export';
+        $sqlitePath = $this->root . '/crash.sqlite';
+        $this->writeItemDump(5000);
+        $client = $this->newClient($remoteUrl);
+        $this->writeReplacementDumpRecord($client);
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+
+        [$process] = $this->startCli([
+            'db-apply',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . $sqlitePath,
+            '--target-db=wordpress',
+            '--progress=jsonl',
+        ], true);
+
+        $savedStatements = 0;
+        $this->waitUntil(function () use ($process, $pullStatePath, &$savedStatements): bool {
+            $processStatus = proc_get_status($process);
+            if (!$processStatus['running']) {
+                return false;
+            }
+            $state = json_decode( (string) @file_get_contents($pullStatePath), true );
+            $savedStatements = (int) ( $state['apply']['statements_executed'] ?? 0 );
+            return $savedStatements >= 100;
+        }, 'db-apply completed before the test could stop it at a saved boundary.');
+
+        $status = proc_get_status($process);
+        $this->assertTrue(posix_kill($status['pid'], SIGSTOP));
+        $this->assertTrue(posix_kill($status['pid'], SIGCONT));
+        usleep(20000);
+        $this->assertTrue(posix_kill($status['pid'], SIGKILL));
+        proc_close($process);
+
+        $crashState = json_decode( (string) file_get_contents($pullStatePath), true );
+        $savedStatements = (int) ( $crashState['apply']['statements_executed'] ?? 0 );
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        $committedRows = (int) $pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
+        $this->assertGreaterThan($savedStatements - 2, $committedRows);
+        $this->assertLessThan(5000, $committedRows);
+        $pdo = null;
+
+        $result = $this->runCli([
+            'db-apply',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . $sqlitePath,
+            '--target-db=wordpress',
+            '--progress=jsonl',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('"event":"restarting"', $result['output']);
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        $this->assertSame(5000, (int) $pdo->query('SELECT COUNT(*) FROM items')->fetchColumn());
+    }
+
+    public function testDbApplyRefusesToRestartAnUnconfirmedDump(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGKILL') || !defined('SIGSTOP')) {
+            $this->markTestSkipped('The process-death test requires posix signals.');
+        }
+
+        $remoteUrl = 'http://db-apply-unconfirmed.test/export';
+        $sqlitePath = $this->root . '/unconfirmed.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(5000));
+        $client = $this->newClient($remoteUrl);
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+
+        [$process] = $this->startCli(
+            $this->databaseApplyArguments($remoteUrl, $sqlitePath),
+            true,
+        );
+        $this->waitUntil(function () use ($process, $pullStatePath): bool {
+            $processStatus = proc_get_status($process);
+            if (!$processStatus['running']) {
+                return false;
+            }
+            $state = json_decode( (string) @file_get_contents($pullStatePath), true );
+            return (int) ( $state['apply']['statements_executed'] ?? 0 ) >= 100;
+        }, 'db-apply completed before the test could stop it at a saved boundary.');
+        $status = proc_get_status($process);
+        $this->assertTrue(posix_kill($status['pid'], SIGSTOP));
+        $this->assertTrue(posix_kill($status['pid'], SIGKILL));
+        proc_close($process);
+
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+        $state = json_decode(
+            (string) file_get_contents($pullStatePath),
+            true,
+        );
+        $this->assertSame('in_progress', $state['active_resumable_command']['completion_state']);
+
+        $secondResult = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertNotSame(0, $secondResult['exit'], $secondResult['output']);
+        $this->assertStringContainsString('db-apply stopped after it may have changed the target database', $secondResult['output']);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+    }
+
+    public function testFreshDbApplyConnectionFailureDoesNotStartAnAttempt(): void
+    {
+        $remoteUrl = 'http://fresh-db-apply-admission.test/export';
+        $sqlitePath = $this->root . '/fresh-db-apply-admission.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(10));
+        $client = new class(
+            $remoteUrl,
+            $this->root . '/state',
+            $this->root . '/files',
+            $sqlitePath,
+        ) extends \ImportClient {
+            private string $targetSqlitePath;
+            public bool $observedAttemptBeforeTargetSql = false;
+
+            public function __construct(
+                string $remoteUrl,
+                string $stateDirectory,
+                string $filesystemRoot,
+                string $targetSqlitePath
+            ) {
+                $this->targetSqlitePath = $targetSqlitePath;
+                parent::__construct($remoteUrl, $stateDirectory, $filesystemRoot);
+            }
+
+            public function save_state(): void
+            {
+                $activeCommand = $this->get_state()->active_resumable_command;
+                if (
+                    !$this->observedAttemptBeforeTargetSql
+                    && $activeCommand->command_name === 'db-apply'
+                    && $activeCommand->completion_state === 'in_progress'
+                ) {
+                    $attempt = json_decode(
+                        (string) @file_get_contents(
+                            $this->pull_state_directory . '/database-apply.json',
+                        ),
+                        true,
+                    );
+                    if (( $attempt['status'] ?? null ) !== 'in_progress') {
+                        throw new \LogicException(
+                            'db-apply state was saved before its restart information.',
+                        );
+                    }
+                    $pdo = new \PDO('sqlite:' . $this->targetSqlitePath);
+                    $targetAttempts = (int) $pdo->query(
+                        'SELECT attempts FROM restart_probe WHERE id = 1',
+                    )->fetchColumn();
+                    if ($targetAttempts !== 0) {
+                        throw new \LogicException(
+                            'db-apply executed target SQL before saving its restart information.',
+                        );
+                    }
+                    $this->observedAttemptBeforeTargetSql = true;
+                }
+
+                parent::save_state();
+            }
+        };
+        $client->get_state()->set_preflight_record([
+            'http_code' => 200,
+            'data' => ['ok' => true],
+        ]);
+        $client->save_state();
+
+        try {
+            $client->run_db_apply([
+                'target_engine' => 'sqlite',
+                'target_sqlite_path' => $this->root . '/files',
+                'target_db' => 'wordpress',
+            ]);
+            $this->fail('The directory path unexpectedly opened as a SQLite database.');
+        } catch (\RuntimeException $error) {
+            $this->assertStringContainsString(
+                'Cannot connect to target SQLite database',
+                $error->getMessage(),
+            );
+        }
+
+        $attemptPath = $client->pull_state_directory . '/database-apply.json';
+        $this->assertFileDoesNotExist($attemptPath);
+        $failedState = json_decode(
+            (string) file_get_contents($client->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertNull($failedState['active_resumable_command']['command_name']);
+        $this->assertNull($failedState['active_resumable_command']['completion_state']);
+        $this->assertFalse($client->observedAttemptBeforeTargetSql);
+
+        $client->run_db_apply([
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wordpress',
+        ]);
+
+        $this->assertTrue($client->observedAttemptBeforeTargetSql);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+    }
+
+    public function testDbApplyAttemptSurvivesDbIndexCommandState(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGKILL') || !defined('SIGSTOP')) {
+            $this->markTestSkipped('The process-death test requires posix signals.');
+        }
+        [$remoteUrl, $serverPid] = $this->startOneResponseServer(function (array $query): string {
+            $this->assertSame('db_index', $query['endpoint'] ?? null);
+            return $this->multipartResponse([
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'completion',
+                        'X-Status' => 'complete',
+                    ],
+                    'body' => '',
+                ],
+            ]);
+        }, 60);
+        $sqlitePath = $this->root . '/db-index-overwrite.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(5000));
+        $client = $this->newClient($remoteUrl);
+        [$process] = $this->startCli(
+            $this->databaseApplyArguments($remoteUrl, $sqlitePath),
+            true,
+        );
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+        $this->waitUntil(function () use ($process, $pullStatePath): bool {
+            $processStatus = proc_get_status($process);
+            if (!$processStatus['running']) {
+                return false;
+            }
+            $state = json_decode( (string) @file_get_contents($pullStatePath), true );
+            return (int) ( $state['apply']['statements_executed'] ?? 0 ) >= 100;
+        }, 'db-apply completed before the test could stop it at a saved boundary.');
+
+        $status = proc_get_status($process);
+        $this->assertTrue(posix_kill($status['pid'], SIGSTOP));
+        $this->assertTrue(posix_kill($status['pid'], SIGKILL));
+        proc_close($process);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+
+        try {
+            $indexResult = $this->runCli([
+                'db-index',
+                $remoteUrl,
+                '--state-dir=' . $this->root . '/state',
+                '--fs-root=' . $this->root . '/files',
+                '--progress=jsonl',
+            ]);
+        } finally {
+            pcntl_waitpid($serverPid, $serverStatus);
+        }
+
+        $this->assertSame(0, $indexResult['exit'], $indexResult['output']);
+        $this->assertTrue(pcntl_wifexited($serverStatus));
+        $this->assertSame(0, pcntl_wexitstatus($serverStatus));
+        $state = json_decode(
+            (string) file_get_contents($client->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertSame('db-index', $state['active_resumable_command']['command_name']);
+        $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
+
+        $result = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertNotSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('db-apply stopped after it may have changed the target database', $result['output']);
+        $this->assertSame(
+            1,
+            $this->restartAttempts($sqlitePath),
+            'db-apply executed the interrupted dump as a new attempt',
+        );
+    }
+
+    public function testCompletedDbApplyAttemptRepairsTargetStateAfterDbIndexAbort(): void
+    {
+        $remoteUrl = 'http://completed-apply-repair.test/export';
+        $sqlitePath = $this->root . '/completed-db-index-overwrite.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(10));
+        $client = $this->newClient($remoteUrl);
+
+        $firstApply = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+        $this->assertSame(0, $firstApply['exit'], $firstApply['output']);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+
+        $abortedIndex = $this->runCli([
+            'db-index',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--abort',
+            '--progress=jsonl',
+        ]);
+        $this->assertSame(0, $abortedIndex['exit'], $abortedIndex['output']);
+        $clearedState = json_decode(
+            (string) file_get_contents($client->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertNull($clearedState['apply']['target_engine']);
+
+        $secondApply = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertSame(0, $secondApply['exit'], $secondApply['output']);
+        $this->assertSame(
+            1,
+            $this->restartAttempts($sqlitePath),
+            'db-apply repeated target work after another command replaced its completed state',
+        );
+        $repairedState = json_decode(
+            (string) file_get_contents($client->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertSame('sqlite', $repairedState['apply']['target_engine']);
+        $this->assertSame('wordpress', $repairedState['apply']['target_db']);
+        $this->assertSame(realpath($sqlitePath), $repairedState['apply']['target_sqlite_path']);
+    }
+
+    public function testCompletedDbApplyReturnsWithoutRunningSqlAgain(): void
+    {
+        $remoteUrl = 'http://completed-apply.test/export';
+        $sqlitePath = $this->root . '/completed-apply.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(10));
+        $this->newClient($remoteUrl);
+
+        $firstApply = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+        $this->assertSame(0, $firstApply['exit'], $firstApply['output']);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+
+        $secondApply = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertSame(0, $secondApply['exit'], $secondApply['output']);
+        $this->assertSame(
+            1,
+            $this->restartAttempts($sqlitePath),
+            'db-apply ran SQL again after it had already completed',
+        );
+    }
+
+    public function testCompletedDbApplyAttemptRepairsTheInProgressStateSaveBoundary(): void
+    {
+        $remoteUrl = 'http://completed-apply-state-boundary.test/export';
+        $sqlitePath = $this->root . '/completed-state-boundary.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        file_put_contents($this->root . '/state/db.sql', $this->restartProbeDump(10));
+        $boundaryClient = new class(
+            $remoteUrl,
+            $this->root . '/state',
+            $this->root . '/files',
+        ) extends \ImportClient {
+            private bool $hasFailedCompletionStateSave = false;
+
+            public function save_state(): void
+            {
+                $attempt = json_decode(
+                    (string) @file_get_contents(
+                        $this->pull_state_directory . '/database-apply.json',
+                    ),
+                    true,
+                );
+                $activeCommand = $this->get_state()->active_resumable_command;
+                if (
+                    !$this->hasFailedCompletionStateSave
+                    && ( $attempt['status'] ?? null ) === 'complete'
+                    && $activeCommand->command_name === 'db-apply'
+                    && $activeCommand->completion_state === 'complete'
+                ) {
+                    $this->hasFailedCompletionStateSave = true;
+                    throw new \RuntimeException(
+                        'Injected failure before saving completed db-apply state.',
+                    );
+                }
+
+                parent::save_state();
+            }
+        };
+        $boundaryClient->get_state()->set_preflight_record([
+            'http_code' => 200,
+            'data' => ['ok' => true],
+        ]);
+        $boundaryClient->save_state();
+        $this->writeReplacementDumpRecord($boundaryClient);
+
+        try {
+            $boundaryClient->run_db_apply([
+                'target_engine' => 'sqlite',
+                'target_sqlite_path' => $sqlitePath,
+                'target_db' => 'wordpress',
+            ]);
+            $this->fail('The test client did not interrupt the completion state save.');
+        } catch (\RuntimeException $error) {
+            $this->assertSame(
+                'Injected failure before saving completed db-apply state.',
+                $error->getMessage(),
+            );
+        }
+
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+        $boundaryState = json_decode(
+            (string) file_get_contents($boundaryClient->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertSame('db-apply', $boundaryState['active_resumable_command']['command_name']);
+        $this->assertSame('in_progress', $boundaryState['active_resumable_command']['completion_state']);
+        $boundaryAttempt = json_decode(
+            (string) file_get_contents(
+                $boundaryClient->pull_state_directory . '/database-apply.json',
+            ),
+            true,
+        );
+        $this->assertSame('complete', $boundaryAttempt['status']);
+
+        $secondApply = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertSame(0, $secondApply['exit'], $secondApply['output']);
+        $this->assertSame(
+            1,
+            $this->restartAttempts($sqlitePath),
+            'db-apply repeated target work instead of repairing its state',
+        );
+        $repairedState = json_decode(
+            (string) file_get_contents($boundaryClient->pull_state_directory . '/state.json'),
+            true,
+        );
+        $this->assertSame('complete', $repairedState['active_resumable_command']['completion_state']);
+        $this->assertGreaterThan(0, $repairedState['apply']['statements_executed']);
+    }
+
+    public function testDbApplyRejectsADeliberatelyTamperedSqlFileOnRestart(): void
+    {
+        $this->requireOrderlyStopSignals();
+        [$remoteUrl, $client] = $this->pullDatabaseDump($this->restartProbeDump(5000));
+        $sqlitePath = $this->root . '/changed-dump.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        $this->interruptDatabaseApply($client, $remoteUrl, $sqlitePath);
+        file_put_contents(
+            $this->root . '/state/db.sql',
+            "-- changed after the first apply process stopped\n",
+            FILE_APPEND,
+        );
+
+        $result = $this->runCli($this->databaseApplyArguments($remoteUrl, $sqlitePath));
+
+        $this->assertNotSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('db-apply stopped after it may have changed the target database', $result['output']);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+    }
+
+    public function testDbApplyRefusesToRestartAgainstAnotherTarget(): void
+    {
+        $this->requireOrderlyStopSignals();
+        [$remoteUrl, $client] = $this->pullDatabaseDump($this->restartProbeDump(5000));
+        $firstSqlitePath = $this->root . '/first-target.sqlite';
+        $secondSqlitePath = $this->root . '/second-target.sqlite';
+        $this->createRestartProbe($firstSqlitePath);
+        $this->createRestartProbe($secondSqlitePath);
+        $this->interruptDatabaseApply($client, $remoteUrl, $firstSqlitePath);
+
+        $result = $this->runCli($this->databaseApplyArguments($remoteUrl, $secondSqlitePath));
+
+        $this->assertNotSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('db-apply stopped after it may have changed the target database', $result['output']);
+        $this->assertSame(0, $this->restartAttempts($secondSqlitePath));
+    }
+
+    public function testDbApplyRefusesANewSiteUrlOnRestart(): void
+    {
+        $this->requireOrderlyStopSignals();
+        [$remoteUrl, $client] = $this->pullDatabaseDump($this->restartProbeDump(5000));
+        $sqlitePath = $this->root . '/changed-url-map.sqlite';
+        $this->createRestartProbe($sqlitePath);
+        $this->interruptDatabaseApply($client, $remoteUrl, $sqlitePath);
+
+        $result = $this->runCli(array_merge(
+            $this->databaseApplyArguments($remoteUrl, $sqlitePath),
+            ['--new-site-url=http://replacement.test'],
+        ));
+
+        $this->assertNotSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('db-apply stopped after it may have changed the target database', $result['output']);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+    }
+
+    private function newClient(string $remoteUrl): \ImportClient
+    {
+        $client = new \ImportClient(
+            $remoteUrl,
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+        $client->get_state()->set_preflight_record([
+            'http_code' => 200,
+            'data' => ['ok' => true],
+        ]);
+        $client->save_state();
+        return $client;
+    }
+
+    private function writeReplacementDumpIntent(\ImportClient $client): void
+    {
+        file_put_contents(
+            $client->pull_state_directory . '/database-dump.intent',
+            json_encode(['create_table_query' => true], JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function writeReplacementDumpRecord(\ImportClient $client): void
+    {
+        file_put_contents(
+            $client->pull_state_directory . '/database-dump.json',
+            json_encode([
+                'sha256' => hash_file('sha256', $this->root . '/state/db.sql'),
+                'create_table_query' => true,
+            ], JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /** @return array{exit:int,stdout:string,stderr:string,output:string} */
+    private function runCli(array $arguments): array
+    {
+        [$process, $pipes] = $this->startCli($arguments);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($process);
+        return [
+            'exit' => $exit,
+            'stdout' => (string) $stdout,
+            'stderr' => (string) $stderr,
+            'output' => (string) $stdout . (string) $stderr,
+        ];
+    }
+
+    /** @return array{0:resource,1:array<int,resource>} */
+    private function startCli(array $arguments, bool $discardOutput = false): array
+    {
+        $descriptors = $discardOutput
+            ? [['pipe', 'r'], ['file', '/dev/null', 'w'], ['file', '/dev/null', 'w']]
+            : [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']];
+        $process = proc_open(
+            array_merge([PHP_BINARY, __DIR__ . '/../../packages/reprint-client/bin/reprint-client'], $arguments),
+            $descriptors,
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [$process, $pipes];
+    }
+
+    /** @return array{0:string,1:\ImportClient} */
+    private function pullDatabaseDump(string $sql): array
+    {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('The local streaming endpoint requires pcntl.');
+        }
+
+        [$remoteUrl, $serverPid] = $this->startDatabasePullServer($sql);
+        $client = $this->newClient($remoteUrl);
+        try {
+            $result = $this->runCli([
+                'db-pull',
+                $remoteUrl,
+                '--state-dir=' . $this->root . '/state',
+                '--fs-root=' . $this->root . '/files',
+                '--progress=jsonl',
+            ]);
+        } finally {
+            pcntl_waitpid($serverPid, $serverStatus);
+        }
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertTrue(pcntl_wifexited($serverStatus));
+        $this->assertSame(0, pcntl_wexitstatus($serverStatus));
+        return [$remoteUrl, $client];
+    }
+
+    private function interruptDatabaseApply(
+        \ImportClient $client,
+        string $remoteUrl,
+        string $sqlitePath
+    ): void {
+        [$process, $pipes] = $this->startCli(
+            $this->databaseApplyArguments($remoteUrl, $sqlitePath),
+        );
+        $pullStatePath = $client->pull_state_directory . '/state.json';
+        $this->waitUntil(function () use ($process, $pullStatePath): bool {
+            $processStatus = proc_get_status($process);
+            if (!$processStatus['running']) {
+                return false;
+            }
+            $state = json_decode( (string) @file_get_contents($pullStatePath), true );
+            return (int) ( $state['apply']['statements_executed'] ?? 0 ) >= 100;
+        }, 'db-apply completed before the test could request an orderly stop.');
+
+        $status = proc_get_status($process);
+        $this->assertTrue(posix_kill($status['pid'], SIGSTOP));
+        $this->assertTrue(posix_kill($status['pid'], SIGTERM));
+        $this->assertTrue(posix_kill($status['pid'], SIGCONT));
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $this->assertSame(2, proc_close($process), (string) $stdout . (string) $stderr);
+        $this->assertSame(1, $this->restartAttempts($sqlitePath));
+    }
+
+    /** @return string[] */
+    private function databaseApplyArguments(string $remoteUrl, string $sqlitePath): array
+    {
+        return [
+            'db-apply',
+            $remoteUrl,
+            '--state-dir=' . $this->root . '/state',
+            '--fs-root=' . $this->root . '/files',
+            '--target-engine=sqlite',
+            '--target-sqlite-path=' . $sqlitePath,
+            '--target-db=wordpress',
+            '--progress=jsonl',
+        ];
+    }
+
+    private function createRestartProbe(string $sqlitePath): void
+    {
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        $pdo->exec('CREATE TABLE restart_probe (id INTEGER PRIMARY KEY, attempts INTEGER NOT NULL)');
+        $pdo->exec('INSERT INTO restart_probe (id, attempts) VALUES (1, 0)');
+    }
+
+    private function restartAttempts(string $sqlitePath): int
+    {
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        return (int) $pdo->query('SELECT attempts FROM restart_probe WHERE id = 1')->fetchColumn();
+    }
+
+    private function restartProbeDump(int $rows): string
+    {
+        $sql = "UPDATE `restart_probe` SET `attempts` = `attempts` + 1 WHERE `id` = 1;\n"
+            . "DROP TABLE IF EXISTS `items`;\n"
+            . "CREATE TABLE `items` (`id` INTEGER PRIMARY KEY, `value` TEXT);\n";
+        for ($id = 1; $id <= $rows; $id++) {
+            $sql .= "INSERT INTO `items` (`id`, `value`) VALUES ({$id}, 'value-{$id}');\n";
+        }
+        return $sql;
+    }
+
+    private function requireOrderlyStopSignals(): void
+    {
+        if (!function_exists('posix_kill') || !defined('SIGTERM') || !defined('SIGSTOP') || !defined('SIGCONT')) {
+            $this->markTestSkipped('The orderly interruption test requires posix signals.');
+        }
+    }
+
+    /** @return array{0:string,1:int} */
+    private function startDatabasePullServer(string $sql): array
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($listener, $errorMessage);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+        if ($pid === 0) {
+            $indexConnection = stream_socket_accept($listener, 10);
+            if (!is_resource($indexConnection)) {
+                exit(2);
+            }
+            $indexRequest = $this->readHttpRequest($indexConnection);
+            parse_str( (string) parse_url($indexRequest['target'], PHP_URL_QUERY), $indexQuery );
+            if ( ( $indexQuery['endpoint'] ?? null ) !== 'db_index' ) {
+                exit(3);
+            }
+            fwrite($indexConnection, $this->multipartResponse([
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'completion',
+                        'X-Status' => 'complete',
+                    ],
+                    'body' => '',
+                ],
+            ]));
+            fclose($indexConnection);
+
+            $sqlConnection = stream_socket_accept($listener, 10);
+            if (!is_resource($sqlConnection)) {
+                exit(4);
+            }
+            $sqlRequest = $this->readHttpRequest($sqlConnection);
+            parse_str( (string) parse_url($sqlRequest['target'], PHP_URL_QUERY), $sqlQuery );
+            if ( ( $sqlQuery['endpoint'] ?? null ) !== 'sql_chunk' ) {
+                exit(5);
+            }
+            if ( ( $sqlQuery['create_table_query'] ?? null ) !== '1' ) {
+                exit(6);
+            }
+            fwrite($sqlConnection, $this->multipartResponse([
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'sql',
+                        'X-Query-Complete' => '1',
+                        'X-Cursor' => base64_encode('complete-dump'),
+                    ],
+                    'body' => $sql,
+                ],
+                [
+                    'headers' => [
+                        'X-Chunk-Type' => 'completion',
+                        'X-Status' => 'complete',
+                    ],
+                    'body' => '',
+                ],
+            ]));
+            fclose($sqlConnection);
+            fclose($listener);
+            exit(0);
+        }
+        fclose($listener);
+        $this->childPids[] = $pid;
+        return ['http://' . $address . '/export', $pid];
+    }
+
+    /** @return array{0:string,1:int} */
+    private function startOneResponseServer(callable $response, int $acceptTimeout = 10): array
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($listener, $errorMessage);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+        if ($pid === 0) {
+            $connection = stream_socket_accept($listener, $acceptTimeout);
+            if (!is_resource($connection)) {
+                exit(2);
+            }
+            $request = $this->readHttpRequest($connection);
+            parse_str( (string) parse_url($request['target'], PHP_URL_QUERY), $query );
+            fwrite($connection, $response($query));
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+        fclose($listener);
+        $this->childPids[] = $pid;
+        return ['http://' . $address . '/export', $pid];
+    }
+
+    /** @return array{0:string,1:int} */
+    private function startTwoResponseSqlServer(string $readyPath, string $releasePath): array
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($listener, $errorMessage);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+        if ($pid === 0) {
+            $first = stream_socket_accept($listener, 10);
+            if (!is_resource($first)) {
+                exit(2);
+            }
+            $firstRequest = $this->readHttpRequest($first);
+            parse_str( (string) parse_url($firstRequest['target'], PHP_URL_QUERY), $firstQuery );
+            if ( ( $firstQuery['create_table_query'] ?? null ) !== '1' ) {
+                exit(3);
+            }
+            fwrite($first, $this->multipartResponseHeaders('restart-boundary'));
+            for ($part = 1; $part <= 50; $part++) {
+                fwrite($first, $this->multipartPart('restart-boundary', [
+                    'X-Chunk-Type' => 'sql',
+                    'X-Query-Complete' => '1',
+                    'X-Cursor' => base64_encode('cursor-' . $part),
+                ], sprintf("SELECT %d;\n", $part)));
+                fflush($first);
+            }
+            file_put_contents($readyPath, '');
+            while (!is_file($releasePath)) {
+                usleep(10000);
+            }
+            fclose($first);
+
+            $second = stream_socket_accept($listener, 10);
+            if (!is_resource($second)) {
+                exit(4);
+            }
+            $request = $this->readHttpRequest($second);
+            parse_str( (string) parse_url($request['target'], PHP_URL_QUERY), $query );
+            if (base64_decode($query['cursor'] ?? '', true) !== 'cursor-50') {
+                exit(5);
+            }
+            if ( ( $query['create_table_query'] ?? null ) !== '1' ) {
+                exit(6);
+            }
+            $parts = [];
+            for ($part = 51; $part <= 60; $part++) {
+                $parts[] = [
+                    'headers' => [
+                        'X-Chunk-Type' => 'sql',
+                        'X-Query-Complete' => '1',
+                        'X-Cursor' => base64_encode('cursor-' . $part),
+                    ],
+                    'body' => sprintf("SELECT %d;\n", $part),
+                ];
+            }
+            $parts[] = [
+                'headers' => [
+                    'X-Chunk-Type' => 'completion',
+                    'X-Status' => 'complete',
+                ],
+                'body' => '',
+            ];
+            fwrite($second, $this->multipartResponse($parts, 'restart-boundary'));
+            fclose($second);
+            fclose($listener);
+            exit(0);
+        }
+        fclose($listener);
+        $this->childPids[] = $pid;
+        return ['http://' . $address . '/export', $pid];
+    }
+
+    /** @return array{0:string,1:int} */
+    private function startThreeResponseSqlServer(
+        string $firstReadyPath,
+        string $firstReleasePath,
+        string $secondReadyPath,
+        string $secondReleasePath
+    ): array {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+        $this->assertIsResource($listener, $errorMessage);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+        if ($pid === 0) {
+            $first = stream_socket_accept($listener, 10);
+            if (!is_resource($first)) {
+                exit(2);
+            }
+            $firstRequest = $this->readHttpRequest($first);
+            parse_str( (string) parse_url($firstRequest['target'], PHP_URL_QUERY), $firstQuery );
+            if (isset($firstQuery['cursor'])) {
+                exit(3);
+            }
+            if ( ( $firstQuery['create_table_query'] ?? null ) !== '1' ) {
+                exit(4);
+            }
+            fwrite($first, $this->multipartResponseHeaders('cursorless-boundary'));
+            for ($part = 1; $part <= 10; $part++) {
+                fwrite($first, $this->multipartPart('cursorless-boundary', [
+                    'X-Chunk-Type' => 'sql',
+                    'X-Query-Complete' => '1',
+                    'X-Cursor' => base64_encode('unconfirmed-' . $part),
+                ], sprintf("SELECT %d;\n", $part)));
+                fflush($first);
+            }
+            file_put_contents($firstReadyPath, '');
+            while (!is_file($firstReleasePath)) {
+                usleep(10000);
+            }
+            fclose($first);
+
+            $second = stream_socket_accept($listener, 10);
+            if (!is_resource($second)) {
+                exit(5);
+            }
+            $secondRequest = $this->readHttpRequest($second);
+            parse_str( (string) parse_url($secondRequest['target'], PHP_URL_QUERY), $secondQuery );
+            if (isset($secondQuery['cursor'])) {
+                exit(6);
+            }
+            if ( ( $secondQuery['create_table_query'] ?? null ) !== '1' ) {
+                exit(7);
+            }
+            fwrite($second, $this->multipartResponseHeaders('cursorless-boundary'));
+            for ($part = 1; $part <= 50; $part++) {
+                fwrite($second, $this->multipartPart('cursorless-boundary', [
+                    'X-Chunk-Type' => 'sql',
+                    'X-Query-Complete' => '1',
+                    'X-Cursor' => base64_encode('cursor-' . $part),
+                ], sprintf("SELECT %d;\n", $part)));
+                fflush($second);
+            }
+            file_put_contents($secondReadyPath, '');
+            while (!is_file($secondReleasePath)) {
+                usleep(10000);
+            }
+            fclose($second);
+
+            $third = stream_socket_accept($listener, 10);
+            if (!is_resource($third)) {
+                exit(8);
+            }
+            $thirdRequest = $this->readHttpRequest($third);
+            parse_str( (string) parse_url($thirdRequest['target'], PHP_URL_QUERY), $thirdQuery );
+            if (base64_decode($thirdQuery['cursor'] ?? '', true) !== 'cursor-50') {
+                exit(9);
+            }
+            if ( ( $thirdQuery['create_table_query'] ?? null ) !== '1' ) {
+                exit(10);
+            }
+            $parts = [];
+            for ($part = 51; $part <= 60; $part++) {
+                $parts[] = [
+                    'headers' => [
+                        'X-Chunk-Type' => 'sql',
+                        'X-Query-Complete' => '1',
+                        'X-Cursor' => base64_encode('cursor-' . $part),
+                    ],
+                    'body' => sprintf("SELECT %d;\n", $part),
+                ];
+            }
+            $parts[] = [
+                'headers' => [
+                    'X-Chunk-Type' => 'completion',
+                    'X-Status' => 'complete',
+                ],
+                'body' => '',
+            ];
+            fwrite($third, $this->multipartResponse($parts, 'cursorless-boundary'));
+            fclose($third);
+            fclose($listener);
+            exit(0);
+        }
+        fclose($listener);
+        $this->childPids[] = $pid;
+        return ['http://' . $address . '/export', $pid];
+    }
+
+    /** @return array{target:string} */
+    private function readHttpRequest($connection): array
+    {
+        stream_set_timeout($connection, 10);
+        $request = '';
+        while (strpos($request, "\r\n\r\n") === false) {
+            $chunk = fread($connection, 8192);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            $request .= $chunk;
+        }
+        $requestLine = strtok($request, "\r\n");
+        $parts = is_string($requestLine) ? explode(' ', $requestLine) : [];
+        return ['target' => $parts[1] ?? ''];
+    }
+
+    private function multipartResponse(array $parts, string $boundary = 'database-restart'): string
+    {
+        $body = '';
+        foreach ($parts as $part) {
+            $body .= $this->multipartPart($boundary, $part['headers'], $part['body']);
+        }
+        $body .= "--{$boundary}--\r\n";
+        return $this->multipartResponseHeaders($boundary, strlen($body)) . $body;
+    }
+
+    private function multipartResponseHeaders(string $boundary, ?int $contentLength = null): string
+    {
+        $headers = "HTTP/1.1 200 OK\r\n"
+            . "Content-Type: multipart/mixed; boundary={$boundary}\r\n"
+            . "Connection: close\r\n";
+        if ($contentLength !== null) {
+            $headers .= "Content-Length: {$contentLength}\r\n";
+        }
+        return $headers . "\r\n";
+    }
+
+    private function multipartPart(string $boundary, array $headers, string $body): string
+    {
+        $part = "--{$boundary}\r\nContent-Length: " . strlen($body) . "\r\n";
+        foreach ($headers as $name => $value) {
+            $part .= "{$name}: {$value}\r\n";
+        }
+        return $part . "\r\n{$body}\r\n";
+    }
+
+    private function sqlStatements(int $first, int $last): string
+    {
+        $sql = '';
+        for ($statement = $first; $statement <= $last; $statement++) {
+            $sql .= sprintf("SELECT %d;\n", $statement);
+        }
+        return $sql;
+    }
+
+    private function writeItemDump(int $rows): void
+    {
+        $sql = "DROP TABLE IF EXISTS `items`;\n"
+            . "CREATE TABLE `items` (`id` INTEGER PRIMARY KEY, `value` TEXT);\n";
+        for ($id = 1; $id <= $rows; $id++) {
+            $sql .= "INSERT INTO `items` (`id`, `value`) VALUES ({$id}, 'value-{$id}');\n";
+        }
+        file_put_contents($this->root . '/state/db.sql', $sql);
+    }
+
+    private function waitUntil(callable $condition, string $failure): void
+    {
+        for ($attempt = 0; $attempt < 1000; $attempt++) {
+            if ($condition()) {
+                return;
+            }
+            usleep(10000);
+        }
+        $this->fail($failure);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->removeTree($path . '/' . $entry);
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -13,6 +13,10 @@ class PullFilterFakeClient extends \ImportClient
     public int $files_pull_runs = 0;
     public int $db_sync_runs = 0;
     public int $db_apply_runs = 0;
+    public int $database_apply_signal_enables = 0;
+    public int $command_signal_restores = 0;
+    public bool $db_apply_stops_partial_once = false;
+    public bool $db_apply_throws = false;
     public array $progress_events = [];
     public array $progress_file_errors = [];
 
@@ -128,12 +132,30 @@ class PullFilterFakeClient extends \ImportClient
     public function run_db_apply(array $options): void
     {
         $this->db_apply_runs++;
+        if ($this->db_apply_throws) {
+            throw new \RuntimeException('Injected db-apply failure.');
+        }
         $state = $this->get_state();
         $state->active_resumable_command->command_name = "db-apply";
-        $state->active_resumable_command->completion_state = "complete";
+        if ($this->db_apply_stops_partial_once) {
+            $this->db_apply_stops_partial_once = false;
+            $state->active_resumable_command->completion_state = "partial";
+        } else {
+            $state->active_resumable_command->completion_state = "complete";
+        }
         $state->active_resumable_command->current_stage = null;
         $state->apply->statements_executed = 42;
         $this->save_state();
+    }
+
+    public function enable_database_apply_signal_handling(): void
+    {
+        ++$this->database_apply_signal_enables;
+    }
+
+    public function restore_command_signal_handling(): void
+    {
+        ++$this->command_signal_restores;
     }
 }
 
@@ -647,6 +669,139 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
         $this->assertSame(42, $state["apply"]["statements_executed"]);
+    }
+
+    public function testPullDbReturnsAfterAPartialApplyWithoutAdvancingThePipeline(): void
+    {
+        $client = $this->makeClient();
+        $client->db_apply_stops_partial_once = true;
+
+        ob_start();
+        $client->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(2, $client->exit_code);
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame(1, $client->database_apply_signal_enables);
+        $this->assertSame(1, $client->command_signal_restores);
+        $this->assertSame('db-pull', $state["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
+        $this->assertSame('partial', $state["active_resumable_command"]["completion_state"]);
+
+        $resumedClient = $this->makeClient();
+        ob_start();
+        $resumedClient->run([
+            "command" => "pull-db",
+            "target_engine" => "sqlite",
+        ]);
+        ob_end_clean();
+
+        $completedState = $this->readState();
+        $this->assertSame(0, $resumedClient->exit_code);
+        $this->assertSame(1, $resumedClient->db_apply_runs);
+        $this->assertSame(1, $resumedClient->database_apply_signal_enables);
+        $this->assertSame(1, $resumedClient->command_signal_restores);
+        $this->assertSame('db-apply', $completedState["pull_pipeline"]["last_completed_stage"]);
+        $this->assertSame('complete', $completedState["active_resumable_command"]["completion_state"]);
+    }
+
+    public function testDatabaseApplySignalScopeRestoresTheWrapperPolicy(): void
+    {
+        if (
+            !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_signal')
+            || !function_exists('pcntl_signal_get_handler')
+            || !function_exists('pcntl_sigprocmask')
+        ) {
+            $this->markTestSkipped('The signal policy test requires PCNTL signal APIs.');
+        }
+
+        $originalAsyncSignals = pcntl_async_signals();
+        $originalSigintHandler = pcntl_signal_get_handler(SIGINT);
+        $originalSigtermHandler = pcntl_signal_get_handler(SIGTERM);
+        pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $originalSignalMask);
+        pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+
+        try {
+            $client = new \ImportClient(
+                'http://fake.invalid',
+                $this->stateDir,
+                $this->filesystem_root,
+                'pull-db',
+            );
+            $client->enable_database_apply_signal_handling();
+
+            $this->assertFalse(pcntl_async_signals());
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $databaseApplySignalMask);
+            pcntl_sigprocmask(SIG_SETMASK, $databaseApplySignalMask);
+            $this->assertContains(SIGINT, $databaseApplySignalMask);
+            $this->assertContains(SIGTERM, $databaseApplySignalMask);
+            $databaseApplySigintHandler = pcntl_signal_get_handler(SIGINT);
+            $databaseApplySigtermHandler = pcntl_signal_get_handler(SIGTERM);
+            $this->assertIsArray($databaseApplySigintHandler);
+            $this->assertSame($client, $databaseApplySigintHandler[0]);
+            $this->assertSame(
+                'handle_database_apply_shutdown',
+                $databaseApplySigintHandler[1],
+            );
+            $this->assertIsArray($databaseApplySigtermHandler);
+            $this->assertSame($client, $databaseApplySigtermHandler[0]);
+            $this->assertSame(
+                'handle_database_apply_shutdown',
+                $databaseApplySigtermHandler[1],
+            );
+
+            $client->restore_command_signal_handling();
+
+            $this->assertTrue(pcntl_async_signals());
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM], $restoredSignalMask);
+            pcntl_sigprocmask(SIG_SETMASK, $restoredSignalMask);
+            $this->assertNotContains(SIGINT, $restoredSignalMask);
+            $this->assertNotContains(SIGTERM, $restoredSignalMask);
+            $restoredSigintHandler = pcntl_signal_get_handler(SIGINT);
+            $restoredSigtermHandler = pcntl_signal_get_handler(SIGTERM);
+            $this->assertIsArray($restoredSigintHandler);
+            $this->assertSame($client, $restoredSigintHandler[0]);
+            $this->assertSame('handle_shutdown', $restoredSigintHandler[1]);
+            $this->assertIsArray($restoredSigtermHandler);
+            $this->assertSame($client, $restoredSigtermHandler[0]);
+            $this->assertSame('handle_shutdown', $restoredSigtermHandler[1]);
+        } finally {
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals(false);
+            pcntl_signal(SIGINT, $originalSigintHandler);
+            pcntl_signal(SIGTERM, $originalSigtermHandler);
+            pcntl_sigprocmask(SIG_BLOCK, [SIGINT, SIGTERM]);
+            pcntl_async_signals($originalAsyncSignals);
+            pcntl_sigprocmask(SIG_SETMASK, $originalSignalMask);
+        }
+    }
+
+    public function testPullDbRestoresItsSignalPolicyWhenApplyFails(): void
+    {
+        $client = $this->makeClient();
+        $client->db_apply_throws = true;
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull-db",
+                "target_engine" => "sqlite",
+            ]);
+            $this->fail('Expected db-apply to fail.');
+        } catch (\RuntimeException $error) {
+            $this->assertSame('Injected db-apply failure.', $error->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame(1, $client->db_apply_runs);
+        $this->assertSame(1, $client->database_apply_signal_enables);
+        $this->assertSame(1, $client->command_signal_restores);
     }
 
     public function testPullDbRejectsConflictingInProgressPullFiles(): void

--- a/tests/Import/SqliteRuntimeConfigTest.php
+++ b/tests/Import/SqliteRuntimeConfigTest.php
@@ -388,10 +388,15 @@ class SqliteRuntimeConfigTest extends TestCase
             $this->fsRoot,
         );
         $this->loadClientState($client);
+        $target = $this->callPrivate(
+            $client,
+            'resolve_database_apply_target',
+            [['target_engine' => 'sqlite']],
+        );
         [$connection] = $this->callPrivate(
             $client,
             'create_target_db_apply_connection',
-            [['target_engine' => 'sqlite']],
+            [$target],
         );
         $resolved_filesystem_root = realpath($this->fsRoot);
         $this->assertIsString($resolved_filesystem_root);
@@ -399,7 +404,7 @@ class SqliteRuntimeConfigTest extends TestCase
         $this->assertIsObject($connection);
         $this->assertSame(
             $resolved_filesystem_root . '/database/.ht.sqlite',
-            $this->callPrivate($client, 'get_state')->apply->target_sqlite_path,
+            $target['sqlite_path'],
         );
     }
 

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -139,6 +139,24 @@
     },
     "db-index-interruption": {
       "port": 8125
+    },
+    "db-apply-process-death": {
+      "port": 8126
+    },
+    "stdout-db-pull-process-death": {
+      "port": 8127
+    },
+    "pull-db-shutdown": {
+      "port": 8128
+    },
+    "file-db-pull-artifact-guards": {
+      "port": 8130
+    },
+    "mysql-db-pull-pipeline": {
+      "port": 8131
+    },
+    "db-pull-index-interruption": {
+      "port": 8132
     }
   }
 }

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -86,7 +86,7 @@ describe('Import: SQL Output Modes', () => {
             await conn.end();
         });
 
-        it('streams SQL directly into MySQL and matches source', async () => {
+        it('downloads SQL, applies it to MySQL, and matches source', async () => {
             const result = runImporter(
                 `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
                 tempDir, 'db-pull', {
@@ -103,9 +103,8 @@ describe('Import: SQL Output Modes', () => {
             assert.equal(result.exitCode, 0,
                 `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-            // No db.sql should be on disk
-            assert.ok(!existsSync(join(tempDir, 'db.sql')),
-                'Expected no db.sql file when using --sql-output=mysql');
+            assert.ok(existsSync(join(tempDir, 'db.sql')),
+                'Expected the confirmed db.sql used by --sql-output=mysql');
 
             // Compare imported database against source
             const comparison = await compareDatabases(getDbName(site), importDb);
@@ -114,7 +113,7 @@ describe('Import: SQL Output Modes', () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('state file records sql_output mode', () => {
+        it('state records the completed file and apply stages', () => {
             const stateFile = join(
                 pullStateDirectory(
                     tempDir,
@@ -124,8 +123,12 @@ describe('Import: SQL Output Modes', () => {
             );
             assert.ok(existsSync(stateFile), 'Expected state file to exist');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.sql_output, 'mysql',
-                `Expected sql_output=mysql in state, got ${state.sql_output}`);
+            assert.equal(state.sql_output, 'file',
+                `Expected sql_output=file in state, got ${state.sql_output}`);
+            assert.equal(state.pull_pipeline.started_by_command, 'pull-db');
+            assert.equal(state.pull_pipeline.last_completed_stage, 'db-apply');
+            assert.equal(state.active_resumable_command.command_name, 'db-apply');
+            assert.equal(state.active_resumable_command.completion_state, 'complete');
         });
     });
 });

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -1,29 +1,25 @@
 /**
- * Test 36: MySQL Mode Crash Recovery
+ * Test 36: MySQL Mode Source Interruption
  *
- * When using --sql-output=mysql with short execution times, the server
- * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to pull/sql-buffer on disk as each
- * chunk arrives. If the process dies at any point, the next run reloads
- * whatever was accumulated.
+ * When using --sql-output=mysql with short execution times, the server may
+ * pause mid-query. The importer appends every received fragment to db.sql,
+ * confirms the completed dump, and then applies it through db-apply.
  *
- * This test forces many resume cycles with --max-exec=1, verifies the
- * database is correct after completion, and confirms pull/sql-buffer is
- * cleaned up.
+ * This test forces many source-response cycles with --max-exec=1 and verifies
+ * same-process completion.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    readAuditLog, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
+describe('Import: MySQL Mode Source Interruption', { timeout: 120000 }, () => {
     const site = 'basic';
 
     beforeAll(async () => {
@@ -42,7 +38,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         '--mysql-password=e2e_password',
     ];
 
-    describe('resume with short --max-exec completes correctly', () => {
+    describe('same-process source retries with short --max-exec', () => {
         let tempDir;
         const importDb = 'e2e_basic_import_36_resume';
 
@@ -61,9 +57,9 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
             await conn.end();
         });
 
-        it('completes via multiple resume cycles and database matches source', async () => {
+        it('completes and matches the source database', async () => {
             // Use --max-exec=1 to force the server to pause frequently,
-            // creating many resume cycles. auto-resume handles exit code 2.
+            // creating many source responses within one importer process.
             const result = runImporter(importUrl(), tempDir, 'db-pull', {
                 secret: getSiteSecret(site),
                 extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
@@ -79,65 +75,10 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer')),
-                'Expected pull/sql-buffer to be cleaned up after successful completion');
-        });
-
-        it('no db.sql on disk', () => {
-            assert.ok(!existsSync(join(tempDir, 'db.sql')),
-                'Expected no db.sql file when using --sql-output=mysql');
+        it('keeps the confirmed db.sql on disk', () => {
+            assert.ok(existsSync(join(tempDir, 'db.sql')),
+                'Expected db.sql when using --sql-output=mysql');
         });
     });
 
-    describe('pre-seeded pull/sql-buffer is loaded on resume', () => {
-        let tempDir;
-        const importDb = 'e2e_basic_import_36_seeded';
-
-        beforeAll(async () => {
-            tempDir = createTempDir('e2e-mysql-seeded-buffer');
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.query(`CREATE DATABASE \`${importDb}\``);
-            await conn.end();
-        });
-
-        afterAll(async () => {
-            cleanupTempDir(tempDir);
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.end();
-        });
-
-        it('loads pull/sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
-            // Run preflight so db-pull can proceed
-            runImporter(importUrl(), tempDir, 'preflight', {
-                secret: getSiteSecret(site),
-            });
-
-            // Seed a pull/sql-buffer file before running db-pull.
-            // The content is a harmless SQL comment that won't affect execution
-            // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer');
-            writeFileSync(bufferFile, '-- pre-seeded buffer\n');
-
-            // Run a fresh db-pull — the importer should detect the buffer file
-            const result = runImporter(importUrl(), tempDir, 'db-pull', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                skipPreflight: true,
-            });
-            assert.equal(result.exitCode, 0,
-                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
-
-            // Verify recovery was logged
-            const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('pull/sql-buffer'),
-                'Expected audit log to mention pull/sql-buffer crash recovery');
-
-            // Buffer should be cleaned up
-            assert.ok(!existsSync(bufferFile),
-                'Expected pull/sql-buffer to be removed after completion');
-        });
-    });
 });

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -195,11 +195,6 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(
-                    pullStateDirectory(tempDir, importUrl()),
-                    'sql-buffer',
-                )),
-                    'Expected pull/sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);
                 if (mode === 'mysql') {

--- a/tests/e2e/tests/import-54-db-pull-index-interruption.test.js
+++ b/tests/e2e/tests/import-54-db-pull-index-interruption.test.js
@@ -1,0 +1,177 @@
+/**
+ * Test 54b: Database pull index response interruption.
+ *
+ * The source exits after sending its table-stat parts but before sending the
+ * completion part. The first db-pull invocation must return exit code 2 and
+ * retain partial state; a later process must continue that db-pull lifecycle
+ * instead of silently replacing it with a new one.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    writeTestHooks, removeTestHooks,
+    readHookState, clearHookState, pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Database Pull Response Interruption', () => {
+    const site = 'db-pull-index-interruption';
+    const hookState = `/srv/e2e-sites/.e2e-hook-state-${site}`;
+    let tempDir;
+    let savedDbIndexCursor;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-db-pull-index-interruption');
+        clearHookState(site);
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('first db-pull process exits partial when the db-index completion part is interrupted', () => {
+        writeTestHooks(site, [
+            'function test_hook_before_completion($status, $gz, $boundary) {',
+            "    if (($_GET['endpoint'] ?? '') !== 'db_index') { return; }",
+            `    $state = file_exists('${hookState}')`,
+            `        ? json_decode(file_get_contents('${hookState}'), true)`,
+            '        : [];',
+            "    $state['requests'] = ($state['requests'] ?? 0) + 1;",
+            "    $state['request_cursor'][] = $_GET['cursor'] ?? null;",
+            `    file_put_contents('${hookState}', json_encode($state));`,
+            "    if ($state['requests'] === 1) {",
+            "        $progress = json_encode(['phase' => 'tables']);",
+            '        $gz->write(',
+            '            "--{$boundary}\\r\\n" .',
+            '            "Content-Type: application/json\\r\\n" .',
+            '            "Content-Length: " . strlen($progress) . "\\r\\n" .',
+            '            "X-Chunk-Type: progress\\r\\n" .',
+            '            "\\r\\n" .',
+            '            $progress . "\\r\\n"',
+            '        );',
+            '        $gz->write("--{$boundary}--\\r\\n");',
+            '        $gz->finish();',
+            '        exit(1);',
+            '    }',
+            '}',
+        ].join('\n'));
+
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+        });
+
+        assert.equal(
+            result.exitCode,
+            2,
+            `Expected exit 2 after the interrupted db-index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+        assert.deepEqual(
+            readHookState(site),
+            { requests: 1, request_cursor: [null] },
+            'Expected the first db-index request to start without a cursor',
+        );
+
+        const state = JSON.parse(
+            readFileSync(join(pullStateDirectory(tempDir, importUrl()), 'state.json'), 'utf-8'),
+        );
+        assert.equal(
+            state.active_resumable_command.completion_state,
+            'partial',
+            'Expected db-pull to retain a partial checkpoint',
+        );
+        assert.equal(
+            state.active_resumable_command.current_stage,
+            'db-index',
+            'Expected db-pull to stop in its db-index stage',
+        );
+        savedDbIndexCursor = state.active_resumable_command.remote_cursor;
+        assert.ok(
+            savedDbIndexCursor,
+            'Expected the interrupted db-index response to save its table cursor',
+        );
+        assert.equal(state.sql_output, 'file');
+        assert.equal(
+            existsSync(join(pullStateDirectory(tempDir, importUrl()), 'database-dump.intent')),
+            true,
+            'Expected current file output to retain its download intent',
+        );
+    });
+
+    it('the next db-pull process continues the partial lifecycle and completes', () => {
+        const changedMode = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: ['--sql-output=stdout'],
+        });
+        assert.equal(
+            changedMode.exitCode,
+            1,
+            `Expected output-mode drift to fail:\n${changedMode.stderr}\n${changedMode.stdout}`,
+        );
+        assert.match(
+            `${changedMode.stderr}\n${changedMode.stdout}`,
+            /Cannot change --sql-output/,
+        );
+        assert.equal(
+            readHookState(site).requests,
+            1,
+            'Output-mode drift requested another database-index response',
+        );
+
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `Expected db-pull resume to complete\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+
+        const hookState = readHookState(site);
+        assert.equal(hookState.requests, 2, 'Expected a second db-index request');
+        assert.equal(
+            hookState.request_cursor[1],
+            savedDbIndexCursor,
+            'Expected the second db-index request to carry the first process cursor',
+        );
+
+        const lines = readFileSync(
+            join(tempDir, 'db-tables.jsonl'),
+            'utf-8',
+        ).trim().split('\n').filter(Boolean);
+        const tableNames = lines.map((line) => JSON.parse(line).name);
+
+        assert.ok(tableNames.length > 0, 'Expected table rows after resume');
+        assert.equal(
+            new Set(tableNames).size,
+            tableNames.length,
+            'Expected each table exactly once after resume',
+        );
+
+        const state = JSON.parse(
+            readFileSync(join(pullStateDirectory(tempDir, importUrl()), 'state.json'), 'utf-8'),
+        );
+        assert.equal(
+            state.active_resumable_command.completion_state,
+            'complete',
+            'Expected db-pull to complete after resuming db-index',
+        );
+        assert.match(
+            result.stdout,
+            /"event":"resuming".*"command":"db-pull"/,
+            'Expected the second process to report that it continued db-pull',
+        );
+    });
+});

--- a/tests/e2e/tests/import-56-db-apply-mysql-process-death.test.js
+++ b/tests/e2e/tests/import-56-db-apply-mysql-process-death.test.js
@@ -1,0 +1,380 @@
+/**
+ * A stopped MySQL db-apply must replay the complete replacement dump. The
+ * first 32 tables put statement 100 at their last INSERT, while the next
+ * table's metadata lock keeps the process at that boundary until it is killed.
+ * A restarted process must wait for that lingering target session to finish.
+ * Later tables require both the replayed SQL mode and disabled foreign-key checks.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, compareDatabases, fsRootDir,
+    pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+// The PHP.wasm wrapper is a Node process. Killing it closes the emulated MySQL
+// connection immediately, so it cannot exercise a lingering PHP target session.
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: MySQL db-apply process death', { timeout: 300000 }, () => {
+    const site = 'db-apply-process-death';
+    const checkpointTables = Array.from(
+        { length: 32 },
+        (_, index) => `aa_db_apply_${String(index + 1).padStart(2, '0')}`,
+    );
+    const lockedTable = 'ab_db_apply_lock';
+    const sqlModeTable = 'ac_db_apply_sql_mode';
+    const childTable = 'ad_db_apply_child';
+    const parentTable = 'ae_db_apply_parent';
+    const customTables = [
+        ...checkpointTables, lockedTable, sqlModeTable, childTable, parentTable,
+    ];
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function targetArguments() {
+        return [
+            '--target-engine=mysql',
+            '--target-host=127.0.0.1',
+            '--target-user=e2e_admin',
+            '--target-pass=e2e_password',
+            `--target-db=${targetDb}`,
+            '--progress=jsonl',
+        ];
+    }
+
+    function spawnDatabaseApply() {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-apply',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...targetArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+
+        return { childProcess, output, exit };
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                for (const [index, table] of checkpointTables.entries()) {
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `checkpoint-row-${index + 1}`],
+                    );
+                }
+
+                await connection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${lockedTable}\` (id, value) VALUES (1, 'locked-row')`
+                );
+
+                await connection.query(
+                    `CREATE TABLE \`${sqlModeTable}\` (`
+                    + "`id` INT NOT NULL, `value` ENUM('allowed') NOT NULL, "
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                // INSERT IGNORE creates ENUM's index-zero error value under the
+                // source's strict default. The dump emits that value as '', which
+                // a fresh strict target session rejects unless the SQL_MODE header
+                // is replayed first.
+                await connection.query(
+                    `INSERT IGNORE INTO \`${sqlModeTable}\` (id, value) `
+                    + "VALUES (1, 'not-an-enum-member')"
+                );
+
+                // Create the parent first, but name the child first so the dump
+                // needs its header's disabled foreign-key checks during replay.
+                await connection.query(
+                    `CREATE TABLE \`${parentTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${parentTable}\` (id, value) VALUES (1, 'parent-row')`
+                );
+                await connection.query(
+                    `CREATE TABLE \`${childTable}\` (`
+                    + '`id` INT NOT NULL, `parent_id` INT NOT NULL, '
+                    + 'PRIMARY KEY (`id`), '
+                    + `CONSTRAINT \`fk_db_apply_process_death\` FOREIGN KEY (\`parent_id\`) `
+                    + `REFERENCES \`${parentTable}\` (\`id\`)) ENGINE=InnoDB`
+                );
+                await connection.query(
+                    `INSERT INTO \`${childTable}\` (id, parent_id) VALUES (1, 1)`
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-db-apply-process-death');
+        const pullResult = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            wallTimeout: 240000,
+        });
+        assert.equal(
+            pullResult.exitCode,
+            0,
+            `db-pull failed:\n${pullResult.stderr}\n${pullResult.stdout}`,
+        );
+    });
+
+    afterAll(async () => {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        try {
+            await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('waits for the lingering target session before replaying the dump', async () => {
+        const adminConnection = await createMysqlConnection();
+        let lockConnection;
+        let firstApplyProcess;
+        let firstApplyExit;
+        let resumedApplyProcess;
+        let resumedApplyExit;
+        let targetThreadId = null;
+        let resumedTargetThreadId = null;
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDb}\``);
+
+            const setupConnection = await createMysqlConnection(targetDb);
+            try {
+                await setupConnection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await setupConnection.query(
+                    "CREATE TEMPORARY TABLE `db_apply_sql_mode_probe` ("
+                    + "`value` ENUM('allowed') NOT NULL) ENGINE=InnoDB"
+                );
+                await assert.rejects(
+                    setupConnection.query(
+                        "INSERT INTO `db_apply_sql_mode_probe` (value) VALUES ('')"
+                    ),
+                    error => Number(error.errno) === 1265,
+                    'a fresh target session did not reject the ENUM index-zero value with error 1265',
+                );
+            } finally {
+                await setupConnection.end();
+            }
+
+            lockConnection = await createMysqlConnection(targetDb);
+            await lockConnection.query(`LOCK TABLES \`${lockedTable}\` WRITE`);
+
+            const firstApply = spawnDatabaseApply();
+            firstApplyProcess = firstApply.childProcess;
+            firstApplyExit = firstApply.exit;
+
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+            const checkpointDeadline = Date.now() + 60000;
+            while (Date.now() < checkpointDeadline) {
+                if (
+                    firstApplyProcess.exitCode !== null
+                    || firstApplyProcess.signalCode !== null
+                ) {
+                    const result = await firstApplyExit;
+                    assert.fail(
+                        `db-apply exited before statement 100 (${result.code}/${result.signal}):\n`
+                        + firstApply.output.stderr + firstApply.output.stdout,
+                    );
+                }
+
+                let statementsExecuted = 0;
+                if (existsSync(statePath)) {
+                    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                    statementsExecuted = Number(state.apply?.statements_executed || 0);
+                }
+                const [threads] = await adminConnection.query(
+                    'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                    + 'WHERE DB = ? AND COMMAND = ? AND INFO LIKE ?',
+                    [targetDb, 'Query', `%${lockedTable}%`],
+                );
+                if (statementsExecuted === 100 && threads.length === 1) {
+                    targetThreadId = Number(threads[0].ID);
+                    break;
+                }
+                await sleep(25);
+            }
+
+            assert.notEqual(targetThreadId, null, 'db-apply did not stop after statement 100');
+            const exitAfterKill = firstApplyExit;
+            assert.equal(firstApplyProcess.kill('SIGKILL'), true);
+            const killedResult = await exitAfterKill;
+            assert.equal(killedResult.code, null);
+            assert.equal(killedResult.signal, 'SIGKILL');
+
+            const resumedApply = spawnDatabaseApply();
+            resumedApplyProcess = resumedApply.childProcess;
+            resumedApplyExit = resumedApply.exit;
+
+            const advisoryLockDeadline = Date.now() + 10000;
+            let advisoryLockWaiters = [];
+            while (Date.now() < advisoryLockDeadline) {
+                [advisoryLockWaiters] = await adminConnection.query(
+                    'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                    + 'WHERE DB = ? AND COMMAND = ? AND INFO LIKE ? AND ID <> ?',
+                    [targetDb, 'Query', '%GET_LOCK%', targetThreadId],
+                );
+                if (advisoryLockWaiters.length === 1) {
+                    resumedTargetThreadId = Number(advisoryLockWaiters[0].ID);
+                    break;
+                }
+                if (
+                    resumedApplyProcess.exitCode !== null
+                    || resumedApplyProcess.signalCode !== null
+                ) {
+                    const result = await resumedApplyExit;
+                    assert.fail(
+                        `restarted db-apply exited before waiting for the target lock `
+                        + `(${result.code}/${result.signal}):\n`
+                        + resumedApply.output.stderr + resumedApply.output.stdout,
+                    );
+                }
+                await sleep(25);
+            }
+
+            assert.equal(
+                advisoryLockWaiters.length,
+                1,
+                'db-apply did not wait for the target apply advisory lock',
+            );
+            const [blockedTargetThreads] = await adminConnection.query(
+                'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                + 'WHERE ID = ? AND COMMAND = ? AND INFO LIKE ?',
+                [targetThreadId, 'Query', `%${lockedTable}%`],
+            );
+            assert.equal(
+                blockedTargetThreads.length,
+                1,
+                'the first target query stopped waiting for the metadata lock',
+            );
+            assert.equal(resumedApplyProcess.exitCode, null);
+            assert.equal(resumedApplyProcess.signalCode, null);
+
+            await lockConnection.query('UNLOCK TABLES');
+            await lockConnection.end();
+            lockConnection = null;
+
+            const resumed = await resumedApplyExit;
+            assert.equal(
+                resumed.code,
+                0,
+                `restarted db-apply failed (${resumed.code}/${resumed.signal}):\n`
+                + resumedApply.output.stderr + resumedApply.output.stdout,
+            );
+            assert.equal(resumed.signal, null);
+
+            const comparison = await compareDatabases(getDbName(site), targetDb);
+            assert.deepEqual(comparison.missingTables, []);
+            assert.deepEqual(comparison.extraTables, []);
+            assert.ok(
+                Object.values(comparison.rowCounts).every(counts => counts.match),
+                `row counts differ: ${JSON.stringify(comparison.rowCounts)}`,
+            );
+
+            const sourceConnection = await createMysqlConnection(getDbName(site));
+            const targetConnection = await createMysqlConnection(targetDb);
+            try {
+                for (const table of customTables) {
+                    const [sourceRows] = await sourceConnection.query(
+                        `SELECT * FROM \`${table}\` ORDER BY id`
+                    );
+                    const [targetRows] = await targetConnection.query(
+                        `SELECT * FROM \`${table}\` ORDER BY id`
+                    );
+                    assert.deepEqual(targetRows, sourceRows, `${table} differs after restart`);
+                }
+                const [sqlModeRows] = await targetConnection.query(
+                    `SELECT value, value + 0 AS enumIndex FROM \`${sqlModeTable}\``
+                );
+                assert.equal(sqlModeRows.length, 1);
+                assert.equal(sqlModeRows[0].value, '');
+                assert.equal(Number(sqlModeRows[0].enumIndex), 0);
+            } finally {
+                await sourceConnection.end();
+                await targetConnection.end();
+            }
+        } finally {
+            if (
+                firstApplyProcess
+                && firstApplyProcess.exitCode === null
+                && firstApplyProcess.signalCode === null
+            ) {
+                firstApplyProcess.kill('SIGKILL');
+                await firstApplyExit;
+            }
+            if (
+                resumedApplyProcess
+                && resumedApplyProcess.exitCode === null
+                && resumedApplyProcess.signalCode === null
+            ) {
+                resumedApplyProcess.kill('SIGKILL');
+                await resumedApplyExit;
+            }
+            if (resumedTargetThreadId !== null) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${resumedTargetThreadId}`);
+                } catch {}
+            }
+            if (targetThreadId !== null) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${targetThreadId}`);
+                } catch {}
+            }
+            if (lockConnection) {
+                try { await lockConnection.query('UNLOCK TABLES'); } catch {}
+                await lockConnection.end();
+            }
+            await adminConnection.end();
+        }
+    });
+});

--- a/tests/e2e/tests/import-57-non-file-db-pull-process-death.test.js
+++ b/tests/e2e/tests/import-57-non-file-db-pull-process-death.test.js
@@ -1,0 +1,246 @@
+/**
+ * A db-pull writing to stdout has no local SQL file to resume. Stop its
+ * process after SQL reaches stdout, then verify that a later file-mode run
+ * refuses to write only the unconsumed suffix of the dump.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, fsRootDir,
+    writeTestHooks, removeTestHooks,
+    readHookState, clearHookState, pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: stdout db-pull process death', { timeout: 180000 }, () => {
+    const site = 'stdout-db-pull-process-death';
+    const earlyTable = 'aa_stdout_process_death_early';
+    const lateTable = 'zz_stdout_process_death_late';
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                const tables = [
+                    earlyTable,
+                    ...Array.from(
+                        { length: 40 },
+                        (_, index) => `mm_stdout_process_death_${String(index).padStart(2, '0')}`,
+                    ),
+                    lateTable,
+                ];
+                for (const [index, table] of tables.entries()) {
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `stdout-process-death-${index + 1}`],
+                    );
+                }
+            },
+        });
+        tempDir = createTempDir('e2e-stdout-db-pull-process-death');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = file_exists($state_file)',
+            '        ? json_decode(file_get_contents($state_file), true)',
+            '        : [];',
+            "    $state['sql_batches'] = ($state['sql_batches'] ?? 0) + 1;",
+            "    if ($state['sql_batches'] === 61) {",
+            "        $state['pause_started'] = true;",
+            '        file_put_contents($state_file, json_encode($state));',
+            '        usleep(3000000);',
+            "        $state['pause_finished'] = true;",
+            '    }',
+            '    file_put_contents($state_file, json_encode($state));',
+            '}',
+        ].join('\n'));
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    it('refuses a new file pull after a stdout process stops', async () => {
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+
+        const output = { stdout: '', stderr: '' };
+        const firstProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            '--sql-output=stdout',
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        firstProcess.stdout.setEncoding('utf8');
+        firstProcess.stderr.setEncoding('utf8');
+        firstProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        firstProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const firstExit = new Promise(resolve => {
+            firstProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+
+        const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+        const pauseDeadline = Date.now() + 60000;
+        let interruptedState = null;
+        while (Date.now() < pauseDeadline) {
+            if (firstProcess.exitCode !== null || firstProcess.signalCode !== null) {
+                const result = await firstExit;
+                assert.fail(
+                    `db-pull exited before the SQL pause (${result.code}/${result.signal}):\n`
+                    + output.stderr + output.stdout,
+                );
+            }
+
+            const hookState = readHookState(site);
+            if (hookState?.pause_started && existsSync(statePath)) {
+                const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                const command = state.active_resumable_command;
+                const databasePullOutputStatus = join(
+                    pullStateDirectory(tempDir, importUrl()),
+                    'database-stdout-output.json',
+                );
+                if (command?.current_stage === 'sql' && existsSync(databasePullOutputStatus)) {
+                    interruptedState = state;
+                    break;
+                }
+            }
+            await sleep(20);
+        }
+
+        assert.ok(interruptedState, 'db-pull did not record direct output before the pause');
+        assert.equal(interruptedState.sql_output, 'stdout');
+        assert.equal(existsSync(join(tempDir, 'db.sql')), false);
+
+        assert.equal(firstProcess.kill('SIGKILL'), true);
+        const killed = await firstExit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        const serverDeadline = Date.now() + 10000;
+        while (!readHookState(site)?.pause_finished && Date.now() < serverDeadline) {
+            await sleep(20);
+        }
+        assert.equal(
+            readHookState(site)?.pause_finished,
+            true,
+            'source did not leave the pause after the client process stopped',
+        );
+
+        const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--sql-output=file',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+        });
+
+        const sqlFile = join(tempDir, 'db.sql');
+        if (resumed.exitCode === 0) {
+            const sql = existsSync(sqlFile) ? readFileSync(sqlFile, 'utf8') : '';
+            assert.fail(
+                'db-pull silently continued the stdout cursor into db.sql; '
+                + `early_table=${sql.includes(earlyTable)}, late_table=${sql.includes(lateTable)}`,
+            );
+        }
+        assert.equal(
+            resumed.exitCode,
+            1,
+            `Expected file-mode continuation to fail closed:\n${resumed.stderr}\n${resumed.stdout}`,
+        );
+        assert.equal(existsSync(sqlFile), false, 'db-pull created a suffix-only db.sql');
+        const resumeError = `${resumed.stderr}\n${resumed.stdout}`;
+        assert.match(resumeError, /db-pull stopped while writing SQL to stdout\./);
+        assert.match(
+            resumeError,
+            /Reprint does not know how much SQL the receiving program or file got\./,
+        );
+        assert.match(
+            resumeError,
+            /Reset that program or file, then run db-pull --abort\./,
+        );
+        assert.match(
+            resumeError,
+            /Start again with --sql-output=file and apply db\.sql with db-apply\./,
+        );
+
+        const aborted = runImporter(importUrl(), tempDir, 'pull-db', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--abort',
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${join(tempDir, 'unused.sqlite')}`,
+                '--target-db=wordpress',
+            ],
+        });
+        assert.equal(
+            aborted.exitCode,
+            0,
+            `pull-db --abort failed:\n${aborted.stderr}\n${aborted.stdout}`,
+        );
+
+        const restarted = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--sql-output=file',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+        });
+        assert.equal(
+            restarted.exitCode,
+            0,
+            `fresh file db-pull failed after wrapper abort:\n`
+            + restarted.stderr + restarted.stdout,
+        );
+        const restartedSql = readFileSync(sqlFile, 'utf8');
+        assert.match(restartedSql, new RegExp(earlyTable));
+        assert.match(restartedSql, new RegExp(lateTable));
+    });
+});

--- a/tests/e2e/tests/import-58-pull-db-shutdown.test.js
+++ b/tests/e2e/tests/import-58-pull-db-shutdown.test.js
@@ -1,0 +1,262 @@
+/**
+ * A pull-db SIGTERM during db-apply must stop at the next SQL chunk boundary.
+ * The wrapper must leave db-apply unfinished instead of retrying it or marking
+ * the pipeline complete, and a later process must finish the replacement.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, compareDatabases, fsRootDir,
+    pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+// The PHP.wasm wrapper is a Node process. SIGTERM stops Node instead of being
+// delivered to PHP, so it cannot exercise the importer's deferred signal path.
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: pull-db shutdown during db-apply', { timeout: 300000 }, () => {
+    const site = 'pull-db-shutdown';
+    const lockedTable = 'aa_pull_db_shutdown_lock';
+    const payloadTable = 'ab_pull_db_shutdown_payload';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function targetArguments() {
+        return [
+            '--target-engine=mysql',
+            '--target-host=127.0.0.1',
+            '--target-user=e2e_admin',
+            '--target-pass=e2e_password',
+            `--target-db=${targetDb}`,
+            '--progress=jsonl',
+        ];
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${lockedTable}\` (id, value) VALUES (1, 'locked-row')`
+                );
+                await connection.query(
+                    `CREATE TABLE \`${payloadTable}\` (`
+                    + '`id` INT NOT NULL, `value` LONGTEXT NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${payloadTable}\` (id, value) VALUES (?, ?)`,
+                    [1, 'x'.repeat(192 * 1024)],
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-pull-db-shutdown');
+    });
+
+    afterAll(async () => {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        try {
+            await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('returns 2 without advancing the pipeline and completes in the next process', async () => {
+        const adminConnection = await createMysqlConnection();
+        let lockConnection;
+        let pullProcess;
+        let pullExit;
+        let targetThreadId = null;
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDb}\``);
+
+            const setupConnection = await createMysqlConnection(targetDb);
+            try {
+                await setupConnection.query(
+                    `CREATE TABLE \`${lockedTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+            } finally {
+                await setupConnection.end();
+            }
+
+            lockConnection = await createMysqlConnection(targetDb);
+            await lockConnection.query(`LOCK TABLES \`${lockedTable}\` WRITE`);
+
+            const output = { stdout: '', stderr: '' };
+            pullProcess = spawn(phpBinary, [
+                importerPath,
+                'pull-db',
+                importUrl(),
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
+                `--secret=${getSiteSecret(site)}`,
+                ...targetArguments(),
+            ], {
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            pullProcess.stdout.setEncoding('utf8');
+            pullProcess.stderr.setEncoding('utf8');
+            pullProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+            pullProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+            pullExit = new Promise(resolve => {
+                pullProcess.once('exit', (code, signal) => resolve({ code, signal }));
+            });
+
+            const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+            const lockDeadline = Date.now() + 120000;
+            while (Date.now() < lockDeadline) {
+                if (pullProcess.exitCode !== null || pullProcess.signalCode !== null) {
+                    const result = await pullExit;
+                    assert.fail(
+                        `pull-db exited before db-apply blocked (${result.code}/${result.signal}):\n`
+                        + output.stderr + output.stdout,
+                    );
+                }
+
+                let atApplyStage = false;
+                if (existsSync(statePath)) {
+                    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                    atApplyStage = state.pull_pipeline?.last_completed_stage === 'db-pull'
+                        && state.active_resumable_command?.command_name === 'db-apply';
+                }
+                const [threads] = await adminConnection.query(
+                    'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                    + 'WHERE DB = ? AND COMMAND = ? AND INFO LIKE ?',
+                    [targetDb, 'Query', `%${lockedTable}%`],
+                );
+                if (atApplyStage && threads.length === 1) {
+                    targetThreadId = Number(threads[0].ID);
+                    break;
+                }
+                await sleep(25);
+            }
+
+            assert.notEqual(targetThreadId, null, 'pull-db did not block in db-apply');
+            assert.equal(pullProcess.kill('SIGTERM'), true);
+
+            // The db-apply signal policy keeps the signal blocked during the
+            // active query. A wrapper using the generic policy exits here, so
+            // remove its abandoned target session before releasing the lock.
+            await sleep(250);
+            const processExited = pullProcess.exitCode !== null
+                || pullProcess.signalCode !== null;
+            if (processExited) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${targetThreadId}`);
+                } catch (error) {
+                    if (error.code !== 'ER_NO_SUCH_THREAD') {
+                        throw error;
+                    }
+                }
+            }
+
+            await lockConnection.query('UNLOCK TABLES');
+            await lockConnection.end();
+            lockConnection = null;
+
+            const stopped = await Promise.race([
+                pullExit,
+                sleep(60000).then(() => ({ timedOut: true })),
+            ]);
+            assert.equal(stopped.timedOut, undefined, 'pull-db did not stop after SIGTERM');
+            assert.equal(
+                stopped.code,
+                2,
+                `pull-db stopped as ${stopped.code}/${stopped.signal}:\n`
+                + output.stderr + output.stdout,
+            );
+
+            const interruptedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(interruptedState.pull_pipeline.started_by_command, 'pull-db');
+            assert.equal(interruptedState.pull_pipeline.last_completed_stage, 'db-pull');
+            assert.equal(interruptedState.active_resumable_command.command_name, 'db-apply');
+            assert.equal(interruptedState.active_resumable_command.completion_state, 'partial');
+            assert.equal(interruptedState.apply.target_engine, 'mysql');
+            assert.equal(interruptedState.apply.target_host, '127.0.0.1');
+            assert.equal(interruptedState.apply.target_port, 3306);
+            assert.equal(interruptedState.apply.target_user, 'e2e_admin');
+            assert.equal(interruptedState.apply.target_pass, 'e2e_password');
+            assert.equal(interruptedState.apply.target_db, targetDb);
+            assert.ok(
+                Number(interruptedState.apply?.statements_executed || 0) > 0,
+                'db-apply did not finish the active SQL chunk before stopping',
+            );
+
+            const resumed = runImporter(importUrl(), tempDir, 'pull-db', {
+                secret: getSiteSecret(site),
+                extraArgs: targetArguments(),
+                autoResume: false,
+                timeout: 180000,
+                wallTimeout: 240000,
+            });
+            assert.equal(
+                resumed.exitCode,
+                0,
+                `resumed pull-db failed:\n${resumed.stderr}\n${resumed.stdout}`,
+            );
+
+            const completedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(completedState.pull_pipeline.last_completed_stage, 'db-apply');
+            assert.equal(completedState.active_resumable_command.completion_state, 'complete');
+
+            const comparison = await compareDatabases(getDbName(site), targetDb);
+            assert.deepEqual(comparison.missingTables, []);
+            assert.deepEqual(comparison.extraTables, []);
+            assert.ok(
+                Object.values(comparison.rowCounts).every(counts => counts.match),
+                `row counts differ: ${JSON.stringify(comparison.rowCounts)}`,
+            );
+        } finally {
+            if (
+                pullProcess
+                && pullProcess.exitCode === null
+                && pullProcess.signalCode === null
+            ) {
+                pullProcess.kill('SIGKILL');
+                await pullExit;
+            }
+            if (targetThreadId !== null) {
+                try {
+                    await adminConnection.query(`KILL CONNECTION ${targetThreadId}`);
+                } catch {}
+            }
+            if (lockConnection) {
+                try { await lockConnection.query('UNLOCK TABLES'); } catch {}
+                await lockConnection.end();
+            }
+            await adminConnection.end();
+        }
+    });
+});

--- a/tests/e2e/tests/import-59-file-db-pull-artifact-guards.test.js
+++ b/tests/e2e/tests/import-59-file-db-pull-artifact-guards.test.js
@@ -1,0 +1,300 @@
+/**
+ * Test 59: File database-pull artifact guards.
+ *
+ * The first cases deliberately tamper with db.sql after a causal process stop
+ * to lock the refusal when the file is shorter than the saved size. Another case
+ * proves that an actual unfinished managed pull cannot feed its prefix to
+ * db-apply as a one-shot arbitrary dump.
+ */
+import { describe, it, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import {
+    existsSync,
+    readFileSync,
+    truncateSync,
+    unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter,
+    createTempDir,
+    cleanupTempDir,
+    getSiteUrl,
+    getSiteSecret,
+    getSiteDir,
+    fsRootDir,
+    writeTestHooks,
+    removeTestHooks,
+    readHookState,
+    clearHookState,
+    pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: file db-pull artifact guards', { timeout: 300000 }, () => {
+    const site = 'file-db-pull-artifact-guards';
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    const partialPullArguments = [
+        '--sql-fragments-start=1',
+        '--sql-fragments-min=1',
+        '--sql-fragments-max=1',
+        '--progress=jsonl',
+    ];
+    let tempDir;
+    let activeProcess;
+    let activeExit;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                for (let index = 1; index <= 40; index++) {
+                    const table = `artifact_guard_${String(index).padStart(2, '0')}`;
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index, `artifact-guard-${index}`],
+                    );
+                }
+            },
+        });
+    });
+
+    beforeEach(() => {
+        tempDir = createTempDir('e2e-file-db-pull-artifact-guards');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = file_exists($state_file)',
+            '        ? json_decode(file_get_contents($state_file), true)',
+            '        : [];',
+            "    $state['sql_batches'] = ($state['sql_batches'] ?? 0) + 1;",
+            "    if ($state['sql_batches'] === 61) {",
+            "        $state['pause_started'] = true;",
+            '        file_put_contents($state_file, json_encode($state));',
+            '        usleep(3000000);',
+            "        $state['pause_finished'] = true;",
+            '    }',
+            '    file_put_contents($state_file, json_encode($state));',
+            '}',
+        ].join('\n'));
+    });
+
+    afterEach(async () => {
+        if (
+            activeProcess
+            && activeProcess.exitCode === null
+            && activeProcess.signalCode === null
+        ) {
+            activeProcess.kill('SIGKILL');
+            await activeExit;
+        }
+        activeProcess = null;
+        activeExit = null;
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+    });
+
+    async function stopFilePullAfterSavedCursor() {
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+
+        const output = { stdout: '', stderr: '' };
+        activeProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...partialPullArguments,
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        activeProcess.stdout.setEncoding('utf8');
+        activeProcess.stderr.setEncoding('utf8');
+        activeProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        activeProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        activeExit = new Promise(resolve => {
+            activeProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+
+        const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+        const sqlPath = join(tempDir, 'db.sql');
+        const pauseDeadline = Date.now() + 60000;
+        let interruptedState = null;
+        while (Date.now() < pauseDeadline) {
+            if (activeProcess.exitCode !== null || activeProcess.signalCode !== null) {
+                const result = await activeExit;
+                assert.fail(
+                    `db-pull exited before the SQL pause (${result.code}/${result.signal}):\n`
+                    + output.stderr + output.stdout,
+                );
+            }
+
+            const hookState = readHookState(site);
+            if (hookState?.pause_started && existsSync(statePath) && existsSync(sqlPath)) {
+                const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                const command = state.active_resumable_command;
+                if (
+                    command?.current_stage === 'sql'
+                    && command.remote_cursor
+                    && Number(state.sql_bytes || 0) > 0
+                ) {
+                    interruptedState = state;
+                    break;
+                }
+            }
+            await sleep(20);
+        }
+
+        assert.ok(interruptedState, 'db-pull did not save the file size before the pause');
+        assert.equal(interruptedState.sql_output, 'file');
+        assert.equal(activeProcess.kill('SIGKILL'), true);
+        const killed = await activeExit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+        activeProcess = null;
+        activeExit = null;
+
+        const serverDeadline = Date.now() + 10000;
+        while (!readHookState(site)?.pause_finished && Date.now() < serverDeadline) {
+            await sleep(20);
+        }
+        assert.equal(
+            readHookState(site)?.pause_finished,
+            true,
+            'source did not leave the pause after the client process died',
+        );
+        await sleep(500);
+
+        return { interruptedState, sqlPath };
+    }
+
+    it.each(['missing', 'shorter'])(
+        'rejects a deliberately tampered %s db.sql before requesting the saved cursor',
+        async artifactState => {
+            const { interruptedState, sqlPath } = await stopFilePullAfterSavedCursor();
+            const savedBytes = Number(interruptedState.sql_bytes);
+            if (artifactState === 'missing') {
+                unlinkSync(sqlPath);
+            } else {
+                assert.ok(savedBytes > 1, 'saved SQL size is too small to shorten');
+                truncateSync(sqlPath, savedBytes - 1);
+            }
+            const sqlBatchesBeforeResume = readHookState(site).sql_batches;
+
+            const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                autoResume: false,
+                extraArgs: partialPullArguments,
+            });
+
+            assert.equal(
+                resumed.exitCode,
+                1,
+                `Expected ${artifactState} db.sql to fail closed:\n`
+                + resumed.stderr + resumed.stdout,
+            );
+            const hookState = readHookState(site);
+            assert.equal(
+                hookState.sql_batches,
+                sqlBatchesBeforeResume,
+                'db-pull requested a suffix after deliberate local artifact tampering',
+            );
+            assert.match(`${resumed.stderr}\n${resumed.stdout}`, /db\.sql/i);
+        },
+    );
+
+    it('rejects db-apply while a managed file pull contains only a prefix', async () => {
+        await stopFilePullAfterSavedCursor();
+        const targetPath = join(tempDir, 'must-not-be-created.sqlite');
+        const sqlBatchesBeforeApply = readHookState(site).sql_batches;
+
+        const applied = runImporter(importUrl(), tempDir, 'db-apply', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: [
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${targetPath}`,
+                '--target-db=wordpress',
+                '--progress=jsonl',
+            ],
+        });
+
+        assert.equal(
+            applied.exitCode,
+            1,
+            `Expected db-apply to reject an unfinished managed dump:\n`
+            + applied.stderr + applied.stdout,
+        );
+        assert.equal(
+            existsSync(targetPath),
+            false,
+            'db-apply opened the target before rejecting the unfinished dump',
+        );
+        assert.equal(readHookState(site).sql_batches, sqlBatchesBeforeApply);
+        assert.match(`${applied.stderr}\n${applied.stdout}`, /still being downloaded/i);
+    });
+
+    it('rejects an output-mode change and preserves the file resume', async () => {
+        const { sqlPath } = await stopFilePullAfterSavedCursor();
+
+        const changedMode = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: ['--sql-output=stdout'],
+        });
+        assert.equal(
+            changedMode.exitCode,
+            1,
+            `Expected output-mode change to fail:\n${changedMode.stderr}${changedMode.stdout}`,
+        );
+        assert.match(`${changedMode.stderr}\n${changedMode.stdout}`, /Cannot change --sql-output/);
+
+        const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            extraArgs: partialPullArguments,
+        });
+        assert.equal(
+            resumed.exitCode,
+            0,
+            `file db-pull did not resume after rejected mode change:\n`
+            + resumed.stderr + resumed.stdout,
+        );
+        const sql = readFileSync(sqlPath, 'utf8');
+        assert.match(sql, /artifact_guard_01/);
+        assert.match(sql, /artifact_guard_40/);
+    });
+});

--- a/tests/e2e/tests/import-60-mysql-db-pull-pipeline.test.js
+++ b/tests/e2e/tests/import-60-mysql-db-pull-pipeline.test.js
@@ -1,0 +1,264 @@
+/**
+ * MySQL db-pull first downloads all of db.sql. A stopped
+ * download must not touch the target, and the next process must finish the
+ * file before applying it through db-apply.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, compareDatabases, fsRootDir,
+    pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: MySQL db-pull through complete db.sql replay', { timeout: 300000 }, () => {
+    const site = 'mysql-db-pull-pipeline';
+    const guardTable = 'aa_mysql_pipeline_guard';
+    const sqlModeTable = 'ab_mysql_pipeline_sql_mode';
+    const childTable = 'ac_mysql_pipeline_child';
+    const parentTable = 'ad_mysql_pipeline_parent';
+    const targetDatabase = `${getDbName(site)}_pipeline_target`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlOutputArguments() {
+        return [
+            '--sql-output=mysql',
+            `--mysql-database=${targetDatabase}`,
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_databaseName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${guardTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${guardTable}\` (id, value) VALUES (1, 'source-value')`
+                );
+
+                for (let index = 0; index < 40; index++) {
+                    const table = `mm_mysql_pipeline_${String(index).padStart(2, '0')}`;
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `checkpoint-${index + 1}`],
+                    );
+                }
+
+                await connection.query(
+                    `CREATE TABLE \`${sqlModeTable}\` (`
+                    + "`id` INT NOT NULL, `value` ENUM('allowed') NOT NULL, "
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT IGNORE INTO \`${sqlModeTable}\` (id, value) `
+                    + "VALUES (1, 'not-an-enum-member')"
+                );
+                await connection.query(
+                    `CREATE TABLE \`${parentTable}\` (`
+                    + '`id` INT NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(`INSERT INTO \`${parentTable}\` (id) VALUES (1)`);
+                await connection.query(
+                    `CREATE TABLE \`${childTable}\` (`
+                    + '`id` INT NOT NULL, `parent_id` INT NOT NULL, PRIMARY KEY (`id`), '
+                    + `CONSTRAINT \`fk_mysql_pipeline_parent\` FOREIGN KEY (parent_id) `
+                    + `REFERENCES \`${parentTable}\` (id)) ENGINE=InnoDB`
+                );
+                await connection.query(
+                    `INSERT INTO \`${childTable}\` (id, parent_id) VALUES (1, 1)`
+                );
+            },
+        });
+    });
+
+    afterAll(async () => {
+        const connection = await createMysqlConnection();
+        try {
+            await connection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('resumes the dump before applying it with the dump session settings', async () => {
+        const tempDir = createTempDir('e2e-mysql-db-pull-pipeline');
+        const adminConnection = await createMysqlConnection();
+        let firstProcess;
+        let firstExit;
+
+        try {
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.query(`CREATE DATABASE \`${targetDatabase}\``);
+
+            const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+                autoResume: false,
+            });
+            assert.equal(
+                preflight.exitCode,
+                0,
+                `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+            );
+
+            const output = { stdout: '', stderr: '' };
+            firstProcess = spawn(phpBinary, [
+                importerPath,
+                'db-pull',
+                importUrl(),
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
+                `--secret=${getSiteSecret(site)}`,
+                ...mysqlOutputArguments(),
+            ], {
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            firstProcess.stdout.setEncoding('utf8');
+            firstProcess.stderr.setEncoding('utf8');
+            firstProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+            firstProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+            firstExit = new Promise(resolve => {
+                firstProcess.once('exit', (code, signal) => resolve({ code, signal }));
+            });
+
+            const stateDirectory = pullStateDirectory(tempDir, importUrl());
+            const statePath = join(stateDirectory, 'state.json');
+            const checkpointDeadline = Date.now() + 60000;
+            let interruptedState;
+            let targetChanged = false;
+            while (Date.now() < checkpointDeadline) {
+                if (firstProcess.exitCode !== null || firstProcess.signalCode !== null) {
+                    const result = await firstExit;
+                    assert.fail(
+                        `db-pull exited before a SQL checkpoint (${result.code}/${result.signal}):\n`
+                        + output.stderr + output.stdout,
+                    );
+                }
+
+                if (existsSync(statePath)) {
+                    interruptedState = JSON.parse(readFileSync(statePath, 'utf8'));
+                    if (
+                        interruptedState.active_resumable_command?.command_name === 'db-pull'
+                        && interruptedState.active_resumable_command?.current_stage === 'sql'
+                        && interruptedState.active_resumable_command?.remote_cursor
+                    ) {
+                        break;
+                    }
+                }
+                const [targetTables] = await adminConnection.query(
+                    'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES '
+                    + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                    [targetDatabase, guardTable],
+                );
+                if (targetTables.length !== 0) {
+                    targetChanged = true;
+                    break;
+                }
+                await sleep(20);
+            }
+
+            assert.equal(
+                targetChanged,
+                false,
+                'db-pull changed the target before saving a resumable dump checkpoint',
+            );
+            assert.ok(interruptedState, 'db-pull did not save a SQL download checkpoint');
+            assert.equal(interruptedState.sql_output, 'file');
+            assert.equal(interruptedState.pull_pipeline?.started_by_command, 'pull-db');
+            assert.ok(existsSync(join(tempDir, 'db.sql')), 'db-pull did not retain db.sql');
+            assert.ok(
+                !existsSync(join(stateDirectory, 'database-stdout-output.json')),
+                'MySQL pipeline created a direct-output attempt',
+            );
+
+            assert.equal(firstProcess.kill('SIGKILL'), true);
+            const killed = await firstExit;
+            assert.equal(killed.code, null);
+            assert.equal(killed.signal, 'SIGKILL');
+            firstProcess = null;
+
+            const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlOutputArguments(),
+                autoResume: false,
+                timeout: 180000,
+                wallTimeout: 240000,
+            });
+            assert.equal(
+                resumed.exitCode,
+                0,
+                `resumed db-pull failed:\n${resumed.stderr}\n${resumed.stdout}`,
+            );
+
+            const completedState = JSON.parse(readFileSync(statePath, 'utf8'));
+            assert.equal(completedState.pull_pipeline.last_completed_stage, 'db-apply');
+            assert.equal(completedState.active_resumable_command.command_name, 'db-apply');
+            assert.equal(completedState.active_resumable_command.completion_state, 'complete');
+
+            const comparison = await compareDatabases(getDbName(site), targetDatabase);
+            assert.deepEqual(comparison.missingTables, []);
+            assert.deepEqual(comparison.extraTables, []);
+            assert.ok(
+                Object.values(comparison.rowCounts).every(counts => counts.match),
+                `row counts differ: ${JSON.stringify(comparison.rowCounts)}`,
+            );
+
+            const targetConnection = await createMysqlConnection(targetDatabase);
+            try {
+                const [sqlModeRows] = await targetConnection.query(
+                    `SELECT value, value + 0 AS enumIndex FROM \`${sqlModeTable}\``
+                );
+                assert.equal(sqlModeRows.length, 1);
+                assert.equal(sqlModeRows[0].value, '');
+                assert.equal(Number(sqlModeRows[0].enumIndex), 0);
+                const [[childRow]] = await targetConnection.query(
+                    `SELECT parent_id FROM \`${childTable}\` WHERE id = 1`
+                );
+                assert.equal(Number(childRow.parent_id), 1);
+            } finally {
+                await targetConnection.end();
+            }
+        } finally {
+            if (
+                firstProcess
+                && firstProcess.exitCode === null
+                && firstProcess.signalCode === null
+            ) {
+                firstProcess.kill('SIGKILL');
+                await firstExit;
+            }
+            await adminConnection.query(`DROP DATABASE IF EXISTS \`${targetDatabase}\``);
+            await adminConnection.end();
+            cleanupTempDir(tempDir);
+        }
+    });
+});


### PR DESCRIPTION
An interrupted `pull-db` now continues the `db.sql` download or restarts the database apply instead of asking the user to discard work that Reprint can reuse.

File downloads save the file size together with the source position, after the bytes have been flushed. A later process removes any later, unfinished bytes and continues from that saved position.

Database apply starts `db.sql` from the beginning after an interruption. The new connection therefore runs the dump header again, including `SQL_MODE`, foreign-key checks, and autocommit settings. MySQL output uses this same download-then-apply path instead of writing directly to a target that Reprint cannot inspect after the process dies.

`pull-db` handles SIGINT and SIGTERM between SQL chunks, exits with code 2, and leaves the current stage unfinished. Running the command again continues it. Repeating an already completed `db-pull` or `db-apply` reports the saved result instead of throwing an error.

Reprint still stops when SQL was written to stdout, `db.sql` or the target settings changed, a required file is missing, or an actual read/write operation fails. In those cases continuing would risk skipping or repeating unknown work.

This is a single-PR alternative to the #590 → #591 → #595 → #582 → #607 stack.

## Testing

The focused PHP suites cover exit code 2, process death, repeated completed commands, saved file sizes, changed inputs, SQL replay, and wrapper signal handling. The MySQL tests cover a lingering old connection, SQL mode and foreign-key setup on the replacement connection, and the download-then-apply path.
