### PR TITLE
[PHP] Resume db-pull from the cursor saved in MySQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely and changes whenever the table schema changes. Reprint logs and excludes that internal name from the source dump. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely and changes whenever the table schema changes. Reprint logs and excludes that internal name from the source dump. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` waits for the old target connection, reapplies `db-session-setup.sql`, and continues from the position stored in the target database. Repeated INSERT statements skip rows identified by a non-null unique key, which also permits keyed MyISAM tables to continue. Nontransactional tables without such a key, and nontransactional oversized-value UPDATE sequences, require a fresh import.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely; if the source has the same internal table, Reprint logs and skips it. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `<remote-state-directory>/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely. Reprint logs and excludes that internal name from the source dump. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely and changes whenever the table schema changes. Reprint logs and excludes that internal name from the source dump. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely; if the source has the same internal table, Reprint logs and skips it. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress_<uuid>` and commits the current target transaction. The UUID makes an accidental table-name clash unlikely. Reprint logs and excludes that internal name from the source dump. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
 
 ### Progress Tracking
 

--- a/README.md
+++ b/README.md
@@ -371,10 +371,12 @@ The three modes:
 When a source response stops mid-stream, the same importer asks for the
 remaining SQL and keeps an unfinished statement in memory. Direct MySQL
 output stores the last committed source position in the target table
-`__reprint_db_pull_progress`. For transactional target tables, each completed
-SQL group and its source position are committed together. If the importer
-process stops, the next `db-pull` starts the dump from the beginning rather
-than relying on unfinished SQL from the dead process.
+`__reprint_db_pull_progress_<uuid>`. The UUID makes an accidental name clash
+unlikely. If the source has the same internal table, Reprint logs and skips it.
+For transactional target tables, each completed SQL group and its source
+position are committed together. If the importer process stops, the next
+`db-pull` starts the dump from the beginning rather than relying on unfinished
+SQL from the dead process.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ When a source response stops mid-stream, the same importer asks for the
 remaining SQL and keeps an unfinished statement in memory. Direct MySQL
 output stores the last committed source position in the target table
 `__reprint_db_pull_progress_<uuid>`. The UUID makes an accidental name clash
-unlikely. Reprint logs and excludes that internal name from the source dump.
-For transactional target tables, each completed SQL group and its source position
-are committed together. If the importer process stops, the next `db-pull` starts
-the dump from the beginning rather than relying on unfinished SQL from the dead
-process.
+unlikely and changes whenever the table schema changes. Reprint logs and excludes
+that internal name from the source dump. For transactional target tables, each
+completed SQL group and its source position are committed together. If the
+importer process stops, the next `db-pull` starts the dump from the beginning
+rather than relying on unfinished SQL from the dead process.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ When a source response stops mid-stream, the same importer asks for the
 remaining SQL and keeps an unfinished statement in memory. Direct MySQL
 output stores the last committed source position in the target table
 `__reprint_db_pull_progress_<uuid>`. The UUID makes an accidental name clash
-unlikely. If the source has the same internal table, Reprint logs and skips it.
-For transactional target tables, each completed SQL group and its source
-position are committed together. If the importer process stops, the next
-`db-pull` starts the dump from the beginning rather than relying on unfinished
-SQL from the dead process.
+unlikely. Reprint logs and excludes that internal name from the source dump.
+For transactional target tables, each completed SQL group and its source position
+are committed together. If the importer process stops, the next `db-pull` starts
+the dump from the beginning rather than relying on unfinished SQL from the dead
+process.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -375,8 +375,13 @@ output stores the last committed source position in the target table
 unlikely and changes whenever the table schema changes. Reprint logs and excludes
 that internal name from the source dump. For transactional target tables, each
 completed SQL group and its source position are committed together. If the
-importer process stops, the next `db-pull` starts the dump from the beginning
-rather than relying on unfinished SQL from the dead process.
+importer process stops, the next `db-pull` waits for the old target connection
+to finish, reapplies the saved MySQL session setup, and continues from the
+position stored in the target database. A repeated INSERT skips rows already
+identified by a non-null unique key, so this also works for keyed MyISAM tables.
+Reprint cannot continue a nontransactional table without such a key, or while
+an oversized value is being appended in separate UPDATE statements; those
+cases require `db-pull --abort` and a fresh import.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -368,12 +368,13 @@ The three modes:
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
 | `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
 
-All three modes recover from server crashes mid-stream (PHP fatal errors,
-OOM kills, `max_execution_time` expiry). When the server dies before sending
-a completion chunk, the importer detects the transport failure, saves its
-cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/sql-buffer`
-so the next run reloads it and continues.
+When a source response stops mid-stream, the same importer asks for the
+remaining SQL and keeps an unfinished statement in memory. Direct MySQL
+output stores the last committed source position in the target table
+`__reprint_db_pull_progress`. For transactional target tables, each completed
+SQL group and its source position are committed together. If the importer
+process stops, the next `db-pull` starts the dump from the beginning rather
+than relying on unfinished SQL from the dead process.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -671,9 +672,9 @@ are absent while the plan is still being built.
 #### `<remote-state-directory>/pull/state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it
-back periodically and on shutdown. It stores everything needed to resume after
-a crash or interruption: the current command, cursor position, AIMD tuning
-state, and per-phase bookmarks.
+back periodically and on shutdown. It stores the current command, cursor
+position, AIMD tuning state, and per-phase bookmarks. Direct MySQL output also
+records each committed source position in the target database.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -192,8 +192,7 @@ their parent directories.
         │   ├── remote-index.next.jsonl
         │   ├── fetch-list.jsonl
         │   ├── volatile-files.json
-        │   ├── sql-stats.json
-        │   └── sql-buffer
+        │   └── sql-stats.json
         └── push/
 ```
 

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -211,7 +211,6 @@ Use these path names:
 | Fetch list file | `$fetch_list_file` |
 | Volatile files file | `$volatile_files_file` |
 | SQL statistics file | `$sql_stats_file` |
-| SQL buffer file | `$sql_buffer_file` |
 | Audit log file | `$audit_log_file` |
 | Progress file | `$progress_file` |
 | Reprint process lock path | `$process_lock_path` |

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7934,7 +7934,10 @@ class ImportClient
                     $source_table_name = is_array($source_table)
                         ? $source_table["name"] ?? null
                         : null;
-                    if ($source_table_name === $table) {
+                    if (
+                        is_string($source_table_name)
+                        && strcasecmp($source_table_name, $table) === 0
+                    ) {
                         throw new RuntimeException(
                             "The source database has a table named {$table}, which Reprint needs " .
                             "to save db-pull progress. Rename that source table before using " .

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -176,6 +176,7 @@ class ImportClient
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
     private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress";
+    private const MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT = "Reprint db-pull progress v1";
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -7914,6 +7915,36 @@ class ImportClient
             $user = $this->mysql_user ?? "root";
             $pass = $this->mysql_password ?? "";
             $name = $this->mysql_database;
+            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+
+            $tables_file = wp_join_unix_paths($this->state_dir, "db-tables.jsonl");
+            $tables_handle = @fopen($tables_file, "r");
+            if (!$tables_handle) {
+                throw new RuntimeException(
+                    "Cannot check the source table names because db-tables.jsonl cannot be read."
+                );
+            }
+            try {
+                while (true) {
+                    $table_line = fgets($tables_handle);
+                    if ($table_line === false) {
+                        break;
+                    }
+                    $source_table = json_decode($table_line, true);
+                    $source_table_name = is_array($source_table)
+                        ? $source_table["name"] ?? null
+                        : null;
+                    if ($source_table_name === $table) {
+                        throw new RuntimeException(
+                            "The source database has a table named {$table}, which Reprint needs " .
+                            "to save db-pull progress. Rename that source table before using " .
+                            "--sql-output=mysql."
+                        );
+                    }
+                }
+            } finally {
+                fclose($tables_handle);
+            }
 
             // Parse host for port/socket (same format as WordPress DB_HOST).
             // An explicit --mysql-port takes precedence over a port embedded
@@ -7936,17 +7967,91 @@ class ImportClient
             $mysql_conn->set_charset("utf8mb4");
 
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
-            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
             $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
                 "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
                 "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
                 "`source_cursor` MEDIUMTEXT NOT NULL" .
-                ") ENGINE=InnoDB";
+                ") ENGINE=InnoDB COMMENT='" . self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT . "'";
             if (!$mysql_conn->query($create_table_sql)) {
                 throw new RuntimeException(
                     "MySQL could not create the db-pull progress table: " . $mysql_conn->error
                 );
             }
+
+            $table_result = $mysql_conn->query(
+                "SELECT `ENGINE`, `TABLE_COMMENT` FROM `INFORMATION_SCHEMA`.`TABLES` " .
+                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}'"
+            );
+            if (!$table_result) {
+                throw new RuntimeException(
+                    "MySQL could not inspect the db-pull progress table: " . $mysql_conn->error
+                );
+            }
+            $table_info = $table_result->fetch_assoc();
+            $table_result->free();
+            $table_engine = strtoupper($table_info["ENGINE"] ?? "");
+            $table_comment = $table_info["TABLE_COMMENT"] ?? "";
+            if (
+                !$table_info ||
+                $table_engine !== "INNODB" ||
+                $table_comment !== self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT
+            ) {
+                throw new RuntimeException(
+                    "The target database already has a table named {$table}, and Reprint did not create it. " .
+                    "Rename or remove that table before using --sql-output=mysql."
+                );
+            }
+
+            $columns_result = $mysql_conn->query(
+                "SELECT `COLUMN_NAME`, `DATA_TYPE`, `COLUMN_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, " .
+                "`IS_NULLABLE`, `COLUMN_KEY` FROM `INFORMATION_SCHEMA`.`COLUMNS` " .
+                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}' " .
+                "ORDER BY `ORDINAL_POSITION`"
+            );
+            if (!$columns_result) {
+                throw new RuntimeException(
+                    "MySQL could not inspect the db-pull progress columns: " . $mysql_conn->error
+                );
+            }
+            $columns = [];
+            while (true) {
+                $column = $columns_result->fetch_assoc();
+                if (!$column) {
+                    break;
+                }
+                $columns[$column["COLUMN_NAME"]] = $column;
+            }
+            $columns_result->free();
+            $id_column = $columns["id"] ?? [];
+            $source_hash_column = $columns["source_hash"] ?? [];
+            $source_cursor_column = $columns["source_cursor"] ?? [];
+            $id_data_type = $id_column["DATA_TYPE"] ?? null;
+            $id_column_type = $id_column["COLUMN_TYPE"] ?? "";
+            $id_is_nullable = $id_column["IS_NULLABLE"] ?? null;
+            $id_key = $id_column["COLUMN_KEY"] ?? null;
+            $source_hash_data_type = $source_hash_column["DATA_TYPE"] ?? null;
+            $source_hash_length = $source_hash_column["CHARACTER_MAXIMUM_LENGTH"] ?? 0;
+            $source_hash_is_nullable = $source_hash_column["IS_NULLABLE"] ?? null;
+            $source_cursor_data_type = $source_cursor_column["DATA_TYPE"] ?? null;
+            $source_cursor_is_nullable = $source_cursor_column["IS_NULLABLE"] ?? null;
+            $has_expected_columns =
+                array_keys($columns) === ["id", "source_hash", "source_cursor"] &&
+                $id_data_type === "tinyint" &&
+                strpos($id_column_type, "unsigned") !== false &&
+                $id_is_nullable === "NO" &&
+                $id_key === "PRI" &&
+                $source_hash_data_type === "char" &&
+                (int) $source_hash_length === 64 &&
+                $source_hash_is_nullable === "NO" &&
+                $source_cursor_data_type === "mediumtext" &&
+                $source_cursor_is_nullable === "NO";
+            if (!$has_expected_columns) {
+                throw new RuntimeException(
+                    "The target table {$table} does not have the columns Reprint expects. " .
+                    "Remove it before using --sql-output=mysql."
+                );
+            }
+
             if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
                 throw new RuntimeException(
                     "MySQL could not reset the previous db-pull position: " . $mysql_conn->error

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -175,6 +175,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    // Change this UUID whenever the progress-table schema changes.
     private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress_728f9e0b-42f7-4d85-a7f3-8f53e90a6f4c";
 
     /**
@@ -7936,9 +7937,17 @@ class ImportClient
             }
             $mysql_conn->set_charset("utf8mb4");
 
-            $this->ensure_progress_table($mysql_conn);
-
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+            $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
+                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+                "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
+                "`source_cursor` MEDIUMTEXT NOT NULL" .
+                ") ENGINE=InnoDB";
+            if (!$mysql_conn->query($create_table_sql)) {
+                throw new RuntimeException(
+                    "MySQL could not create the db-pull progress table: " . $mysql_conn->error
+                );
+            }
             if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
                 throw new RuntimeException(
                     "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
@@ -8259,64 +8268,6 @@ class ImportClient
                 " bytes) — incomplete export?"
             );
         }
-    }
-
-    /** Creates the db-pull progress table, replacing it when its schema is wrong. */
-    private function ensure_progress_table(\mysqli $connection): void
-    {
-        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
-        $expected_table = "__reprint_expected_db_pull_progress";
-        $columns = "(" .
-            "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
-            "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
-            "`source_cursor` MEDIUMTEXT NOT NULL" .
-            ") ENGINE=InnoDB";
-
-        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
-        if (!$connection->query("CREATE TABLE IF NOT EXISTS `{$table}` {$columns}")) {
-            throw new RuntimeException(
-                "MySQL could not create the db-pull progress table: " . $connection->error
-            );
-        }
-        if (!$connection->query("CREATE TEMPORARY TABLE `{$expected_table}` {$columns}")) {
-            throw new RuntimeException(
-                "MySQL could not prepare the expected db-pull progress schema: " . $connection->error
-            );
-        }
-
-        try {
-            $schemas = [];
-            foreach ([$table, $expected_table] as $schema_table) {
-                $result = $connection->query("SHOW CREATE TABLE `{$schema_table}`");
-                $row = $result ? $result->fetch_row() : null;
-                if (!$row || !isset($row[1])) {
-                    throw new RuntimeException(
-                        "MySQL could not inspect the db-pull progress table: " . $connection->error
-                    );
-                }
-                $result->free();
-                $schemas[] = preg_replace(
-                    '/^CREATE (?:TEMPORARY )?TABLE `[^`]+`/',
-                    'CREATE TABLE',
-                    $row[1]
-                );
-            }
-        } finally {
-            $connection->query("DROP TEMPORARY TABLE `{$expected_table}`");
-        }
-
-        if ($schemas[0] !== $schemas[1]) {
-            if (
-                !$connection->query("DROP TABLE `{$table}`")
-                || !$connection->query("CREATE TABLE `{$table}` {$columns}")
-            ) {
-                throw new RuntimeException(
-                    "MySQL could not recreate the db-pull progress table: " . $connection->error
-                );
-            }
-            $this->audit_log("RECREATED DB-PULL PROGRESS TABLE | its schema did not match", true);
-        }
-        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
     /** Saves the source cursor and commits the current target transaction. */

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -175,8 +175,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
-    private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress";
-    private const MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT = "Reprint db-pull progress v1";
+    private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress_728f9e0b-42f7-4d85-a7f3-8f53e90a6f4c";
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -7938,10 +7937,10 @@ class ImportClient
                         is_string($source_table_name)
                         && strcasecmp($source_table_name, $table) === 0
                     ) {
-                        throw new RuntimeException(
-                            "The source database has a table named {$table}, which Reprint needs " .
-                            "to save db-pull progress. Rename that source table before using " .
-                            "--sql-output=mysql."
+                        $this->audit_log(
+                            "SKIPPED SOURCE TABLE | {$source_table_name} matches Reprint's " .
+                            "db-pull progress table {$table}",
+                            true,
                         );
                     }
                 }
@@ -7969,92 +7968,9 @@ class ImportClient
             }
             $mysql_conn->set_charset("utf8mb4");
 
