### PR TITLE
[PHP] Reapply MySQL dump settings after reconnect

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7534,6 +7534,8 @@ class ImportClient
         $sql_buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
+        // A cursor means this connection starts after the dump header.
+        $mysql_session_is_configured = $mode !== "mysql" || $cursor === null;
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
@@ -7686,6 +7688,7 @@ class ImportClient
                     $mysql_conn,
                     &$sql_buffer_handle,
                     &$sql_buffer,
+                    &$mysql_session_is_configured,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -7702,6 +7705,19 @@ class ImportClient
                     // Allow signal handlers to run
                     if (function_exists("pcntl_signal_dispatch")) {
                         pcntl_signal_dispatch();
+                    }
+
+                    $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+                    if ($chunk_type === "sql_session_setup") {
+                        if ($mode === "mysql" && !$mysql_session_is_configured) {
+                            $this->execute_mysql_queries($mysql_conn, $chunk["body"]);
+                            $mysql_session_is_configured = true;
+                            $this->audit_log(
+                                "SQL OUTPUT mysql | applied session settings after reconnect",
+                                true,
+                            );
+                        }
+                        return;
                     }
 
                     $cursor = $chunk["headers"]["x-cursor"] ?? $cursor;
@@ -7738,8 +7754,6 @@ class ImportClient
                             }
                         }
                     }
