### PR TITLE
[PHP] Keep database row cursors stable across adapters, support SQLite integration 2.x and 3.x

### DIFF
--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -476,9 +476,10 @@ class DatabaseRowsReader {
     /** Returns primary key column names in ordinal order, or an empty array. */
     private function get_primary_key_columns($table)
     {
+        $primary_key_columns = [];
         $columns_by_position = [];
-        $query = "SHOW INDEX FROM " . $this->quote_identifier($table) .
-            " WHERE Key_name = 'PRIMARY'";
+        $has_usable_positions = true;
+        $query = "SHOW INDEX FROM " . $this->quote_identifier($table);
         try {
             $statement = $this->db->query($query);
         } catch (\PDOException $e) {
@@ -488,8 +489,31 @@ class DatabaseRowsReader {
         }
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
-            $columns_by_position[$row["Seq_in_index"]] = $row["Column_name"];
+            if (!isset($row["Key_name"]) || strcasecmp($row["Key_name"], "PRIMARY") !== 0) {
+                $row = $statement->fetch(PDO::FETCH_ASSOC);
+                continue;
+            }
+
+            $column = $row["Column_name"];
+            $primary_key_columns[] = $column;
+            $position = $row["Seq_in_index"] ?? null;
+            if (is_string($position) && ctype_digit($position)) {
+                $position = intval($position);
+            }
+            if (
+                !is_int($position) ||
+                $position < 1 ||
+                isset($columns_by_position[$position])
+            ) {
+                $has_usable_positions = false;
+            } else {
+                $columns_by_position[$position] = $column;
+            }
             $row = $statement->fetch(PDO::FETCH_ASSOC);
+        }
+
+        if (!$has_usable_positions) {
+            return $primary_key_columns;
         }
         ksort($columns_by_position, SORT_NUMERIC);
         return array_values($columns_by_position);

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -66,6 +66,9 @@ class DatabaseRowsReader {
     /** @var array|null */
     private $current_row = null;
 
+    /** @var bool */
+    private $current_row_ends_query_batch = false;
+
     /** @var array|null */
     private $current_column_types = null;
 
@@ -133,6 +136,7 @@ class DatabaseRowsReader {
      */
     public function next_record()
     {
+        $this->current_row_ends_query_batch = false;
         if (!$this->current_result_set) {
             $query = $this->build_select_query();
             try {
@@ -179,6 +183,7 @@ class DatabaseRowsReader {
 
         $this->current_row = $record;
         if ($this->rows_fetched_from_current_query >= $this->batch_size) {
+            $this->current_row_ends_query_batch = true;
             $this->release_current_result_set();
         }
         return true;
@@ -219,6 +224,13 @@ class DatabaseRowsReader {
     public function clear_current_record()
     {
         $this->current_row = null;
+        $this->current_row_ends_query_batch = false;
+    }
+
+    /** Returns whether the retained record is the final row of its bounded query. */
+    public function is_current_record_at_query_batch_boundary()
+    {
+        return $this->current_row_ends_query_batch;
     }
 
     /** Returns column names in table order. */
@@ -248,6 +260,7 @@ class DatabaseRowsReader {
      *     @type array|null  $last_pk_values      Encoded primary key values.
      *     @type int         $current_offset      Offset for a table without a primary key.
      *     @type array|null  $current_row         Encoded retained record.
+     *     @type bool        $current_row_ends_query_batch Whether the retained record ends its query batch.
      *     @type array|null  $current_column_names Current column names.
      * }
      */
@@ -259,6 +272,7 @@ class DatabaseRowsReader {
             "last_pk_values" => $this->encode_database_values_for_cursor($this->last_pk_values),
             "current_offset" => $this->current_offset,
             "current_row" => $this->encode_database_values_for_cursor($this->current_row),
+            "current_row_ends_query_batch" => $this->current_row_ends_query_batch,
             "current_column_names" => $this->current_column_names,
         ];
     }
@@ -291,6 +305,13 @@ class DatabaseRowsReader {
         $this->current_row = $this->decode_database_values_from_cursor(
             $cursor_data["current_row"] ?? null
         );
+        $this->current_row_ends_query_batch = $cursor_data["current_row_ends_query_batch"] ?? false;
+        if (!is_bool($this->current_row_ends_query_batch)) {
+            throw new \InvalidArgumentException(
+                "Invalid cursor: current_row_ends_query_batch must be boolean, got " .
+                gettype($this->current_row_ends_query_batch)
+            );
+        }
         $this->current_column_names = $cursor_data["current_column_names"] ?? null;
 
         if ($this->tables_to_process === null) {
@@ -536,6 +557,7 @@ class DatabaseRowsReader {
             $this->current_column_types = $this->get_column_types($this->current_table);
             $this->current_column_names = null;
             $this->current_row = null;
+            $this->current_row_ends_query_batch = false;
         }
         return (bool) $this->current_table;
     }

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -178,7 +178,23 @@ class DatabaseRowsReader {
         }
 
         $this->current_row = $record;
+        if ($this->rows_fetched_from_current_query >= $this->batch_size) {
+            $this->release_current_result_set();
+        }
         return true;
+    }
+
+    /** Drains unconsumed records and releases the active LIMIT-sized result set. */
+    private function release_current_result_set()
+    {
+        if ($this->current_result_set === null) {
+            return;
+        }
+        $record = $this->current_result_set->fetch(PDO::FETCH_ASSOC);
+        while ($record !== false) {
+            $record = $this->current_result_set->fetch(PDO::FETCH_ASSOC);
+        }
+        $this->current_result_set = null;
     }
 
     /** Returns whether the table list has been initialized. */
@@ -279,33 +295,28 @@ class DatabaseRowsReader {
 
         if ($this->tables_to_process === null) {
             $this->initialize_tables_to_process();
-            if ($this->current_table) {
-                $found = false;
-                reset($this->tables_to_process);
-                while (true) {
-                    $table = current($this->tables_to_process);
-                    if ($table === false) {
-                        break;
-                    }
-                    if ($table === $this->current_table) {
-                        $found = true;
-                        break;
-                    }
-                    next($this->tables_to_process);
-                }
-                // Table was dropped between requests — let the producer restart discovery.
-                if (!$found) {
-                    $this->current_table = null;
-                    return false;
-                }
-            }
         }
         if ($this->current_table) {
+            $position = array_search($this->current_table, $this->tables_to_process, true);
+            if ($position === false) {
+                $this->current_table = null;
+                return false;
+            }
+            reset($this->tables_to_process);
+            while (key($this->tables_to_process) !== $position) {
+                next($this->tables_to_process);
+            }
+            if ($this->get_primary_key_columns($this->current_table) !== $this->current_pk_columns) {
+                throw new \RuntimeException(
+                    "Cannot restore the database row cursor because the primary key for table " .
+                    $this->quote_identifier($this->current_table) . " changed."
+                );
+            }
             $this->current_column_types = $this->get_column_types($this->current_table);
             if (empty($this->current_column_types)) {
                 throw new \RuntimeException(
                     "Table " . $this->quote_identifier($this->current_table) . " was dropped between export requests " .
-                    "(no columns found in INFORMATION_SCHEMA)"
+                    "(no columns found in SHOW FULL COLUMNS)"
                 );
             }
         }
@@ -465,17 +476,11 @@ class DatabaseRowsReader {
     /** Returns primary key column names in ordinal order, or an empty array. */
     private function get_primary_key_columns($table)
     {
-        $primary_key_columns = [];
-        $query = "SELECT COLUMN_NAME
-            FROM information_schema.KEY_COLUMN_USAGE
-            WHERE TABLE_SCHEMA = ?
-            AND TABLE_NAME = ?
-            AND CONSTRAINT_NAME = 'PRIMARY'
-            ORDER BY ORDINAL_POSITION";
+        $columns_by_position = [];
+        $query = "SHOW INDEX FROM " . $this->quote_identifier($table) .
+            " WHERE Key_name = 'PRIMARY'";
         try {
-            $database_name = $this->db->query("SELECT DATABASE()")->fetchColumn();
-            $statement = $this->db->prepare($query);
-            $statement->execute([$database_name, $table]);
+            $statement = $this->db->query($query);
         } catch (\PDOException $e) {
             throw new \RuntimeException(
                 "Failed to get primary key columns for " . $this->quote_identifier($table) . ": " . $e->getMessage() . " Query: {$query}"
@@ -483,10 +488,11 @@ class DatabaseRowsReader {
         }
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
-            $primary_key_columns[] = $row["COLUMN_NAME"];
+            $columns_by_position[$row["Seq_in_index"]] = $row["Column_name"];
             $row = $statement->fetch(PDO::FETCH_ASSOC);
         }
-        return $primary_key_columns;
+        ksort($columns_by_position, SORT_NUMERIC);
+        return array_values($columns_by_position);
     }
 
     public function move_to_next_table()
@@ -518,38 +524,27 @@ class DatabaseRowsReader {
     public function initialize_tables_to_process()
     {
         $this->tables_to_process = [];
-        $database_name = $this->db->query("SELECT DATABASE()")->fetchColumn();
-        $statement = $this->db->prepare(
-            "SELECT TABLE_NAME
-             FROM INFORMATION_SCHEMA.TABLES
-             WHERE TABLE_SCHEMA = ?
-               AND TABLE_TYPE = 'BASE TABLE'
-             ORDER BY TABLE_NAME"
-        );
-        $statement->execute([$database_name]);
+        $statement = $this->db->query("SHOW FULL TABLES");
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
-            $this->tables_to_process[] = $row["TABLE_NAME"];
+            $values = array_values($row);
+            if (isset($values[0], $values[1]) && strcasecmp($values[1], "BASE TABLE") === 0) {
+                $this->tables_to_process[] = $values[0];
+            }
             $row = $statement->fetch(PDO::FETCH_ASSOC);
         }
     }
 
-    /** Returns cached INFORMATION_SCHEMA column metadata for a table. */
+    /** Returns cached column metadata for a table. */
     private function get_column_types($table_name)
     {
         if (isset($this->column_type_cache[$table_name])) {
             return $this->column_type_cache[$table_name];
         }
         try {
-            $database_name = $this->db->query("SELECT DATABASE()")->fetchColumn();
-            $statement = $this->db->prepare(
-                'SELECT COLUMN_NAME, DATA_TYPE, COLUMN_TYPE
-                 FROM INFORMATION_SCHEMA.COLUMNS
-                 WHERE TABLE_SCHEMA = ?
-                   AND TABLE_NAME = ?
-                 ORDER BY ORDINAL_POSITION'
+            $statement = $this->db->query(
+                "SHOW FULL COLUMNS FROM " . $this->quote_identifier($table_name)
             );
-            $statement->execute([$database_name, $table_name]);
         } catch (\PDOException $e) {
             throw new \RuntimeException(
                 "Failed to get column types for " . $this->quote_identifier($table_name) . ": " . $e->getMessage()
@@ -558,9 +553,10 @@ class DatabaseRowsReader {
         $columns = [];
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
-            $columns[$row["COLUMN_NAME"]] = [
-                "data_type" => $row["DATA_TYPE"],
-                "column_type" => $row["COLUMN_TYPE"],
+            $column_type = $row["Type"];
+            $columns[$row["Field"]] = [
+                "data_type" => preg_replace('/[\s(].*$/', '', $column_type),
+                "column_type" => $column_type,
             ];
             $row = $statement->fetch(PDO::FETCH_ASSOC);
         }
@@ -599,7 +595,7 @@ class DatabaseRowsReader {
             throw new \RuntimeException(
                 "No column type info for '{$column}' in table " .
                 $this->quote_identifier($this->current_table) .
-                ". This is a bug — INFORMATION_SCHEMA should have returned it."
+                ". This is a bug — SHOW FULL COLUMNS should have returned it."
             );
         }
         return $this->current_column_types[$column]["data_type"];

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -236,6 +236,7 @@ class MySQLDumpProducer
         $header = "INSERT INTO " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . " ({$column_list}) VALUES\n";
         $this->current_statement_size = strlen($header);
 
+        $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
         $first_row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
         $this->current_statement_size += strlen($first_row_sql) + 1;
 
@@ -246,7 +247,10 @@ class MySQLDumpProducer
         // subsequent UPDATE statements are syntactically separate.
         $has_oversized = $this->has_pending_oversized_updates();
 
-        if ($this->rows_in_batch >= $this->row_reader->get_batch_size()) {
+        if (
+            $current_record_ends_query_batch ||
+            $this->rows_in_batch >= $this->row_reader->get_batch_size()
+        ) {
             $this->finish_insert_batch($header . $first_row_sql, $has_oversized);
             return true;
         }
@@ -289,6 +293,7 @@ class MySQLDumpProducer
             return false;
         }
 
+        $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
         $row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
         $this->current_statement_size += strlen($row_sql) + 2;
         $this->row_reader->clear_current_record();
@@ -296,7 +301,10 @@ class MySQLDumpProducer
 
         $has_oversized = $this->has_pending_oversized_updates();
 
-        if ($this->rows_in_batch >= $this->row_reader->get_batch_size()) {
+        if (
+            $current_record_ends_query_batch ||
+            $this->rows_in_batch >= $this->row_reader->get_batch_size()
+        ) {
             $this->finish_insert_batch($row_sql, $has_oversized);
             return true;
         }

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -242,11 +242,16 @@ class MySQLDumpProducer
         $this->row_reader->clear_current_record();
         $this->rows_in_batch = 1;
 
-        $has_next_row = $this->row_reader->next_record();
-
         // Oversized updates require closing this INSERT with a semicolon so the
         // subsequent UPDATE statements are syntactically separate.
         $has_oversized = $this->has_pending_oversized_updates();
+
+        if ($this->rows_in_batch >= $this->row_reader->get_batch_size()) {
+            $this->finish_insert_batch($header . $first_row_sql, $has_oversized);
+            return true;
+        }
+
+        $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
             $sql = $header . $first_row_sql . ";";
@@ -258,16 +263,12 @@ class MySQLDumpProducer
             } else {
                 $this->state = self::STATE_NEXT_TABLE;
             }
-        } elseif ($this->rows_in_batch >= $this->row_reader->get_batch_size() || $has_oversized) {
+        } elseif ($has_oversized) {
             $sql = $header . $first_row_sql . ";";
             $this->current_sql_fragment = $sql;
             $this->current_statement_size = 0;
-            if ($has_oversized) {
-                $this->state_after_oversized = self::STATE_START_INSERT;
-                $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
-            } else {
-                $this->state = self::STATE_START_INSERT;
-            }
+            $this->state_after_oversized = self::STATE_START_INSERT;
+            $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
         } else {
             $sql = $header . $first_row_sql . ",";
             $this->current_sql_fragment = $sql;
@@ -293,8 +294,14 @@ class MySQLDumpProducer
         $this->row_reader->clear_current_record();
         $this->rows_in_batch++;
 
-        $has_next_row = $this->row_reader->next_record();
         $has_oversized = $this->has_pending_oversized_updates();
+
+        if ($this->rows_in_batch >= $this->row_reader->get_batch_size()) {
+            $this->finish_insert_batch($row_sql, $has_oversized);
+            return true;
+        }
+
+        $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
             $this->current_sql_fragment = $row_sql . ";";
@@ -305,20 +312,29 @@ class MySQLDumpProducer
             } else {
                 $this->state = self::STATE_NEXT_TABLE;
             }
-        } elseif ($this->rows_in_batch >= $this->row_reader->get_batch_size() || $has_oversized) {
+        } elseif ($has_oversized) {
             $this->current_sql_fragment = $row_sql . ";";
             $this->current_statement_size = 0;
-            if ($has_oversized) {
-                $this->state_after_oversized = self::STATE_START_INSERT;
-                $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
-            } else {
-                $this->state = self::STATE_START_INSERT;
-            }
+            $this->state_after_oversized = self::STATE_START_INSERT;
+            $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
         } else {
             $this->current_sql_fragment = $row_sql . ",";
         }
 
         return true;
+    }
+
+    /** Finishes an INSERT batch at its bounded row limit. */
+    private function finish_insert_batch($sql, $has_oversized)
+    {
+        $this->current_sql_fragment = $sql . ";";
+        $this->current_statement_size = 0;
+        if ($has_oversized) {
+            $this->state_after_oversized = self::STATE_START_INSERT;
+            $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
+        } else {
+            $this->state = self::STATE_START_INSERT;
+        }
     }
 
     /**

--- a/packages/reprint-server/src/class-sqlite-driver-pdo.php
+++ b/packages/reprint-server/src/class-sqlite-driver-pdo.php
@@ -165,9 +165,9 @@ class SqliteDriverPDOStatement
         $result = $this->driver->query($sql);
         $supply_table_types = false;
         if ($result === false && strcasecmp(trim($sql), 'SHOW FULL TABLES') === 0) {
-            // The version 2 driver supports SHOW TABLES but not SHOW FULL TABLES.
-            // Its SHOW TABLES implementation reads only SQLite tables, not views.
-            $result = $this->driver->query('SHOW TABLES');
+            // The version 2 driver cannot parse SHOW FULL TABLES. Its public
+            // SHOW TABLE STATUS path already removes SQLite system tables.
+            $result = $this->driver->query('SHOW TABLE STATUS');
             $supply_table_types = true;
         }
         if ($result instanceof PDOStatement) {
@@ -184,7 +184,10 @@ class SqliteDriverPDOStatement
                 $this->rows[$i] = (array) $row;
             }
             if ($supply_table_types) {
-                $this->rows[$i]['Table_type'] = 'BASE TABLE';
+                $this->rows[$i] = [
+                    'Name' => $this->rows[$i]['Name'],
+                    'Table_type' => 'BASE TABLE',
+                ];
             }
         }
 

--- a/packages/reprint-server/src/class-sqlite-driver-pdo.php
+++ b/packages/reprint-server/src/class-sqlite-driver-pdo.php
@@ -9,10 +9,9 @@
  * driver does not implement so the dump producer can use either supported
  * plugin version without knowing it is talking to SQLite.
  *
- * Every MySQL query goes through the driver's AST-based translator, which
- * converts it to SQLite on the fly. The result is transparent: the dump
- * producer sends MySQL queries, gets rows back, and produces valid MySQL
- * SQL output.
+ * Every MySQL query goes through the active driver's translator, which converts
+ * it to SQLite on the fly. The result is transparent: the dump producer sends
+ * MySQL queries, gets rows back, and produces valid MySQL SQL output.
  */
 
 /**
@@ -164,6 +163,13 @@ class SqliteDriverPDOStatement
         }
 
         $result = $this->driver->query($sql);
+        $supply_table_types = false;
+        if ($result === false && strcasecmp(trim($sql), 'SHOW FULL TABLES') === 0) {
+            // The version 2 driver supports SHOW TABLES but not SHOW FULL TABLES.
+            // Its SHOW TABLES implementation reads only SQLite tables, not views.
+            $result = $this->driver->query('SHOW TABLES');
+            $supply_table_types = true;
+        }
         if ($result instanceof PDOStatement) {
             $this->rows = $result->fetchAll(PDO::FETCH_ASSOC);
         } else {
@@ -176,6 +182,9 @@ class SqliteDriverPDOStatement
         foreach ($this->rows as $i => $row) {
             if (is_object($row)) {
                 $this->rows[$i] = (array) $row;
+            }
+            if ($supply_table_types) {
+                $this->rows[$i]['Table_type'] = 'BASE TABLE';
             }
         }
 

--- a/packages/reprint-server/src/class-sqlite-driver-pdo.php
+++ b/packages/reprint-server/src/class-sqlite-driver-pdo.php
@@ -167,7 +167,7 @@ class SqliteDriverPDOStatement
         if ($result === false && strcasecmp(trim($sql), 'SHOW FULL TABLES') === 0) {
             // The version 2 driver cannot parse SHOW FULL TABLES. Its public
             // SHOW TABLE STATUS path already removes SQLite system tables.
-            $result = $this->driver->query('SHOW TABLE STATUS');
+            $result = $this->driver->query('SHOW TABLE STATUS;');
             $supply_table_types = true;
         }
         if ($result instanceof PDOStatement) {
@@ -175,6 +175,26 @@ class SqliteDriverPDOStatement
         } else {
             $result = $this->driver->get_query_results();
             $this->rows = is_array($result) ? $result : [];
+        }
+
+        if (
+            count($this->rows) === 0 &&
+            preg_match(
+                '/\ASHOW (?:INDEX|FULL COLUMNS) FROM `([A-Za-z0-9_$]+)`\z/i',
+                trim($sql),
+                $matches
+            )
+        ) {
+            // The version 2 parser treats backticks as part of the table name
+            // in these SHOW forms. Retry only identifiers which are safe bare.
+            $legacy_sql = str_replace("`{$matches[1]}`", $matches[1], trim($sql));
+            $result = $this->driver->query($legacy_sql);
+            if ($result instanceof PDOStatement) {
+                $this->rows = $result->fetchAll(PDO::FETCH_ASSOC);
+            } else {
+                $result = $this->driver->get_query_results();
+                $this->rows = is_array($result) ? $result : [];
+            }
         }
 
         // The version 2 driver returns arrays of objects. Convert those rows

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -313,9 +313,10 @@ function create_db_connection(array $creds, array $options = [])
 /**
  * Wraps the SQLite plugin's already-loaded driver in a PDO-compatible adapter.
  *
- * Version 3 exposes WP_MySQL_On_SQLite through $wpdb->get_driver(). Version 2
- * stores WP_SQLite_Driver in $wpdb->dbh. Both drivers translate MySQL queries,
- * but neither provides every PDO operation used by MySQLDumpProducer.
+ * Version 3 exposes its active translator through $wpdb->get_driver(). Version
+ * 2 exposes its active translator through wpdb's backward-compatible dbh
+ * property. Both translate MySQL queries, but neither provides every PDO
+ * operation used by MySQLDumpProducer.
  *
  * @return object PDO-compatible adapter (SqliteDriverPDO).
  * @throws RuntimeException If the driver is not available or unsupported.
@@ -325,8 +326,7 @@ function create_sqlite_pdo_adapter()
     global $wpdb;
 
     /**
-     * Minimum sqlite-database-integration version that exposes the legacy
-     * WP_SQLite_Driver API used below.
+     * Minimum supported sqlite-database-integration version.
      */
     $min_version = '2.1.0';
 
@@ -335,21 +335,40 @@ function create_sqlite_pdo_adapter()
     $driver = null;
     $raw_pdo = null;
 
-    if (isset($wpdb) && method_exists($wpdb, 'get_driver')) {
+    if (isset($wpdb) && is_object($wpdb) && method_exists($wpdb, 'get_driver')) {
         $candidate = $wpdb->get_driver();
-        if (is_a($candidate, 'WP_MySQL_On_SQLite')) {
+        if (
+            is_object($candidate) &&
+            method_exists($candidate, 'query') &&
+            method_exists($candidate, 'get_sqlite_pdo')
+        ) {
+            $candidate_pdo = call_user_func([$candidate, 'get_sqlite_pdo']);
+        } else {
+            $candidate_pdo = null;
+        }
+        if ($candidate_pdo instanceof PDO) {
             $driver = $candidate;
-            $raw_pdo = call_user_func([$driver, 'get_sqlite_pdo']);
+            $raw_pdo = $candidate_pdo;
         }
     }
 
-    if (
-        $driver === null &&
-        isset($wpdb) &&
-        $wpdb->dbh instanceof WP_SQLite_Driver
-    ) {
-        $driver = $wpdb->dbh;
-        $raw_pdo = $driver->get_connection()->get_pdo();
+    if ($driver === null && isset($wpdb) && is_object($wpdb)) {
+        $candidate = $wpdb->dbh;
+        $candidate_pdo = null;
+        if (is_object($candidate) && method_exists($candidate, 'query')) {
+            if (method_exists($candidate, 'get_pdo')) {
+                $candidate_pdo = call_user_func([$candidate, 'get_pdo']);
+            } elseif (method_exists($candidate, 'get_connection')) {
+                $connection = call_user_func([$candidate, 'get_connection']);
+                if (is_object($connection) && method_exists($connection, 'get_pdo')) {
+                    $candidate_pdo = call_user_func([$connection, 'get_pdo']);
+                }
+            }
+        }
+        if ($candidate_pdo instanceof PDO) {
+            $driver = $candidate;
+            $raw_pdo = $candidate_pdo;
+        }
     }
 
     if ($driver === null) {

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -192,7 +192,7 @@ final class CreateDbConnectionTest extends TestCase {
         $this->assertSame('sqlite-3', $result['stdout']);
     }
 
-    public function testSqliteDatabaseIntegrationTwoDriverStillWorks(): void
+    public function testSqliteDatabaseIntegrationTwoLegacyDriverStillWorks(): void
     {
         if (!extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('pdo_sqlite extension required');
@@ -200,13 +200,24 @@ final class CreateDbConnectionTest extends TestCase {
 
         $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
         $export_path = realpath(__DIR__ . '/../packages/reprint-server/src/export.php');
-        $sqlite_load_path = realpath(
-            __DIR__ . '/../lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php'
-        );
         $this->assertIsString($autoload_path);
         $this->assertIsString($export_path);
-        $this->assertIsString($sqlite_load_path);
         $connection_script = <<<'PHP'
+        class LegacySqliteDriverTestDouble {
+            private $pdo;
+            public function __construct($pdo) {
+                $this->pdo = $pdo;
+            }
+            public function query($query) {
+                return $this->pdo->query($query);
+            }
+            public function get_query_results() {
+                return [];
+            }
+            public function get_pdo() {
+                return $this->pdo;
+            }
+        }
         class SqliteTwoWordPressDatabaseTestDouble {
             public $dbh;
             public function __construct($driver) {
@@ -215,12 +226,8 @@ final class CreateDbConnectionTest extends TestCase {
         }
         require $argv[1];
         require $argv[2];
-        require $argv[3];
         $pdo = new PDO('sqlite::memory:');
-        $driver = new WP_SQLite_Driver(
-            new WP_SQLite_Connection(['pdo' => $pdo]),
-            'wp_test'
-        );
+        $driver = new LegacySqliteDriverTestDouble($pdo);
         $GLOBALS['wpdb'] = new SqliteTwoWordPressDatabaseTestDouble($driver);
         $connection = create_db_connection(['db_engine' => 'sqlite']);
         fwrite(STDOUT, $connection->query('SELECT 2')->fetchColumn());
@@ -232,7 +239,6 @@ final class CreateDbConnectionTest extends TestCase {
             $connection_script,
             $autoload_path,
             $export_path,
-            $sqlite_load_path,
         ]);
         $this->assertSame(
             0,

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
@@ -22,13 +22,31 @@ final class DatabaseRowsReaderMetadataTest extends TestCase {
         $this->assertSame(
             [
                 'SHOW FULL TABLES',
-                "SHOW INDEX FROM `z_table` WHERE Key_name = 'PRIMARY'",
+                'SHOW INDEX FROM `z_table`',
                 'SHOW FULL COLUMNS FROM `z_table`',
-                "SHOW INDEX FROM `A_table` WHERE Key_name = 'PRIMARY'",
+                'SHOW INDEX FROM `A_table`',
                 'SHOW FULL COLUMNS FROM `A_table`',
             ],
             $database->queries
         );
+    }
+
+    public function testUsesReturnedOrderWhenPrimaryKeyPositionsAreNotUsable(): void
+    {
+        $database = new DatabaseRowsReaderMetadataConnection(
+            ['composite_table'],
+            [
+                ['Key_name' => 'secondary', 'Column_name' => 'ignored', 'Seq_in_index' => 0],
+                ['Key_name' => 'PRIMARY', 'Column_name' => 'part_a', 'Seq_in_index' => 0],
+                ['Key_name' => 'PRIMARY', 'Column_name' => 'part_b', 'Seq_in_index' => 0],
+            ]
+        );
+        $reader = new DatabaseRowsReader($database);
+
+        $reader->initialize_tables_to_process();
+
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertSame(['part_a', 'part_b'], $reader->get_current_primary_key_columns());
     }
 
     public function testRestoreAlignsAProvidedTableListWithTheCurrentTable(): void

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
@@ -3,6 +3,8 @@
 use PHPUnit\Framework\TestCase;
 use WordPress\DataLiberation\DatabaseRowsReader;
 
+require_once __DIR__ . '/fixtures/DatabaseRowsReaderMetadataConnection.php';
+
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 final class DatabaseRowsReaderMetadataTest extends TestCase {
 
@@ -28,61 +30,24 @@ final class DatabaseRowsReaderMetadataTest extends TestCase {
             $database->queries
         );
     }
-}
 
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
-final class DatabaseRowsReaderMetadataConnection {
-    /** @var string[] */
-    private $tables;
-
-    /** @var string[] */
-    public $queries = [];
-
-    /** @param string[] $tables */
-    public function __construct(array $tables)
+    public function testRestoreAlignsAProvidedTableListWithTheCurrentTable(): void
     {
-        $this->tables = $tables;
-    }
+        $database = new DatabaseRowsReaderMetadataConnection(['first', 'second', 'third']);
+        $reader = new DatabaseRowsReader($database, [
+            'tables_to_process' => ['first', 'second', 'third'],
+        ]);
 
-    public function query(string $query): DatabaseRowsReaderMetadataStatement
-    {
-        $this->queries[] = $query;
-        if ($query === 'SHOW FULL TABLES') {
-            return new DatabaseRowsReaderMetadataStatement(array_map(static function ($table) {
-                return ['table' => $table, 'type' => 'BASE TABLE'];
-            }, $this->tables));
-        }
-        if (strpos($query, 'SHOW INDEX FROM ') === 0) {
-            return new DatabaseRowsReaderMetadataStatement([
-                ['Column_name' => 'id', 'Seq_in_index' => 1],
-            ]);
-        }
-        if (strpos($query, 'SHOW FULL COLUMNS FROM ') === 0) {
-            return new DatabaseRowsReaderMetadataStatement([
-                ['Field' => 'id', 'Type' => 'int(11)'],
-            ]);
-        }
-        throw new RuntimeException("Unexpected query: {$query}");
-    }
-}
+        $this->assertTrue($reader->restore_cursor_state([
+            'current_table' => 'second',
+            'current_pk_columns' => ['id'],
+            'last_pk_values' => ['id' => 1],
+            'current_offset' => 0,
+            'current_row' => null,
+            'current_column_names' => ['id'],
+        ]));
 
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
-final class DatabaseRowsReaderMetadataStatement {
-    /** @var array[] */
-    private $rows;
-
-    /** @param array[] $rows */
-    public function __construct(array $rows)
-    {
-        $this->rows = $rows;
-    }
-
-    /** @return array|false */
-    public function fetch()
-    {
-        if (count($this->rows) === 0) {
-            return false;
-        }
-        return array_shift($this->rows);
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertSame('third', $reader->get_current_table());
     }
 }

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderMetadataTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\DatabaseRowsReader;
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderMetadataTest extends TestCase {
+
+    public function testUsesPublicMetadataQueriesAndPreservesTheirTableOrder(): void
+    {
+        $database = new DatabaseRowsReaderMetadataConnection(['z_table', 'A_table']);
+        $reader = new DatabaseRowsReader($database);
+
+        $reader->initialize_tables_to_process();
+
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertSame('z_table', $reader->get_current_table());
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertSame('A_table', $reader->get_current_table());
+        $this->assertSame(
+            [
+                'SHOW FULL TABLES',
+                "SHOW INDEX FROM `z_table` WHERE Key_name = 'PRIMARY'",
+                'SHOW FULL COLUMNS FROM `z_table`',
+                "SHOW INDEX FROM `A_table` WHERE Key_name = 'PRIMARY'",
+                'SHOW FULL COLUMNS FROM `A_table`',
+            ],
+            $database->queries
+        );
+    }
+}
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderMetadataConnection {
+    /** @var string[] */
+    private $tables;
+
+    /** @var string[] */
+    public $queries = [];
+
+    /** @param string[] $tables */
+    public function __construct(array $tables)
+    {
+        $this->tables = $tables;
+    }
+
+    public function query(string $query): DatabaseRowsReaderMetadataStatement
+    {
+        $this->queries[] = $query;
+        if ($query === 'SHOW FULL TABLES') {
+            return new DatabaseRowsReaderMetadataStatement(array_map(static function ($table) {
+                return ['table' => $table, 'type' => 'BASE TABLE'];
+            }, $this->tables));
+        }
+        if (strpos($query, 'SHOW INDEX FROM ') === 0) {
+            return new DatabaseRowsReaderMetadataStatement([
+                ['Column_name' => 'id', 'Seq_in_index' => 1],
+            ]);
+        }
+        if (strpos($query, 'SHOW FULL COLUMNS FROM ') === 0) {
+            return new DatabaseRowsReaderMetadataStatement([
+                ['Field' => 'id', 'Type' => 'int(11)'],
+            ]);
+        }
+        throw new RuntimeException("Unexpected query: {$query}");
+    }
+}
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderMetadataStatement {
+    /** @var array[] */
+    private $rows;
+
+    /** @param array[] $rows */
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    /** @return array|false */
+    public function fetch()
+    {
+        if (count($this->rows) === 0) {
+            return false;
+        }
+        return array_shift($this->rows);
+    }
+}

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderSqliteTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderSqliteTest.php
@@ -48,7 +48,7 @@ final class DatabaseRowsReaderSqliteTest extends TestCase {
         $this->assertSame('wp_posts', $reader->get_current_table());
         $this->assertSame(['ID'], $reader->get_current_primary_key_columns());
         $this->assertSame(
-            ['ID' => '1', 'post_content' => 'https://old.example/one'],
+            ['ID' => 1, 'post_content' => 'https://old.example/one'],
             $reader->get_current_record()
         );
     }

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderSqliteTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderSqliteTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\DatabaseRowsReader;
+
+require_once __DIR__ . '/../../lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php';
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderSqliteTest extends TestCase {
+    /** @var string */
+    private $database_path;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->database_path = tempnam(sys_get_temp_dir(), 'reprint-reader-');
+        $database = new PDO('sqlite:' . $this->database_path);
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec(
+            'CREATE TABLE wp_posts (' .
+            'ID INTEGER PRIMARY KEY, post_content TEXT NOT NULL)'
+        );
+        $database->exec(
+            "INSERT INTO wp_posts VALUES " .
+            "(1, 'https://old.example/one'), (2, 'https://old.example/two')"
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_string($this->database_path) && file_exists($this->database_path)) {
+            unlink($this->database_path);
+        }
+    }
+
+    public function testReadsThroughTheSqliteIntegrationPublicQueryApi(): void
+    {
+        $database = $this->open_database();
+        $reader = new DatabaseRowsReader($database, ['batch_size' => 1]);
+
+        $reader->initialize_tables_to_process();
+
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+        $this->assertSame('wp_posts', $reader->get_current_table());
+        $this->assertSame(['ID'], $reader->get_current_primary_key_columns());
+        $this->assertSame(
+            ['ID' => '1', 'post_content' => 'https://old.example/one'],
+            $reader->get_current_record()
+        );
+    }
+
+    public function testReleasesTheReadResultAtTheBatchBoundary(): void
+    {
+        $database = $this->open_database();
+        $reader = new DatabaseRowsReader($database, ['batch_size' => 1]);
+        $reader->initialize_tables_to_process();
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+
+        $other_connection = new PDO('sqlite:' . $this->database_path);
+        $other_connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $other_connection->setAttribute(PDO::ATTR_TIMEOUT, 1);
+        $this->assertSame(
+            1,
+            $other_connection->exec("UPDATE wp_posts SET post_content = 'changed' WHERE ID = 2")
+        );
+    }
+
+    private function open_database(): WP_PDO_MySQL_On_SQLite
+    {
+        $database = new WP_PDO_MySQL_On_SQLite(
+            "mysql-on-sqlite:path={$this->database_path};dbname=wp_test",
+            null,
+            null,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]
+        );
+        $database->get_connection()->get_pdo()->sqliteCreateFunction(
+            'FROM_BASE64',
+            static function ($data) {
+                return $data === null ? null : base64_decode($data);
+            }
+        );
+        return $database;
+    }
+}

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+require_once __DIR__ . '/MySQLDumpProducerTestBase.php';
+
+use WordPress\DataLiberation\DatabaseRowsReader;
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+class DatabaseRowsReaderTest extends MySQLDumpProducerTestBase {
+
+    public function testReturnsStructuredRecordsWithoutFormattingSql(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE structured_records (' .
+            'id INT PRIMARY KEY, content VARBINARY(255), nullable_value TEXT NULL)'
+        );
+        $insert = $this->pdo->prepare(
+            'INSERT INTO structured_records VALUES (?, ?, ?)'
+        );
+        $raw_content = "raw\0bytes\xFF";
+        $insert->execute([7, $raw_content, null]);
+
+        $reader = new DatabaseRowsReader($this->pdo, ['batch_size' => 1]);
+        $reader->initialize_tables_to_process();
+
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+        $this->assertSame('structured_records', $reader->get_current_table());
+        $this->assertSame(['id'], $reader->get_current_primary_key_columns());
+        $this->assertSame(
+            ['id' => 7, 'content' => $raw_content, 'nullable_value' => null],
+            $reader->get_current_record()
+        );
+    }
+
+    public function testCursorResumesAfterTheLastReturnedCompositeKey(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE structured_resume (' .
+            'part_a INT NOT NULL, part_b VARCHAR(20) NOT NULL, content TEXT, ' .
+            'PRIMARY KEY (part_a, part_b))'
+        );
+        $this->pdo->exec(
+            "INSERT INTO structured_resume VALUES " .
+            "(1, 'a', 'first'), (1, 'b', 'second'), (2, 'a', 'third')"
+        );
+
+        $reader = new DatabaseRowsReader($this->pdo, ['batch_size' => 1]);
+        $reader->initialize_tables_to_process();
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+        $this->assertSame('first', $reader->get_current_record()['content']);
+
+        $resumed = new DatabaseRowsReader($this->pdo, ['batch_size' => 1]);
+        $this->assertTrue($resumed->restore_cursor_state($reader->get_cursor_state()));
+        $remaining_content = [];
+        while ($resumed->next_record()) {
+            $remaining_content[] = $resumed->get_current_record()['content'];
+        }
+
+        $this->assertSame(['second', 'third'], $remaining_content);
+    }
+
+    public function testRestoreRejectsAChangedPrimaryKey(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE changed_primary_key (' .
+            'id INT NOT NULL, replacement_id INT NOT NULL, content TEXT, ' .
+            'PRIMARY KEY (id), UNIQUE KEY (replacement_id))'
+        );
+        $this->pdo->exec(
+            "INSERT INTO changed_primary_key VALUES (1, 10, 'first'), (2, 20, 'second')"
+        );
+
+        $reader = new DatabaseRowsReader($this->pdo, ['batch_size' => 1]);
+        $reader->initialize_tables_to_process();
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+        $cursor = $reader->get_cursor_state();
+
+        $this->pdo->exec(
+            'ALTER TABLE changed_primary_key DROP PRIMARY KEY, ADD PRIMARY KEY (replacement_id)'
+        );
+
+        $resumed = new DatabaseRowsReader($this->pdo, ['batch_size' => 1]);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Cannot restore the database row cursor because the primary key for table `changed_primary_key` changed.'
+        );
+        $resumed->restore_cursor_state($cursor);
+    }
+}

--- a/tests/MySQLDumpProducer/EdgeCasesTest.php
+++ b/tests/MySQLDumpProducer/EdgeCasesTest.php
@@ -136,6 +136,22 @@ class EdgeCasesTest extends MySQLDumpProducerTestBase
         $this->assertDatabasesEqual($this->pdo, $importPdo, ['t']);
     }
 
+    public function testBatchBoundaryCursorDoesNotPrefetchTheNextRow(): void
+    {
+        $this->pdo->exec("CREATE TABLE t (id INT PRIMARY KEY, v INT)");
+        $this->pdo->exec("INSERT INTO t VALUES (1, 10), (2, 20)");
+        $producer = $this->createProducer(['batch_size' => 1]);
+
+        do {
+            $producer->next_sql_fragment();
+            $sql = (string) $producer->get_sql_fragment();
+        } while (strpos($sql, 'INSERT INTO') !== 0);
+
+        $cursor = json_decode($producer->get_reentrancy_cursor(), true);
+        $this->assertNull($cursor['current_row']);
+        $this->assertSame(['id' => 1], $cursor['last_pk_values']);
+    }
+
     // ──────────────────────────────────────────────────
     // tables_to_process filtering
     // ──────────────────────────────────────────────────

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -168,6 +168,66 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $this->assertEquals($data3, $rows[2]['content']);
     }
 
+    public function testRetainedRowKeepsItsQueryBoundaryAcrossResume(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE retained_boundary (id INT PRIMARY KEY, content LONGBLOB)"
+        );
+        $insert = $this->pdo->prepare("INSERT INTO retained_boundary VALUES (?, ?)");
+        $insert->execute([1, str_repeat('x', 20 * 1024)]);
+        $insert->execute([2, 'second']);
+        $insert->execute([3, 'third']);
+
+        $options = [
+            'batch_size' => 2,
+            'max_statement_size' => 8 * 1024,
+        ];
+        $producer = $this->createProducer($options);
+        do {
+            $this->assertTrue($producer->next_sql_fragment());
+            $fragment = (string) $producer->get_sql_fragment();
+        } while (strpos($fragment, 'INSERT INTO `retained_boundary`') !== 0);
+
+        $options['cursor'] = $producer->get_reentrancy_cursor();
+        $producer = $this->createProducer($options);
+        do {
+            $this->assertTrue($producer->next_sql_fragment());
+            $fragment = (string) $producer->get_sql_fragment();
+        } while (
+            strpos($fragment, 'INSERT INTO `retained_boundary`') !== 0 ||
+            strpos($fragment, base64_encode('second')) === false
+        );
+
+        $cursor = json_decode($producer->get_reentrancy_cursor(), true);
+        $this->assertNull($cursor['current_row']);
+        $this->assertSame(['id' => 2], $cursor['last_pk_values']);
+    }
+
+    public function testRowEmitterStopsAtTheReaderQueryBoundary(): void
+    {
+        $this->pdo->exec(
+            "CREATE TABLE emitted_boundary (id INT PRIMARY KEY, content LONGBLOB)"
+        );
+        $insert = $this->pdo->prepare("INSERT INTO emitted_boundary VALUES (?, ?)");
+        $insert->execute([1, str_repeat('x', 20 * 1024)]);
+        $insert->execute([2, 'second']);
+        $insert->execute([3, 'third']);
+        $insert->execute([4, 'fourth']);
+
+        $producer = $this->createProducer([
+            'batch_size' => 3,
+            'max_statement_size' => 8 * 1024,
+        ]);
+        do {
+            $this->assertTrue($producer->next_sql_fragment());
+            $fragment = (string) $producer->get_sql_fragment();
+        } while (strpos($fragment, base64_encode('third')) === false);
+
+        $cursor = json_decode($producer->get_reentrancy_cursor(), true);
+        $this->assertNull($cursor['current_row']);
+        $this->assertSame(['id' => 3], $cursor['last_pk_values']);
+    }
+
     /**
      * Test with composite primary key.
      */

--- a/tests/MySQLDumpProducer/ReentrancyTest.php
+++ b/tests/MySQLDumpProducer/ReentrancyTest.php
@@ -505,7 +505,7 @@ class ReentrancyTest extends MySQLDumpProducerTestBase
             }
         }
 
-        // Get cursor - should be at row 5
+        // Get cursor at the completed batch boundary after row 5.
         $cursor = $producer->get_reentrancy_cursor();
 
         // DELETE remaining rows - simulate data disappearing
@@ -532,13 +532,11 @@ class ReentrancyTest extends MySQLDumpProducerTestBase
         $this->assertStringNotContainsString(",\n\n", $completeSQL);
         $this->assertStringNotContainsString(",\nCOMMIT", $completeSQL);
 
-        // Verify it imports correctly
-        // Note: We expect 6 rows because row 6 was cached in the cursor
-        // even though rows 6-10 were deleted from the database.
-        // The cursor represents a consistent snapshot.
+        // The producer does not prefetch beyond the completed batch boundary,
+        // so rows deleted before resume are not emitted from saved state.
         $importPdo = $this->executeDumpInNewDatabase($completeSQL);
         $count = $importPdo->query("SELECT COUNT(*) FROM resume_test")->fetchColumn();
-        $this->assertEquals(6, $count, "Should have 6 rows (5 from first batch + 1 cached row)");
+        $this->assertEquals(5, $count);
     }
 
     /**

--- a/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
+++ b/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
@@ -19,6 +19,6 @@ final class SqliteDriverPDOLegacyMetadataTest extends TestCase {
             [['Name' => 'wp_posts', 'Table_type' => 'BASE TABLE']],
             $adapter->query('SHOW FULL TABLES')->fetchAll(PDO::FETCH_ASSOC)
         );
-        $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLE STATUS'], $driver->queries);
+        $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLE STATUS;'], $driver->queries);
     }
 }

--- a/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
+++ b/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/fixtures/LegacySqliteMetadataDriver.php';
 
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 final class SqliteDriverPDOLegacyMetadataTest extends TestCase {
-    public function testSuppliesTableTypesWhenTheLegacyDriverOnlySupportsShowTables(): void
+    public function testSuppliesTableTypesFromLegacyTableStatusMetadata(): void
     {
         if (!extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('pdo_sqlite extension required');
@@ -16,9 +16,9 @@ final class SqliteDriverPDOLegacyMetadataTest extends TestCase {
         $adapter = new SqliteDriverPDO($driver, new PDO('sqlite::memory:'));
 
         $this->assertSame(
-            [['Tables_in_wp_test' => 'wp_posts', 'Table_type' => 'BASE TABLE']],
+            [['Name' => 'wp_posts', 'Table_type' => 'BASE TABLE']],
             $adapter->query('SHOW FULL TABLES')->fetchAll(PDO::FETCH_ASSOC)
         );
-        $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLES'], $driver->queries);
+        $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLE STATUS'], $driver->queries);
     }
 }

--- a/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
+++ b/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
@@ -21,4 +21,32 @@ final class SqliteDriverPDOLegacyMetadataTest extends TestCase {
         );
         $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLE STATUS;'], $driver->queries);
     }
+
+    public function testRetriesQuotedMetadataQueriesForTheLegacyParser(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $driver = new LegacySqliteMetadataDriver();
+        $adapter = new SqliteDriverPDO($driver, new PDO('sqlite::memory:'));
+
+        $this->assertSame(
+            [['Key_name' => 'PRIMARY', 'Column_name' => 'ID', 'Seq_in_index' => 0]],
+            $adapter->query('SHOW INDEX FROM `wp_posts`')->fetchAll(PDO::FETCH_ASSOC)
+        );
+        $this->assertSame(
+            [['Field' => 'ID', 'Type' => 'INTEGER']],
+            $adapter->query('SHOW FULL COLUMNS FROM `wp_posts`')->fetchAll(PDO::FETCH_ASSOC)
+        );
+        $this->assertSame(
+            [
+                'SHOW INDEX FROM `wp_posts`',
+                'SHOW INDEX FROM wp_posts',
+                'SHOW FULL COLUMNS FROM `wp_posts`',
+                'SHOW FULL COLUMNS FROM wp_posts',
+            ],
+            $driver->queries
+        );
+    }
 }

--- a/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
+++ b/tests/MySQLDumpProducer/SqliteDriverPDOLegacyMetadataTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/fixtures/LegacySqliteMetadataDriver.php';
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class SqliteDriverPDOLegacyMetadataTest extends TestCase {
+    public function testSuppliesTableTypesWhenTheLegacyDriverOnlySupportsShowTables(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $driver = new LegacySqliteMetadataDriver();
+        $adapter = new SqliteDriverPDO($driver, new PDO('sqlite::memory:'));
+
+        $this->assertSame(
+            [['Tables_in_wp_test' => 'wp_posts', 'Table_type' => 'BASE TABLE']],
+            $adapter->query('SHOW FULL TABLES')->fetchAll(PDO::FETCH_ASSOC)
+        );
+        $this->assertSame(['SHOW FULL TABLES', 'SHOW TABLES'], $driver->queries);
+    }
+}

--- a/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataConnection.php
+++ b/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataConnection.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/DatabaseRowsReaderMetadataStatement.php';
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderMetadataConnection {
+    /** @var string[] */
+    private $tables;
+
+    /** @var string[] */
+    public $queries = [];
+
+    /** @param string[] $tables */
+    public function __construct(array $tables)
+    {
+        $this->tables = $tables;
+    }
+
+    public function query(string $query): DatabaseRowsReaderMetadataStatement
+    {
+        $this->queries[] = $query;
+        if ($query === 'SHOW FULL TABLES') {
+            return new DatabaseRowsReaderMetadataStatement(array_map(static function ($table) {
+                return ['table' => $table, 'type' => 'BASE TABLE'];
+            }, $this->tables));
+        }
+        if (strpos($query, 'SHOW INDEX FROM ') === 0) {
+            return new DatabaseRowsReaderMetadataStatement([
+                ['Column_name' => 'id', 'Seq_in_index' => 1],
+            ]);
+        }
+        if (strpos($query, 'SHOW FULL COLUMNS FROM ') === 0) {
+            return new DatabaseRowsReaderMetadataStatement([
+                ['Field' => 'id', 'Type' => 'int(11)'],
+            ]);
+        }
+        // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        throw new RuntimeException("Unexpected query: {$query}");
+    }
+}

--- a/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataConnection.php
+++ b/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataConnection.php
@@ -7,13 +7,22 @@ final class DatabaseRowsReaderMetadataConnection {
     /** @var string[] */
     private $tables;
 
+    /** @var array[] */
+    private $index_rows;
+
     /** @var string[] */
     public $queries = [];
 
-    /** @param string[] $tables */
-    public function __construct(array $tables)
+    /**
+     * @param string[]   $tables     Tables returned by SHOW FULL TABLES.
+     * @param array[]|null $index_rows Rows returned by SHOW INDEX.
+     */
+    public function __construct(array $tables, $index_rows = null)
     {
         $this->tables = $tables;
+        $this->index_rows = $index_rows ?? [
+            ['Key_name' => 'PRIMARY', 'Column_name' => 'id', 'Seq_in_index' => 1],
+        ];
     }
 
     public function query(string $query): DatabaseRowsReaderMetadataStatement
@@ -25,9 +34,7 @@ final class DatabaseRowsReaderMetadataConnection {
             }, $this->tables));
         }
         if (strpos($query, 'SHOW INDEX FROM ') === 0) {
-            return new DatabaseRowsReaderMetadataStatement([
-                ['Column_name' => 'id', 'Seq_in_index' => 1],
-            ]);
+            return new DatabaseRowsReaderMetadataStatement($this->index_rows);
         }
         if (strpos($query, 'SHOW FULL COLUMNS FROM ') === 0) {
             return new DatabaseRowsReaderMetadataStatement([

--- a/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataStatement.php
+++ b/tests/MySQLDumpProducer/fixtures/DatabaseRowsReaderMetadataStatement.php
@@ -1,0 +1,22 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class DatabaseRowsReaderMetadataStatement {
+    /** @var array[] */
+    private $rows;
+
+    /** @param array[] $rows */
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    /** @return array|false */
+    public function fetch()
+    {
+        if (count($this->rows) === 0) {
+            return false;
+        }
+        return array_shift($this->rows);
+    }
+}

--- a/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
+++ b/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
@@ -20,6 +20,24 @@ final class LegacySqliteMetadataDriver {
             $this->query_results = [ (object) ['Name' => 'wp_posts', 'Engine' => 'myisam'] ];
             return true;
         }
+        if ($query === 'SHOW INDEX FROM `wp_posts`' || $query === 'SHOW FULL COLUMNS FROM `wp_posts`') {
+            $this->query_results = [];
+            return [];
+        }
+        if ($query === 'SHOW INDEX FROM wp_posts') {
+            $this->query_results = [
+                (object) [
+                    'Key_name' => 'PRIMARY',
+                    'Column_name' => 'ID',
+                    'Seq_in_index' => 0,
+                ],
+            ];
+            return $this->query_results;
+        }
+        if ($query === 'SHOW FULL COLUMNS FROM wp_posts') {
+            $this->query_results = [ (object) ['Field' => 'ID', 'Type' => 'INTEGER'] ];
+            return $this->query_results;
+        }
         // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
         throw new RuntimeException("Unexpected query: {$query}");
     }

--- a/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
+++ b/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
@@ -1,0 +1,32 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+final class LegacySqliteMetadataDriver {
+    /** @var string[] */
+    public $queries = [];
+
+    /** @var object[] */
+    private $query_results = [];
+
+    /** @return bool */
+    public function query(string $query)
+    {
+        $this->queries[] = $query;
+        if ($query === 'SHOW FULL TABLES') {
+            $this->query_results = [];
+            return false;
+        }
+        if ($query === 'SHOW TABLES') {
+            $this->query_results = [ (object) ['Tables_in_wp_test' => 'wp_posts'] ];
+            return true;
+        }
+        // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        throw new RuntimeException("Unexpected query: {$query}");
+    }
+
+    /** @return object[] */
+    public function get_query_results(): array
+    {
+        return $this->query_results;
+    }
+}

--- a/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
+++ b/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
@@ -16,8 +16,8 @@ final class LegacySqliteMetadataDriver {
             $this->query_results = [];
             return false;
         }
-        if ($query === 'SHOW TABLES') {
-            $this->query_results = [ (object) ['Tables_in_wp_test' => 'wp_posts'] ];
+        if ($query === 'SHOW TABLE STATUS') {
+            $this->query_results = [ (object) ['Name' => 'wp_posts', 'Engine' => 'myisam'] ];
             return true;
         }
         // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
+++ b/tests/MySQLDumpProducer/fixtures/LegacySqliteMetadataDriver.php
@@ -16,7 +16,7 @@ final class LegacySqliteMetadataDriver {
             $this->query_results = [];
             return false;
         }
-        if ($query === 'SHOW TABLE STATUS') {
+        if ($query === 'SHOW TABLE STATUS;') {
             $this->query_results = [ (object) ['Name' => 'wp_posts', 'Engine' => 'myisam'] ];
             return true;
         }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -139,6 +139,9 @@
     },
     "db-index-interruption": {
       "port": 8125
+    },
+    "sqlite-legacy": {
+      "port": 8126
     }
   }
 }

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -1,9 +1,9 @@
 /**
  * Test 35: SQLite Export
  *
- * Sets up a WordPress site running on SQLite (via the sqlite-database-
- * integration plugin) and verifies that the export produces valid MySQL
- * dump output that can be imported into a real MySQL database.
+ * Sets up WordPress sites running on SQLite Database Integration 2.x and 3.x,
+ * verifies that both export, and imports the 3.x dump into a real MySQL
+ * database.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -17,149 +17,136 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
+async function ensureSqliteSite(site, pluginVersion) {
+    await ensureSite(site, {
+        db: 'none',
+        files: 'sample',
+        afterCreate: async (siteDir) => {
+            const pluginsDir = join(siteDir, 'wp-content', 'plugins');
+            const pluginDir = join(pluginsDir, 'sqlite-database-integration');
+            const pluginZip = `/tmp/sqlite-database-integration-${pluginVersion}.zip`;
+
+            // Pin the plugin version so this test always exercises the intended driver.
+            if (!existsSync(pluginZip)) {
+                execSync(
+                    `curl -sfL "https://downloads.wordpress.org/plugin/` +
+                    `sqlite-database-integration.${pluginVersion}.zip" -o "${pluginZip}"`,
+                    { timeout: 120000 },
+                );
+            }
+            if (!existsSync(pluginDir)) {
+                try {
+                    execSync(
+                        `unzip -qo "${pluginZip}" -d "${pluginsDir}"`,
+                        { timeout: 30000 },
+                    );
+                } catch {
+                    // unzip is not present on every runner, so use PHP's ZipArchive there.
+                    execSync(
+                        `php -r "\\$z = new ZipArchive;` +
+                        ` \\$z->open('${pluginZip}');` +
+                        ` \\$z->extractTo('${pluginsDir}');` +
+                        ` \\$z->close();"`,
+                        { timeout: 30000 },
+                    );
+                }
+            }
+
+            // Create the db.php drop-in that activates the SQLite backend.
+            // This mimics what the plugin writes when activated through the
+            // WordPress admin UI (based on the plugin's db.copy template).
+            writeFileSync(join(siteDir, 'wp-content', 'db.php'), [
+                '<?php',
+                "define('SQLITE_DB_DROPIN_VERSION', '1.8.0');",
+                "$sqlite_plugin_implementation_folder_path = __DIR__ . '/plugins/sqlite-database-integration';",
+                "if (!defined('DATABASE_TYPE')) define('DATABASE_TYPE', 'sqlite');",
+                "if (!defined('DB_ENGINE')) define('DB_ENGINE', 'sqlite');",
+                "require_once $sqlite_plugin_implementation_folder_path . '/wp-includes/sqlite/db.php';",
+                '',
+            ].join('\n'));
+
+            // Create the database directory where the .ht.sqlite file will live.
+            mkdirSync(join(siteDir, 'wp-content', 'database'), { recursive: true });
+
+            // Write a full wp-config.php with SQLite constants.
+            // DB_HOST/DB_NAME/DB_USER/DB_PASSWORD are required by WordPress's
+            // config structure but are unused when the db.php drop-in is active.
+            writeFileSync(join(siteDir, 'wp-config.php'), [
+                '<?php',
+                "define('DB_HOST', 'unused');",
+                "define('DB_NAME', 'wordpress');",
+                "define('DB_USER', 'unused');",
+                "define('DB_PASSWORD', 'unused');",
+                "define('DB_CHARSET', 'utf8mb4');",
+                "define('DB_COLLATE', '');",
+                "define('AUTH_KEY',         'e2e-test-key-1');",
+                "define('SECURE_AUTH_KEY',  'e2e-test-key-2');",
+                "define('LOGGED_IN_KEY',    'e2e-test-key-3');",
+                "define('NONCE_KEY',        'e2e-test-key-4');",
+                "define('AUTH_SALT',        'e2e-test-salt-1');",
+                "define('SECURE_AUTH_SALT', 'e2e-test-salt-2');",
+                "define('LOGGED_IN_SALT',   'e2e-test-salt-3');",
+                "define('NONCE_SALT',       'e2e-test-salt-4');",
+                "$table_prefix = 'wp_';",
+                "if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');",
+                "require_once ABSPATH . 'wp-settings.php';",
+                '',
+            ].join('\n'));
+
+            // Install WordPress into the SQLite database.
+            // With the db.php drop-in in place, wp core install creates
+            // all standard WP tables in the .ht.sqlite file rather than MySQL.
+            const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
+            const port = new URL(getSiteUrl(site)).port;
+            execSync(
+                `php /tmp/wp-cli.phar core install` +
+                ` --path=${JSON.stringify(siteDir)}` +
+                ` --url="http://127.0.0.1:${port}"` +
+                ` --title="E2E: ${site}"` +
+                ` --admin_user=admin` +
+                ` --admin_password=password` +
+                ` --admin_email=admin@example.com` +
+                ` --skip-email` +
+                allowRoot,
+                { timeout: 60000, stdio: 'pipe' },
+            );
+
+            // Finish any pending DB upgrade before the site is served.
+            // On the Playground CLI job, the first PHP-FPM request can otherwise
+            // race WordPress's upgrade flow and briefly leave the fresh SQLite
+            // site in maintenance mode.
+            execSync(
+                `php /tmp/wp-cli.phar core update-db` +
+                ` --path=${JSON.stringify(siteDir)}` +
+                allowRoot,
+                { timeout: 60000, stdio: 'pipe' },
+            );
+            rmSync(join(siteDir, '.maintenance'), { force: true });
+
+            // Activate the site-export plugin.
+            execSync(
+                `php /tmp/wp-cli.phar plugin activate site-export` +
+                ` --path=${JSON.stringify(siteDir)}` +
+                allowRoot,
+                { timeout: 30000, stdio: 'pipe' },
+            );
+        },
+    });
+}
+
 describe('Import: SQLite Export', () => {
     const site = 'sqlite';
+    const legacySite = 'sqlite-legacy';
     let tempDir;
+    let legacyTempDir;
     const importDb = 'e2e_sqlite_import';
 
     beforeAll(async () => {
-        await ensureSite(site, {
-            db: 'none',
-            files: 'sample',
-            afterCreate: async (siteDir) => {
-                const pluginsDir = join(siteDir, 'wp-content', 'plugins');
-                const pluginDir = join(pluginsDir, 'sqlite-database-integration');
-
-                // Download and install the sqlite-database-integration plugin.
-                // Try WordPress.org first (zip), fall back to GitHub tarball.
-                const pluginZip = '/tmp/sqlite-database-integration.zip';
-                if (!existsSync(pluginZip) && !existsSync(pluginDir)) {
-                    try {
-                        execSync(
-                            `curl -sfL "https://downloads.wordpress.org/plugin/sqlite-database-integration.zip"` +
-                            ` -o "${pluginZip}"`,
-                            { timeout: 120000 },
-                        );
-                    } catch {
-                        // WordPress.org might not have it; try GitHub
-                        execSync(
-                            `curl -sfL "https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.tar.gz"` +
-                            ` -o "/tmp/sqlite-plugin-gh.tar.gz"`,
-                            { timeout: 120000 },
-                        );
-                        mkdirSync(pluginDir, { recursive: true });
-                        execSync(
-                            `tar xzf "/tmp/sqlite-plugin-gh.tar.gz"` +
-                            ` -C "${pluginDir}" --strip-components=1`,
-                            { timeout: 30000 },
-                        );
-                    }
-                }
-
-                // Extract the zip if we downloaded one and the plugin dir doesn't exist yet
-                if (existsSync(pluginZip) && !existsSync(pluginDir)) {
-                    try {
-                        execSync(
-                            `unzip -qo "${pluginZip}" -d "${pluginsDir}"`,
-                            { timeout: 30000 },
-                        );
-                    } catch {
-                        // unzip not available — fall back to PHP's ZipArchive
-                        execSync(
-                            `php -r "\\$z = new ZipArchive;` +
-                            ` \\$z->open('${pluginZip}');` +
-                            ` \\$z->extractTo('${pluginsDir}');` +
-                            ` \\$z->close();"`,
-                            { timeout: 30000 },
-                        );
-                    }
-                }
-
-                // Create the db.php drop-in that activates the SQLite backend.
-                // This mimics what the plugin writes when activated through the
-                // WordPress admin UI (based on the plugin's db.copy template).
-                writeFileSync(join(siteDir, 'wp-content', 'db.php'), [
-                    '<?php',
-                    "define('SQLITE_DB_DROPIN_VERSION', '1.8.0');",
-                    "$sqlite_plugin_implementation_folder_path = __DIR__ . '/plugins/sqlite-database-integration';",
-                    "if (!defined('DATABASE_TYPE')) define('DATABASE_TYPE', 'sqlite');",
-                    "if (!defined('DB_ENGINE')) define('DB_ENGINE', 'sqlite');",
-                    "require_once $sqlite_plugin_implementation_folder_path . '/wp-includes/sqlite/db.php';",
-                    '',
-                ].join('\n'));
-
-                // Create the database directory where the .ht.sqlite file will live.
-                mkdirSync(join(siteDir, 'wp-content', 'database'), { recursive: true });
-
-                // Write a full wp-config.php with SQLite constants.
-                // DB_HOST/DB_NAME/DB_USER/DB_PASSWORD are required by WordPress's
-                // config structure but are unused when the db.php drop-in is active.
-                // WP_SQLITE_AST_DRIVER enables the new AST-based query translator
-                // (WP_SQLite_Driver) that our export code relies on.
-                writeFileSync(join(siteDir, 'wp-config.php'), [
-                    '<?php',
-                    "define('DB_HOST', 'unused');",
-                    "define('DB_NAME', 'wordpress');",
-                    "define('DB_USER', 'unused');",
-                    "define('DB_PASSWORD', 'unused');",
-                    "define('DB_CHARSET', 'utf8mb4');",
-                    "define('DB_COLLATE', '');",
-                    "define('WP_SQLITE_AST_DRIVER', true);",
-                    "define('AUTH_KEY',         'e2e-test-key-1');",
-                    "define('SECURE_AUTH_KEY',  'e2e-test-key-2');",
-                    "define('LOGGED_IN_KEY',    'e2e-test-key-3');",
-                    "define('NONCE_KEY',        'e2e-test-key-4');",
-                    "define('AUTH_SALT',        'e2e-test-salt-1');",
-                    "define('SECURE_AUTH_SALT', 'e2e-test-salt-2');",
-                    "define('LOGGED_IN_SALT',   'e2e-test-salt-3');",
-                    "define('NONCE_SALT',       'e2e-test-salt-4');",
-                    "$table_prefix = 'wp_';",
-                    "if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');",
-                    "require_once ABSPATH . 'wp-settings.php';",
-                    '',
-                ].join('\n'));
-
-                // Install WordPress into the SQLite database.
-                // With the db.php drop-in in place, wp core install creates
-                // all standard WP tables in the .ht.sqlite file rather than MySQL.
-                const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
-                const port = 8102;
-                execSync(
-                    `php /tmp/wp-cli.phar core install` +
-                    ` --path=${JSON.stringify(siteDir)}` +
-                    ` --url="http://127.0.0.1:${port}"` +
-                    ` --title="E2E: sqlite"` +
-                    ` --admin_user=admin` +
-                    ` --admin_password=password` +
-                    ` --admin_email=admin@example.com` +
-                    ` --skip-email` +
-                    allowRoot,
-                    { timeout: 60000, stdio: 'pipe' },
-                );
-
-                // Finish any pending DB upgrade before the site is served.
-                // On the Playground CLI job, the first PHP-FPM request can otherwise
-                // race WordPress's upgrade flow and briefly leave the fresh SQLite
-                // site in maintenance mode.
-                execSync(
-                    `php /tmp/wp-cli.phar core update-db` +
-                    ` --path=${JSON.stringify(siteDir)}` +
-                    allowRoot,
-                    { timeout: 60000, stdio: 'pipe' },
-                );
-                rmSync(join(siteDir, '.maintenance'), { force: true });
-
-                // Activate the site-export plugin.
-                execSync(
-                    `php /tmp/wp-cli.phar plugin activate site-export` +
-                    ` --path=${JSON.stringify(siteDir)}` +
-                    allowRoot,
-                    { timeout: 30000, stdio: 'pipe' },
-                );
-            },
-        });
+        await ensureSqliteSite(site, '3.0.0');
+        await ensureSqliteSite(legacySite, '2.2.23');
 
         tempDir = createTempDir('e2e-import-sqlite');
+        legacyTempDir = createTempDir('e2e-import-sqlite-legacy');
 
         // Ensure the import target DB doesn't exist
         const conn = await createMysqlConnection();
@@ -169,13 +156,14 @@ describe('Import: SQLite Export', () => {
 
     afterAll(async () => {
         cleanupTempDir(tempDir);
+        cleanupTempDir(legacyTempDir);
         const conn = await createMysqlConnection();
         await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
         await conn.end();
     });
 
-    function importUrl() {
-        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    function importUrl(siteName = site) {
+        return `${getSiteUrl(siteName)}&directory=${getSiteDir(siteName)}`;
     }
 
     it('preflight reports SQLite engine', async () => {
@@ -204,6 +192,20 @@ describe('Import: SQLite Export', () => {
         assert.ok(sql.includes('wp_options'), 'Expected wp_options table in dump');
         assert.ok(sql.includes('wp_posts'), 'Expected wp_posts table in dump');
         assert.ok(sql.includes('wp_users'), 'Expected wp_users table in dump');
+    });
+
+    it('db-pull supports SQLite Database Integration 2.2.23', () => {
+        const result = runImporter(importUrl(legacySite), legacyTempDir, 'db-pull', {
+            secret: getSiteSecret(legacySite),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const sql = readFileSync(join(legacyTempDir, 'db.sql'), 'utf-8');
+        assert.ok(sql.includes('CREATE TABLE'), 'Expected CREATE TABLE in db.sql');
+        assert.ok(sql.includes('INSERT INTO'), 'Expected INSERT INTO in db.sql');
+        assert.ok(sql.includes('wp_options'), 'Expected wp_options table in dump');
+        assert.ok(sql.includes('wp_posts'), 'Expected wp_posts table in dump');
     });
 
     it('exported dump imports into MySQL and contains expected data', async () => {


### PR DESCRIPTION
Makes `db-pull` read WordPress database rows through the same public query surface whether the source site uses MySQL or SQLite Database Integration.

## Background

A MySQL site can answer `INFORMATION_SCHEMA` queries directly through PDO. A WordPress site backed by SQLite exposes a MySQL-compatible query translator through `$wpdb` instead. The exporter still needs the same facts from both sites: which tables exist, which columns they contain, how their primary keys are ordered, and which row comes next after an interrupted request.

There was also a separate boundary problem. When a large row is split into an `INSERT` followed by `UPDATE` chunks, the SQL statement boundary no longer matches the reader's bounded `SELECT` boundary. Using the INSERT row count to decide when to fetch again could retain a row from the next query before the current boundary was saved.

## This change

`DatabaseRowsReader` now discovers tables, columns, and primary keys with `SHOW FULL TABLES`, `SHOW FULL COLUMNS`, and `SHOW INDEX`. MySQL answers those queries directly. SQLite runs them through the plugin's active translator.

SQLite Database Integration 3.x supports that query shape directly. For the 2.x legacy translator, the adapter uses its filtered `SHOW TABLE STATUS` result, preserves returned composite-key order when no usable positions are reported, and retries the two metadata forms that the old parser cannot read with quoted identifiers. It does not depend on plugin implementation constants or class names.

The resumable cursor now records whether a retained row ended its bounded query. The producer checks that boundary before fetching again, including after oversized-row `UPDATE` chunks. Restore also realigns a caller-supplied table list, rejects a changed primary key, and releases each result set at the query boundary so SQLite does not retain a read lock while the caller processes the batch.

No new CLI option is required. The source engine comes from preflight.

## Usage

Pull either a MySQL-backed or SQLite-backed WordPress database into `db.sql`:

```bash
php reprint.phar db-pull "$URL" \
    --state-dir="$STATE_DIR" \
    --fs-root="$FS_ROOT" \
    --secret="$SECRET"
```

Stream the same export directly into MySQL:

```bash
php reprint.phar db-pull "$URL" \
    --state-dir="$STATE_DIR" \
    --fs-root="$FS_ROOT" \
    --secret="$SECRET" \
    --sql-output=mysql \
    --mysql-host=127.0.0.1 \
    --mysql-user=root \
    --mysql-password=secret \
    --mysql-database=wordpress
```

If `db-pull` stops, run the same command again. It resumes from the saved table and row cursor; there is no separate resume flag.

## Testing

The E2E suite provisions WordPress sites pinned to SQLite Database Integration 2.2.23 and 3.0.0 and pulls a SQL dump from both. The focused tests cover structured rows, composite primary keys, changed primary keys, SQLite read-lock release, retained rows across resume, and oversized rows crossing a query boundary.