+            $this->ensure_progress_table($mysql_conn);
+
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
-            $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
-                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
-                "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
-                "`source_cursor` MEDIUMTEXT NOT NULL" .
-                ") ENGINE=InnoDB COMMENT='" . self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT . "'";
-            if (!$mysql_conn->query($create_table_sql)) {
-                throw new RuntimeException(
-                    "MySQL could not create the db-pull progress table: " . $mysql_conn->error
-                );
-            }
-
-            $table_result = $mysql_conn->query(
-                "SELECT `ENGINE`, `TABLE_COMMENT` FROM `INFORMATION_SCHEMA`.`TABLES` " .
-                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}'"
-            );
-            if (!$table_result) {
-                throw new RuntimeException(
-                    "MySQL could not inspect the db-pull progress table: " . $mysql_conn->error
-                );
-            }
-            $table_info = $table_result->fetch_assoc();
-            $table_result->free();
-            $table_engine = strtoupper($table_info["ENGINE"] ?? "");
-            $table_comment = $table_info["TABLE_COMMENT"] ?? "";
-            if (
-                !$table_info ||
-                $table_engine !== "INNODB" ||
-                $table_comment !== self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT
-            ) {
-                throw new RuntimeException(
-                    "The target database already has a table named {$table}, and Reprint did not create it. " .
-                    "Rename or remove that table before using --sql-output=mysql."
-                );
-            }
-
-            $columns_result = $mysql_conn->query(
-                "SELECT `COLUMN_NAME`, `DATA_TYPE`, `COLUMN_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, " .
-                "`IS_NULLABLE`, `COLUMN_KEY` FROM `INFORMATION_SCHEMA`.`COLUMNS` " .
-                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}' " .
-                "ORDER BY `ORDINAL_POSITION`"
-            );
-            if (!$columns_result) {
-                throw new RuntimeException(
-                    "MySQL could not inspect the db-pull progress columns: " . $mysql_conn->error
-                );
-            }
-            $columns = [];
-            while (true) {
-                $column = $columns_result->fetch_assoc();
-                if (!$column) {
-                    break;
-                }
-                $columns[$column["COLUMN_NAME"]] = $column;
-            }
-            $columns_result->free();
-            $id_column = $columns["id"] ?? [];
-            $source_hash_column = $columns["source_hash"] ?? [];
-            $source_cursor_column = $columns["source_cursor"] ?? [];
-            $id_data_type = $id_column["DATA_TYPE"] ?? null;
-            $id_column_type = $id_column["COLUMN_TYPE"] ?? "";
-            $id_is_nullable = $id_column["IS_NULLABLE"] ?? null;
-            $id_key = $id_column["COLUMN_KEY"] ?? null;
-            $source_hash_data_type = $source_hash_column["DATA_TYPE"] ?? null;
-            $source_hash_length = $source_hash_column["CHARACTER_MAXIMUM_LENGTH"] ?? 0;
-            $source_hash_is_nullable = $source_hash_column["IS_NULLABLE"] ?? null;
-            $source_cursor_data_type = $source_cursor_column["DATA_TYPE"] ?? null;
-            $source_cursor_is_nullable = $source_cursor_column["IS_NULLABLE"] ?? null;
-            $has_expected_columns =
-                array_keys($columns) === ["id", "source_hash", "source_cursor"] &&
-                $id_data_type === "tinyint" &&
-                strpos($id_column_type, "unsigned") !== false &&
-                $id_is_nullable === "NO" &&
-                $id_key === "PRI" &&
-                $source_hash_data_type === "char" &&
-                (int) $source_hash_length === 64 &&
-                $source_hash_is_nullable === "NO" &&
-                $source_cursor_data_type === "mediumtext" &&
-                $source_cursor_is_nullable === "NO";
-            if (!$has_expected_columns) {
-                throw new RuntimeException(
-                    "The target table {$table} does not have the columns Reprint expects. " .
-                    "Remove it before using --sql-output=mysql."
-                );
-            }
-
             if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
                 throw new RuntimeException(
                     "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
@@ -8094,6 +8010,9 @@ class ImportClient
         try {
             while (!$complete) {
                 $params = $this->get_tuned_params("sql_chunk");
+                if ($mode === "mysql") {
+                    $params["skip_tables"] = [self::MYSQL_DB_PULL_PROGRESS_TABLE];
+                }
                 $url = $this->build_url("sql_chunk", $cursor, $params);
 
                 $context = new StreamingContext();
@@ -8366,6 +8285,64 @@ class ImportClient
                 " bytes) — incomplete export?"
             );
         }
+    }
+
+    /** Creates the db-pull progress table, replacing it when its schema is wrong. */
+    private function ensure_progress_table(\mysqli $connection): void
+    {
+        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+        $expected_table = "__reprint_expected_db_pull_progress";
+        $columns = "(" .
+            "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+            "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
+            "`source_cursor` MEDIUMTEXT NOT NULL" .
+            ") ENGINE=InnoDB";
+
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        if (!$connection->query("CREATE TABLE IF NOT EXISTS `{$table}` {$columns}")) {
+            throw new RuntimeException(
+                "MySQL could not create the db-pull progress table: " . $connection->error
+            );
+        }
+        if (!$connection->query("CREATE TEMPORARY TABLE `{$expected_table}` {$columns}")) {
+            throw new RuntimeException(
+                "MySQL could not prepare the expected db-pull progress schema: " . $connection->error
+            );
+        }
+
+        try {
+            $schemas = [];
+            foreach ([$table, $expected_table] as $schema_table) {
+                $result = $connection->query("SHOW CREATE TABLE `{$schema_table}`");
+                $row = $result ? $result->fetch_row() : null;
+                if (!$row || !isset($row[1])) {
+                    throw new RuntimeException(
+                        "MySQL could not inspect the db-pull progress table: " . $connection->error
+                    );
+                }
+                $result->free();
+                $schemas[] = preg_replace(
+                    '/^CREATE (?:TEMPORARY )?TABLE `[^`]+`/',
+                    'CREATE TABLE',
+                    $row[1]
+                );
+            }
+        } finally {
+            $connection->query("DROP TEMPORARY TABLE `{$expected_table}`");
+        }
+
+        if ($schemas[0] !== $schemas[1]) {
+            if (
+                !$connection->query("DROP TABLE `{$table}`")
+                || !$connection->query("CREATE TABLE `{$table}` {$columns}")
+            ) {
+                throw new RuntimeException(
+                    "MySQL could not recreate the db-pull progress table: " . $connection->error
+                );
+            }
+            $this->audit_log("RECREATED DB-PULL PROGRESS TABLE | its schema did not match", true);
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
     /** Saves the source cursor and commits the current target transaction. */

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7992,7 +7992,7 @@ class ImportClient
                 $this->get_state()->active_resumable_command->remote_cursor = null;
                 $this->save_state();
             } else {
-                $cursor = $this->read_mysql_output_cursor($mysql_conn);
+                $cursor = $this->read_and_validate_mysql_resume_cursor($mysql_conn);
             }
             $mysql_committed_cursor = $cursor;
             // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
@@ -8362,11 +8362,14 @@ class ImportClient
         // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
-    /** Returns the source position committed by MySQL, if one exists. */
-    private function read_mysql_output_cursor(\mysqli $connection): ?string
+    /** Reads MySQL's saved cursor and checks that its next SQL can be repeated safely. */
+    private function read_and_validate_mysql_resume_cursor(\mysqli $connection): ?string
     {
         // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors and table names are CLI text, not HTML.
         $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+
+        // The target stores one cursor after each complete SQL group. No row
+        // means this is a new pull.
         $result = $connection->query(
             "SELECT `source_hash`, `source_cursor` FROM `{$table}` WHERE `id` = 1"
         );
@@ -8381,6 +8384,8 @@ class ImportClient
             return null;
         }
 
+        // A cursor from another source describes a different SQL stream. It
+        // cannot tell this source where to continue.
         $source_hash = hash("sha256", $this->remote_reprint_api_url);
         if (!hash_equals($source_hash, $row["source_hash"])) {
             throw new RuntimeException(
@@ -8389,6 +8394,8 @@ class ImportClient
             );
         }
 
+        // The cursor is base64-encoded JSON produced by the exporter. We need
+        // its current table to decide whether an interrupted query can be run again.
         $cursor = $row["source_cursor"];
         $cursor_json = base64_decode($cursor, true);
         $cursor_data = $cursor_json === false ? null : json_decode($cursor_json, true);
@@ -8401,6 +8408,8 @@ class ImportClient
 
         $current_table = $cursor_data["current_table"] ?? null;
         if ($current_table === null) {
+            // This cursor sits outside a table's row stream, so there cannot be
+            // a partly applied INSERT for a table to inspect.
             return $cursor;
         }
         if (!is_string($current_table) || $current_table === "") {
@@ -8410,6 +8419,8 @@ class ImportClient
             );
         }
 
