### PR TITLE
[PHP] Resume transactional table imports after committed SQL groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional tables, the imported rows and source position commit together. `DROP TABLE` and `CREATE TABLE` are one source fragment and one client action. The target also saves the position before that pair while the table is being filled. A replacement process rebuilds the unfinished table before inserting its rows again, including for nontransactional tables.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional tables, the imported rows and source position commit together, and a replacement process continues after that position. `DROP TABLE` and `CREATE TABLE` are one source fragment and one client action. For a nontransactional table, the target keeps the position before that pair until the table finishes, so a replacement process rebuilds the unfinished table before inserting its rows again.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional tables, the imported rows and source position commit together. `DROP TABLE` and `CREATE TABLE` are one source fragment and one client action. The target also saves the position before that pair while the table is being filled. A replacement process rebuilds the unfinished table before inserting its rows again, including for nontransactional tables.
 
 ### Progress Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Entries in `paths_to_remove` under `wp-content/plugins/` also trigger automatic 
 
 ### SQL Streaming Crash Recovery
 
-When the export server crashes mid-SQL-stream (`--sql-output=mysql` mode), the importer detects the transport failure (missing completion chunk, curl communication errors), saves the cursor, persists accumulated SQL in `<remote-state-directory>/pull/sql-buffer`, and exits with code 2 for automatic retry. The next run reloads the buffer and continues. The `finally` block avoids masking the original exception with a secondary buffer-related throw.
+Direct MySQL output keeps incomplete SQL only in memory while one importer process requests more source responses. After each complete SQL group, it updates `__reprint_db_pull_progress` and commits the current target transaction. For transactional target tables, the imported rows and source position commit together. If the importer process stops, the next `db-pull` starts the dump from the beginning rather than using incomplete SQL from the dead process.
 
 ### Progress Tracking
 

--- a/README.md
+++ b/README.md
@@ -375,10 +375,11 @@ SQL group and its source position are committed together. A replacement
 process reads the target position before it asks for more SQL. Incomplete SQL
 stays in memory and is requested again after process death. The source sends
 each `DROP TABLE` + `CREATE TABLE` pair as one replacement action. While a
-table is being filled, the target also keeps the position before that pair.
-After process death, the replacement process rebuilds the unfinished table
-before inserting its rows again. This also works for nontransactional tables
-such as MyISAM.
+nontransactional table is being filled, the target also keeps the position
+before that pair. After process death, the replacement process rebuilds that
+unfinished table before inserting its rows again. Transactional tables such as
+InnoDB continue after their last committed SQL group instead of rebuilding the
+whole table.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -367,12 +367,13 @@ The three modes:
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
 | `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
 
-All three modes recover from server crashes mid-stream (PHP fatal errors,
-OOM kills, `max_execution_time` expiry). When the server dies before sending
-a completion chunk, the importer detects the transport failure, saves its
-cursor, and exits with code 2 for automatic retry. Accumulated SQL is
-persisted in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/sql-buffer`
-so the next run reloads it and continues.
+When a source response stops mid-stream, the same importer asks for the
+remaining SQL and keeps an unfinished statement in memory. Direct MySQL
+output stores the last committed source position in the target table
+`__reprint_db_pull_progress`. For transactional target tables, each completed
+SQL group and its source position are committed together. If the importer
+process stops, the next `db-pull` starts the dump from the beginning rather
+than relying on unfinished SQL from the dead process.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -670,9 +671,9 @@ are absent while the plan is still being built.
 #### `<remote-state-directory>/pull/state.json` — the pull state store
 
 This is the pull state store. Pull commands read it on startup and write it
-back periodically and on shutdown. It stores everything needed to resume after
-a crash or interruption: the current command, cursor position, AIMD tuning
-state, and per-phase bookmarks.
+back periodically and on shutdown. It stores the current command, cursor
+position, AIMD tuning state, and per-phase bookmarks. Direct MySQL output also
+records each committed source position in the target database.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to

--- a/README.md
+++ b/README.md
@@ -367,13 +367,18 @@ The three modes:
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
 | `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
 
-When a source response stops mid-stream, the same importer asks for the
-remaining SQL and keeps an unfinished statement in memory. Direct MySQL
-output stores the last committed source position in the target table
+When a source response stops mid-stream, the importer asks for the remaining
+SQL again. Direct MySQL output also survives importer process death. It stores
+the last committed source position in the target table
 `__reprint_db_pull_progress`. For transactional target tables, each completed
-SQL group and its source position are committed together. If the importer
-process stops, the next `db-pull` starts the dump from the beginning rather
-than relying on unfinished SQL from the dead process.
+SQL group and its source position are committed together. A replacement
+process reads the target position before it asks for more SQL. Incomplete SQL
+stays in memory and is requested again after process death. The source sends
+each `DROP TABLE` + `CREATE TABLE` pair as one replacement action. While a
+table is being filled, the target also keeps the position before that pair.
+After process death, the replacement process rebuilds the unfinished table
+before inserting its rows again. This also works for nontransactional tables
+such as MyISAM.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
@@ -672,8 +677,9 @@ are absent while the plan is still being built.
 
 This is the pull state store. Pull commands read it on startup and write it
 back periodically and on shutdown. It stores the current command, cursor
-position, AIMD tuning state, and per-phase bookmarks. Direct MySQL output also
-records each committed source position in the target database.
+position, AIMD tuning state, and per-phase bookmarks. Direct MySQL output uses
+the source position committed in the target database instead of the cursor in
+this file.
 
 Written atomically (temp file + rename) so a crash mid-write never corrupts it.
 If the JSON is invalid on load, the importer renames it to

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -192,8 +192,7 @@ their parent directories.
         │   ├── remote-index.next.jsonl
         │   ├── fetch-list.jsonl
         │   ├── volatile-files.json
-        │   ├── sql-stats.json
-        │   └── sql-buffer
+        │   └── sql-stats.json
         └── push/
 ```
 

--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -211,7 +211,6 @@ Use these path names:
 | Fetch list file | `$fetch_list_file` |
 | Volatile files file | `$volatile_files_file` |
 | SQL statistics file | `$sql_stats_file` |
-| SQL buffer file | `$sql_buffer_file` |
 | Audit log file | `$audit_log_file` |
 | Progress file | `$progress_file` |
 | Reprint process lock path | `$process_lock_path` |

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -172,6 +172,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress";
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -7455,13 +7456,13 @@ class ImportClient
 
         $sql_handle = null;
         $mysql_conn = null;
-        $sql_buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
         $session_setup_file = wp_join_unix_paths(
             $this->state_dir,
             "db-session-setup.sql",
         );
+        $mysql_committed_cursor = null;
 
         if ($mode === "file") {
             $sql_file = wp_join_unix_paths($this->state_dir, "db.sql");
@@ -7527,44 +7528,30 @@ class ImportClient
             }
             $mysql_conn->set_charset("utf8mb4");
 
-            if ($cursor !== null) {
-                $session_setup_sql = @file_get_contents($session_setup_file);
-                if ($session_setup_sql === false || trim($session_setup_sql) === "") {
-                    throw new RuntimeException(
-                        "Cannot resume db-pull because db-session-setup.sql is missing or empty. " .
-                        "Run db-pull --abort and start again.",
-                    );
-                }
-                $this->execute_mysql_queries($mysql_conn, $session_setup_sql);
-                $this->audit_log(
-                    "SQL OUTPUT mysql | ran saved session setup after reconnect",
-                    true,
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+            $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
+                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+                "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
+                "`source_cursor` MEDIUMTEXT NOT NULL" .
+                ") ENGINE=InnoDB";
+            if (!$mysql_conn->query($create_table_sql)) {
+                throw new RuntimeException(
+                    "MySQL could not create the db-pull progress table: " . $mysql_conn->error
                 );
             }
+            if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
+                throw new RuntimeException(
+                    "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
+                );
+            }
+            $cursor = null;
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
             $this->audit_log(
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
                 true,
             );
-
-            // Open a persistent buffer file so partial queries survive crashes.
-            // Each SQL chunk is appended to this file as it arrives; when the
-            // query completes and executes, the file is truncated. If the process
-            // dies at any point, the next run reloads whatever was accumulated.
-            $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-            if (file_exists($sql_buffer_file)) {
-                $sql_buffer = file_get_contents($sql_buffer_file);
-                $this->audit_log(
-                    sprintf("CRASH RECOVERY | Restored %d bytes from pull/sql-buffer", strlen($sql_buffer)),
-                    true,
-                );
-            }
-            // Open in write mode (truncate) if we loaded nothing, append if we
-            // have a partial query to continue accumulating into.
-            $sql_buffer_handle = fopen($sql_buffer_file, $sql_buffer !== "" ? "a" : "w");
-            if (!$sql_buffer_handle) {
-                throw new RuntimeException("Cannot open SQL buffer file: {$sql_buffer_file}");
-            }
         }
 
         // Count SQL statements during download for db-apply progress reporting.
@@ -7601,9 +7588,9 @@ class ImportClient
                     &$complete,
                     &$sql_handle,
                     $mysql_conn,
-                    &$sql_buffer_handle,
                     &$sql_buffer,
                     $session_setup_file,
+                    &$mysql_committed_cursor,
                     &$sql_bytes_written,
                     $context,
                     $query_stream,
@@ -7653,7 +7640,8 @@ class ImportClient
                         if ($sql_handle) {
                             fflush($sql_handle);
                         }
-                        $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                        $this->get_state()->active_resumable_command->remote_cursor =
+                            $mode === "mysql" ? $mysql_committed_cursor : $cursor;
                         $this->get_state()->sql_bytes = $sql_bytes_written;
                         $this->get_state()->sql_statements_counted = $sql_statements_counted;
                         $this->save_state();
@@ -7688,24 +7676,13 @@ class ImportClient
                                 break;
 
                             case "mysql":
