### PR TITLE
Fall back to $wpdb when PDO can’t connect

### DIFF
--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -264,15 +264,18 @@ function is_sqlite_site(): bool
 /**
  * Creates a database connection appropriate for the detected backend.
  *
- * For MySQL sites, returns a standard PDO connection.
+ * For MySQL sites, returns a standard PDO connection, falling back to the
+ * wpdb adapter when that connection fails and WordPress is loaded.
  * For SQLite sites, wraps the MySQL-on-SQLite driver which WordPress already
  * loaded in a PDO-compatible adapter. The driver's translator converts every
  * MySQL query to SQLite on the fly, so MySQLDumpProducer sees MySQL-shaped
  * results and produces valid MySQL SQL output.
  *
  * @param array $creds   Credentials from resolve_db_credentials().
- * @param array $options PDO options (only used for MySQL connections).
- * @return PDO A real PDO for MySQL, or a PDO-compatible adapter for SQLite.
+ * @param array $options PDO options. Reach the real PDO connection only; the
+ *                       wpdb adapter has no handle to set them on.
+ * @return PDO A real PDO for MySQL, or a PDO-compatible adapter for SQLite
+ *             and for MySQL hosts reached through wpdb.
  */
 function create_db_connection(array $creds, array $options = [])
 {
@@ -292,12 +295,22 @@ function create_db_connection(array $creds, array $options = [])
         ];
         $merged_options = $options + $default_options;
 
-        $mysql = new PDO(
-            build_pdo_dsn($creds['db_host'], $creds['db_name']),
-            $creds["db_user"],
-            $creds["db_password"],
-            $merged_options
-        );
+        try {
+            $mysql = new PDO(
+                build_pdo_dsn($creds['db_host'], $creds['db_name']),
+                $creds["db_user"],
+                $creds["db_password"],
+                $merged_options
+            );
+        } catch (PDOException $connection_error) {
+            global $wpdb;
+            if (!isset($wpdb) || !is_object($wpdb)) {
+                throw $connection_error;
+            }
+
+            // Fallback to using wpdb if we failed to connect directly to the database.
+            $mysql = create_wpdb_pdo_adapter();
+        }
     }
 
     // SET NAMES normalizes the client, connection, and result charsets plus

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -130,6 +130,117 @@ final class CreateDbConnectionTest extends TestCase {
         );
     }
 
+    public function testRefusedDirectConnectionFallsBackToWordPressDatabaseHandle(): void
+    {
+        if (!extension_loaded('pdo_mysql')) {
+            $this->markTestSkipped('pdo_mysql extension required');
+        }
+
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-server/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        class WpdbFallbackTestDouble {
+            public $last_error = '';
+            public $queries = [];
+            public function suppress_errors($suppress = true) {
+            }
+            public function hide_errors() {
+            }
+            public function get_results($query, $output) {
+                $this->queries[] = $query;
+                return [];
+            }
+        }
+        require $argv[1];
+        require $argv[2];
+        $wpdb = new WpdbFallbackTestDouble();
+        $GLOBALS['wpdb'] = $wpdb;
+        $connection = create_db_connection(
+            [
+                'db_engine' => 'mysql',
+                'db_host' => '127.0.0.1:1',
+                'db_name' => 'unused',
+                'db_user' => 'unused',
+                'db_password' => 'unused',
+            ],
+            [PDO::ATTR_TIMEOUT => 1]
+        );
+        fwrite(STDOUT, json_encode([
+            'class' => get_class($connection),
+            'queries' => $wpdb->queries,
+        ]));
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+        $this->assertSame(
+            [
+                'class' => 'WpdbDriverPDO',
+                'queries' => ['SET NAMES utf8mb4 COLLATE utf8mb4_bin'],
+            ],
+            json_decode($result['stdout'], true)
+        );
+    }
+
+    public function testRefusedDirectConnectionReportsTheDriverFailureWithoutWordPress(): void
+    {
+        if (!extension_loaded('pdo_mysql')) {
+            $this->markTestSkipped('pdo_mysql extension required');
+        }
+
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $export_path = realpath(__DIR__ . '/../packages/reprint-server/src/export.php');
+        $this->assertIsString($autoload_path);
+        $this->assertIsString($export_path);
+        $connection_script = <<<'PHP'
+        require $argv[1];
+        require $argv[2];
+        try {
+            create_db_connection(
+                [
+                    'db_engine' => 'mysql',
+                    'db_host' => '127.0.0.1:1',
+                    'db_name' => 'unused',
+                    'db_user' => 'unused',
+                    'db_password' => 'unused',
+                ],
+                [PDO::ATTR_TIMEOUT => 1]
+            );
+            fwrite(STDERR, "The connection unexpectedly completed.\n");
+            exit(2);
+        } catch (PDOException $exception) {
+            fwrite(STDOUT, $exception->getMessage());
+        }
+        PHP;
+
+        $result = $this->runPhpProcess([
+            PHP_BINARY,
+            '-r',
+            $connection_script,
+            $autoload_path,
+            $export_path,
+        ]);
+        $this->assertSame(
+            0,
+            $result['status'],
+            $result['stderr'] . $result['stdout']
+        );
+        $this->assertStringContainsString('SQLSTATE', $result['stdout']);
+        $this->assertStringNotContainsString('wpdb', $result['stdout']);
+    }
+
     public function testSqliteDatabaseIntegrationThreeDriverSupportsPreparedQueries(): void
     {
         if (!extension_loaded('pdo_sqlite')) {


### PR DESCRIPTION
Had a preflight fail with this error:

```
SQLSTATE[HY000] [3159] Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

Rather than attempt to find compatibility with misc hosts and their cert setups and whatnot, let's fall back to using $wpdb if the direct connection failed. That gives us much broader compat, for example with hosts that have custom db.php drop-ins.