-
-                    $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                     if ($chunk_type === "sql") {
                         $query_complete = ($chunk["headers"]["x-query-complete"] ?? "1") === "1";
@@ -7780,18 +7794,7 @@ class ImportClient
                                 $sql_bytes_written += strlen($data);
 
                                 if ($query_complete) {
-                                    if (!$mysql_conn->multi_query($sql_buffer)) {
-                                        throw new RuntimeException("MySQL execution failed: " . $mysql_conn->error);
-                                    }
-                                    // Drain all result sets from multi_query before sending the
-                                    // next chunk — mysqli requires this.
-                                    do {
-                                        $result = $mysql_conn->store_result();
-                                        if ($result) { $result->free(); }
-                                        if ($mysql_conn->errno) {
-                                            throw new RuntimeException("MySQL statement error: " . $mysql_conn->error);
-                                        }
-                                    } while ($mysql_conn->more_results() && $mysql_conn->next_result());
+                                    $this->execute_mysql_queries($mysql_conn, $sql_buffer);
 
                                     // Query executed — truncate the buffer file and reset.
                                     if ($sql_buffer_handle) {
@@ -7999,6 +8002,32 @@ class ImportClient
                 " bytes) — incomplete export?"
             );
         }
+    }
+
+    /** Executes SQL and consumes every result before the next query. */
+    private function execute_mysql_queries(\mysqli $connection, string $sql): void
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        if (!$connection->multi_query($sql)) {
+            throw new RuntimeException("MySQL execution failed: " . $connection->error);
+        }
+
+        while (true) {
+            $result = $connection->store_result();
+            if ($result) {
+                $result->free();
+            }
+            if ($connection->errno) {
+                throw new RuntimeException("MySQL statement error: " . $connection->error);
+            }
+            if (!$connection->more_results()) {
+                break;
+            }
+            if (!$connection->next_result()) {
+                throw new RuntimeException("MySQL statement error: " . $connection->error);
+            }
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
     /**

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2236,6 +2236,16 @@ class ImportClient
                         );
                     }
                 }
+                $session_setup_file = wp_join_unix_paths(
+                    $this->state_dir,
+                    "db-session-setup.sql",
+                );
+                if (file_exists($session_setup_file)) {
+                    unlink($session_setup_file);
+                    $this->audit_log(
+                        "FILE DELETE | {$session_setup_file} | abort db-pull",
+                    );
+                }
                 $tables_file = wp_join_unix_paths($this->state_dir, "db-tables.jsonl");
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
@@ -5634,6 +5644,10 @@ class ImportClient
     public function run_db_apply(array $options): void
     {
         $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
+        $session_setup_file = wp_join_unix_paths(
+            $this->state_dir,
+            "db-session-setup.sql",
+        );
         if (!file_exists($sql_file)) {
             throw new RuntimeException(
                 "db.sql not found in {$this->state_dir}. Run db-pull first.",
@@ -5783,6 +5797,21 @@ class ImportClient
             "CONNECTED | {$connection_label}",
             false,
         );
+
+        if ($is_resume && $this->get_state()->apply->target_engine === "mysql") {
+            $session_setup_sql = @file_get_contents($session_setup_file);
+            if ($session_setup_sql === false || trim($session_setup_sql) === "") {
+                throw new RuntimeException(
+                    "Cannot resume db-apply because db-session-setup.sql is missing or empty. " .
+                    "Run db-apply --abort and start again.",
+                );
+            }
+            $pdo->exec($session_setup_sql);
+            $this->audit_log(
+                "DB-APPLY | ran saved MySQL session setup after reconnect",
+                true,
+            );
+        }
 
         // Stream db.sql through the query stream and execute. Use the
         // fast strcspn-based parser by default; it self-falls-back to
@@ -7534,8 +7563,10 @@ class ImportClient
         $sql_buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
-        // A cursor means this connection starts after the dump header.
-        $mysql_session_ran_initial_SET_statements = $mode !== "mysql" || $cursor === null;
+        $session_setup_file = wp_join_unix_paths(
+            $this->state_dir,
+            "db-session-setup.sql",
+        );
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
@@ -7600,6 +7631,21 @@ class ImportClient
                 throw new RuntimeException("MySQL connection failed: " . $mysql_conn->connect_error);
             }
             $mysql_conn->set_charset("utf8mb4");
+
+            if ($cursor !== null) {
+                $session_setup_sql = @file_get_contents($session_setup_file);
+                if ($session_setup_sql === false || trim($session_setup_sql) === "") {
+                    throw new RuntimeException(
+                        "Cannot resume db-pull because db-session-setup.sql is missing or empty. " .
+                        "Run db-pull --abort and start again.",
+                    );
+                }
+                $this->execute_mysql_queries($mysql_conn, $session_setup_sql);
+                $this->audit_log(
+                    "SQL OUTPUT mysql | ran saved session setup after reconnect",
+                    true,
+                );
+            }
 
             $this->audit_log(
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
@@ -7688,7 +7734,7 @@ class ImportClient
                     $mysql_conn,
                     &$sql_buffer_handle,
                     &$sql_buffer,
-                    &$mysql_session_ran_initial_SET_statements,
+                    $session_setup_file,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -7709,12 +7755,18 @@ class ImportClient
 
                     $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
                     if ($chunk_type === "sql_session_setup") {
-                        if ($mode === "mysql" && !$mysql_session_ran_initial_SET_statements) {
-                            $this->execute_mysql_queries($mysql_conn, $chunk["body"]);
-                            $mysql_session_ran_initial_SET_statements = true;
-                            $this->audit_log(
-                                "SQL OUTPUT mysql | applied session settings after reconnect",
-                                true,
+                        $session_setup_sql = $chunk["body"];
+                        $session_setup_tmp_file = $session_setup_file . ".tmp";
+                        $written = file_put_contents(
+                            $session_setup_tmp_file,
+                            $session_setup_sql,
+                        );
+                        if (
+                            $written !== strlen($session_setup_sql)
+                            || !rename($session_setup_tmp_file, $session_setup_file)
+                        ) {
+                            throw new RuntimeException(
+                                "Cannot save MySQL session setup to db-session-setup.sql",
                             );
                         }
                         return;

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7535,7 +7535,7 @@ class ImportClient
         $sql_bytes_written = 0;
         $sql_buffer = "";
         // A cursor means this connection starts after the dump header.
-        $mysql_session_is_configured = $mode !== "mysql" || $cursor === null;
+        $mysql_session_ran_initial_SET_statements = $mode !== "mysql" || $cursor === null;
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
@@ -7688,7 +7688,7 @@ class ImportClient
                     $mysql_conn,
                     &$sql_buffer_handle,
                     &$sql_buffer,
-                    &$mysql_session_is_configured,
+                    &$mysql_session_ran_initial_SET_statements,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -7709,9 +7709,9 @@ class ImportClient
 
                     $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
                     if ($chunk_type === "sql_session_setup") {
-                        if ($mode === "mysql" && !$mysql_session_is_configured) {
+                        if ($mode === "mysql" && !$mysql_session_ran_initial_SET_statements) {
                             $this->execute_mysql_queries($mysql_conn, $chunk["body"]);
-                            $mysql_session_is_configured = true;
+                            $mysql_session_ran_initial_SET_statements = true;
                             $this->audit_log(
                                 "SQL OUTPUT mysql | applied session settings after reconnect",
                                 true,

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -324,6 +324,7 @@ class Pull
                 $this->client->save_state();
                 foreach ([
                     "{$state_dir}/db.sql",
+                    "{$state_dir}/db-session-setup.sql",
                     "{$state_dir}/db-tables.jsonl",
                     "{$pull_state_directory}/domains.json",
                 ] as $path) {
@@ -830,6 +831,7 @@ class Pull
         }
         if ($reset_db_state) {
             $paths[] = wp_join_unix_paths($state_dir, 'db.sql');
+            $paths[] = wp_join_unix_paths($state_dir, 'db-session-setup.sql');
             $paths[] = wp_join_unix_paths($state_dir, 'db-tables.jsonl');
             $paths[] = wp_join_unix_paths($pull_state_directory, 'domains.json');
         }

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -400,13 +400,17 @@ class MySQLDumpProducer
      */
     private function emit_sql_header()
     {
-        $header =
-            "SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;\n" .
+        $this->current_sql_fragment = self::get_session_setup_sql();
+    }
+
+    /** Returns the connection settings required before executing dump SQL. */
+    public static function get_session_setup_sql()
+    {
+        return "SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;\n" .
             "SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;\n" .
             // @TODO: Restore STRICT_TRANS_TABLES
             "SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';\n" .
             "SET AUTOCOMMIT=0;\n";
-        $this->current_sql_fragment = $header;
     }
 
     /** Emits COMMIT and restores the session variables saved in the header. */

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -908,19 +908,21 @@ function endpoint_sql_chunk(
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
     }
 
-    // A resumed source cursor starts after the dump header. Send the required
-    // connection settings separately so a new MySQL process can run them first.
-    $session_setup = WordPress\DataLiberation\MySQLDumpProducer::get_session_setup_sql();
-    $gz->write(
-        "--{$boundary}\r\n" .
-        "Content-Type: application/sql\r\n" .
-        "Content-Length: " . strlen($session_setup) . "\r\n" .
-        "X-Chunk-Type: sql_session_setup\r\n" .
-        "\r\n"
-    );
-    $gz->write($session_setup);
-    $gz->write("\r\n");
-    $gz->sync();
+    if (!isset($config["cursor"])) {
+        // Send the initial connection settings separately so the client can save
+        // them outside db.sql for a later MySQL connection.
+        $session_setup = WordPress\DataLiberation\MySQLDumpProducer::get_session_setup_sql();
+        $gz->write(
+            "--{$boundary}\r\n" .
+            "Content-Type: application/sql\r\n" .
+            "Content-Length: " . strlen($session_setup) . "\r\n" .
+            "X-Chunk-Type: sql_session_setup\r\n" .
+            "\r\n"
+        );
+        $gz->write($session_setup);
+        $gz->write("\r\n");
+        $gz->sync();
+    }
 
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -908,6 +908,20 @@ function endpoint_sql_chunk(
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
     }
 
+    // A resumed source cursor starts after the dump header. Send the required
+    // connection settings separately so a new MySQL process can run them first.
+    $session_setup = WordPress\DataLiberation\MySQLDumpProducer::get_session_setup_sql();
+    $gz->write(
+        "--{$boundary}\r\n" .
+        "Content-Type: application/sql\r\n" .
+        "Content-Length: " . strlen($session_setup) . "\r\n" .
+        "X-Chunk-Type: sql_session_setup\r\n" .
+        "\r\n"
+    );
+    $gz->write($session_setup);
+    $gz->write("\r\n");
+    $gz->sync();
+
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch
     // as a multipart chunk. Stop when the producer is exhausted or the

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -139,6 +139,9 @@
     },
     "db-index-interruption": {
       "port": 8125
+    },
+    "mysql-session-settings-resume": {
+      "port": 8126
     }
   }
 }

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -1,0 +1,232 @@
+/**
+ * A new MySQL process resumes after the dump header, but still needs the
+ * header's connection settings before it executes later table data.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, fsRootDir, pullStateDirectory,
+    writeTestHooks, removeTestHooks,
+    writeHookState, readHookState, clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: MySQL session settings after restart', { timeout: 300000 }, () => {
+    const site = 'mysql-session-settings-resume';
+    const setupTables = Array.from(
+        { length: 32 },
+        (_, index) => `aa_session_setup_${String(index + 1).padStart(2, '0')}`,
+    );
+    const sqlModeTable = 'zz_session_setup_sql_mode';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlArguments() {
+        return [
+            '--sql-output=mysql',
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            `--mysql-database=${targetDb}`,
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    function spawnDatabasePull() {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...mysqlArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+        return { childProcess, output, exit };
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                for (const [index, table] of setupTables.entries()) {
+                    await connection.query(
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                    );
+                    await connection.query(
+                        `INSERT INTO \`${table}\` (id, value) VALUES (?, ?)`,
+                        [index + 1, `session-row-${index + 1}`],
+                    );
+                }
+
+                await connection.query(
+                    `CREATE TABLE \`${sqlModeTable}\` (`
+                    + "`id` INT NOT NULL, `value` ENUM('allowed') NOT NULL, "
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT IGNORE INTO \`${sqlModeTable}\` (id, value) `
+                    + "VALUES (1, 'not-an-enum-member')"
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-mysql-session-settings-resume');
+        clearHookState(site);
+        writeHookState(site, { batches: 0, release: false });
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = json_decode(file_get_contents($state_file), true);',
+            '    $state[\'batches\'] = ($state[\'batches\'] ?? 0) + 1;',
+            '    if ($state[\'batches\'] === 60) {',
+            '        $state[\'paused\'] = true;',
+            '        file_put_contents($state_file, json_encode($state));',
+            '        do {',
+            '            usleep(10000);',
+            '            $state = json_decode(file_get_contents($state_file), true);',
+            '        } while (empty($state[\'release\']));',
+            '    } else {',
+            '        file_put_contents($state_file, json_encode($state));',
+            '    }',
+            '}',
+        ].join('\n'));
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.query(`CREATE DATABASE \`${targetDb}\``);
+        await connection.end();
+
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            await targetConnection.query(
+                "CREATE TEMPORARY TABLE `session_setup_probe` ("
+                + "`value` ENUM('allowed') NOT NULL) ENGINE=InnoDB"
+            );
+            await assert.rejects(
+                targetConnection.query(
+                    "INSERT INTO `session_setup_probe` (value) VALUES ('')"
+                ),
+                error => Number(error.errno) === 1265,
+                'a fresh target session did not reject the ENUM index-zero value',
+            );
+        } finally {
+            await targetConnection.end();
+        }
+
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.end();
+    });
+
+    it('runs the dump connection settings before resumed SQL', async () => {
+        const first = spawnDatabasePull();
+        const statePath = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
+        const deadline = Date.now() + 60000;
+        let savedCursor = null;
+
+        while (Date.now() < deadline) {
+            if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
+                const result = await first.exit;
+                assert.fail(
+                    `db-pull exited before the source paused (${result.code}/${result.signal}):\n`
+                    + first.output.stderr + first.output.stdout,
+                );
+            }
+
+            const hookState = readHookState(site);
+            if (existsSync(statePath)) {
+                const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                savedCursor = state.active_resumable_command?.remote_cursor || null;
+            }
+            if (hookState?.paused && savedCursor) {
+                break;
+            }
+            await sleep(25);
+        }
+
+        assert.ok(savedCursor, 'db-pull did not save a source position before the pause');
+        assert.equal(first.childProcess.kill('SIGKILL'), true);
+        const killed = await first.exit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        const hookState = readHookState(site);
+        writeHookState(site, { ...hookState, release: true });
+        await sleep(100);
+        removeTestHooks(site);
+
+        const resumed = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: mysqlArguments(),
+            wallTimeout: 240000,
+        });
+        assert.equal(
+            resumed.exitCode,
+            0,
+            `resumed db-pull failed:\n${resumed.stderr}\n${resumed.stdout}`,
+        );
+
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            const [rows] = await targetConnection.query(
+                `SELECT value, value + 0 AS enumIndex FROM \`${sqlModeTable}\``
+            );
+            assert.equal(rows.length, 1);
+            assert.equal(rows[0].value, '');
+            assert.equal(Number(rows[0].enumIndex), 0);
+        } finally {
+            await targetConnection.end();
+        }
+    });
+});

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -179,6 +179,9 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
 
         const targetConnection = await createMysqlConnection(targetDb);
         try {
+            // A fresh connection rejects ENUM index zero in strict mode. Both
+            // restart cases begin after the dump header, so accepting this value
+            // later proves that db-session-setup.sql restored the dump SQL mode.
             await targetConnection.query(
                 "CREATE TEMPORARY TABLE `session_setup_probe` ("
                 + "`value` ENUM('allowed') NOT NULL) ENGINE=InnoDB"

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -34,9 +34,20 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
         || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
     const phpBinary = process.env.PHP_BINARY || 'php';
     let tempDir;
+    let fileTempDir;
 
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function targetMysqlArguments() {
+        return [
+            '--target-engine=mysql',
+            '--target-host=127.0.0.1',
+            '--target-user=e2e_admin',
+            '--target-pass=e2e_password',
+            `--target-db=${targetDb}`,
+        ];
     }
 
     function mysqlArguments() {
@@ -64,6 +75,31 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
             `--fs-root=${fsRootDir(tempDir)}`,
             `--secret=${getSiteSecret(site)}`,
             ...mysqlArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+        return { childProcess, output, exit };
+    }
+
+    function spawnDatabaseApply(stateDir) {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-apply',
+            importUrl(),
+            `--state-dir=${stateDir}`,
+            `--fs-root=${fsRootDir(stateDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...targetMysqlArguments(),
+            '--progress=jsonl',
         ], {
             env: { ...process.env },
             stdio: ['ignore', 'pipe', 'pipe'],
@@ -174,6 +210,9 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
         if (tempDir) {
             cleanupTempDir(tempDir);
         }
+        if (fileTempDir) {
+            cleanupTempDir(fileTempDir);
+        }
         const connection = await createMysqlConnection();
         await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
         await connection.end();
@@ -225,6 +264,106 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
             resumed.exitCode,
             0,
             `resumed db-pull failed:\n${resumed.stderr}\n${resumed.stdout}`,
+        );
+
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            const [rows] = await targetConnection.query(
+                `SELECT value, value + 0 AS enumIndex FROM \`${sqlModeTable}\``
+            );
+            assert.equal(rows.length, 1);
+            assert.equal(rows[0].value, '');
+            assert.equal(Number(rows[0].enumIndex), 0);
+        } finally {
+            await targetConnection.end();
+        }
+    });
+
+    it('runs locally saved dump settings before resumed db-apply SQL', async () => {
+        fileTempDir = createTempDir('e2e-mysql-file-session-settings-resume');
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            "    if (substr(rtrim($sql), -1) === ';') {",
+            "        $sql .= \"\\nDO SLEEP(0.03);\\n\";",
+            '    }',
+            '}',
+        ].join('\n'));
+
+        const preflight = runImporter(importUrl(), fileTempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+
+        const pulled = runImporter(importUrl(), fileTempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--sql-output=file',
+                '--sql-fragments-start=1',
+                '--sql-fragments-min=1',
+                '--sql-fragments-max=1',
+            ],
+            wallTimeout: 240000,
+        });
+        removeTestHooks(site);
+        assert.equal(
+            pulled.exitCode,
+            0,
+            `file db-pull failed:\n${pulled.stderr}\n${pulled.stdout}`,
+        );
+        assert.equal(
+            existsSync(join(fileTempDir, 'db-session-setup.sql')),
+            true,
+            'db-pull did not save the MySQL session setup beside db.sql',
+        );
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.query(`CREATE DATABASE \`${targetDb}\``);
+        await connection.end();
+
+        const first = spawnDatabaseApply(fileTempDir);
+        const statePath = join(pullStateDirectory(fileTempDir, importUrl()), 'state.json');
+        const deadline = Date.now() + 60000;
+        let statementsExecuted = 0;
+
+        while (Date.now() < deadline) {
+            if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
+                const result = await first.exit;
+                assert.fail(
+                    `db-apply exited before its first saved position (${result.code}/${result.signal}):\n`
+                    + first.output.stderr + first.output.stdout,
+                );
+            }
+            if (existsSync(statePath)) {
+                const state = JSON.parse(readFileSync(statePath, 'utf8'));
+                statementsExecuted = Number(state.apply?.statements_executed || 0);
+            }
+            if (statementsExecuted >= 100) {
+                break;
+            }
+            await sleep(10);
+        }
+
+        assert.ok(statementsExecuted >= 100, 'db-apply did not save a position');
+        assert.equal(first.childProcess.kill('SIGKILL'), true);
+        const killed = await first.exit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+        await sleep(100);
+
+        const resumed = runImporter(importUrl(), fileTempDir, 'db-apply', {
+            secret: getSiteSecret(site),
+            extraArgs: targetMysqlArguments(),
+            wallTimeout: 240000,
+        });
+        assert.equal(
+            resumed.exitCode,
+            0,
+            `resumed db-apply failed:\n${resumed.stderr}\n${resumed.stdout}`,
         );
 
         const targetConnection = await createMysqlConnection(targetDb);

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -49,6 +49,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
             '--sql-fragments-start=1',
             '--sql-fragments-min=1',
             '--sql-fragments-max=1',
+            '--max-exec=1',
             '--progress=jsonl',
         ];
     }
@@ -107,13 +108,13 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
 
         tempDir = createTempDir('e2e-mysql-session-settings-resume');
         clearHookState(site);
-        writeHookState(site, { batches: 0, release: false });
+        writeHookState(site, { requests: 0, batches: 0, release: false });
         writeTestHooks(site, [
-            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            'function test_hook_after_gzip_init($gz, $boundary) {',
             `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
             '    $state = json_decode(file_get_contents($state_file), true);',
-            '    $state[\'batches\'] = ($state[\'batches\'] ?? 0) + 1;',
-            '    if ($state[\'batches\'] === 60) {',
+            '    $state[\'requests\'] = ($state[\'requests\'] ?? 0) + 1;',
+            '    if ($state[\'requests\'] === 2) {',
             '        $state[\'paused\'] = true;',
             '        file_put_contents($state_file, json_encode($state));',
             '        do {',
@@ -122,6 +123,15 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
             '        } while (empty($state[\'release\']));',
             '    } else {',
             '        file_put_contents($state_file, json_encode($state));',
+            '    }',
+            '}',
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = json_decode(file_get_contents($state_file), true);',
+            '    $state[\'batches\'] = ($state[\'batches\'] ?? 0) + 1;',
+            '    file_put_contents($state_file, json_encode($state));',
+            '    if ($state[\'requests\'] === 1 && $state[\'batches\'] === 60) {',
+            '        usleep(1500000);',
             '    }',
             '}',
         ].join('\n'));


### PR DESCRIPTION
A resumed MySQL import now reloads the dump's initial `SET` statements from a local file before continuing after the dump header.

## Problem

These settings belong to one MySQL connection. A dump starts with:

```sql
SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';
SET AUTOCOMMIT=0;
```

If `db-pull` or `db-apply` stops after that header, the next process opens a new MySQL connection. The new connection does not inherit those settings. Continuing from the saved position can then reject rows because of foreign keys or a different SQL mode.

## This change

The first SQL response includes the setup block as a separate part. The client saves it as `db-session-setup.sql` beside `db.sql`.

A direct-MySQL `db-pull` continuing from a saved source position runs that local file before requesting more SQL. A file-backed `db-apply` runs the same local file before seeking to its saved position. An import starting from the beginning still runs the normal header in `db.sql`.

This PR only restores the connection settings. #620 stores the source position alongside committed target data. #621 restarts an unfinished table from its `DROP TABLE` and `CREATE TABLE` statements.

## Testing

One end-to-end case kills a direct-MySQL `db-pull` after it saves a source position. Another downloads `db.sql`, kills `db-apply` after it saves a file position, and resumes from the file. Both continue on a new MySQL connection and import an ENUM value that the target's default SQL mode rejects, but the saved dump SQL mode accepts.