-                                // Append to disk immediately so the buffer survives
-                                // even if the process is killed mid-chunk.
-                                if ($sql_buffer_handle) {
-                                    fwrite($sql_buffer_handle, $data);
-                                    fflush($sql_buffer_handle);
-                                }
-
                                 $sql_buffer .= $data;
                                 $sql_bytes_written += strlen($data);
 
                                 if ($query_complete) {
                                     $this->execute_mysql_queries($mysql_conn, $sql_buffer);
-
-                                    // Query executed — truncate the buffer file and reset.
-                                    if ($sql_buffer_handle) {
-                                        ftruncate($sql_buffer_handle, 0);
-                                        rewind($sql_buffer_handle);
-                                    }
+                                    $this->save_mysql_output_cursor($mysql_conn, $cursor);
+                                    $mysql_committed_cursor = $cursor;
                                     $sql_buffer = "";
                                 }
                                 break;
@@ -7813,7 +7790,8 @@ class ImportClient
                     fflush($sql_handle);
                 }
 
-                $this->get_state()->active_resumable_command->remote_cursor = $cursor;
+                $this->get_state()->active_resumable_command->remote_cursor =
+                    $mode === "mysql" ? $mysql_committed_cursor : $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->get_state()->sql_bytes = $complete ? null : $sql_bytes_written;
                 $this->save_state();
@@ -7849,30 +7827,15 @@ class ImportClient
             if ($sql_handle) {
                 fclose($sql_handle);
             }