+        // The saved cursor comes before any SQL that was still running when
+        // the process stopped. Check the target table before repeating that SQL.
         $table_statement = $connection->prepare(
             "SELECT `TABLES`.`TABLE_TYPE`, `TABLES`.`ENGINE`, `ENGINES`.`TRANSACTIONS` " .
             "FROM `INFORMATION_SCHEMA`.`TABLES` AS `TABLES` " .
@@ -8442,9 +8453,15 @@ class ImportClient
             );
         }
         if ($table_type === "VIEW" || $supports_transactions === "YES") {
+            // InnoDB rolls back an interrupted statement, so repeating it
+            // starts from the same rows that existed at the saved cursor. Views
+            // do not need the non-transactional table key check below.
             return $cursor;
         }
 
+        // Large values are written by UPDATE statements which append pieces.
+        // A non-transactional table may keep one piece, so repeating the UPDATE
+        // could append those bytes twice.
         if (!empty($cursor_data["oversized_queue"])) {
             throw new RuntimeException(
                 "Cannot continue db-pull in target table `{$current_table}` because {$engine} may have " .
@@ -8452,6 +8469,9 @@ class ImportClient
             );
         }
 
+        // MyISAM may keep the first rows from an interrupted INSERT. The dump's
+        // ON DUPLICATE KEY no-op makes repeating those rows safe only when a
+        // non-null unique key can identify them.
         $key_statement = $connection->prepare(
             "SELECT `STATISTICS`.`INDEX_NAME` " .
             "FROM `INFORMATION_SCHEMA`.`STATISTICS` AS `STATISTICS` " .

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3813,7 +3813,11 @@ class ImportClient
 
         $has_progress =
             $state_command === "db-pull" &&
-            ($this->get_state()->active_resumable_command->completion_state ?? null) === "in_progress";
+            in_array(
+                $this->get_state()->active_resumable_command->completion_state ?? null,
+                ["in_progress", "partial"],
+                true,
+            );
         $current_status =
             $state_command === "db-pull"
                 ? $this->get_state()->active_resumable_command->completion_state ?? null
@@ -3841,6 +3845,7 @@ class ImportClient
 
         if ($has_progress) {
             $stage = $this->get_state()->active_resumable_command->current_stage ?? "db-index";
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
             $this->audit_log(
                 sprintf(
                     "RESUME db-pull | stage=%s | cursor=%s",
@@ -3906,7 +3911,8 @@ class ImportClient
             );
 
             // Transition to sql stage
-            $this->get_state()->active_resumable_command->current_stage = "sql";
+            $stage = $this->sql_output_mode === "mysql" ? "mysql-start" : "sql";
+            $this->get_state()->active_resumable_command->current_stage = $stage;
             $this->get_state()->active_resumable_command->remote_cursor = null;
             $this->save_state();
         }
@@ -3918,7 +3924,7 @@ class ImportClient
             "message" => "Downloading SQL dump",
         ]);
 
-        $this->fetch_sql();
+        $this->fetch_sql($stage === "mysql-start");
 
         // Interrupted response during SQL download — state already saved, exit partial.
         if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
@@ -7853,8 +7859,10 @@ class ImportClient
 
     /**
      * Download SQL from remote.
+     *
+     * @param bool $starts_mysql_output Whether to clear an older target position before reading SQL.
      */
-    private function fetch_sql(): void
+    private function fetch_sql(bool $starts_mysql_output = false): void
     {
         $cursor = $this->get_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
@@ -7937,6 +7945,28 @@ class ImportClient
             }
             $mysql_conn->set_charset("utf8mb4");
 
+            $lock_name = "reprint-db-pull-" . substr(
+                hash("sha256", (string) $this->mysql_database),
+                0,
+                40,
+            );
+            $lock_result = $mysql_conn->query(
+                "SELECT GET_LOCK('{$lock_name}', 60) AS `lock_acquired`"
+            );
+            if (!$lock_result) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+                throw new RuntimeException(
+                    "MySQL could not lock the target database for db-pull: " . $mysql_conn->error
+                );
+            }
+            $lock_row = $lock_result->fetch_assoc();
+            $lock_result->free();
+            if ( (int) ( $lock_row["lock_acquired"] ?? 0 ) !== 1) {
+                throw new RuntimeException(
+                    "Another db-pull is still writing to the target database. Try again after it stops."
+                );
+            }
+
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
             $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
                 "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
@@ -7948,13 +7978,42 @@ class ImportClient
                     "MySQL could not create the db-pull progress table: " . $mysql_conn->error
                 );
             }
-            if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
-                throw new RuntimeException(
-                    "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
+            if ($starts_mysql_output) {
+                // Keep the mysql-start stage until the old target position is gone.
+                // If this process stops before save_state(), the next process
+                // deletes that position again instead of treating it as current.
+                if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
+                    throw new RuntimeException(
+                        "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
+                    );
+                }
+                $cursor = null;
+                $this->get_state()->active_resumable_command->current_stage = "sql";
+                $this->get_state()->active_resumable_command->remote_cursor = null;
+                $this->save_state();
+            } else {
+                $cursor = $this->read_mysql_output_cursor($mysql_conn);
+            }
+            $mysql_committed_cursor = $cursor;
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+            if ($cursor !== null) {
+                $session_setup_sql = @file_get_contents($session_setup_file);
+                if ($session_setup_sql === false || trim($session_setup_sql) === "") {
+                    throw new RuntimeException(
+                        "Cannot continue db-pull because db-session-setup.sql is missing or empty. " .
+                        "Run db-pull --abort and start again.",
+                    );
+                }
+                $this->execute_mysql_queries($mysql_conn, $session_setup_sql);
+                $this->audit_log(
+                    "SQL OUTPUT mysql | ran saved session setup after reconnect",
+                    true,
                 );
             }