-            if ($sql_buffer_handle) {
-                fclose($sql_buffer_handle);
-                $sql_buffer_handle = null;
-            }
             if ($mysql_conn) {
                 $pending = $sql_buffer;
                 $mysql_conn->close();
                 $mysql_conn = null;
-                // Clean up buffer file — if we got here with an empty buffer,
-                // all queries were executed successfully.
-                $sql_buffer_file = wp_join_unix_paths($this->pull_state_directory, "sql-buffer");
-                if ($pending === "" && file_exists($sql_buffer_file)) {
-                    unlink($sql_buffer_file);
-                }
                 if ($pending !== "") {
                     if ($caught_exception !== null) {
-                        // An exception is already in flight (e.g. curl error,
-                        // MySQL error). Don't mask it by throwing about the
-                        // buffer — the buffer data is safely persisted in
-                        // pull/sql-buffer and will be recovered on the next run.
                         $this->audit_log(
-                            "BUFFER NOT FLUSHED | " . strlen($pending) .
-                            " bytes in SQL buffer during exception unwind" .
-                            " (original error: " . $caught_exception->getMessage() . ")",
+                            "DISCARDED INCOMPLETE SQL | " . strlen($pending) .
+                            " bytes | a new process will request the dump from the beginning",
                             true,
                         );
                     } else {
@@ -7888,6 +7851,39 @@ class ImportClient
                 " bytes) — incomplete export?"
             );
         }
+    }
+
+    /** Saves the source cursor and commits the current target transaction. */
+    private function save_mysql_output_cursor(\mysqli $connection, ?string $cursor): void
+    {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        if ($cursor === null) {
+            throw new RuntimeException("The source returned SQL without a position to save.");
+        }
+
+        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+        $statement = $connection->prepare(
+            "INSERT INTO `{$table}` (`id`, `source_hash`, `source_cursor`) VALUES (1, ?, ?) " .
+            "ON DUPLICATE KEY UPDATE `source_hash` = VALUES(`source_hash`), " .
+            "`source_cursor` = VALUES(`source_cursor`)"
+        );
+        if (!$statement) {
+            throw new RuntimeException("MySQL could not prepare the db-pull position update: " . $connection->error);
+        }
+
+        $source_hash = hash("sha256", $this->remote_reprint_api_url);
+        $statement->bind_param("ss", $source_hash, $cursor);
+        if (!$statement->execute()) {
+            $error = $statement->error;
+            $statement->close();
+            throw new RuntimeException("MySQL could not save the db-pull position: " . $error);
+        }
+        $statement->close();
+
+        if (!$connection->commit()) {
+            throw new RuntimeException("MySQL could not commit the imported SQL and its source position: " . $connection->error);
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
     }
 
     /** Count complete SQL queries waiting in the stream. */

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7527,7 +7527,10 @@ class ImportClient
                     $source_table_name = is_array($source_table)
                         ? $source_table["name"] ?? null
                         : null;
-                    if ($source_table_name === $table) {
+                    if (
+                        is_string($source_table_name)
+                        && strcasecmp($source_table_name, $table) === 0
+                    ) {
                         throw new RuntimeException(
                             "The source database has a table named {$table}, which Reprint needs " .
                             "to save db-pull progress. Rename that source table before using " .

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -7723,14 +7723,31 @@ class ImportClient
                                 $sql_bytes_written += strlen($data);
 
                                 if ($query_complete) {
-                                    $table_start_cursor = $sql_action === "replace_table"
-                                        ? $mysql_committed_cursor
-                                        : null;
+                                    $replaces_table = $sql_action === "replace_table";
+                                    $replaced_table = null;
+                                    if ($replaces_table) {
+                                        $encoded_table = $chunk["headers"]["x-table-name-base64"] ?? "";
+                                        $replaced_table = base64_decode($encoded_table, true);
+                                        if ($replaced_table === false || $replaced_table === "") {
+                                            throw new RuntimeException(
+                                                "The source did not identify the table being replaced."
+                                            );
+                                        }
+                                    }
                                     $this->execute_mysql_queries($mysql_conn, $sql_buffer);
+                                    $table_start_cursor =
+                                        $replaces_table &&
+                                        !$this->mysql_table_supports_transactions(
+                                            $mysql_conn,
+                                            $replaced_table,
+                                        )
+                                            ? $mysql_committed_cursor
+                                            : null;
                                     $this->save_mysql_output_cursor(
                                         $mysql_conn,
                                         $cursor,
                                         $table_start_cursor,
+                                        $replaces_table,
                                     );
                                     $mysql_committed_cursor = $cursor;
                                     $sql_buffer = "";
@@ -7925,6 +7942,46 @@ class ImportClient
         }
     }
 
+    /** Returns whether the target table's actual storage engine supports transactions. */
+    private function mysql_table_supports_transactions(
+        \mysqli $connection,
+        string $table_name
+    ): bool {
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        $statement = $connection->prepare(
+            "SELECT `TABLES`.`TABLE_TYPE`, `ENGINES`.`TRANSACTIONS` " .
+            "FROM `INFORMATION_SCHEMA`.`TABLES` AS `TABLES` " .
+            "LEFT JOIN `INFORMATION_SCHEMA`.`ENGINES` AS `ENGINES` " .
+            "ON `ENGINES`.`ENGINE` = `TABLES`.`ENGINE` " .
+            "WHERE `TABLES`.`TABLE_SCHEMA` = DATABASE() " .
+            "AND BINARY `TABLES`.`TABLE_NAME` = BINARY ?"
+        );
+        if (!$statement) {
+            throw new RuntimeException(
+                "MySQL could not prepare the target table engine query: " . $connection->error
+            );
+        }
+        $statement->bind_param("s", $table_name);
+        if (!$statement->execute()) {
+            $error = $statement->error;
+            $statement->close();
+            throw new RuntimeException("MySQL could not read the target table engine: " . $error);
+        }
+        $table_type = null;
+        $transactions = null;
+        $statement->bind_result($table_type, $transactions);
+        $found_table = $statement->fetch() === true;
+        $statement->close();
+        if (!$found_table) {
+            throw new RuntimeException(
+                "MySQL created no target table or view named `{$table_name}`."
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        // Views have no storage engine and no rows to replay.
+        return $table_type === "VIEW" || $transactions === "YES";
+    }
+
     /** Starts a fresh target import or returns the source cursor saved by MySQL. */
     private function start_or_resume_mysql_output(
         \mysqli $connection,
@@ -8079,7 +8136,8 @@ class ImportClient
     private function save_mysql_output_cursor(
         \mysqli $connection,
         ?string $cursor,
-        ?string $table_start_cursor = null
+        ?string $table_start_cursor = null,
+        bool $replaces_table = false
     ): void
     {
         if ($cursor === null) {
@@ -8092,14 +8150,15 @@ class ImportClient
             "VALUES (1, ?, ?, ?) " .
             "ON DUPLICATE KEY UPDATE `source_hash` = VALUES(`source_hash`), " .
             "`source_cursor` = VALUES(`source_cursor`), " .
-            "`table_start_cursor` = COALESCE(VALUES(`table_start_cursor`), `table_start_cursor`)"
+            "`table_start_cursor` = IF(? = 1, VALUES(`table_start_cursor`), `table_start_cursor`)"
         );
         if (!$statement) {
             throw new RuntimeException("MySQL could not prepare the db-pull position update: " . $connection->error);
         }
 
         $source_hash = hash("sha256", $this->remote_reprint_api_url);
-        $statement->bind_param("sss", $source_hash, $cursor, $table_start_cursor);
+        $replace_table = $replaces_table ? 1 : 0;
+        $statement->bind_param("sssi", $source_hash, $cursor, $table_start_cursor, $replace_table);
         if (!$statement->execute()) {
             $error = $statement->error;
             $statement->close();

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -173,6 +173,7 @@ class ImportClient
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
     private const MYSQL_DB_PULL_PROGRESS_TABLE = "__reprint_db_pull_progress";
+    private const MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT = "Reprint db-pull progress v1";
 
     /**
      * Maximum number of consecutive interrupted responses with no cursor
@@ -7507,6 +7508,36 @@ class ImportClient
             $user = $this->mysql_user ?? "root";
             $pass = $this->mysql_password ?? "";
             $name = $this->mysql_database;
+            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+
+            $tables_file = wp_join_unix_paths($this->state_dir, "db-tables.jsonl");
+            $tables_handle = @fopen($tables_file, "r");
+            if (!$tables_handle) {
+                throw new RuntimeException(
+                    "Cannot check the source table names because db-tables.jsonl cannot be read."
+                );
+            }
+            try {
+                while (true) {
+                    $table_line = fgets($tables_handle);
+                    if ($table_line === false) {
+                        break;
+                    }
+                    $source_table = json_decode($table_line, true);
+                    $source_table_name = is_array($source_table)
+                        ? $source_table["name"] ?? null
+                        : null;
+                    if ($source_table_name === $table) {
+                        throw new RuntimeException(
+                            "The source database has a table named {$table}, which Reprint needs " .
+                            "to save db-pull progress. Rename that source table before using " .
+                            "--sql-output=mysql."
+                        );
+                    }
+                }
+            } finally {
+                fclose($tables_handle);
+            }
 
             // Parse host for port/socket (same format as WordPress DB_HOST).
             // An explicit --mysql-port takes precedence over a port embedded
@@ -7529,17 +7560,91 @@ class ImportClient
             $mysql_conn->set_charset("utf8mb4");
 
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
-            $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
             $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
                 "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
                 "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
                 "`source_cursor` MEDIUMTEXT NOT NULL" .
-                ") ENGINE=InnoDB";
+                ") ENGINE=InnoDB COMMENT='" . self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT . "'";
             if (!$mysql_conn->query($create_table_sql)) {
                 throw new RuntimeException(
                     "MySQL could not create the db-pull progress table: " . $mysql_conn->error
                 );
             }
+
+            $table_result = $mysql_conn->query(
+                "SELECT `ENGINE`, `TABLE_COMMENT` FROM `INFORMATION_SCHEMA`.`TABLES` " .
+                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}'"
+            );
+            if (!$table_result) {
+                throw new RuntimeException(
+                    "MySQL could not inspect the db-pull progress table: " . $mysql_conn->error
+                );
+            }
+            $table_info = $table_result->fetch_assoc();
+            $table_result->free();
+            $table_engine = strtoupper($table_info["ENGINE"] ?? "");
+            $table_comment = $table_info["TABLE_COMMENT"] ?? "";
+            if (
+                !$table_info ||
+                $table_engine !== "INNODB" ||
+                $table_comment !== self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT
+            ) {
+                throw new RuntimeException(
+                    "The target database already has a table named {$table}, and Reprint did not create it. " .
+                    "Rename or remove that table before using --sql-output=mysql."
+                );
+            }
+
+            $columns_result = $mysql_conn->query(
+                "SELECT `COLUMN_NAME`, `DATA_TYPE`, `COLUMN_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, " .
+                "`IS_NULLABLE`, `COLUMN_KEY` FROM `INFORMATION_SCHEMA`.`COLUMNS` " .
+                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}' " .
+                "ORDER BY `ORDINAL_POSITION`"
+            );
+            if (!$columns_result) {
+                throw new RuntimeException(
+                    "MySQL could not inspect the db-pull progress columns: " . $mysql_conn->error
+                );
+            }
+            $columns = [];
+            while (true) {
+                $column = $columns_result->fetch_assoc();
+                if (!$column) {
+                    break;
+                }
+                $columns[$column["COLUMN_NAME"]] = $column;
+            }
+            $columns_result->free();
+            $id_column = $columns["id"] ?? [];
+            $source_hash_column = $columns["source_hash"] ?? [];
+            $source_cursor_column = $columns["source_cursor"] ?? [];
+            $id_data_type = $id_column["DATA_TYPE"] ?? null;
+            $id_column_type = $id_column["COLUMN_TYPE"] ?? "";
+            $id_is_nullable = $id_column["IS_NULLABLE"] ?? null;
+            $id_key = $id_column["COLUMN_KEY"] ?? null;
+            $source_hash_data_type = $source_hash_column["DATA_TYPE"] ?? null;
+            $source_hash_length = $source_hash_column["CHARACTER_MAXIMUM_LENGTH"] ?? 0;
+            $source_hash_is_nullable = $source_hash_column["IS_NULLABLE"] ?? null;
+            $source_cursor_data_type = $source_cursor_column["DATA_TYPE"] ?? null;
+            $source_cursor_is_nullable = $source_cursor_column["IS_NULLABLE"] ?? null;
+            $has_expected_columns =
+                array_keys($columns) === ["id", "source_hash", "source_cursor"] &&
+                $id_data_type === "tinyint" &&
+                strpos($id_column_type, "unsigned") !== false &&
+                $id_is_nullable === "NO" &&
+                $id_key === "PRI" &&
+                $source_hash_data_type === "char" &&
+                (int) $source_hash_length === 64 &&
+                $source_hash_is_nullable === "NO" &&
+                $source_cursor_data_type === "mediumtext" &&
+                $source_cursor_is_nullable === "NO";
+            if (!$has_expected_columns) {
+                throw new RuntimeException(
+                    "The target table {$table} does not have the columns Reprint expects. " .
+                    "Remove it before using --sql-output=mysql."
+                );
+            }
+
             if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
                 throw new RuntimeException(
                     "MySQL could not reset the previous db-pull position: " . $mysql_conn->error

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3742,7 +3742,11 @@ class ImportClient
 
         $has_progress =
             $state_command === "db-pull" &&
-            ($this->get_state()->active_resumable_command->completion_state ?? null) === "in_progress";
+            in_array(
+                $this->get_state()->active_resumable_command->completion_state ?? null,
+                ["in_progress", "partial"],
+                true,
+            );
         $current_status =
             $state_command === "db-pull"
                 ? $this->get_state()->active_resumable_command->completion_state ?? null
@@ -3769,6 +3773,8 @@ class ImportClient
         }
 
         if ($has_progress) {
+            $this->get_state()->active_resumable_command->completion_state = "in_progress";
+            $this->save_state();
             $stage = $this->get_state()->active_resumable_command->current_stage ?? "db-index";
             $this->audit_log(
                 sprintf(
@@ -3847,7 +3853,7 @@ class ImportClient
             "message" => "Downloading SQL dump",
         ]);
 
-        $this->fetch_sql();
+        $this->fetch_sql($has_progress);
 
         // Interrupted response during SQL download — state already saved, exit partial.
         if (($this->get_state()->active_resumable_command->completion_state ?? null) === "partial") {
@@ -7447,7 +7453,7 @@ class ImportClient
     /**
      * Download SQL from remote.
      */
-    private function fetch_sql(): void
+    private function fetch_sql(bool $is_resuming_database_pull = false): void
     {
         $cursor = $this->get_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
@@ -7561,100 +7567,28 @@ class ImportClient
                 throw new RuntimeException("MySQL connection failed: " . $mysql_conn->connect_error);
             }
             $mysql_conn->set_charset("utf8mb4");
+            $this->acquire_mysql_output_lock($mysql_conn);
 
-            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
-            $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
-                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
-                "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
-                "`source_cursor` MEDIUMTEXT NOT NULL" .
-                ") ENGINE=InnoDB COMMENT='" . self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT . "'";
-            if (!$mysql_conn->query($create_table_sql)) {
-                throw new RuntimeException(
-                    "MySQL could not create the db-pull progress table: " . $mysql_conn->error
-                );
-            }
-
-            $table_result = $mysql_conn->query(
-                "SELECT `ENGINE`, `TABLE_COMMENT` FROM `INFORMATION_SCHEMA`.`TABLES` " .
-                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}'"
+            $cursor = $this->start_or_resume_mysql_output(
+                $mysql_conn,
+                $is_resuming_database_pull,
             );
-            if (!$table_result) {
-                throw new RuntimeException(
-                    "MySQL could not inspect the db-pull progress table: " . $mysql_conn->error
-                );
-            }
-            $table_info = $table_result->fetch_assoc();
-            $table_result->free();
-            $table_engine = strtoupper($table_info["ENGINE"] ?? "");
-            $table_comment = $table_info["TABLE_COMMENT"] ?? "";
-            if (
-                !$table_info ||
-                $table_engine !== "INNODB" ||
-                $table_comment !== self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT
-            ) {
-                throw new RuntimeException(
-                    "The target database already has a table named {$table}, and Reprint did not create it. " .
-                    "Rename or remove that table before using --sql-output=mysql."
-                );
-            }
+            $mysql_committed_cursor = $cursor;
 
-            $columns_result = $mysql_conn->query(
-                "SELECT `COLUMN_NAME`, `DATA_TYPE`, `COLUMN_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, " .
-                "`IS_NULLABLE`, `COLUMN_KEY` FROM `INFORMATION_SCHEMA`.`COLUMNS` " .
-                "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}' " .
-                "ORDER BY `ORDINAL_POSITION`"
-            );
-            if (!$columns_result) {
-                throw new RuntimeException(
-                    "MySQL could not inspect the db-pull progress columns: " . $mysql_conn->error
-                );
-            }
-            $columns = [];
-            while (true) {
-                $column = $columns_result->fetch_assoc();
-                if (!$column) {
-                    break;
+            if ($cursor !== null) {
+                $session_setup_sql = @file_get_contents($session_setup_file);
+                if ($session_setup_sql === false || trim($session_setup_sql) === "") {
+                    throw new RuntimeException(
+                        "Cannot resume db-pull because db-session-setup.sql is missing or empty. " .
+                        "Run db-pull --abort and start again.",
+                    );
                 }
-                $columns[$column["COLUMN_NAME"]] = $column;
-            }
-            $columns_result->free();
-            $id_column = $columns["id"] ?? [];
-            $source_hash_column = $columns["source_hash"] ?? [];
-            $source_cursor_column = $columns["source_cursor"] ?? [];
-            $id_data_type = $id_column["DATA_TYPE"] ?? null;
-            $id_column_type = $id_column["COLUMN_TYPE"] ?? "";
-            $id_is_nullable = $id_column["IS_NULLABLE"] ?? null;
-            $id_key = $id_column["COLUMN_KEY"] ?? null;
-            $source_hash_data_type = $source_hash_column["DATA_TYPE"] ?? null;
-            $source_hash_length = $source_hash_column["CHARACTER_MAXIMUM_LENGTH"] ?? 0;
-            $source_hash_is_nullable = $source_hash_column["IS_NULLABLE"] ?? null;
-            $source_cursor_data_type = $source_cursor_column["DATA_TYPE"] ?? null;
-            $source_cursor_is_nullable = $source_cursor_column["IS_NULLABLE"] ?? null;
-            $has_expected_columns =
-                array_keys($columns) === ["id", "source_hash", "source_cursor"] &&
-                $id_data_type === "tinyint" &&
-                strpos($id_column_type, "unsigned") !== false &&
-                $id_is_nullable === "NO" &&
-                $id_key === "PRI" &&
-                $source_hash_data_type === "char" &&
-                (int) $source_hash_length === 64 &&
-                $source_hash_is_nullable === "NO" &&
-                $source_cursor_data_type === "mediumtext" &&
-                $source_cursor_is_nullable === "NO";
-            if (!$has_expected_columns) {
-                throw new RuntimeException(
-                    "The target table {$table} does not have the columns Reprint expects. " .
-                    "Remove it before using --sql-output=mysql."
+                $this->execute_mysql_queries($mysql_conn, $session_setup_sql);
+                $this->audit_log(
+                    "SQL OUTPUT mysql | ran saved session setup after reconnect",
+                    true,
                 );
             }
-
-            if (!$mysql_conn->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
-                throw new RuntimeException(
-                    "MySQL could not reset the previous db-pull position: " . $mysql_conn->error
-                );
-            }
-            $cursor = null;
-            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
             $this->audit_log(
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
@@ -7757,6 +7691,7 @@ class ImportClient
                     }
 
                     if ($chunk_type === "sql") {
+                        $sql_action = $chunk["headers"]["x-sql-action"] ?? "sql";
                         $query_complete = ($chunk["headers"]["x-query-complete"] ?? "1") === "1";
                         $data = $chunk["body"];
 
@@ -7788,8 +7723,15 @@ class ImportClient
                                 $sql_bytes_written += strlen($data);
 
                                 if ($query_complete) {
+                                    $table_start_cursor = $sql_action === "replace_table"
+                                        ? $mysql_committed_cursor
+                                        : null;
                                     $this->execute_mysql_queries($mysql_conn, $sql_buffer);
-                                    $this->save_mysql_output_cursor($mysql_conn, $cursor);
+                                    $this->save_mysql_output_cursor(
+                                        $mysql_conn,
+                                        $cursor,
+                                        $table_start_cursor,
+                                    );
                                     $mysql_committed_cursor = $cursor;
                                     $sql_buffer = "";
                                 }
@@ -7943,7 +7885,7 @@ class ImportClient
                     if ($caught_exception !== null) {
                         $this->audit_log(
                             "DISCARDED INCOMPLETE SQL | " . strlen($pending) .
-                            " bytes | a new process will request the dump from the beginning",
+                            " bytes | the next process will continue from the target database position",
                             true,
                         );
                     } else {
@@ -7961,26 +7903,203 @@ class ImportClient
         }
     }
 
-    /** Saves the source cursor and commits the current target transaction. */
-    private function save_mysql_output_cursor(\mysqli $connection, ?string $cursor): void
+    /** Waits until no earlier db-pull connection is still changing this target. */
+    private function acquire_mysql_output_lock(\mysqli $connection): void
     {
+        $lock_name = "reprint-db-pull-" . substr(
+            hash("sha256", (string) $this->mysql_database),
+            0,
+            40,
+        );
+        $result = $connection->query(
+            "SELECT GET_LOCK('{$lock_name}', 60) AS `lock_acquired`"
+        );
+        $row = $result ? $result->fetch_assoc() : null;
+        if ($result) {
+            $result->free();
+        }
+        if ( (int) ( $row["lock_acquired"] ?? 0 ) !== 1) {
+            throw new RuntimeException(
+                "The target database is still being changed by another db-pull. Try again after it finishes."
+            );
+        }
+    }
+
+    /** Starts a fresh target import or returns the source cursor saved by MySQL. */
+    private function start_or_resume_mysql_output(
+        \mysqli $connection,
+        bool $is_resuming_database_pull
+    ): ?string {
         // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- MySQL errors are CLI text, not HTML.
+        $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
+        $create_table_sql = "CREATE TABLE IF NOT EXISTS `{$table}` (" .
+            "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+            "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
+            "`source_cursor` MEDIUMTEXT NOT NULL," .
+            "`table_start_cursor` MEDIUMTEXT NULL" .
+            ") ENGINE=InnoDB COMMENT='" . self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT . "'";
+        if (!$connection->query($create_table_sql)) {
+            throw new RuntimeException("MySQL could not create the db-pull progress table: " . $connection->error);
+        }
+
+        $table_result = $connection->query(
+            "SELECT `ENGINE`, `TABLE_COMMENT` FROM `INFORMATION_SCHEMA`.`TABLES` " .
+            "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}'"
+        );
+        if (!$table_result) {
+            throw new RuntimeException(
+                "MySQL could not inspect the db-pull progress table: " . $connection->error
+            );
+        }
+        $table_info = $table_result->fetch_assoc();
+        $table_result->free();
+        $table_engine = strtoupper($table_info["ENGINE"] ?? "");
+        $table_comment = $table_info["TABLE_COMMENT"] ?? "";
+        if (
+            !$table_info ||
+            $table_engine !== "INNODB" ||
+            $table_comment !== self::MYSQL_DB_PULL_PROGRESS_TABLE_COMMENT
+        ) {
+            throw new RuntimeException(
+                "The target database already has a table named {$table}, and Reprint did not create it. " .
+                "Rename or remove that table before using --sql-output=mysql."
+            );
+        }
+
+        $columns_result = $connection->query(
+            "SELECT `COLUMN_NAME`, `DATA_TYPE`, `COLUMN_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, " .
+            "`IS_NULLABLE`, `COLUMN_KEY` FROM `INFORMATION_SCHEMA`.`COLUMNS` " .
+            "WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '{$table}' " .
+            "ORDER BY `ORDINAL_POSITION`"
+        );
+        if (!$columns_result) {
+            throw new RuntimeException(
+                "MySQL could not inspect the db-pull progress columns: " . $connection->error
+            );
+        }
+        $columns = [];
+        while (true) {
+            $column = $columns_result->fetch_assoc();
+            if (!$column) {
+                break;
+            }
+            $columns[$column["COLUMN_NAME"]] = $column;
+        }
+        $columns_result->free();
+        $id_column = $columns["id"] ?? [];
+        $source_hash_column = $columns["source_hash"] ?? [];
+        $source_cursor_column = $columns["source_cursor"] ?? [];
+        $table_start_column = $columns["table_start_cursor"] ?? null;
+        $id_data_type = $id_column["DATA_TYPE"] ?? null;
+        $id_column_type = $id_column["COLUMN_TYPE"] ?? "";
+        $id_is_nullable = $id_column["IS_NULLABLE"] ?? null;
+        $id_key = $id_column["COLUMN_KEY"] ?? null;
+        $source_hash_data_type = $source_hash_column["DATA_TYPE"] ?? null;
+        $source_hash_length = $source_hash_column["CHARACTER_MAXIMUM_LENGTH"] ?? 0;
+        $source_hash_is_nullable = $source_hash_column["IS_NULLABLE"] ?? null;
+        $source_cursor_data_type = $source_cursor_column["DATA_TYPE"] ?? null;
+        $source_cursor_is_nullable = $source_cursor_column["IS_NULLABLE"] ?? null;
+        $column_names = array_keys($columns);
+        $has_table_start_cursor = $table_start_column !== null;
+        $has_base_column_names = $column_names === ["id", "source_hash", "source_cursor"];
+        $has_table_start_column_names =
+            $column_names === ["id", "source_hash", "source_cursor", "table_start_cursor"];
+        $table_start_data_type = $table_start_column["DATA_TYPE"] ?? null;
+        $table_start_is_nullable = $table_start_column["IS_NULLABLE"] ?? null;
+        $has_expected_column_names = $has_base_column_names || $has_table_start_column_names;
+        $has_expected_table_start_column =
+            !$has_table_start_cursor ||
+            $table_start_data_type === "mediumtext" && $table_start_is_nullable === "YES";
+        $has_expected_columns =
+            $has_expected_column_names &&
+            $id_data_type === "tinyint" &&
+            strpos($id_column_type, "unsigned") !== false &&
+            $id_is_nullable === "NO" &&
+            $id_key === "PRI" &&
+            $source_hash_data_type === "char" &&
+            (int) $source_hash_length === 64 &&
+            $source_hash_is_nullable === "NO" &&
+            $source_cursor_data_type === "mediumtext" &&
+            $source_cursor_is_nullable === "NO" &&
+            $has_expected_table_start_column;
+        if (!$has_expected_columns) {
+            throw new RuntimeException(
+                "The target table {$table} does not have the columns Reprint expects. " .
+                "Remove it before using --sql-output=mysql."
+            );
+        }
+
+        if (!$has_table_start_cursor) {
+            if (!$connection->query(
+                "ALTER TABLE `{$table}` ADD COLUMN `table_start_cursor` MEDIUMTEXT NULL"
+            )) {
+                throw new RuntimeException(
+                    "MySQL could not prepare the db-pull progress table for table replacement: " .
+                    $connection->error
+                );
+            }
+            // The earlier table has no position before DROP + CREATE. Start the
+            // dump over rather than continue through a possibly unfinished table.
+            $is_resuming_database_pull = false;
+        }
+
+        if (!$is_resuming_database_pull) {
+            if (!$connection->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
+                throw new RuntimeException("MySQL could not reset the previous db-pull position: " . $connection->error);
+            }
+            return null;
+        }
+
+        $result = $connection->query(
+            "SELECT `source_hash`, `source_cursor`, `table_start_cursor` " .
+            "FROM `{$table}` WHERE `id` = 1"
+        );
+        if (!$result) {
+            throw new RuntimeException("MySQL could not read the saved db-pull position: " . $connection->error);
+        }
+        $row = $result->fetch_assoc();
+        $result->free();
+        if (!$row) {
+            return null;
+        }
+
+        $source_hash = hash("sha256", $this->remote_reprint_api_url);
+        if (!hash_equals($source_hash, $row["source_hash"])) {
+            if (!$connection->query("DELETE FROM `{$table}` WHERE `id` = 1")) {
+                throw new RuntimeException("MySQL could not reset the saved db-pull position: " . $connection->error);
+            }
+            return null;
+        }
+
+        $this->audit_log("SQL OUTPUT mysql | continuing from the position saved in the target database", true);
+        return $row["table_start_cursor"] ?? $row["source_cursor"];
+    }
+
+    /** Saves the source cursor and commits the current target transaction. */
+    private function save_mysql_output_cursor(
+        \mysqli $connection,
+        ?string $cursor,
+        ?string $table_start_cursor = null
+    ): void
+    {
         if ($cursor === null) {
             throw new RuntimeException("The source returned SQL without a position to save.");
         }
 
         $table = self::MYSQL_DB_PULL_PROGRESS_TABLE;
         $statement = $connection->prepare(
-            "INSERT INTO `{$table}` (`id`, `source_hash`, `source_cursor`) VALUES (1, ?, ?) " .
+            "INSERT INTO `{$table}` (`id`, `source_hash`, `source_cursor`, `table_start_cursor`) " .
+            "VALUES (1, ?, ?, ?) " .
             "ON DUPLICATE KEY UPDATE `source_hash` = VALUES(`source_hash`), " .
-            "`source_cursor` = VALUES(`source_cursor`)"
+            "`source_cursor` = VALUES(`source_cursor`), " .
+            "`table_start_cursor` = COALESCE(VALUES(`table_start_cursor`), `table_start_cursor`)"
         );
         if (!$statement) {
             throw new RuntimeException("MySQL could not prepare the db-pull position update: " . $connection->error);
         }
 
         $source_hash = hash("sha256", $this->remote_reprint_api_url);
-        $statement->bind_param("ss", $source_hash, $cursor);
+        $statement->bind_param("sss", $source_hash, $cursor, $table_start_cursor);
         if (!$statement->execute()) {
             $error = $statement->error;
             $statement->close();

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -103,6 +103,9 @@ class MySQLDumpProducer
     /** @var int */
     private $current_statement_size = 0;
 
+    /** @var string */
+    private $current_sql_fragment_type = "sql";
+
     /**
      * @param PDO $db Database connection — either a real PDO (MySQL) or a
      *        PDO-compatible adapter (SQLite sites). No type hint because the
@@ -130,6 +133,12 @@ class MySQLDumpProducer
         return $this->current_sql_fragment;
     }
 
+    /** Returns "replace_table" for a DROP + CREATE pair, or "sql" otherwise. */
+    public function get_sql_fragment_type(): string
+    {
+        return $this->current_sql_fragment_type;
+    }
+
     public function is_finished(): bool
     {
         return self::STATE_FINISHED === $this->state;
@@ -146,6 +155,8 @@ class MySQLDumpProducer
         if ($this->is_finished()) {
             return false;
         }
+
+        $this->current_sql_fragment_type = "sql";
 
         if (self::STATE_INIT === $this->state) {
             if (!$this->row_reader->has_initialized_tables()) {
@@ -376,6 +387,7 @@ class MySQLDumpProducer
             $header = "--\n-- Table structure for table ".str_replace("\n",'\n',$quoted_table)."\n--\n\n";
             $drop = "DROP TABLE IF EXISTS {$quoted_table};\n";
             $this->current_sql_fragment = $header . $drop . $sql . ";";
+            $this->current_sql_fragment_type = "replace_table";
         } else {
             $keys = $row ? implode(", ", array_keys($row)) : "(no row returned)";
             throw new \RuntimeException(

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -106,6 +106,9 @@ class MySQLDumpProducer
     /** @var string */
     private $current_sql_fragment_type = "sql";
 
+    /** @var string|null */
+    private $current_sql_fragment_table = null;
+
     /**
      * @param PDO $db Database connection — either a real PDO (MySQL) or a
      *        PDO-compatible adapter (SQLite sites). No type hint because the
@@ -139,6 +142,12 @@ class MySQLDumpProducer
         return $this->current_sql_fragment_type;
     }
 
+    /** Returns the table replaced by the current fragment, or null. */
+    public function get_sql_fragment_table(): ?string
+    {
+        return $this->current_sql_fragment_table;
+    }
+
     public function is_finished(): bool
     {
         return self::STATE_FINISHED === $this->state;
@@ -157,6 +166,7 @@ class MySQLDumpProducer
         }
 
         $this->current_sql_fragment_type = "sql";
+        $this->current_sql_fragment_table = null;
 
         if (self::STATE_INIT === $this->state) {
             if (!$this->row_reader->has_initialized_tables()) {
@@ -388,6 +398,7 @@ class MySQLDumpProducer
             $drop = "DROP TABLE IF EXISTS {$quoted_table};\n";
             $this->current_sql_fragment = $header . $drop . $sql . ";";
             $this->current_sql_fragment_type = "replace_table";
+            $this->current_sql_fragment_table = $this->row_reader->get_current_table();
         } else {
             $keys = $row ? implode(", ", array_keys($row)) : "(no row returned)";
             throw new \RuntimeException(

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -950,7 +950,7 @@ function endpoint_sql_chunk(
     $batches_processed = 0;
     $sql_bytes_processed = 0;
     $aborted = false;
-    /** @var array{sql:string,cursor:string}|null $pending_table_replacement */
+    /** @var array{sql:string,cursor:string,table:string}|null $pending_table_replacement */
     $pending_table_replacement = null;
 
     try {
@@ -959,11 +959,13 @@ function endpoint_sql_chunk(
         ) {
             $sql = [];
             $sql_action = "sql";
+            $sql_table = null;
             $cursor = null;
 
             if ($pending_table_replacement !== null) {
                 $sql[] = $pending_table_replacement["sql"];
                 $cursor = $pending_table_replacement["cursor"];
+                $sql_table = $pending_table_replacement["table"];
                 $sql_action = "replace_table";
                 $pending_table_replacement = null;
             } else {
@@ -972,14 +974,22 @@ function endpoint_sql_chunk(
                     $fragment = (string) $reader->get_sql_fragment();
                     $fragment_cursor = $reader->get_reentrancy_cursor();
                     if ($reader->get_sql_fragment_type() === "replace_table") {
+                        $fragment_table = $reader->get_sql_fragment_table();
+                        if ($fragment_table === null) {
+                            throw new RuntimeException(
+                                "The database dump did not identify the table being replaced."
+                            );
+                        }
                         if ($sql === []) {
                             $sql[] = $fragment;
                             $cursor = $fragment_cursor;
+                            $sql_table = $fragment_table;
                             $sql_action = "replace_table";
                         } else {
                             $pending_table_replacement = [
                                 "sql" => $fragment,
                                 "cursor" => $fragment_cursor,
+                                "table" => $fragment_table,
                             ];
                         }
                         break;
@@ -1021,12 +1031,16 @@ function endpoint_sql_chunk(
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
+            $table_header = $sql_table === null
+                ? ""
+                : "X-Table-Name-Base64: " . base64_encode($sql_table) . "\r\n";
             $gz->write(
                 "--{$boundary}\r\n" .
                 "Content-Type: application/sql\r\n" .
                 "Content-Length: " . strlen($sql) . "\r\n" .
                 "X-Chunk-Type: sql\r\n" .
                 "X-SQL-Action: {$sql_action}\r\n" .
+                $table_header .
                 "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
                 "X-Cursor: " . base64_encode($cursor) . "\r\n" .
                 "\r\n"

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -959,8 +959,17 @@ function endpoint_sql_chunk(
 
             $i = 0;
             while ($reader->next_sql_fragment()) {
-                $sql[] = $reader->get_sql_fragment();
+                $fragment = (string) $reader->get_sql_fragment();
+                $sql[] = $fragment;
                 $i++;
+
+                // Direct MySQL output saves its source position after this
+                // part. Stop at the end of a statement so a following DROP or
+                // CREATE cannot commit imported rows before that position is saved.
+                $trimmed_fragment = rtrim($fragment);
+                if ($trimmed_fragment !== "" && $trimmed_fragment[-1] === ";") {
+                    break;
+                }
 
                 if ($i >= $fragments_per_batch) {
                     break;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -950,36 +950,60 @@ function endpoint_sql_chunk(
     $batches_processed = 0;
     $sql_bytes_processed = 0;
     $aborted = false;
+    /** @var array{sql:string,cursor:string}|null $pending_table_replacement */
+    $pending_table_replacement = null;
 
     try {
         while (
             $budget->has_remaining()
         ) {
             $sql = [];
+            $sql_action = "sql";
+            $cursor = null;
 
-            $i = 0;
-            while ($reader->next_sql_fragment()) {
-                $fragment = (string) $reader->get_sql_fragment();
-                $sql[] = $fragment;
-                $i++;
+            if ($pending_table_replacement !== null) {
+                $sql[] = $pending_table_replacement["sql"];
+                $cursor = $pending_table_replacement["cursor"];
+                $sql_action = "replace_table";
+                $pending_table_replacement = null;
+            } else {
+                $i = 0;
+                while ($reader->next_sql_fragment()) {
+                    $fragment = (string) $reader->get_sql_fragment();
+                    $fragment_cursor = $reader->get_reentrancy_cursor();
+                    if ($reader->get_sql_fragment_type() === "replace_table") {
+                        if ($sql === []) {
+                            $sql[] = $fragment;
+                            $cursor = $fragment_cursor;
+                            $sql_action = "replace_table";
+                        } else {
+                            $pending_table_replacement = [
+                                "sql" => $fragment,
+                                "cursor" => $fragment_cursor,
+                            ];
+                        }
+                        break;
+                    }
 
-                // Direct MySQL output saves its source position after this
-                // part. Stop at the end of a statement so a following DROP or
-                // CREATE cannot commit imported rows before that position is saved.
-                $trimmed_fragment = rtrim($fragment);
-                if ($trimmed_fragment !== "" && $trimmed_fragment[-1] === ";") {
-                    break;
+                    $sql[] = $fragment;
+                    $cursor = $fragment_cursor;
+                    $i++;
+
+                    // Direct MySQL output saves its source position after this
+                    // part. Stop at the end of a statement so a later COMMIT,
+                    // DROP, or CREATE cannot make rows durable first.
+                    $trimmed_fragment = rtrim($fragment);
+                    if ($trimmed_fragment !== "" && $trimmed_fragment[-1] === ";") {
+                        break;
+                    }
+
+                    if ($i >= $fragments_per_batch || !$budget->has_remaining()) {
+                        break;
+                    }
                 }
-
-                if ($i >= $fragments_per_batch) {
-                    break;
-                }
-
-                if (
-                    !$budget->has_remaining()
-                ) {
-                    break;
-                }
+            }
+            if ($sql === []) {
+                break;
             }
             $sql = implode("", $sql);
             $sql_bytes_processed += strlen($sql);
@@ -993,17 +1017,16 @@ function endpoint_sql_chunk(
 
             // E2E test hook: before SQL batch is emitted
             if (getenv('SITE_EXPORT_TEST_MODE')) {
-                $cursor_for_hook = $reader->get_reentrancy_cursor();
-                $hook_args = [&$sql, $cursor_for_hook];
+                $hook_args = [&$sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
-            $cursor = $reader->get_reentrancy_cursor();
             $gz->write(
                 "--{$boundary}\r\n" .
                 "Content-Type: application/sql\r\n" .
                 "Content-Length: " . strlen($sql) . "\r\n" .
                 "X-Chunk-Type: sql\r\n" .
+                "X-SQL-Action: {$sql_action}\r\n" .
                 "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
                 "X-Cursor: " . base64_encode($cursor) . "\r\n" .
                 "\r\n"
@@ -1014,7 +1037,7 @@ function endpoint_sql_chunk(
 
             $batches_processed++;
 
-            if ($reader->is_finished()) {
+            if ($reader->is_finished() && $pending_table_replacement === null) {
                 break;
             }
         }

--- a/tests/MySQLDumpProducer/BasicDumpTest.php
+++ b/tests/MySQLDumpProducer/BasicDumpTest.php
@@ -42,6 +42,26 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         $this->assertSQLNotContains('INSERT INTO', $sql, 'Empty table should have no INSERTs');
     }
 
+    public function testTableReplacementIsOneFragment(): void
+    {
+        $this->pdo->exec('CREATE TABLE replace_me (id INT PRIMARY KEY)');
+
+        $producer = $this->createProducer();
+        $this->assertTrue($producer->next_sql_fragment());
+        $this->assertSame('sql', $producer->get_sql_fragment_type());
+        $this->assertTrue($producer->next_sql_fragment());
+
+        $fragment = $producer->get_sql_fragment();
+        $this->assertNotNull($fragment);
+        $this->assertSame('replace_table', $producer->get_sql_fragment_type());
+        $this->assertStringContainsString('DROP TABLE IF EXISTS `replace_me`;', $fragment);
+        $this->assertStringContainsString('CREATE TABLE `replace_me`', $fragment);
+        $this->assertLessThan(
+            strpos($fragment, 'CREATE TABLE `replace_me`'),
+            strpos($fragment, 'DROP TABLE IF EXISTS `replace_me`;'),
+        );
+    }
+
     public function testSingleTableWithData(): void
     {
         $this->pdo->exec("

--- a/tests/MySQLDumpProducer/BasicDumpTest.php
+++ b/tests/MySQLDumpProducer/BasicDumpTest.php
@@ -49,11 +49,13 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         $producer = $this->createProducer();
         $this->assertTrue($producer->next_sql_fragment());
         $this->assertSame('sql', $producer->get_sql_fragment_type());
+        $this->assertNull($producer->get_sql_fragment_table());
         $this->assertTrue($producer->next_sql_fragment());
 
         $fragment = $producer->get_sql_fragment();
         $this->assertNotNull($fragment);
         $this->assertSame('replace_table', $producer->get_sql_fragment_type());
+        $this->assertSame('replace_me', $producer->get_sql_fragment_table());
         $this->assertStringContainsString('DROP TABLE IF EXISTS `replace_me`;', $fragment);
         $this->assertStringContainsString('CREATE TABLE `replace_me`', $fragment);
         $this->assertLessThan(

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -148,6 +148,9 @@
     },
     "mysql-target-cursor-resume": {
       "port": 8128
+    },
+    "mysql-table-replacement-resume": {
+      "port": 8129
     }
   }
 }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -145,6 +145,9 @@
     },
     "sqlite-legacy": {
       "port": 8127
+    },
+    "mysql-target-cursor-resume": {
+      "port": 8128
     }
   }
 }

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -1,25 +1,22 @@
 /**
- * Test 36: MySQL Mode Crash Recovery
+ * Test 36: MySQL mode source-request continuation
  *
  * When using --sql-output=mysql with short execution times, the server
  * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to pull/sql-buffer on disk as each
- * chunk arrives. If the process dies at any point, the next run reloads
- * whatever was accumulated.
+ * partial SQL in memory while the same importer asks for the next response.
  *
  * This test forces many resume cycles with --max-exec=1, verifies the
- * database is correct after completion, and confirms pull/sql-buffer is
- * cleaned up.
+ * database is correct after completion, and confirms direct MySQL mode does
+ * not write db.sql.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    readAuditLog, pullStateDirectory,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -79,65 +76,9 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('pull/sql-buffer is cleaned up after completion', () => {
-            assert.ok(!existsSync(join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer')),
-                'Expected pull/sql-buffer to be cleaned up after successful completion');
-        });
-
         it('no db.sql on disk', () => {
             assert.ok(!existsSync(join(tempDir, 'db.sql')),
                 'Expected no db.sql file when using --sql-output=mysql');
-        });
-    });
-
-    describe('pre-seeded pull/sql-buffer is loaded on resume', () => {
-        let tempDir;
-        const importDb = 'e2e_basic_import_36_seeded';
-
-        beforeAll(async () => {
-            tempDir = createTempDir('e2e-mysql-seeded-buffer');
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.query(`CREATE DATABASE \`${importDb}\``);
-            await conn.end();
-        });
-
-        afterAll(async () => {
-            cleanupTempDir(tempDir);
-            const conn = await createMysqlConnection();
-            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
-            await conn.end();
-        });
-
-        it('loads pull/sql-buffer from disk and logs recovery', { timeout: 300000 }, () => {
-            // Run preflight so db-pull can proceed
-            runImporter(importUrl(), tempDir, 'preflight', {
-                secret: getSiteSecret(site),
-            });
-
-            // Seed a pull/sql-buffer file before running db-pull.
-            // The content is a harmless SQL comment that won't affect execution
-            // — the point is to verify the importer reads it and logs recovery.
-            const bufferFile = join(pullStateDirectory(tempDir, importUrl()), 'sql-buffer');
-            writeFileSync(bufferFile, '-- pre-seeded buffer\n');
-
-            // Run a fresh db-pull — the importer should detect the buffer file
-            const result = runImporter(importUrl(), tempDir, 'db-pull', {
-                secret: getSiteSecret(site),
-                extraArgs: mysqlArgs(importDb),
-                skipPreflight: true,
-            });
-            assert.equal(result.exitCode, 0,
-                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
-
-            // Verify recovery was logged
-            const audit = readAuditLog(tempDir);
-            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('pull/sql-buffer'),
-                'Expected audit log to mention pull/sql-buffer crash recovery');
-
-            // Buffer should be cleaned up
-            assert.ok(!existsSync(bufferFile),
-                'Expected pull/sql-buffer to be removed after completion');
         });
     });
 });

--- a/tests/e2e/tests/import-43-sql-stream-crash.test.js
+++ b/tests/e2e/tests/import-43-sql-stream-crash.test.js
@@ -195,11 +195,6 @@ describe('Import: SQL Stream Crash Recovery', { timeout: 300000 }, () => {
                     `Expected ${mode} mode to retry the interrupted REST request`,
                 );
 
-                assert.ok(!existsSync(join(
-                    pullStateDirectory(tempDir, importUrl()),
-                    'sql-buffer',
-                )),
-                    'Expected pull/sql-buffer to be absent after successful completion');
             } finally {
                 cleanupTempDir(tempDir);
                 if (mode === 'mysql') {

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -1,7 +1,7 @@
 /**
  * A MySQL target records the source position in the same transaction as each
- * completed INSERT. A replacement process still starts the dump from the
- * beginning until table replacement can make target-side continuation safe.
+ * completed InnoDB INSERT. A replacement process continues after that position
+ * without dropping and rebuilding the table.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -13,7 +13,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir, getDbName,
     createMysqlConnection, fsRootDir,
     writeTestHooks, removeTestHooks,
-    clearHookState,
+    writeHookState, readHookState, clearHookState,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -213,7 +213,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         await connection.end();
     });
 
-    it('records committed rows and safely starts a replacement process over', async () => {
+    it('continues an InnoDB table after its last committed SQL group', async () => {
         const first = spawnDatabasePull();
 
         // Kill only after another MySQL connection can see both the imported
@@ -287,6 +287,18 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         await sleep(100);
         removeTestHooks(site);
 
+        writeHookState(site, { replacementDrops: 0 });
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = json_decode(file_get_contents($state_file), true);',
+            `    if (strpos($sql, 'DROP TABLE IF EXISTS \`${sourceTable}\`') !== false) {`,
+            '        $state[\'replacementDrops\'] = ($state[\'replacementDrops\'] ?? 0) + 1;',
+            '        file_put_contents($state_file, json_encode($state));',
+            '    }',
+            '}',
+        ].join('\n'));
+
         const replacement = runImporter(importUrl(), tempDir, 'db-pull', {
             secret: getSiteSecret(site),
             extraArgs: mysqlArguments(),
@@ -296,6 +308,11 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             replacement.exitCode,
             0,
             `replacement db-pull failed:\n${replacement.stderr}\n${replacement.stdout}`,
+        );
+        assert.equal(
+            readHookState(site)?.replacementDrops,
+            0,
+            'the replacement process dropped an InnoDB table that had a committed source position',
         );
 
         const targetConnection = await createMysqlConnection(targetDb);

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -1,0 +1,221 @@
+/**
+ * A MySQL target records the source position in the same transaction as each
+ * completed INSERT. A replacement process still starts the dump from the
+ * beginning until table replacement can make target-side continuation safe.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, fsRootDir,
+    writeTestHooks, removeTestHooks,
+    clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: source position saved in MySQL target', { timeout: 300000 }, () => {
+    const site = 'mysql-target-cursor-resume';
+    const sourceTable = 'aa_target_cursor_rows';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlArguments() {
+        return [
+            '--sql-output=mysql',
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            `--mysql-database=${targetDb}`,
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    function spawnDatabasePull() {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...mysqlArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+        return { childProcess, output, exit };
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${sourceTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=InnoDB'
+                );
+                const rows = Array.from({ length: 600 }, (_, index) => [
+                    index + 1,
+                    `target-cursor-row-${index + 1}`,
+                ]);
+                for (let offset = 0; offset < rows.length; offset += 100) {
+                    await connection.query(
+                        `INSERT INTO \`${sourceTable}\` (id, value) VALUES ?`,
+                        [rows.slice(offset, offset + 100)],
+                    );
+                }
+            },
+        });
+
+        tempDir = createTempDir('e2e-mysql-target-cursor-resume');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            '    usleep(5000);',
+            '}',
+        ].join('\n'));
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.query(`CREATE DATABASE \`${targetDb}\``);
+        await connection.end();
+
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.end();
+    });
+
+    it('records committed rows and safely starts a replacement process over', async () => {
+        const first = spawnDatabasePull();
+
+        // Kill only after another MySQL connection can see both the imported
+        // rows and the position committed with them.
+        const interruptedTarget = await createMysqlConnection(targetDb);
+        let importedRowCount = 0;
+        let savedSourceCursor = null;
+        try {
+            const targetDeadline = Date.now() + 60000;
+            while (Date.now() < targetDeadline) {
+                try {
+                    const [[importedRows]] = await interruptedTarget.query(
+                        `SELECT COUNT(*) AS rowCount FROM \`${sourceTable}\``
+                    );
+                    const [[savedPosition]] = await interruptedTarget.query(
+                        'SELECT source_cursor FROM `__reprint_db_pull_progress` WHERE id = 1'
+                    );
+                    importedRowCount = Number(importedRows.rowCount);
+                    savedSourceCursor = savedPosition?.source_cursor ?? null;
+                    if (
+                        importedRowCount > 0
+                        && importedRowCount < 600
+                        && typeof savedSourceCursor === 'string'
+                        && savedSourceCursor.length > 0
+                    ) {
+                        break;
+                    }
+                } catch (error) {
+                    if (error?.code !== 'ER_NO_SUCH_TABLE') {
+                        throw error;
+                    }
+                }
+                if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
+                    const result = await first.exit;
+                    assert.fail(
+                        `db-pull exited before MySQL committed partial work (${result.code}/${result.signal}):\n`
+                        + first.output.stderr + first.output.stdout,
+                    );
+                }
+                await sleep(25);
+            }
+        } finally {
+            await interruptedTarget.end();
+        }
+        assert.ok(
+            importedRowCount > 0 && importedRowCount < 600,
+            `expected a partially imported table, got ${importedRowCount} rows`,
+        );
+        assert.equal(typeof savedSourceCursor, 'string');
+        assert.ok(savedSourceCursor.length > 0);
+
+        assert.equal(first.childProcess.kill('SIGKILL'), true);
+        const killed = await first.exit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        await sleep(100);
+        removeTestHooks(site);
+
+        const replacement = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: mysqlArguments(),
+            wallTimeout: 240000,
+        });
+        assert.equal(
+            replacement.exitCode,
+            0,
+            `replacement db-pull failed:\n${replacement.stderr}\n${replacement.stdout}`,
+        );
+
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            const [summary] = await targetConnection.query(
+                `SELECT COUNT(*) AS rowCount, MIN(id) AS firstId, MAX(id) AS lastId `
+                + `FROM \`${sourceTable}\``
+            );
+            assert.deepEqual(
+                {
+                    rowCount: Number(summary[0].rowCount),
+                    firstId: Number(summary[0].firstId),
+                    lastId: Number(summary[0].lastId),
+                },
+                { rowCount: 600, firstId: 1, lastId: 600 },
+            );
+        } finally {
+            await targetConnection.end();
+        }
+    });
+});

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -99,7 +99,17 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         clearHookState(site);
         writeTestHooks(site, [
             'function test_hook_before_sql_batch(&$sql, $cursor) {',
-            '    usleep(100000);',
+            '    static $sent_complete_target_insert = false;',
+            '    static $paused_after_target_insert = false;',
+            '    if ($sent_complete_target_insert && !$paused_after_target_insert) {',
+            '        $paused_after_target_insert = true;',
+            '        usleep(10000000);',
+            '        return;',
+            '    }',
+            `    if (strpos($sql, 'INSERT INTO \`${sourceTable}\`') !== false`,
+            `        && substr(rtrim($sql), -1) === ';') {`,
+            '        $sent_complete_target_insert = true;',
+            '    }',
             '}',
         ].join('\n'));
 

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -128,18 +128,18 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
     });
 
-    it('refuses a source table that uses the progress-table name', async () => {
+    it('refuses any capitalization of the progress-table name in the source', async () => {
         const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
         const sourceConnection = await createMysqlConnection(getDbName(site));
         const targetConnection = await createMysqlConnection(targetDb);
         try {
             await sourceConnection.query(
-                'CREATE TABLE `__reprint_db_pull_progress` ('
+                'CREATE TABLE `__REPRINT_DB_PULL_PROGRESS` ('
                 + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
                 + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
             );
             await sourceConnection.query(
-                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'source row')"
+                "INSERT INTO `__REPRINT_DB_PULL_PROGRESS` (id, note) VALUES (1, 'source row')"
             );
 
             const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
@@ -160,7 +160,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             );
             assert.equal(Number(targetTable.tableCount), 0);
         } finally {
-            await sourceConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await sourceConnection.query('DROP TABLE IF EXISTS `__REPRINT_DB_PULL_PROGRESS`');
             await sourceConnection.end();
             await targetConnection.end();
             cleanupTempDir(collisionDir);

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -269,7 +269,15 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
         assert.equal(decodedSourceCursor.current_table, sourceTable);
         assert.deepEqual(decodedSourceCursor.current_pk_columns, ['id']);
-        assert.equal(Number(decodedSourceCursor.last_pk_values.id), importedRowCount);
+        const savedPrimaryKey = decodedSourceCursor.last_pk_values.id;
+        const savedPrimaryKeyValue = (
+            typeof savedPrimaryKey === 'object'
+            && savedPrimaryKey !== null
+            && typeof savedPrimaryKey.__binary__ === 'string'
+        )
+            ? Buffer.from(savedPrimaryKey.__binary__, 'base64').toString('utf8')
+            : savedPrimaryKey;
+        assert.equal(Number(savedPrimaryKeyValue), importedRowCount);
 
         assert.equal(first.childProcess.kill('SIGKILL'), true);
         const killed = await first.exit;

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -42,9 +42,9 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             '--mysql-user=e2e_admin',
             '--mysql-password=e2e_password',
             `--mysql-database=${targetDb}`,
-            '--sql-fragments-start=1',
-            '--sql-fragments-min=1',
-            '--sql-fragments-max=1',
+            '--sql-fragments-start=5000',
+            '--sql-fragments-min=5000',
+            '--sql-fragments-max=5000',
             '--progress=jsonl',
         ];
     }
@@ -99,7 +99,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         clearHookState(site);
         writeTestHooks(site, [
             'function test_hook_before_sql_batch(&$sql, $cursor) {',
-            '    usleep(5000);',
+            '    usleep(100000);',
             '}',
         ].join('\n'));
 
@@ -116,6 +116,80 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             0,
             `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
         );
+    });
+
+    it('refuses a source table that uses the progress-table name', async () => {
+        const collisionDir = createTempDir('e2e-mysql-source-cursor-collision');
+        const sourceConnection = await createMysqlConnection(getDbName(site));
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            await sourceConnection.query(
+                'CREATE TABLE `__reprint_db_pull_progress` ('
+                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
+                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
+            );
+            await sourceConnection.query(
+                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'source row')"
+            );
+
+            const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(preflight.exitCode, 0, preflight.stderr + preflight.stdout);
+
+            const result = runImporter(importUrl(), collisionDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlArguments(),
+            });
+            assert.notEqual(result.exitCode, 0, 'db-pull should reject the reserved source table');
+
+            const [[targetTable]] = await targetConnection.query(
+                'SELECT COUNT(*) AS tableCount FROM INFORMATION_SCHEMA.TABLES '
+                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                [targetDb, '__reprint_db_pull_progress'],
+            );
+            assert.equal(Number(targetTable.tableCount), 0);
+        } finally {
+            await sourceConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await sourceConnection.end();
+            await targetConnection.end();
+            cleanupTempDir(collisionDir);
+        }
+    });
+
+    it('does not alter an unrelated target table with the progress-table name', async () => {
+        const collisionDir = createTempDir('e2e-mysql-target-cursor-collision');
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            await targetConnection.query(
+                'CREATE TABLE `__reprint_db_pull_progress` ('
+                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
+                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
+            );
+            await targetConnection.query(
+                "INSERT INTO `__reprint_db_pull_progress` (id, note) VALUES (1, 'keep this row')"
+            );
+
+            const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(preflight.exitCode, 0, preflight.stderr + preflight.stdout);
+
+            const result = runImporter(importUrl(), collisionDir, 'db-pull', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlArguments(),
+            });
+            assert.notEqual(result.exitCode, 0, 'db-pull should reject the table-name collision');
+
+            const [[row]] = await targetConnection.query(
+                'SELECT note FROM `__reprint_db_pull_progress` WHERE id = 1'
+            );
+            assert.equal(row.note, 'keep this row');
+        } finally {
+            await targetConnection.query('DROP TABLE IF EXISTS `__reprint_db_pull_progress`');
+            await targetConnection.end();
+            cleanupTempDir(collisionDir);
+        }
     });
 
     afterAll(async () => {
@@ -180,6 +254,12 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         );
         assert.equal(typeof savedSourceCursor, 'string');
         assert.ok(savedSourceCursor.length > 0);
+        const decodedSourceCursor = JSON.parse(
+            Buffer.from(savedSourceCursor, 'base64').toString('utf8')
+        );
+        assert.equal(decodedSourceCursor.current_table, sourceTable);
+        assert.deepEqual(decodedSourceCursor.current_pk_columns, ['id']);
+        assert.equal(Number(decodedSourceCursor.last_pk_values.id), importedRowCount);
 
         assert.equal(first.childProcess.kill('SIGKILL'), true);
         const killed = await first.exit;

--- a/tests/e2e/tests/import-58-mysql-table-replacement-resume.test.js
+++ b/tests/e2e/tests/import-58-mysql-table-replacement-resume.test.js
@@ -1,0 +1,241 @@
+/**
+ * A nontransactional INSERT can survive process death before its source
+ * position is saved. The replacement process must start at that table's
+ * DROP + CREATE pair rather than repeat the INSERT against the old table.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection, fsRootDir,
+    writeTestHooks, removeTestHooks,
+    writeHookState, readHookState, clearHookState,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: replayable MySQL table replacement', { timeout: 300000 }, () => {
+    const site = 'mysql-table-replacement-resume';
+    const sourceTable = 'aa_replay_table';
+    const targetDb = `${getDbName(site)}_import`;
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const importerPath = process.env.IMPORTER_PATH
+        || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function mysqlArguments() {
+        return [
+            '--sql-output=mysql',
+            '--mysql-host=127.0.0.1',
+            '--mysql-user=e2e_admin',
+            '--mysql-password=e2e_password',
+            `--mysql-database=${targetDb}`,
+            '--sql-fragments-start=1',
+            '--sql-fragments-min=1',
+            '--sql-fragments-max=1',
+            '--progress=jsonl',
+        ];
+    }
+
+    function spawnDatabasePull() {
+        const output = { stdout: '', stderr: '' };
+        const childProcess = spawn(phpBinary, [
+            importerPath,
+            'db-pull',
+            importUrl(),
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--secret=${getSiteSecret(site)}`,
+            ...mysqlArguments(),
+        ], {
+            env: { ...process.env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        childProcess.stdout.setEncoding('utf8');
+        childProcess.stderr.setEncoding('utf8');
+        childProcess.stdout.on('data', chunk => { output.stdout += chunk; });
+        childProcess.stderr.on('data', chunk => { output.stderr += chunk; });
+        const exit = new Promise(resolve => {
+            childProcess.once('exit', (code, signal) => resolve({ code, signal }));
+        });
+        return { childProcess, output, exit };
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    `CREATE TABLE \`${sourceTable}\` (`
+                    + '`id` INT NOT NULL, `value` VARCHAR(64) NOT NULL, '
+                    + 'PRIMARY KEY (`id`)) ENGINE=MyISAM'
+                );
+                await connection.query(
+                    `INSERT INTO \`${sourceTable}\` (id, value) `
+                    + "VALUES (1, 'row-written-before-process-death')"
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-mysql-table-replacement-resume');
+        clearHookState(site);
+        writeHookState(site, { injected: false });
+        writeTestHooks(site, [
+            'function test_hook_before_sql_batch(&$sql, $cursor) {',
+            `    $state_file = '/srv/e2e-sites/.e2e-hook-state-${site}';`,
+            '    $state = json_decode(file_get_contents($state_file), true);',
+            `    if (empty($state['injected']) && strpos($sql, 'INSERT INTO \`${sourceTable}\`') !== false) {`,
+            "        $sql .= \"\\nSELECT SLEEP(60);\";",
+            '        $state[\'injected\'] = true;',
+            '        file_put_contents($state_file, json_encode($state));',
+            '    }',
+            '}',
+        ].join('\n'));
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.query(`CREATE DATABASE \`${targetDb}\``);
+        await connection.end();
+
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(
+            preflight.exitCode,
+            0,
+            `preflight failed:\n${preflight.stderr}\n${preflight.stdout}`,
+        );
+    });
+
+    afterAll(async () => {
+        removeTestHooks(site);
+        clearHookState(site);
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        await connection.end();
+    });
+
+    it('starts the unfinished table again after process death', async () => {
+        const first = spawnDatabasePull();
+        const admin = await createMysqlConnection();
+        let oldTargetConnectionId = null;
+        const deadline = Date.now() + 60000;
+
+        while (Date.now() < deadline) {
+            const [processes] = await admin.query(
+                'SELECT ID, INFO FROM INFORMATION_SCHEMA.PROCESSLIST '
+                + 'WHERE DB = ? AND INFO LIKE \'SELECT SLEEP(60)%\'',
+                [targetDb],
+            );
+            if (readHookState(site)?.injected && processes.length > 0) {
+                oldTargetConnectionId = Number(processes[0].ID);
+                break;
+            }
+            if (first.childProcess.exitCode !== null || first.childProcess.signalCode !== null) {
+                const result = await first.exit;
+                assert.fail(
+                    `db-pull exited before the target reached SLEEP (${result.code}/${result.signal}):\n`
+                    + first.output.stderr + first.output.stdout,
+                );
+            }
+            await sleep(25);
+        }
+
+        assert.ok(oldTargetConnectionId, 'the target never reached the statement after the MyISAM INSERT');
+        assert.equal(first.childProcess.kill('SIGKILL'), true);
+        const killed = await first.exit;
+        assert.equal(killed.code, null);
+        assert.equal(killed.signal, 'SIGKILL');
+
+        const target = await createMysqlConnection(targetDb);
+        const [[persistedRow]] = await target.query(
+            `SELECT id, value FROM \`${sourceTable}\``
+        );
+        await target.end();
+        assert.deepEqual(
+            { id: Number(persistedRow.id), value: persistedRow.value },
+            { id: 1, value: 'row-written-before-process-death' },
+        );
+
+        removeTestHooks(site);
+        const resumed = spawnDatabasePull();
+
+        const waitDeadline = Date.now() + 10000;
+        while (Date.now() < waitDeadline) {
+            const [oldConnection] = await admin.query(
+                'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE ID = ?',
+                [oldTargetConnectionId],
+            );
+            if (oldConnection.length === 0) {
+                break;
+            }
+            const [waiters] = await admin.query(
+                'SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST '
+                + 'WHERE DB = ? AND ID <> ? AND INFO LIKE \'SELECT GET_LOCK(%\'',
+                [targetDb, oldTargetConnectionId],
+            );
+            if (waiters.length > 0) {
+                try {
+                    await admin.query(`KILL CONNECTION ${oldTargetConnectionId}`);
+                } catch (error) {
+                    if (Number(error.errno) !== 1094) {
+                        throw error;
+                    }
+                }
+                oldTargetConnectionId = null;
+                break;
+            }
+            if (resumed.childProcess.exitCode !== null || resumed.childProcess.signalCode !== null) {
+                break;
+            }
+            await sleep(25);
+        }
+
+        if (oldTargetConnectionId !== null) {
+            try {
+                await admin.query(`KILL CONNECTION ${oldTargetConnectionId}`);
+            } catch (error) {
+                if (Number(error.errno) !== 1094) {
+                    throw error;
+                }
+            }
+        }
+        await admin.end();
+
+        const resumedResult = await resumed.exit;
+        assert.equal(
+            resumedResult.code,
+            0,
+            `resumed db-pull failed (${resumedResult.code}/${resumedResult.signal}):\n`
+            + resumed.output.stderr + resumed.output.stdout,
+        );
+
+        const imported = await createMysqlConnection(targetDb);
+        try {
+            const [rows] = await imported.query(
+                `SELECT id, value FROM \`${sourceTable}\` ORDER BY id`
+            );
+            assert.deepEqual(
+                rows.map(row => ({ id: Number(row.id), value: row.value })),
+                [{ id: 1, value: 'row-written-before-process-death' }],
+            );
+        } finally {
+            await imported.end();
+        }
+    });
+});


### PR DESCRIPTION
Transactional tables now continue after their last committed SQL group instead of rebuilding the entire unfinished table.

#621 safely replays every unfinished table from `DROP TABLE` and `CREATE TABLE`. That is required for MyISAM, but it can repeat millions of already committed InnoDB rows after an importer process stops.

The exporter now includes the replaced table name with the replacement action. After creating the target table, the importer asks the target which storage engine it actually selected. Transactional engines clear the table-start position and continue from the source position committed with their rows. Nontransactional engines retain the table-start position and continue to rebuild the unfinished table.

For example:

```text
InnoDB: rows 1–20,000,000 committed → continue at row 20,000,001
MyISAM: process stops while filling table → run DROP + CREATE and refill that table
```

The InnoDB end-to-end case stops the importer after a committed batch and checks that the replacement process does not send a second `DROP TABLE`. #621's MyISAM case continues to require a complete table rebuild.

Stack: #619 → #620 → #621 → this PR