-            $cursor = null;
-            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+            $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+            $this->save_state();
 
             $this->audit_log(
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
@@ -8252,7 +8311,7 @@ class ImportClient
                     if ($caught_exception !== null) {
                         $this->audit_log(
                             "DISCARDED INCOMPLETE SQL | " . strlen($pending) .
-                            " bytes | a new process will request the dump from the beginning",
+                            " bytes | the next process will request them again from the saved target position",
                             true,
                         );
                     } else {
@@ -8301,6 +8360,139 @@ class ImportClient
             throw new RuntimeException("MySQL could not commit the imported SQL and its source position: " . $connection->error);
         }
         // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+    }
+
+    /** Returns the source position committed by MySQL, if one exists. */
+    private function read_mysql_output_cursor(\mysqli $connection): ?string
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors and table names are CLI text, not HTML.
+        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+        $result = $connection->query(
+            "SELECT `source_hash`, `source_cursor` FROM `{$table}` WHERE `id` = 1"
+        );
+        if (!$result) {
+            throw new RuntimeException(
+                "MySQL could not read the saved db-pull position: " . $connection->error
+            );
+        }
+        $row = $result->fetch_assoc();
+        $result->free();
+        if (!$row) {
+            return null;
+        }
+
+        $source_hash = hash("sha256", $this->remote_reprint_api_url);
+        if (!hash_equals($source_hash, $row["source_hash"])) {
+            throw new RuntimeException(
+                "The target database contains an unfinished db-pull from a different source. " .
+                "Finish that pull or run db-pull --abort before starting this one."
+            );
+        }
+
+        $cursor = $row["source_cursor"];
+        $cursor_json = base64_decode($cursor, true);
+        $cursor_data = $cursor_json === false ? null : json_decode($cursor_json, true);
+        if (!is_array($cursor_data)) {
+            throw new RuntimeException(
+                "MySQL contains a db-pull position that Reprint cannot read. " .
+                "Run db-pull --abort to start again."
+            );
+        }
+
+        $current_table = $cursor_data["current_table"] ?? null;
+        if ($current_table === null) {
+            return $cursor;
+        }
+        if (!is_string($current_table) || $current_table === "") {
+            throw new RuntimeException(
+                "MySQL contains a db-pull position with an invalid table name. " .
+                "Run db-pull --abort to start again."
+            );
+        }
+
+        $table_statement = $connection->prepare(
+            "SELECT `TABLES`.`TABLE_TYPE`, `TABLES`.`ENGINE`, `ENGINES`.`TRANSACTIONS` " .
+            "FROM `INFORMATION_SCHEMA`.`TABLES` AS `TABLES` " .
+            "LEFT JOIN `INFORMATION_SCHEMA`.`ENGINES` AS `ENGINES` " .
+            "ON `ENGINES`.`ENGINE` = `TABLES`.`ENGINE` " .
+            "WHERE `TABLES`.`TABLE_SCHEMA` = DATABASE() " .
+            "AND BINARY `TABLES`.`TABLE_NAME` = BINARY ?"
+        );
+        if (!$table_statement) {
+            throw new RuntimeException(
+                "MySQL could not check the saved db-pull table: " . $connection->error
+            );
+        }
+        $table_statement->bind_param("s", $current_table);
+        if (!$table_statement->execute()) {
+            $error = $table_statement->error;
+            $table_statement->close();
+            throw new RuntimeException("MySQL could not check the saved db-pull table: " . $error);
+        }
+        $table_type = null;
+        $engine = null;
+        $supports_transactions = null;
+        $table_statement->bind_result($table_type, $engine, $supports_transactions);
+        $found_table = $table_statement->fetch() === true;
+        $table_statement->close();
+        if (!$found_table) {
+            throw new RuntimeException(
+                "Cannot continue db-pull because target table `{$current_table}` is missing. " .
+                "Run db-pull --abort to rebuild the target."
+            );
+        }
+        if ($table_type === "VIEW" || $supports_transactions === "YES") {
+            return $cursor;
+        }
+
+        if (!empty($cursor_data["oversized_queue"])) {
+            throw new RuntimeException(
+                "Cannot continue db-pull in target table `{$current_table}` because {$engine} may have " .
+                "already appended part of a large value. Run db-pull --abort to rebuild the target."
+            );
+        }
+
+        $key_statement = $connection->prepare(
+            "SELECT `STATISTICS`.`INDEX_NAME` " .
+            "FROM `INFORMATION_SCHEMA`.`STATISTICS` AS `STATISTICS` " .
+            "INNER JOIN `INFORMATION_SCHEMA`.`COLUMNS` AS `COLUMNS` " .
+            "ON `COLUMNS`.`TABLE_SCHEMA` = `STATISTICS`.`TABLE_SCHEMA` " .
+            "AND `COLUMNS`.`TABLE_NAME` = `STATISTICS`.`TABLE_NAME` " .
+            "AND `COLUMNS`.`COLUMN_NAME` = `STATISTICS`.`COLUMN_NAME` " .
+            "WHERE `STATISTICS`.`TABLE_SCHEMA` = DATABASE() " .
+            "AND BINARY `STATISTICS`.`TABLE_NAME` = BINARY ? " .
+            "AND `STATISTICS`.`NON_UNIQUE` = 0 " .
+            "GROUP BY `STATISTICS`.`INDEX_NAME` " .
+            "HAVING SUM(`COLUMNS`.`IS_NULLABLE` = 'YES') = 0 LIMIT 1"
+        );
+        if (!$key_statement) {
+            throw new RuntimeException(
+                "MySQL could not check the keys for target table `{$current_table}`: " .
+                $connection->error
+            );
+        }
+        $key_statement->bind_param("s", $current_table);
+        if (!$key_statement->execute()) {
+            $error = $key_statement->error;
+            $key_statement->close();
+            throw new RuntimeException(
+                "MySQL could not check the keys for target table `{$current_table}`: " . $error
+            );
+        }
+        $index_name = null;
+        $key_statement->bind_result($index_name);
+        $has_replay_key = $key_statement->fetch() === true;
+        $key_statement->close();
+        if (!$has_replay_key) {
+            throw new RuntimeException(
+                "Cannot continue db-pull in target table `{$current_table}` because {$engine} may have " .
+                "kept some rows from an interrupted INSERT, and the table has no non-null unique key " .
+                "that can identify them. Run db-pull --abort to rebuild the target."
+            );
+        }
+
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        return $cursor;
     }
 
     /** Count complete SQL queries waiting in the stream. */

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -175,6 +175,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress";
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -7862,13 +7863,13 @@ class ImportClient
 
         $sql_handle = null;
         $mysql_conn = null;
-        $sql_buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
         $session_setup_file = wp_join_unix_paths(
             $this->state_dir,
             "db-session-setup.sql",
         );
+        $mysql_committed_cursor = null;
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
@@ -7934,44 +7935,30 @@ class ImportClient
             }
             $mysql_conn->set_charset("utf8mb4");
 
-            if ($cursor !== null) {
-                $session_setup_sql = @file_get_contents($session_setup_file);
-                if ($session_setup_sql === false || trim($session_setup_sql) === "") {
-                    throw new RuntimeException(
-                        "Cannot resume db-pull because db-session-setup.sql is missing or empty. " .
-                        "Run db-pull --abort and start again.",
-                    );
-                }
-                $this->execute_mysql_queries($mysql_conn, $session_setup_sql);
-                $this->audit_log(
-                    "SQL OUTPUT mysql | ran saved session setup after reconnect",
-                    true,
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+            $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
+                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+                "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
+                "`source_cursor` MEDIUMTEXT NOT NULL" .
+                ") ENGINE=InnoDB";
+            if (!$mysql_conn->query($create_table_sql)) {
+                throw new RuntimeException(
+                    "MySQL could not create the db-pull progress table: " . $mysql_conn->error
                 );
             }
+            if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
+                throw new RuntimeException(
+                    "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
+                );
+            }
+            $cursor = null;
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
             $this->audit_log(
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
                 true,
             );
-
-            // Open a persistent buffer file so partial queries survive crashes.
-            // Each SQL chunk is appended to this file as it arrives; when the
-            // query completes and executes, the file is truncated. If the process
-            // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-            if (file_exists($sql_buffer_file)) {
-                $sql_buffer = file_get_contents($sql_buffer_file);
-                $this->audit_log(
-                    sprintf("CRASH RECOVERY | Restored %d bytes from pull/sql-buffer", strlen($sql_buffer)),
-                    true,
-                );
-            }
-            // Open in write mode (truncate) if we loaded nothing, append if we
-            // have a partial query to continue accumulating into.
-            $sql_buffer_handle = fopen($sql_buffer_file, $sql_buffer !== "" ? "a" : "w");
-            if (!$sql_buffer_handle) {
-                throw new RuntimeException("Cannot open SQL buffer file: {$sql_buffer_file}");
-            }
         }
 
         // Count SQL statements during download for db-apply progress reporting.
@@ -8008,9 +7995,9 @@ class ImportClient
                     &$complete,
                     &$sql_handle,
                     $mysql_conn,
-                    &$sql_buffer_handle,
                     &$sql_buffer,
                     $session_setup_file,
+                    &$mysql_committed_cursor,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -8060,7 +8047,8 @@ class ImportClient
                         if ($sql_handle) {
                             fflush($sql_handle);
                         }
-                        $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                        $this->get_state()->active_resumable_command->remote_cursor =
+                            $mode === "mysql" ? $mysql_committed_cursor : $cursor;
                         $this->get_state()->sql_bytes = $sql_bytes_written;
                         $this->get_state()->sql_statements_counted = $sql_statements_counted;
                         $this->save_state();
@@ -8095,24 +8083,13 @@ class ImportClient
                                 break;
 
                             case "mysql":
-                                // Append to disk immediately so the buffer survives
-                                // even if the process is killed mid-chunk.
-                                if ($sql_buffer_handle) {
-                                    fwrite($sql_buffer_handle, $data);
-                                    fflush($sql_buffer_handle);
-                                }
-
                                 $sql_buffer .= $data;
                                 $sql_bytes_written += strlen($data);
 
                                 if ($query_complete) {
                                     $this->execute_mysql_queries($mysql_conn, $sql_buffer);
-
-                                    // Query executed — truncate the buffer file and reset.
-                                    if ($sql_buffer_handle) {
-                                        ftruncate($sql_buffer_handle, 0);
-                                        rewind($sql_buffer_handle);
-                                    }
+                                    $this->save_mysql_output_cursor($mysql_conn, $cursor);
+                                    $mysql_committed_cursor = $cursor;
                                     $sql_buffer = "";
                                 }
                                 break;
@@ -8220,7 +8197,8 @@ class ImportClient
                     fflush($sql_handle);
                 }
 
-                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                $this->get_state()->active_resumable_command->remote_cursor =
+                    $mode === "mysql" ? $mysql_committed_cursor : $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
                 $this->save_state();
@@ -8256,30 +8234,15 @@ class ImportClient
             if ($sql_handle) {
                 fclose($sql_handle);
             }
-            if ($sql_buffer_handle) {
-                fclose($sql_buffer_handle);
-                $sql_buffer_handle = null;
-            }
             if ($mysql_conn) {
                 $pending = $sql_buffer;
                 $mysql_conn->close();
                 $mysql_conn = null;
-                // Clean up buffer file — if we got here with an empty buffer,
-                // all queries were executed successfully.
-                $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-                if ($pending === "" && file_exists($sql_buffer_file)) {
-                    unlink($sql_buffer_file);
-                }
                 if ($pending !== "") {
                     if ($caught_exception !== null) {
-                        // An exception is already in flight (e.g. curl error,
-                        // MySQL error). Don't mask it by throwing about the
-                        // buffer — the buffer data is safely persisted in
-                        // pull/sql-buffer and will be recovered on the next run.
                         $this->audit_log(
-                            "BUFFER NOT FLUSHED | " . strlen($pending) .
-                            " bytes in SQL buffer during exception unwind" .
-                            " (original error: " . $caught_exception->getMessage() . ")",
+                            "DISCARDED INCOMPLETE SQL | " . strlen($pending) .
+                            " bytes | a new process will request the dump from the beginning",
                             true,
                         );
                     } else {
@@ -8295,6 +8258,39 @@ class ImportClient
                 " bytes) — incomplete export?"
             );
         }
+    }
+
+    /** Saves the source cursor and commits the current target transaction. */
+    private function save_mysql_output_cursor(\mysqli $connection, ?string $cursor): void
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        if ($cursor === null) {
+            throw new RuntimeException("The source returned SQL without a position to save.");
+        }
+
+        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+        $statement = $connection->prepare(
+            "INSERT INTO `{$table}` (`id`, `source_hash`, `source_cursor`) VALUES (1, ?, ?) " .
+            "ON DUPLICATE KEY UPDATE `source_hash` = VALUES(`source_hash`), " .
+            "`source_cursor` = VALUES(`source_cursor`)"
+        );
+        if (!$statement) {
+            throw new RuntimeException("MySQL could not prepare the db-pull position update: " . $connection->error);
+        }
+
+        $source_hash = hash("sha256", $this->remote_reprint_api_url);
+        $statement->bind_param("ss", $source_hash, $cursor);
+        if (!$statement->execute()) {
+            $error = $statement->error;
+            $statement->close();
+            throw new RuntimeException("MySQL could not save the db-pull position: " . $error);
+        }
+        $statement->close();
+
+        if (!$connection->commit()) {
+            throw new RuntimeException("MySQL could not commit the imported SQL and its source position: " . $connection->error);
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
     /** Count complete SQL queries waiting in the stream. */

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7916,38 +7916,6 @@ class ImportClient
             $name = $this->mysql_database;
             $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
 
-            $tables_file = wp_join_unix_paths($this->state_dir, "db-tables.jsonl");
-            $tables_handle = @fopen($tables_file, "r");
-            if (!$tables_handle) {
-                throw new RuntimeException(
-                    "Cannot check the source table names because db-tables.jsonl cannot be read."
-                );
-            }
-            try {
-                while (true) {
-                    $table_line = fgets($tables_handle);
-                    if ($table_line === false) {
-                        break;
-                    }
-                    $source_table = json_decode($table_line, true);
-                    $source_table_name = is_array($source_table)
-                        ? $source_table["name"] ?? null
-                        : null;
-                    if (
-                        is_string($source_table_name)
-                        && strcasecmp($source_table_name, $table) === 0
-                    ) {
-                        $this->audit_log(
-                            "SKIPPED SOURCE TABLE | {$source_table_name} matches Reprint's " .
-                            "db-pull progress table {$table}",
-                            true,
-                        );
-                    }
-                }
-            } finally {
-                fclose($tables_handle);
-            }
-
             // Parse host for port/socket (same format as WordPress DB_HOST).
             // An explicit --mysql-port takes precedence over a port embedded
             // in the host string.
@@ -8008,6 +7976,12 @@ class ImportClient
         $buffer_not_flushed = "";
         $chunks_since_save = 0;
         try {
+            if ($mode === "mysql") {
+                $this->audit_log(
+                    "SKIPPING SOURCE TABLE IF PRESENT | " . self::MYSQL_DB_PULL_PROGRESS_TABLE,
+                    true,
+                );
+            }
             while (!$complete) {
                 $params = $this->get_tuned_params("sql_chunk");
                 if ($mode === "mysql") {

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -84,6 +84,9 @@ class DatabaseRowsReader {
     /** @var array<string,list<array{column:string,value:string}>> Row exclusions keyed by table. */
     private $exclude_rows_by_table = [];
 
+    /** @var string[] Table names omitted from automatic discovery. */
+    private $exclude_tables = [];
+
 
     /**
      * Initializes the bounded database row reader.
@@ -96,6 +99,7 @@ class DatabaseRowsReader {
      *     @type int        $batch_size          Maximum records per query.
      *     @type int|null   $query_time_limit_ms Maximum query duration in milliseconds.
      *     @type array      $exclude_rows        Table, column, and value exclusion rules.
+     *     @type string[]   $exclude_tables      Table names to omit from automatic discovery.
      * }
      */
     public function __construct($db, $options = [])
@@ -103,6 +107,10 @@ class DatabaseRowsReader {
         $this->db = $db;
         $this->tables_to_process = $options["tables_to_process"] ?? null;
         $this->batch_size = max(1, (int) ( $options["batch_size"] ?? 250 ));
+        $this->exclude_tables = array_values(array_filter(
+            $options["exclude_tables"] ?? [],
+            "is_string"
+        ));
 
         if (isset($options["query_time_limit_ms"])) {
             $limit = (int) $options["query_time_limit_ms"];
@@ -574,7 +582,18 @@ class DatabaseRowsReader {
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
             $values = array_values($row);
-            if (isset($values[0], $values[1]) && strcasecmp($values[1], "BASE TABLE") === 0) {
+            $excluded = false;
+            foreach ($this->exclude_tables as $excluded_table) {
+                if (isset($values[0]) && strcasecmp($values[0], $excluded_table) === 0) {
+                    $excluded = true;
+                    break;
+                }
+            }
+            if (
+                isset($values[0], $values[1])
+                && strcasecmp($values[1], "BASE TABLE") === 0
+                && !$excluded
+            ) {
                 $this->tables_to_process[] = $values[0];
             }
             $row = $statement->fetch(PDO::FETCH_ASSOC);

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -959,8 +959,17 @@ function endpoint_sql_chunk(
 
             $i = 0;
             while ($reader->next_sql_fragment()) {
-                $sql[] = $reader->get_sql_fragment();
+                $fragment = (string) $reader->get_sql_fragment();
+                $sql[] = $fragment;
                 $i++;
+
+                // Direct MySQL output saves its source position after this
+                // part. Stop at the end of a statement so a following DROP or
+                // CREATE cannot commit imported rows before that position is saved.
+                $trimmed_fragment = rtrim($fragment);
+                if ($trimmed_fragment !== "" && $trimmed_fragment[-1] === ";") {
+                    break;
+                }
 
                 if ($i >= $fragments_per_batch) {
                     break;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -904,6 +904,20 @@ function endpoint_sql_chunk(
         $producer_options["exclude_rows"] = $exclude_rows;
     }
 
+    if (isset($config["skip_tables"])) {
+        if (!is_array($config["skip_tables"])) {
+            throw new InvalidArgumentException("skip_tables must be an array");
+        }
+        foreach ($config["skip_tables"] as $skipped_table) {
+            if (!is_string($skipped_table) || $skipped_table === "") {
+                throw new InvalidArgumentException(
+                    "Every skip_tables entry must be a non-empty string"
+                );
+            }
+        }
+        $producer_options["exclude_tables"] = array_values($config["skip_tables"]);
+    }
+
     if (isset($config["cursor"])) {
         $producer_options["cursor"] = $config["cursor"];
     }

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
@@ -7,6 +7,26 @@ use WordPress\DataLiberation\DatabaseRowsReader;
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 class DatabaseRowsReaderTest extends MySQLDumpProducerTestBase {
 
+    public function testExcludesRequestedTablesWhenDiscoveringSourceTables(): void
+    {
+        $this->pdo->exec('CREATE TABLE included_table (id INT PRIMARY KEY)');
+        $this->pdo->exec('CREATE TABLE skipped_table (id INT PRIMARY KEY)');
+
+        $reader = new DatabaseRowsReader(
+            $this->pdo,
+            ['exclude_tables' => ['SKIPPED_TABLE']]
+        );
+        $reader->initialize_tables_to_process();
+
+        $tables = [];
+        while ($reader->move_to_next_table()) {
+            $tables[] = $reader->get_current_table();
+        }
+
+        $this->assertContains('included_table', $tables);
+        $this->assertNotContains('skipped_table', $tables);
+    }
+
     public function testReturnsStructuredRecordsWithoutFormattingSql(): void
     {
         $this->pdo->exec(

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -145,6 +145,9 @@
     },
     "sqlite-legacy": {
       "port": 8127
+    },
+    "mysql-target-cursor-resume": {
+      "port": 8128
     }
   }
 }

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -1,25 +1,22 @@
 /**
- * Test 36: MySQL Mode Crash Recovery
+ * Test 36: MySQL mode source-request continuation
  *
  * When using --sql-output=mysql with short execution times, the server
  * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to pull/sql-buffer on disk as each
- * chunk arrives. If the process dies at any point, the next run reloads
- * whatever was accumulated.
+ * partial SQL in memory while the same importer asks for the next response.
  *
  * This test forces many resume cycles with --max-exec=1, verifies the
- * database is correct after completion, and confirms pull/sql-buffer is
- * cleaned up.
+ * database is correct after completion, and confirms direct MySQL mode does
+ * not write db.sql.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    readAuditLog, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -79,65 +76,9 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer')),
-                'Expected pull/sql-buffer to be cleaned up after successful completion');
-        });
-
         it('no db.sql on disk', () => {
             assert.ok(!existsSync(join(tempDir, 'db.sql')),
                 'Expected no db.sql file when using --sql-output=mysql');
-        });
-    });
-
-    describe('pre-seeded pull/sql-buffer is loaded on resume', () => {
-        let tempDir;
-        const importDb = 'e2e_basic_import_36_seeded';
-
-        beforeAll(async () => {
-            tempDir = createTempDir('e2e-mysql-seeded-buffer');
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.query(`CREATE DATABASE \`${importDb}\``);
-            await conn.end();
-        });
-
-        afterAll(async () => {
-            cleanupTempDir(tempDir);
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.end();
-        });
-
-        it('loads pull/sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
-            // Run preflight so db-pull can proceed
-            runImporter(importUrl(), tempDir, 'preflight', {
-                secret: getSiteSecret(site),
-            });
-
-            // Seed a pull/sql-buffer file before running db-pull.
-            // The content is a harmless SQL comment that won't affect execution
-            // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer');
-            writeFileSync(bufferFile, '-- pre-seeded buffer\n');
-
-            // Run a fresh db-pull — the importer should detect the buffer file
-            const result = runImporter(importUrl(), tempDir, 'db-pull', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                skipPreflight: true,
-            });
-            assert.equal(result.exitCode, 0,
-                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
-
-            // Verify recovery was logged
-            const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('pull/sql-buffer'),
-                'Expected audit log to mention pull/sql-buffer crash recovery');
-
-            // Buffer should be cleaned up
-            assert.ok(!existsSync(bufferFile),
-                'Expected pull/sql-buffer to be removed after completion');
         });
     });
 });

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -195,11 +195,6 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(
-                    pullStateDirectory(tempDir, importUrl()),
-                    'sql-buffer',
-                )),
-                    'Expected pull/sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);
                 if (mode === 'mysql') {

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -1,0 +1,221 @@
+/**
+ * A MySQL target records the source position in the same transaction as each
+ * completed INSERT. A replacement process still starts the dump from the
+ * beginning until table replacement can make target-side continuation safe.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, fsRootDir,
+    writeTestHooks, removeTestHooks,
+    clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: source position saved in MySQL target', { timeout: 300000 }, () => {
+    const site = 'mysql-target-cursor-resume';
+    const sourceTable = 'aa_target_cursor_rows';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlArguments() {
+        return [
+            '--sql-output=mysql',
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            `--mysql-database=${targetDb}`,
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    function spawnDatabasePull() {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...mysqlArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+        return { childProcess, output, exit };
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${sourceTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                const rows = Array.from({ length: 600 }, (_, index) => [
+                    index + 1,
+                    `target-cursor-row-${index + 1}`,
+                ]);
+                for (let offset = 0; offset < rows.length; offset += 100) {
+                    await connection.query(
+                        `INSERT INTO \`${sourceTable}\` (id, value) VALUES ?`,
+                        [rows.slice(offset, offset + 100)],
+                    );
+                }
+            },
+        });
+
+        tempDir = createTempDir('e2e-mysql-target-cursor-resume');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            '    usleep(5000);',
+            '}',
+        ].join('\n'));
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.query(`CREATE DATABASE \`${targetDb}\``);
+        await connection.end();
+
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.end();
+    });
+
+    it('records committed rows and safely starts a replacement process over', async () => {
+        const first = spawnDatabasePull();
+
+        // Kill only after another MySQL connection can see both the imported
+        // rows and the position committed with them.
+        const interruptedTarget = await createMysqlConnection(targetDb);
+        let importedRowCount = 0;
+        let savedSourceCursor = null;
+        try {
+            const targetDeadline = Date.now() + 60000;
+            while (Date.now() < targetDeadline) {
+                try {
+                    const [[importedRows]] = await interruptedTarget.query(
+                        `SELECT COUNT(*) AS rowCount FROM \`${sourceTable}\``
+                    );
+                    const [[savedPosition]] = await interruptedTarget.query(
+                        'SELECT source_cursor FROM `__reprint_db_pull_progress` WHERE id = 1'
+                    );
+                    importedRowCount = Number(importedRows.rowCount);
+                    savedSourceCursor = savedPosition?.source_cursor ?? null;
+                    if (
+                        importedRowCount > 0
+                        && importedRowCount < 600
+                        && typeof savedSourceCursor === 'string'
+                        && savedSourceCursor.length > 0
+                    ) {
+                        break;
+                    }
+                } catch (error) {
+                    if (error?.code !== 'ER_NO_SUCH_TABLE') {
+                        throw error;
+                    }
+                }
+                if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
+                    const result = await first.exit;
+                    assert.fail(
+                        `db-pull exited before MySQL committed partial work (${result.code}/${result.signal}):\n`
+                        + first.output.stderr + first.output.stdout,
+                    );
+                }
+                await sleep(25);
+            }
+        } finally {
+            await interruptedTarget.end();
+        }
+        assert.ok(
+            importedRowCount > 0 && importedRowCount < 600,
+            `expected a partially imported table, got ${importedRowCount} rows`,
+        );
+        assert.equal(typeof savedSourceCursor, 'string');
+        assert.ok(savedSourceCursor.length > 0);
+
+        assert.equal(first.childProcess.kill('SIGKILL'), true);
+        const killed = await first.exit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        await sleep(100);
+        removeTestHooks(site);
+
+        const replacement = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: mysqlArguments(),
+            wallTimeout: 240000,
+        });
+        assert.equal(
+            replacement.exitCode,
+            0,
+            `replacement db-pull failed:\n${replacement.stderr}\n${replacement.stdout}`,
+        );
+
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            const [summary] = await targetConnection.query(
+                `SELECT COUNT(*) AS rowCount, MIN(id) AS firstId, MAX(id) AS lastId `
+                + `FROM \`${sourceTable}\``
+            );
+            assert.deepEqual(
+                {
+                    rowCount: Number(summary[0].rowCount),
+                    firstId: Number(summary[0].firstId),
+                    lastId: Number(summary[0].lastId),
+                },
+                { rowCount: 600, firstId: 1, lastId: 600 },
+            );
+        } finally {
+            await targetConnection.end();
+        }
+    });
+});

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -13,7 +13,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir, getDbName,
     createMysqlConnection, fsRootDir,
     writeTestHooks, removeTestHooks,
-    clearHookState,
+    clearHookState, readAuditLog,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -24,6 +24,7 @@ const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground
 describeWithHostPhpProcess('Import: source position saved in MySQL target', { timeout: 300000 }, () => {
     const site = 'mysql-target-cursor-resume';
     const sourceTable = 'aa_target_cursor_rows';
+    const progressTable = '__reprint_db_pull_progress_728f9e0b-42f7-4d85-a7f3-8f53e90a6f4c';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
     const importerPath = process.env.IMPORTER_PATH
@@ -128,18 +129,19 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
     });
 
-    it('refuses any capitalization of the progress-table name in the source', async () => {
+    it('logs and skips the progress table when the source is also a Reprint target', async () => {
         const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
         const sourceConnection = await createMysqlConnection(getDbName(site));
         const targetConnection = await createMysqlConnection(targetDb);
+        const sourceProgressTable = progressTable.toUpperCase();
         try {
             await sourceConnection.query(
-                'CREATE TABLE `__REPRINT_DB_PULL_PROGRESS` ('
+                `CREATE TABLE \`${sourceProgressTable}\` (`
                 + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
                 + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
             );
             await sourceConnection.query(
-                "INSERT INTO `__REPRINT_DB_PULL_PROGRESS` (id, note) VALUES (1, 'source row')"
+                `INSERT INTO \`${sourceProgressTable}\` (id, note) VALUES (1, 'source row')`
             );
 
             const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
@@ -151,33 +153,41 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                 secret: getSiteSecret(site),
                 extraArgs: mysqlArguments(),
             });
-            assert.notEqual(result.exitCode, 0, 'db-pull should reject the reserved source table');
-
-            const [[targetTable]] = await targetConnection.query(
-                'SELECT COUNT(*) AS tableCount FROM INFORMATION_SCHEMA.TABLES '
-                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
-                [targetDb, '__reprint_db_pull_progress'],
+            assert.equal(result.exitCode, 0, result.stderr + result.stdout);
+            assert.match(
+                readAuditLog(collisionDir),
+                new RegExp(`SKIPPED SOURCE TABLE .*${progressTable}`),
             );
-            assert.equal(Number(targetTable.tableCount), 0);
+
+            const [targetColumns] = await targetConnection.query(
+                'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS '
+                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
+                [targetDb, progressTable],
+            );
+            assert.deepEqual(
+                targetColumns.map(column => column.COLUMN_NAME),
+                ['id', 'source_hash', 'source_cursor'],
+            );
         } finally {
-            await sourceConnection.query('DROP TABLE IF EXISTS `__REPRINT_DB_PULL_PROGRESS`');
+            await sourceConnection.query(`DROP TABLE IF EXISTS \`${sourceProgressTable}\``);
             await sourceConnection.end();
             await targetConnection.end();
             cleanupTempDir(collisionDir);
         }
     });
 
-    it('does not alter an unrelated target table with the progress-table name', async () => {
+    it('recreates a progress table whose schema does not match', async () => {
         const collisionDir = createTempDir('e2e-mysql-target-cursor-collision');
         const targetConnection = await createMysqlConnection(targetDb);
         try {
+            await targetConnection.query(`DROP TABLE IF EXISTS \`${progressTable}\``);
             await targetConnection.query(
-                'CREATE TABLE `__reprint_db_pull_progress` ('
+                `CREATE TABLE \`${progressTable}\` (`
                 + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
                 + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
             );
             await targetConnection.query(
-                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'keep this row')"
+                `INSERT INTO \`${progressTable}\` (id, note) VALUES (1, 'old row')`
             );
 
             const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
@@ -189,14 +199,19 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                 secret: getSiteSecret(site),
                 extraArgs: mysqlArguments(),
             });
-            assert.notEqual(result.exitCode, 0, 'db-pull should reject the table-name collision');
+            assert.equal(result.exitCode, 0, result.stderr + result.stdout);
 
-            const [[row]] = await targetConnection.query(
-                'SELECT note FROM `__reprint_db_pull_progress` WHERE id = 1'
+            const [targetColumns] = await targetConnection.query(
+                'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS '
+                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
+                [targetDb, progressTable],
             );
-            assert.equal(row.note, 'keep this row');
+            assert.deepEqual(
+                targetColumns.map(column => column.COLUMN_NAME),
+                ['id', 'source_hash', 'source_cursor'],
+            );
         } finally {
-            await targetConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await targetConnection.query(`DROP TABLE IF EXISTS \`${progressTable}\``);
             await targetConnection.end();
             cleanupTempDir(collisionDir);
         }
@@ -229,7 +244,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                         `SELECT COUNT(*) AS rowCount FROM \`${sourceTable}\``
                     );
                     const [[savedPosition]] = await interruptedTarget.query(
-                        'SELECT source_cursor FROM `__reprint_db_pull_progress` WHERE id = 1'
+                        `SELECT source_cursor FROM \`${progressTable}\` WHERE id = 1`
                     );
                     importedRowCount = Number(importedRows.rowCount);
                     savedSourceCursor = savedPosition?.source_cursor ?? null;

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -99,7 +99,17 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         clearHookState(site);
         writeTestHooks(site, [
             'function test_hook_before_sql_batch(&$sql, $cursor) {',
-            '    usleep(100000);',
+            '    static $sent_complete_target_insert = false;',
+            '    static $paused_after_target_insert = false;',
+            '    if ($sent_complete_target_insert && !$paused_after_target_insert) {',
+            '        $paused_after_target_insert = true;',
+            '        usleep(10000000);',
+            '        return;',
+            '    }',
+            `    if (strpos($sql, 'INSERT INTO \`${sourceTable}\`') !== false`,
+            `        && substr(rtrim($sql), -1) === ';') {`,
+            '        $sent_complete_target_insert = true;',
+            '    }',
             '}',
         ].join('\n'));
 

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -156,7 +156,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             assert.equal(result.exitCode, 0, result.stderr + result.stdout);
             assert.match(
                 readAuditLog(collisionDir),
-                new RegExp(`SKIPPED SOURCE TABLE .*${progressTable}`),
+                new RegExp(`SKIPPING SOURCE TABLE IF PRESENT .*${progressTable}`),
             );
 
             const [targetColumns] = await targetConnection.query(

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -128,18 +128,18 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
     });
 
-    it('refuses a source table that uses the progress-table name', async () => {
+    it('refuses any capitalization of the progress-table name in the source', async () => {
         const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
         const sourceConnection = await createMysqlConnection(getDbName(site));
         const targetConnection = await createMysqlConnection(targetDb);
         try {
             await sourceConnection.query(
-                'CREATE TABLE `__reprint_db_pull_progress` ('
+                'CREATE TABLE `__REPRINT_DB_PULL_PROGRESS` ('
                 + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
                 + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
             );
             await sourceConnection.query(
-                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'source row')"
+                "INSERT INTO `__REPRINT_DB_PULL_PROGRESS` (id, note) VALUES (1, 'source row')"
             );
 
             const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
@@ -160,7 +160,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             );
             assert.equal(Number(targetTable.tableCount), 0);
         } finally {
-            await sourceConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await sourceConnection.query('DROP TABLE IF EXISTS `__REPRINT_DB_PULL_PROGRESS`');
             await sourceConnection.end();
             await targetConnection.end();
             cleanupTempDir(collisionDir);

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -269,7 +269,15 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
         assert.equal(decodedSourceCursor.current_table, sourceTable);
         assert.deepEqual(decodedSourceCursor.current_pk_columns, ['id']);
-        assert.equal(Number(decodedSourceCursor.last_pk_values.id), importedRowCount);
+        const savedPrimaryKey = decodedSourceCursor.last_pk_values.id;
+        const savedPrimaryKeyValue = (
+            typeof savedPrimaryKey === 'object'
+            && savedPrimaryKey !== null
+            && typeof savedPrimaryKey.__binary__ === 'string'
+        )
+            ? Buffer.from(savedPrimaryKey.__binary__, 'base64').toString('utf8')
+            : savedPrimaryKey;
+        assert.equal(Number(savedPrimaryKeyValue), importedRowCount);
 
         assert.equal(first.childProcess.kill('SIGKILL'), true);
         const killed = await first.exit;

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -1,11 +1,11 @@
 /**
- * A MySQL target records the source position in the same transaction as each
- * completed INSERT. A replacement process still starts the dump from the
- * beginning until table replacement can make target-side continuation safe.
+ * A MySQL target records each completed SQL group and its source position
+ * together. A replacement process continues from that target position.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
@@ -13,7 +13,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir, getDbName,
     createMysqlConnection, fsRootDir,
     writeTestHooks, removeTestHooks,
-    clearHookState, readAuditLog,
+    writeHookState, readHookState, clearHookState, readAuditLog,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -24,12 +24,14 @@ const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground
 describeWithHostPhpProcess('Import: source position saved in MySQL target', { timeout: 300000 }, () => {
     const site = 'mysql-target-cursor-resume';
     const sourceTable = 'aa_target_cursor_rows';
+    const myisamSourceTable = 'ab_target_cursor_myisam_rows';
     const progressTable = '__reprint_db_pull_progress_728f9e0b-42f7-4d85-a7f3-8f53e90a6f4c';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
     const importerPath = process.env.IMPORTER_PATH
         || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
     const phpBinary = process.env.PHP_BINARY || 'php';
+    const activeChildren = new Set();
     let tempDir;
 
     function importUrl() {
@@ -69,8 +71,12 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
         childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
         const exit = new Promise(resolve => {
-            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+            childProcess.once('exit', (code, signal) => {
+                activeChildren.delete(childProcess);
+                resolve({ code, signal });
+            });
         });
+        activeChildren.add(childProcess);
         return { childProcess, output, exit };
     }
 
@@ -78,39 +84,66 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         await ensureSite(site, {
             files: 'none',
             customDb: async (_dbName, connection) => {
-                await connection.query(
-                    `CREATE TABLE \`${sourceTable}\` (`
-                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
-                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
-                );
-                const rows = Array.from({ length: 600 }, (_, index) => [
-                    index + 1,
-                    `target-cursor-row-${index + 1}`,
-                ]);
-                for (let offset = 0; offset < rows.length; offset += 100) {
+                for (const [table, engine] of [
+                    [sourceTable, 'InnoDB'],
+                    [myisamSourceTable, 'MyISAM'],
+                ]) {
+                    const key = engine === 'MyISAM'
+                        ? 'UNIQUE KEY `replay_key` (`id`, `value`)'
+                        : 'PRIMARY KEY (`id`)';
                     await connection.query(
-                        `INSERT INTO \`${sourceTable}\` (id, value) VALUES ?`,
-                        [rows.slice(offset, offset + 100)],
+                        `CREATE TABLE \`${table}\` (`
+                        + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                        + `${key}) ENGINE=${engine}`
                     );
+                    const rows = Array.from({ length: 600 }, (_, index) => [
+                        index + 1,
+                        `${table}-row-${index + 1}`,
+                    ]);
+                    for (let offset = 0; offset < rows.length; offset += 100) {
+                        await connection.query(
+                            `INSERT INTO \`${table}\` (id, value) VALUES ?`,
+                            [rows.slice(offset, offset + 100)],
+                        );
+                    }
                 }
             },
         });
 
         tempDir = createTempDir('e2e-mysql-target-cursor-resume');
         clearHookState(site);
+        writeHookState(site, {
+            pauseTable: sourceTable,
+            pauseNextBatch: false,
+            paused: false,
+            countDrops: false,
+            drops: {},
+        });
         writeTestHooks(site, [
             'function test_hook_before_sql_batch(&$sql, $cursor) {',
-            '    static $sent_complete_target_insert = false;',
-            '    static $paused_after_target_insert = false;',
-            '    if ($sent_complete_target_insert && !$paused_after_target_insert) {',
-            '        $paused_after_target_insert = true;',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = json_decode(file_get_contents($state_file), true);',
+            '    if (!empty($state[\'countDrops\'])) {',
+            `        foreach (['${sourceTable}', '${myisamSourceTable}'] as $table) {`,
+            '            if (strpos($sql, "DROP TABLE IF EXISTS `{$table}`") !== false) {',
+            '                $state[\'drops\'][$table] = ($state[\'drops\'][$table] ?? 0) + 1;',
+            '            }',
+            '        }',
+            '    }',
+            '    if (!empty($state[\'pauseNextBatch\'])) {',
+            '        $state[\'pauseNextBatch\'] = false;',
+            '        $state[\'paused\'] = true;',
+            '        file_put_contents($state_file, json_encode($state));',
             '        usleep(10000000);',
             '        return;',
             '    }',
-            `    if (strpos($sql, 'INSERT INTO \`${sourceTable}\`') !== false`,
-            `        && substr(rtrim($sql), -1) === ';') {`,
-            '        $sent_complete_target_insert = true;',
+            '    $pause_table = $state[\'pauseTable\'] ?? null;',
+            '    if ($pause_table !== null',
+            '        && strpos($sql, "INSERT INTO `{$pause_table}`") !== false',
+            '        && substr(rtrim($sql), -1) === \';\') {',
+            '        $state[\'pauseNextBatch\'] = true;',
             '    }',
+            '    file_put_contents($state_file, json_encode($state));',
             '}',
         ].join('\n'));
 
@@ -130,6 +163,12 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     });
 
     it('logs and skips the progress table when the source is also a Reprint target', async () => {
+        writeHookState(site, {
+            ...readHookState(site),
+            pauseTable: null,
+            pauseNextBatch: false,
+            paused: false,
+        });
         const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
         const sourceConnection = await createMysqlConnection(getDbName(site));
         const targetConnection = await createMysqlConnection(targetDb);
@@ -177,6 +216,9 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     });
 
     afterAll(async () => {
+        for (const childProcess of activeChildren) {
+            childProcess.kill('SIGKILL');
+        }
         removeTestHooks(site);
         clearHookState(site);
         if (tempDir) {
@@ -187,63 +229,72 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         await connection.end();
     });
 
-    it('records committed rows and safely starts a replacement process over', async () => {
+    it('continues InnoDB and keyed MyISAM tables from the position saved by MySQL', async () => {
+        writeHookState(site, {
+            pauseTable: sourceTable,
+            pauseNextBatch: false,
+            paused: false,
+            countDrops: false,
+            drops: {},
+        });
         const first = spawnDatabasePull();
 
-        // Kill only after another MySQL connection can see both the imported
-        // rows and the position committed with them.
-        const interruptedTarget = await createMysqlConnection(targetDb);
-        let importedRowCount = 0;
-        let savedSourceCursor = null;
-        try {
-            const targetDeadline = Date.now() + 60000;
-            while (Date.now() < targetDeadline) {
-                try {
-                    const [[importedRows]] = await interruptedTarget.query(
-                        `SELECT COUNT(*) AS rowCount FROM \`${sourceTable}\``
-                    );
-                    const [[savedPosition]] = await interruptedTarget.query(
-                        `SELECT source_cursor FROM \`${progressTable}\` WHERE id = 1`
-                    );
-                    importedRowCount = Number(importedRows.rowCount);
-                    savedSourceCursor = savedPosition?.source_cursor ?? null;
+        async function waitForSavedTablePosition(table, databasePull) {
+            const interruptedTarget = await createMysqlConnection(targetDb);
+            let importedRowCount = 0;
+            let savedSourceCursor = null;
+            try {
+                const targetDeadline = Date.now() + 60000;
+                while (Date.now() < targetDeadline) {
+                    try {
+                        const [[importedRows]] = await interruptedTarget.query(
+                            `SELECT COUNT(*) AS rowCount FROM \`${table}\``
+                        );
+                        const [[savedPosition]] = await interruptedTarget.query(
+                            `SELECT source_cursor FROM \`${progressTable}\` WHERE id = 1`
+                        );
+                        importedRowCount = Number(importedRows.rowCount);
+                        savedSourceCursor = savedPosition?.source_cursor ?? null;
+                        if (
+                            importedRowCount > 0
+                            && importedRowCount < 600
+                            && typeof savedSourceCursor === 'string'
+                            && savedSourceCursor.length > 0
+                            && readHookState(site)?.paused === true
+                        ) {
+                            const decoded = JSON.parse(
+                                Buffer.from(savedSourceCursor, 'base64').toString('utf8')
+                            );
+                            if (decoded.current_table === table) {
+                                return { importedRowCount, savedSourceCursor, decoded };
+                            }
+                        }
+                    } catch (error) {
+                        if (error?.code !== 'ER_NO_SUCH_TABLE') {
+                            throw error;
+                        }
+                    }
                     if (
-                        importedRowCount > 0
-                        && importedRowCount < 600
-                        && typeof savedSourceCursor === 'string'
-                        && savedSourceCursor.length > 0
+                        databasePull.childProcess.exitCode !== null
+                        || databasePull.childProcess.signalCode !== null
                     ) {
-                        break;
+                        const result = await databasePull.exit;
+                        assert.fail(
+                            `db-pull exited before MySQL saved partial work (${result.code}/${result.signal}):\n`
+                            + databasePull.output.stderr + databasePull.output.stdout,
+                        );
                     }
-                } catch (error) {
-                    if (error?.code !== 'ER_NO_SUCH_TABLE') {
-                        throw error;
-                    }
+                    await sleep(25);
                 }
-                if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
-                    const result = await first.exit;
-                    assert.fail(
-                        `db-pull exited before MySQL committed partial work (${result.code}/${result.signal}):\n`
-                        + first.output.stderr + first.output.stdout,
-                    );
-                }
-                await sleep(25);
+            } finally {
+                await interruptedTarget.end();
             }
-        } finally {
-            await interruptedTarget.end();
+            assert.fail(`db-pull did not save a partial position for ${table}`);
         }
-        assert.ok(
-            importedRowCount > 0 && importedRowCount < 600,
-            `expected a partially imported table, got ${importedRowCount} rows`,
-        );
-        assert.equal(typeof savedSourceCursor, 'string');
-        assert.ok(savedSourceCursor.length > 0);
-        const decodedSourceCursor = JSON.parse(
-            Buffer.from(savedSourceCursor, 'base64').toString('utf8')
-        );
-        assert.equal(decodedSourceCursor.current_table, sourceTable);
-        assert.deepEqual(decodedSourceCursor.current_pk_columns, ['id']);
-        const savedPrimaryKey = decodedSourceCursor.last_pk_values.id;
+
+        const firstPosition = await waitForSavedTablePosition(sourceTable, first);
+        assert.deepEqual(firstPosition.decoded.current_pk_columns, ['id']);
+        const savedPrimaryKey = firstPosition.decoded.last_pk_values.id;
         const savedPrimaryKeyValue = (
             typeof savedPrimaryKey === 'object'
             && savedPrimaryKey !== null
@@ -251,15 +302,81 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         )
             ? Buffer.from(savedPrimaryKey.__binary__, 'base64').toString('utf8')
             : savedPrimaryKey;
-        assert.equal(Number(savedPrimaryKeyValue), importedRowCount);
+        assert.equal(Number(savedPrimaryKeyValue), firstPosition.importedRowCount);
 
         assert.equal(first.childProcess.kill('SIGKILL'), true);
-        const killed = await first.exit;
-        assert.equal(killed.code, null);
-        assert.equal(killed.signal, 'SIGKILL');
+        const firstKilled = await first.exit;
+        assert.equal(firstKilled.code, null);
+        assert.equal(firstKilled.signal, 'SIGKILL');
 
-        await sleep(100);
-        removeTestHooks(site);
+        const hookState = readHookState(site);
+        writeHookState(site, {
+            ...hookState,
+            pauseTable: myisamSourceTable,
+            pauseNextBatch: false,
+            paused: false,
+            countDrops: true,
+            drops: {},
+        });
+
+        const lockName = 'reprint-db-pull-'
+            + createHash('sha256').update(targetDb).digest('hex').slice(0, 40);
+        const heldLock = await createMysqlConnection(targetDb);
+        const [[lockResult]] = await heldLock.query('SELECT GET_LOCK(?, 0) AS acquired', [lockName]);
+        assert.equal(Number(lockResult.acquired), 1);
+
+        const second = spawnDatabasePull();
+        try {
+            let waitingForLock = false;
+            const lockDeadline = Date.now() + 10000;
+            while (Date.now() < lockDeadline) {
+                const [[waiting]] = await heldLock.query(
+                    'SELECT COUNT(*) AS waiting FROM INFORMATION_SCHEMA.PROCESSLIST '
+                    + "WHERE INFO LIKE 'SELECT GET_LOCK(%'"
+                );
+                waitingForLock = Number(waiting.waiting) > 0;
+                if (waitingForLock) {
+                    break;
+                }
+                if (second.childProcess.exitCode !== null || second.childProcess.signalCode !== null) {
+                    const result = await second.exit;
+                    assert.fail(
+                        `replacement db-pull exited instead of waiting (${result.code}/${result.signal}):\n`
+                        + second.output.stderr + second.output.stdout,
+                    );
+                }
+                await sleep(25);
+            }
+            assert.equal(waitingForLock, true, 'replacement db-pull did not wait for the target lock');
+        } finally {
+            await heldLock.query('SELECT RELEASE_LOCK(?)', [lockName]);
+            await heldLock.end();
+        }
+
+        const secondPosition = await waitForSavedTablePosition(myisamSourceTable, second);
+        assert.deepEqual(secondPosition.decoded.current_pk_columns, []);
+        assert.equal(
+            readHookState(site)?.drops?.[sourceTable] ?? 0,
+            0,
+            'replacement db-pull restarted the completed part of the InnoDB table',
+        );
+
+        assert.equal(second.childProcess.kill('SIGKILL'), true);
+        const secondKilled = await second.exit;
+        assert.equal(secondKilled.code, null);
+        assert.equal(secondKilled.signal, 'SIGKILL');
+
+        const finalHookState = readHookState(site);
+        writeHookState(site, {
+            ...finalHookState,
+            pauseTable: null,
+            pauseNextBatch: false,
+            paused: false,
+            drops: {
+                ...finalHookState.drops,
+                [myisamSourceTable]: 0,
+            },
+        });
 
         const replacement = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
@@ -271,21 +388,28 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             0,
             `replacement db-pull failed:\n${replacement.stderr}\n${replacement.stdout}`,
         );
+        assert.equal(
+            readHookState(site)?.drops?.[myisamSourceTable] ?? 0,
+            0,
+            'replacement db-pull restarted the completed part of the MyISAM table',
+        );
 
         const targetConnection = await createMysqlConnection(targetDb);
         try {
-            const [summary] = await targetConnection.query(
-                `SELECT COUNT(*) AS rowCount, MIN(id) AS firstId, MAX(id) AS lastId `
-                + `FROM \`${sourceTable}\``
-            );
-            assert.deepEqual(
-                {
-                    rowCount: Number(summary[0].rowCount),
-                    firstId: Number(summary[0].firstId),
-                    lastId: Number(summary[0].lastId),
-                },
-                { rowCount: 600, firstId: 1, lastId: 600 },
-            );
+            for (const table of [sourceTable, myisamSourceTable]) {
+                const [summary] = await targetConnection.query(
+                    `SELECT COUNT(*) AS rowCount, MIN(id) AS firstId, MAX(id) AS lastId `
+                    + `FROM \`${table}\``
+                );
+                assert.deepEqual(
+                    {
+                        rowCount: Number(summary[0].rowCount),
+                        firstId: Number(summary[0].firstId),
+                        lastId: Number(summary[0].lastId),
+                    },
+                    { rowCount: 600, firstId: 1, lastId: 600 },
+                );
+            }
         } finally {
             await targetConnection.end();
         }

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -176,47 +176,6 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         }
     });
 
-    it('recreates a progress table whose schema does not match', async () => {
-        const collisionDir = createTempDir('e2e-mysql-target-cursor-collision');
-        const targetConnection = await createMysqlConnection(targetDb);
-        try {
-            await targetConnection.query(`DROP TABLE IF EXISTS \`${progressTable}\``);
-            await targetConnection.query(
-                `CREATE TABLE \`${progressTable}\` (`
-                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
-                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
-            );
-            await targetConnection.query(
-                `INSERT INTO \`${progressTable}\` (id, note) VALUES (1, 'old row')`
-            );
-
-            const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
-                secret: getSiteSecret(site),
-            });
-            assert.equal(preflight.exitCode, 0, preflight.stderr + preflight.stdout);
-
-            const result = runImporter(importUrl(), collisionDir, 'db-pull', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArguments(),
-            });
-            assert.equal(result.exitCode, 0, result.stderr + result.stdout);
-
-            const [targetColumns] = await targetConnection.query(
-                'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS '
-                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
-                [targetDb, progressTable],
-            );
-            assert.deepEqual(
-                targetColumns.map(column => column.COLUMN_NAME),
-                ['id', 'source_hash', 'source_cursor'],
-            );
-        } finally {
-            await targetConnection.query(`DROP TABLE IF EXISTS \`${progressTable}\``);
-            await targetConnection.end();
-            cleanupTempDir(collisionDir);
-        }
-    });
-
     afterAll(async () => {
         removeTestHooks(site);
         clearHookState(site);

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -42,9 +42,9 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             '--mysql-user=e2e_admin',
             '--mysql-password=e2e_password',
             `--mysql-database=${targetDb}`,
-            '--sql-fragments-start=1',
-            '--sql-fragments-min=1',
-            '--sql-fragments-max=1',
+            '--sql-fragments-start=5000',
+            '--sql-fragments-min=5000',
+            '--sql-fragments-max=5000',
             '--progress=jsonl',
         ];
     }
@@ -99,7 +99,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         clearHookState(site);
         writeTestHooks(site, [
             'function test_hook_before_sql_batch(&$sql, $cursor) {',
-            '    usleep(5000);',
+            '    usleep(100000);',
             '}',
         ].join('\n'));
 
@@ -116,6 +116,80 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             0,
             `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
         );
+    });
+
+    it('refuses a source table that uses the progress-table name', async () => {
+        const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
+        const sourceConnection = await createMysqlConnection(getDbName(site));
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            await sourceConnection.query(
+                'CREATE TABLE `__reprint_db_pull_progress` ('
+                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
+                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
+            );
+            await sourceConnection.query(
+                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'source row')"
+            );
+
+            const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(preflight.exitCode, 0, preflight.stderr + preflight.stdout);
+
+            const result = runImporter(importUrl(), collisionDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlArguments(),
+            });
+            assert.notEqual(result.exitCode, 0, 'db-pull should reject the reserved source table');
+
+            const [[targetTable]] = await targetConnection.query(
+                'SELECT COUNT(*) AS tableCount FROM INFORMATION_SCHEMA.TABLES '
+                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                [targetDb, '__reprint_db_pull_progress'],
+            );
+            assert.equal(Number(targetTable.tableCount), 0);
+        } finally {
+            await sourceConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await sourceConnection.end();
+            await targetConnection.end();
+            cleanupTempDir(collisionDir);
+        }
+    });
+
+    it('does not alter an unrelated target table with the progress-table name', async () => {
+        const collisionDir = createTempDir('e2e-mysql-target-cursor-collision');
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            await targetConnection.query(
+                'CREATE TABLE `__reprint_db_pull_progress` ('
+                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
+                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
+            );
+            await targetConnection.query(
+                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'keep this row')"
+            );
+
+            const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(preflight.exitCode, 0, preflight.stderr + preflight.stdout);
+
+            const result = runImporter(importUrl(), collisionDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlArguments(),
+            });
+            assert.notEqual(result.exitCode, 0, 'db-pull should reject the table-name collision');
+
+            const [[row]] = await targetConnection.query(
+                'SELECT note FROM `__reprint_db_pull_progress` WHERE id = 1'
+            );
+            assert.equal(row.note, 'keep this row');
+        } finally {
+            await targetConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await targetConnection.end();
+            cleanupTempDir(collisionDir);
+        }
     });
 
     afterAll(async () => {
@@ -180,6 +254,12 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
         assert.equal(typeof savedSourceCursor, 'string');
         assert.ok(savedSourceCursor.length > 0);
+        const decodedSourceCursor = JSON.parse(
+            Buffer.from(savedSourceCursor, 'base64').toString('utf8')
+        );
+        assert.equal(decodedSourceCursor.current_table, sourceTable);
+        assert.deepEqual(decodedSourceCursor.current_pk_columns, ['id']);
+        assert.equal(Number(decodedSourceCursor.last_pk_values.id), importedRowCount);
 
         assert.equal(first.childProcess.kill('SIGKILL'), true);
         const killed = await first.exit;


### PR DESCRIPTION
A later `db-pull --sql-output=mysql` process now continues from the cursor committed in the target MySQL database instead of starting the dump again.

## Why the old local buffer was unsafe

The old importer kept an unfinished SQL statement in `pull/sql-buffer`. That file and the cursor were saved separately from the target database. After a crash, Reprint could append repeated SQL bytes, continue past InnoDB rows which MySQL rolled back, or repeat a MyISAM statement after MyISAM had already kept some rows.

This PR removes that file. An unfinished statement exists only in the current importer process. If that process stops, the next process requests the statement again from the last cursor committed in MySQL.

For InnoDB, imported rows and the cursor commit or roll back together.

For MyISAM, a stopped multi-row `INSERT` may keep a complete row prefix:

```sql
INSERT INTO posts (id, title) VALUES
    (1, 'one'),
    (2, 'two'),
    (3, 'three')
ON DUPLICATE KEY UPDATE id = id;
```

If MyISAM keeps rows 1 and 2 before the connection stops, the cursor still points before this statement. The next process requests the statement again. Rows 1 and 2 take the no-op duplicate-key path, and row 3 is inserted.

## How resume works

After each complete multipart SQL part, Reprint writes that part's cursor to `__reprint_db_pull_progress_<uuid>` and commits. A later process waits for the old target connection to finish, reads that cursor, reruns `db-session-setup.sql`, and asks the source for the following SQL.

The target lock prevents an older MySQL query from changing a table while the later process continues. A fresh import clears the target cursor before recording its SQL stage locally, so a stop during setup cannot revive an older import.

Reprint stops only when the next target operation cannot be repeated safely. This currently means a nontransactional table without a non-null unique key, or a nontransactional oversized value assembled through separate `UPDATE ... CONCAT()` statements. The error names the table and asks for `db-pull --abort` instead of guessing.

The progress-table UUID identifies its schema. Reprint logs and excludes that internal table name if the source database is itself a Reprint target.

This PR uses one completed producer action per multipart SQL part so the cursor rule is easy to test. The stacked #621 restores the exporter's existing fragment, time, and memory budgeting, allowing several regular `INSERT` statements to share one part while keeping table replacement and oversized-value updates separate.

## Testing

The MySQL end-to-end test kills the importer after a committed InnoDB part, holds the target lock while the next process starts, kills it again after a keyed MyISAM part, and then completes in a third process. It checks that neither later process sends the earlier table's `DROP TABLE`, that both tables contain every source row, and that the saved MySQL cursor matches the imported rows.

Stack: merged #619 and #639 → this PR → #621
