### PR TITLE
[PHP] Let files-pull mirror the current remote tree

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -88,6 +88,8 @@ require_once __DIR__ . '/lib/merge/load.php';
 require_once __DIR__ . '/lib/sort-index-file.php';
 require_once __DIR__ . '/lib/local-index-update-functions.php';
 require_once __DIR__ . '/lib/index/class-file-index-diff-processor.php';
+require_once __DIR__ . '/lib/index/class-file-sync-cleanup-processor.php';
+require_once __DIR__ . '/lib/index/class-pull-local-index-processor.php';
 require_once __DIR__ . '/lib/index/file-sync-path-functions.php';
 require_once __DIR__ . '/lib/class-reprint-process-lock.php';
 
@@ -326,6 +328,9 @@ class ImportClient
      * with no source).
      */
     private $include_caches = false;
+
+    /** @var string Files-pull behavior: mirror or catch-up. */
+    private $files_pull_mode = 'mirror';
 
     /**
      * @var string Controls behavior when the filesystem root is non-empty at pull start.
@@ -829,6 +834,10 @@ class ImportClient
         $this->progress->set_verbose_mode($this->verbose_mode);
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         $this->include_caches = $options["include_caches"] ?? false;
+        $this->files_pull_mode = $options["files_pull_mode"] ?? 'mirror';
+        if (!in_array($this->files_pull_mode, ['mirror', 'catch-up'], true)) {
+            throw new InvalidArgumentException("Invalid --mode value. Valid values: mirror, catch-up");
+        }
         $this->extra_directory = $options["extra_directory"] ?? null;
         if (isset($options["fs_root_nonempty_behavior"])) {
             $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
@@ -868,7 +877,6 @@ class ImportClient
                 "Invalid command: {$command}. Valid commands: " . implode(", ", self::COMMANDS),
             );
         }
-
         $progress_output_mode = $options['progress'] ?? 'auto';
         if (
             !is_string($progress_output_mode)
@@ -1029,6 +1037,24 @@ class ImportClient
                 $this->include_caches = $this->get_state()->include_caches;
             }
 
+            if ($file_index_lifecycle_command === "files-pull") {
+                if (
+                    $is_resuming_file_index_lifecycle
+                    && !$abort
+                    && array_key_exists("files_pull_mode", $options)
+                    && $this->get_state()->files_pull_mode !== $this->files_pull_mode
+                ) {
+                    throw new RuntimeException(
+                        "Cannot change --mode while resuming files-pull. " .
+                            "Use --abort to start a new files-pull."
+                    );
+                }
+                if ($is_resuming_file_index_lifecycle && !$abort) {
+                    $this->files_pull_mode = $this->get_state()->files_pull_mode;
+                }
+                $options["files_pull_mode"] = $this->files_pull_mode;
+            }
+
             if (array_key_exists("extra_directory", $options)) {
                 if (
                     $is_resuming_file_index_lifecycle
@@ -1049,6 +1075,35 @@ class ImportClient
             $options["follow_symlinks"] = $this->follow_symlinks;
             $options["include_caches"] = $this->include_caches;
             $options["extra_directory"] = $this->extra_directory;
+
+            if (
+                $file_index_lifecycle_command === "files-pull"
+                && !$abort
+                && $this->files_pull_mode === "mirror"
+            ) {
+                if ($this->include_caches) {
+                    throw new InvalidArgumentException(
+                        "--mode=mirror does not yet accept --include-caches. " .
+                            "Use --mode=catch-up when caches are included."
+                    );
+                }
+                if (
+                    in_array(
+                        $options["filter"] ?? $this->get_state()->filter ?? "none",
+                        $command === "files-pull"
+                            ? ["essential-files", "skipped-earlier"]
+                            : ["essential-files"],
+                        true
+                    )
+                    || !empty($options["include"] ?? $options["only"] ?? [])
+                    || !empty($options["exclude"] ?? [])
+                ) {
+                    throw new InvalidArgumentException(
+                        "--mode=mirror does not accept --include, --exclude, or a partial --filter. " .
+                            "Use --mode=catch-up for a partial pull."
+                    );
+                }
+            }
         } elseif (isset($options["follow_symlinks"])) {
             // Persist follow_symlinks in state so it survives across invocations.
             $this->get_state()->follow_symlinks = $this->follow_symlinks;
@@ -1060,11 +1115,22 @@ class ImportClient
         // Persist fs_root_nonempty_behavior in state so it survives across invocations.
         // 'preserve-local' preserves existing local files instead of overwriting
         // them, and gracefully skips non-writable directories.
+        if (!isset($options["fs_root_nonempty_behavior"])) {
+            $this->fs_root_nonempty_behavior = $this->get_state()->fs_root_nonempty_behavior ?? 'error';
+        }
+        if (
+            $file_index_lifecycle_command === "files-pull"
+            && !$abort
+            && $this->files_pull_mode === "mirror"
+            && $this->fs_root_nonempty_behavior === "preserve-local"
+        ) {
+            throw new InvalidArgumentException(
+                "--mode=mirror cannot preserve local files. Use --mode=catch-up instead."
+            );
+        }
         if (isset($options["fs_root_nonempty_behavior"])) {
             $this->get_state()->fs_root_nonempty_behavior = $this->fs_root_nonempty_behavior;
             $this->save_state();
-        } else {
-            $this->fs_root_nonempty_behavior = $this->get_state()->fs_root_nonempty_behavior ?? 'error';
         }
 
         // Persist the path-filter preset in state so it survives across resume cycles.
@@ -3101,7 +3167,7 @@ class ImportClient
             $this->pull_index_journal->apply_pending_records();
         }
         $this->assert_files_pull_path_selection_unchanged_while_resuming($has_progress);
-        $this->assert_local_followed_symlinks_root_unchanged();
+        $this->assert_followed_path_mapping_unchanged();
 
         // Already completed.
         if ($current_status === "complete") {
@@ -3175,7 +3241,12 @@ class ImportClient
             // Starting fresh — validate that the filesystem root is empty.
             // A delta sync ($is_delta) naturally has a non-empty filesystem root
             // because we put those files there during the initial sync.
-            if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
+            if (
+                !$is_empty
+                && !$is_delta
+                && $this->fs_root_nonempty_behavior === 'error'
+                && $this->files_pull_mode === 'catch-up'
+            ) {
                 throw new RuntimeException(
                     "Filesystem root is not empty and no cursor found. " .
                         "Either clear the filesystem root, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
@@ -3195,6 +3266,7 @@ class ImportClient
                     $state->active_resumable_command->current_stage = "index";
                     $state->follow_symlinks = $this->follow_symlinks;
                     $state->include_caches = $this->include_caches;
+                    $state->files_pull_mode = $this->files_pull_mode;
                     $state->extra_directory = $this->extra_directory;
                     $state->files_pull_path_selection_fingerprint =
                         $path_selection_fingerprint;
@@ -3247,6 +3319,14 @@ class ImportClient
         $this->save_state();
 
         $stage = $this->get_state()->active_resumable_command->current_stage ?? "index";
+        $mirror_work_directory = wp_join_unix_paths($this->pull_state_directory, "mirror");
+        if (
+            $this->files_pull_mode === "mirror"
+            && !is_dir($mirror_work_directory)
+            && !mkdir($mirror_work_directory, 0755)
+        ) {
+            throw new RuntimeException("Failed to create the mirror work directory.");
+        }
         if ($stage !== "diff") {
             $this->pull_index_journal->open();
         }
@@ -3365,23 +3445,97 @@ class ImportClient
                 return;
             }
             $this->get_state()->fetch = new FetchListProgressState();
-
+            if ($this->files_pull_mode === "mirror") {
+                $this->pull_index_journal->apply_pending_records();
+                $stage = "mirror-index";
+                $this->save_files_pull_stage($stage);
+            }
             if (file_exists($this->fetch_list_file)) {
                 @unlink($this->fetch_list_file);
-                $this->audit_log(
-                    "FILE DELETE | {$this->fetch_list_file} | fetch complete",
+            }
+        }
+
+        if ($stage === "mirror-index" || $stage === "mirror-verify") {
+            $processor_cursor = $this->get_state()->diff->processor_cursor;
+            $path_mapper = new RemoteToLocalPathMapper(
+                $this->filesystem_root, $this->get_export_directories(),
+                $this->resolved_path_mappings, $this->local_followed_symlinks_root
+            );
+            $processor = $processor_cursor !== null
+                ? PullLocalIndexProcessor::resume($processor_cursor)
+                : ( $stage === "mirror-index"
+                    ? PullLocalIndexProcessor::start_patch_result(
+                        $mirror_work_directory, $this->next_remote_index_file,
+                        $this->remote_index_file, $this->local_index_file, $path_mapper,
+                        [""], [], $this->include_caches
+                    )
+                    : PullLocalIndexProcessor::start_next_local_index(
+                        $mirror_work_directory, $this->next_remote_index_file,
+                        $this->remote_index_file, $this->local_index_file, $path_mapper,
+                        // Mirror checks every local path against today's remote index.
+                        $this->state_dir, true
+                    ) );
+            $has_next_step = $this->take_files_pull_local_index_steps($processor);
+            if ($processor->get_status() === "restart") {
+                $stage = "index";
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_files_pull_stage($stage);
+                return;
+            } elseif (!$has_next_step && $stage === "mirror-index") {
+                $stage = "mirror-cleanup";
+                $this->save_files_pull_stage($stage);
+            } elseif (!$has_next_step) {
+                Reprint\Importer\copy_index_through_swap_file(
+                    wp_join_unix_paths($mirror_work_directory, "next_local_index.jsonl"),
+                    $this->local_index_file
                 );
             }
-
+            if ($has_next_step) {
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
+                return;
+            }
         }
 
-        // Recreate intermediate path symlinks so the full symlink chain
-        // works locally.  The server discovers these (e.g. /srv/wordpress
-        // -> /wordpress) and includes them in the next remote index.
-        if ($this->follow_symlinks) {
-            $this->recreate_intermediate_symlinks();
+        if ($stage === "mirror-cleanup") {
+            $complete = $this->plan_files_pull_mirror_changes($mirror_work_directory);
+            if (!$complete) {
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
+                return;
+            }
+            $stage = "mirror-fetch";
+            $this->save_files_pull_stage($stage);
         }
-        $this->pull_index_journal->apply_pending_records();
+
+        if ($stage === "mirror-fetch") {
+            if (!$this->fetch_files_from_list($this->fetch_list_file)) {
+                $this->get_state()->active_resumable_command->completion_state = "partial";
+                $this->save_state();
+                return;
+            }
+            if ($this->follow_symlinks) {
+                $this->recreate_intermediate_symlinks();
+            }
+            $stage = "mirror-verify";
+            $this->get_state()->active_resumable_command->completion_state = "partial";
+            $this->save_files_pull_stage($stage);
+            $this->pull_index_journal->apply_pending_records();
+            if (file_exists($this->fetch_list_file)) {
+                @unlink($this->fetch_list_file);
+            }
+            return;
+        }
+
+        if ($this->files_pull_mode === "catch-up") {
+            // Recreate intermediate path symlinks so the full symlink chain
+            // works locally. The server discovers these (e.g. /srv/wordpress
+            // -> /wordpress) and includes them in the next remote index.
+            if ($this->follow_symlinks) {
+                $this->recreate_intermediate_symlinks();
+            }
+            $this->pull_index_journal->apply_pending_records();
+        }
 
         $this->ensure_local_index_exists();
         $this->get_state()->active_resumable_command->completion_state = "complete";
@@ -3411,6 +3565,108 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    /** Takes a bounded batch without crossing an unsaved processor phase. */
+    private function take_files_pull_local_index_steps(PullLocalIndexProcessor $processor): bool {
+        $phase = $processor->get_checkpoint_phase();
+        for ($steps = 0; $steps < 200; ++$steps) {
+            $has_next_step = $processor->next_step();
+            $processor->flush_pending_output();
+            if ($has_next_step) {
+                $this->get_state()->diff->processor_cursor = $processor->get_cursor();
+            }
+            if (!$has_next_step || $processor->get_checkpoint_phase() !== $phase) {
+                break;
+            }
+        }
+        $processor->close();
+        return $has_next_step;
+    }
+
+    /** Plans one bounded mirror-cleanup batch and records its completed work. */
+    private function plan_files_pull_mirror_changes(string $work_directory): bool {
+        $progress = $this->get_state()->diff;
+        $fetch_list_handle = null;
+        $processor = null;
+        try {
+            $fetch_list_handle = fopen($this->fetch_list_file, "c+b");
+            $fetch_list_stat = is_resource($fetch_list_handle)
+                ? fstat($fetch_list_handle)
+                : false;
+            if (
+                !is_resource($fetch_list_handle)
+                || $progress->fetch_list_byte_offset < 0
+                || $fetch_list_stat === false
+                || $progress->fetch_list_byte_offset > $fetch_list_stat["size"]
+                || !ftruncate($fetch_list_handle, $progress->fetch_list_byte_offset)
+                || fseek($fetch_list_handle, $progress->fetch_list_byte_offset) !== 0
+            ) {
+                throw new RuntimeException("Failed to resume the mirror fetch list.");
+            }
+            $processor = $progress->processor_cursor === null
+                ? FileSyncCleanupProcessor::start(
+                    $work_directory, $this->filesystem_root,
+                    wp_join_unix_paths($work_directory, "pull_patch_result_index.jsonl"),
+                    // Mirror removes local paths omitted by the remote scan.
+                    $this->state_dir, [""], [], true
+                )
+                : FileSyncCleanupProcessor::resume($progress->processor_cursor);
+            $phase = $processor->get_phase();
+            for ($steps = 0; $steps < 200; ++$steps) {
+                $has_next_step = $processor->next_step();
+                $operation = $processor->get_operation();
+                if ($operation !== null && isset($operation["remote_absolute_path"])) {
+                    $this->append_to_fetch_list($operation["remote_absolute_path"], $fetch_list_handle);
+                }
+                $processor->flush_pending_output();
+                if (!fflush($fetch_list_handle)) {
+                    throw new RuntimeException("Failed to flush the mirror fetch list.");
+                }
+                $fetch_list_byte_offset = ftell($fetch_list_handle);
+                if (!is_int($fetch_list_byte_offset)) {
+                    throw new RuntimeException(
+                        "Failed to read the mirror fetch-list byte offset."
+                    );
+                }
+                $next_progress = new FileDiffProgressState();
+                $next_progress->processor_cursor = $processor->get_cursor();
+                $next_progress->fetch_list_byte_offset = $fetch_list_byte_offset;
+                $this->get_state()->diff = $next_progress;
+                if (!$has_next_step || $processor->get_phase() !== $phase) {
+                    break;
+                }
+            }
+        } finally {
+            if ($processor !== null) {
+                $processor->close();
+            }
+            if (is_resource($fetch_list_handle)) {
+                fclose($fetch_list_handle);
+            }
+        }
+        if ($processor->get_status() === "restart") {
+            $this->get_state()->diff = new FileDiffProgressState();
+            return false;
+        }
+        return !$has_next_step;
+    }
+
+    /** Stores one coherent mirror-stage checkpoint before its first step. */
+    private function save_files_pull_stage(string $stage): void
+    {
+        reprint_update_and_save_state_without_signal_interruption(
+            function () use ($stage): void {
+                $state = $this->get_state();
+                $state->active_resumable_command->current_stage = $stage;
+                $state->diff = new FileDiffProgressState();
+                $state->fetch = new FetchListProgressState();
+                if ($stage === "index") {
+                    $state->index = new RemoteFileIndexState();
+                }
+            },
+            [$this, "save_state"]
+        );
     }
 
     /** Creates an empty local index when files-pull recorded no local paths. */
@@ -7504,12 +7760,18 @@ class ImportClient
         }
 
         $file_diff_progress_state = $this->get_state()->diff;
-        $index_diff = FileIndexDiffProcessor::resume(
-            $this->remote_index_file,
-            $this->next_remote_index_file,
-            $file_diff_progress_state->index_diff_cursor,
-            [RemoteIndexReader::class, "decode_index_line"]
-        );
+        $index_diff = $file_diff_progress_state->processor_cursor === null
+            ? FileIndexDiffProcessor::create(
+                $this->remote_index_file,
+                $this->next_remote_index_file,
+                [RemoteIndexReader::class, "decode_index_line"]
+            )
+            : FileIndexDiffProcessor::resume(
+                $this->remote_index_file,
+                $this->next_remote_index_file,
+                $file_diff_progress_state->processor_cursor,
+                [RemoteIndexReader::class, "decode_index_line"]
+            );
         $remote_to_local_path_mapper = new RemoteToLocalPathMapper(
             $this->filesystem_root,
             $this->get_export_directories(),
@@ -7575,9 +7837,13 @@ class ImportClient
                                 $index_diff->get_preceding_path_in_new_index(),
                                 $index_diff->get_following_path_in_new_index()
                             );
-                        // The remote index is a union across files-pull path
-                        // selections. Keep paths outside this run's selection.
-                        if (
+                        // Catch-up keeps the remote-index union outside this
+                        // run's selection. Mirror follows only today's index.
+                        if ($this->files_pull_mode === "mirror") {
+                            $this->pull_index_journal->record_remote_invalidation(
+                                $remote_absolute_path
+                            );
+                        } elseif (
                             $this->is_selected_for_pulling(
                                 $remote_absolute_path,
                                 false
@@ -7722,7 +7988,7 @@ class ImportClient
                 // saved checkpoint in one assignment. An async signal can save
                 // either complete checkpoint.
                 $next_file_diff_progress_state = new FileDiffProgressState();
-                $next_file_diff_progress_state->index_diff_cursor =
+                $next_file_diff_progress_state->processor_cursor =
                     $index_diff->get_cursor();
                 $next_file_diff_progress_state->fetch_list_byte_offset =
                     $fetch_list_byte_offset;
@@ -9230,38 +9496,40 @@ class ImportClient
     }
 
     /**
-     * Refuse to run files-pull after the local followed symlinks root changed.
-     * Placement of followed content is bound to it, so changing it
-     * mid-state would split content across two layouts. Recorded on the first
-     * run, compared on every run after; --abort resets it.
+     * Refuses to reuse indexes after followed-path placement changes.
+     * Paths outside the original remote roots use the followed-symlinks root,
+     * so changing either input can move an unchanged remote path locally.
      */
-    private function assert_local_followed_symlinks_root_unchanged(): void
+    private function assert_followed_path_mapping_unchanged(): void
     {
-        $fingerprint = $this->local_followed_symlinks_root_fingerprint();
-        $previous = $this->get_state()->local_followed_symlinks_root_fingerprint ?? null;
+        $fingerprint = $this->followed_path_mapping_fingerprint();
+        $previous = $this->get_state()->followed_path_mapping_fingerprint ?? null;
 
         if ($previous !== null && $previous !== $fingerprint) {
             throw new RuntimeException(
-                "Cannot change the local followed symlinks root for an existing files-pull. " .
-                    "Use the original value, or use --abort to start a new files-pull.",
+                "Remote roots or the local followed-symlinks root changed path placement. " .
+                    "Use the original settings, or use a new --state-dir.",
             );
         }
 
         if ($previous === null) {
-            $this->get_state()->local_followed_symlinks_root_fingerprint = $fingerprint;
+            $this->get_state()->followed_path_mapping_fingerprint = $fingerprint;
             $this->save_state();
         }
     }
 
-    /**
-     * Fingerprint of the effective local followed symlinks root. No explicit root
-     * (and bare --follow-symlinks) fingerprints as filesystem root, which is the
-     * equivalent placement — so switching between those spellings is allowed.
-     */
-    private function local_followed_symlinks_root_fingerprint(): string
+    /** Fingerprints roots which can change followed-path placement. */
+    private function followed_path_mapping_fingerprint(): string
     {
         $effective = $this->local_followed_symlinks_root ?? $this->filesystem_root;
-        return hash("sha256", $effective);
+        $remote_roots = $effective === $this->filesystem_root
+            ? []
+            : $this->get_export_directories();
+        sort($remote_roots, SORT_STRING);
+        return hash("sha256", json_encode([
+            "effective_root_b64" => base64_encode($effective),
+            "remote_roots_b64" => array_map("base64_encode", $remote_roots),
+        ], JSON_UNESCAPED_SLASHES));
     }
 
     /**
@@ -11416,7 +11684,10 @@ class ImportClient
         $this->state->webhost = $previous_state->webhost;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;
         $this->state->include_caches = $previous_state->include_caches;
+        $this->state->files_pull_mode = $previous_state->files_pull_mode;
         $this->state->extra_directory = $previous_state->extra_directory;
+        $this->state->followed_path_mapping_fingerprint =
+            $previous_state->followed_path_mapping_fingerprint;
         $this->state->fs_root_nonempty_behavior = $previous_state->fs_root_nonempty_behavior;
         $this->state->max_allowed_packet = $previous_state->max_allowed_packet;
         $this->state->resolved_path_mappings_fingerprint = $previous_state->resolved_path_mappings_fingerprint;
@@ -12150,6 +12421,15 @@ if (
         ],
 
         // ── files-pull options ───────────────────────────────────
+        [
+            'name' => 'mode',
+            'type' => 'value',
+            'target' => 'files_pull_mode',
+            'placeholder' => 'MODE',
+            'valid_values' => ['mirror', 'catch-up'],
+            'help' => 'Mirror the remote tree or only catch up remote changes (default: mirror)',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
+        ],
         [
             'name' => 'filter',
             'type' => 'value',

--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -115,7 +115,7 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * while the processor retains unread entries. The cursor still names only
  * consumed entries and can always be passed to `resume()`.
  *
- * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool,remote_absolute_path?:string}
  * @phpstan-type Cursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  */
 final class FileIndexDiffProcessor
@@ -487,6 +487,13 @@ final class FileIndexDiffProcessor
     {
         $entry = $this->get_new_index_entry_for_current_path();
         return $entry["empty"] ?? null;
+    }
+
+    /** Returns the current result entry's original remote path, when recorded. */
+    public function get_remote_absolute_path_in_new_index(): ?string
+    {
+        $entry = $this->get_new_index_entry_for_current_path();
+        return $entry["remote_absolute_path"] ?? null;
     }
 
     /**

--- a/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-cleanup-processor.php
@@ -28,6 +28,8 @@ require_once __DIR__ . '/class-file-sync-patch-processor.php';
  * never by walking their children. An excluded, skipped, or newly created
  * child therefore keeps its directory in place. Empty parents are pruned in
  * separate steps after patch planning ends.
+ * get_operation() reports a remote-backed copy or replacement when it is
+ * ready to fetch. Store that fetch-list write with the returned cursor.
  *
  * A planned removal is stored in the cursor before it is applied. If a process
  * stops after removing the path but before storing the next cursor, resume()
@@ -55,11 +57,12 @@ require_once __DIR__ . '/class-file-sync-patch-processor.php';
  * @phpstan-type PatchCursor array<string,mixed>
  * @phpstan-type PlanningPosition array{phase:'planning',file_sync_patch_processor_cursor:PatchCursor}
  * @phpstan-type ExpectedBase array{type:string,size:int,ctime:int}
- * @phpstan-type RemovingPosition array{phase:'removing',path_b64:string,expected_base:ExpectedBase,file_sync_patch_processor_cursor:PatchCursor}
+ * @phpstan-type RemovingPosition array{phase:'removing',path_b64:string,remote_absolute_path_b64:string|null,expected_base:ExpectedBase,file_sync_patch_processor_cursor:PatchCursor}
  * @phpstan-type PruningPosition array{phase:'pruning'}
  * @phpstan-type Position PlanningPosition|RemovingPosition|PruningPosition|array{phase:'complete'|'restart'}
  * @phpstan-type Cursor array{filesystem_root_b64:string,empty_parent_paths_file_b64:string,empty_parent_paths_file_byte_offset:int,empty_parent_path_stack_top_byte_offset:int|null,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,position:Position}
  * @phpstan-type EmptyParentPath array{path:string,previous_byte_offset:int|null,expected_ctime:int|null}
+ * @phpstan-type CleanupOperation array{action:'copy'|'replace',path:string,remote_absolute_path:string}
  */
 final class FileSyncCleanupProcessor
 {
@@ -89,6 +92,9 @@ final class FileSyncCleanupProcessor
 
     /** Whether close() released the retained handles. */
     private bool $closed = false;
+
+    /** @var CleanupOperation|null Operation completed by the latest step. */
+    private ?array $operation = null;
 
     /**
      * Starts cleanup before the first local-index step.
@@ -305,6 +311,7 @@ final class FileSyncCleanupProcessor
      */
     public function next_step(): bool
     {
+        $this->operation = null;
         $position = $this->cursor["position"];
         if (
             $position["phase"] === "complete"
@@ -322,6 +329,17 @@ final class FileSyncCleanupProcessor
             $has_next_patch_step = $this->patch_processor->next_step();
             $patch_cursor = $this->patch_processor->get_cursor();
             $operation = $this->patch_processor->get_operation();
+            if (
+                $operation !== null
+                && $operation["action"] === "copy"
+                && isset($operation["remote_absolute_path"])
+            ) {
+                $this->operation = [
+                    "action" => "copy",
+                    "path" => $operation["path"],
+                    "remote_absolute_path" => $operation["remote_absolute_path"],
+                ];
+            }
             // A selected root marks where traversal begins, not a result
             // entry. Keep that boundary when its contents are empty.
             if (
@@ -344,6 +362,10 @@ final class FileSyncCleanupProcessor
                 $this->cursor["position"] = [
                     "phase" => "removing",
                     "path_b64" => base64_encode($operation["path"]),
+                    "remote_absolute_path_b64" =>
+                        isset($operation["remote_absolute_path"])
+                            ? base64_encode($operation["remote_absolute_path"])
+                            : null,
                     "expected_base" => $operation["expected_base"],
                     "file_sync_patch_processor_cursor" => $patch_cursor,
                 ];
@@ -437,6 +459,16 @@ final class FileSyncCleanupProcessor
             }
             if ($path_removed) {
                 $this->schedule_parent_path($index_path);
+            }
+            if ($position["remote_absolute_path_b64"] !== null) {
+                $this->operation = [
+                    "action" => "replace",
+                    "path" => $index_path,
+                    "remote_absolute_path" => self::decode_cursor_path(
+                        $position["remote_absolute_path_b64"],
+                        "pending replacement remote path"
+                    ),
+                ];
             }
             $patch_cursor = $position[
                 "file_sync_patch_processor_cursor"
@@ -556,6 +588,12 @@ final class FileSyncCleanupProcessor
         return $phase === "complete" || $phase === "restart"
             ? $phase
             : null;
+    }
+
+    /** Returns the operation completed by the latest step. */
+    public function get_operation(): ?array
+    {
+        return $this->operation;
     }
 
     /** Flushes processor work files before the caller stores get_cursor(). */

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -98,7 +98,7 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  * @phpstan-type ActiveDeletionRoot array{path:string,previous_byte_offset:int|null}
  * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
  * @phpstan-type DeleteOperation array{action:'delete',path:string,expected_base?:ExpectedSource}
- * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource,expected_base?:ExpectedSource}
+ * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource,expected_base?:ExpectedSource,remote_absolute_path?:string}
  * @phpstan-type SyncOperation DeleteOperation|CopyOperation
  */
 final class FileSyncPatchPlanner
@@ -492,7 +492,11 @@ final class FileSyncPatchPlanner
                 || $patch_base_entry_shape === "symlink";
             $empty_directory_needs_copy =
                 $patch_result_entry_shape === "empty_directory"
-                && $patch_base_entry_shape !== "empty_directory";
+                && (
+                    $patch_base_entry_shape !== "empty_directory"
+                    || ( $path_transition === "modified"
+                        && $this->index_diff->get_remote_absolute_path_in_new_index() !== null )
+                );
             $changed_file_or_symlink_needs_copy =
                 $patch_result_entry_is_file_or_symlink
                 && $path_transition === "modified";
@@ -537,6 +541,12 @@ final class FileSyncPatchPlanner
                     "ctime" => $this->index_diff->get_ctime_in_new_index(),
                 ],
             ];
+            $remote_absolute_path =
+                $this->index_diff->get_remote_absolute_path_in_new_index();
+            if ($remote_absolute_path !== null) {
+                $this->operation["remote_absolute_path"] =
+                    $remote_absolute_path;
+            }
         } elseif ($path_to_delete !== null) {
             $this->operation = [
                 "action" => "delete",
@@ -586,6 +596,7 @@ final class FileSyncPatchPlanner
      *
      *     @type string $action          `copy`, `delete`, or `replace`.
      *     @type string $path            Path on which to operate.
+     *     @type string $remote_absolute_path Original remote path when the result index records one.
      *     @type array  $expected_source {
      *         Source state required by `copy` and `replace`. Absent for `delete`.
      *

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-processor.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/class-fresh-local-index-processor.php';
  * @phpstan-type FreshTreePosition array{phase:'indexing'|'sorting'|'starting_patch',patch_base_index_file_b64:string,patch_result_index_file_b64:string,included_index_path_roots_b64:list<string>,excluded_index_path_roots_b64:list<string>,deletion_policy:'collapsed'|'exact',fresh_local_index_cursor:FreshIndexCursor}
  * @phpstan-type Position FreshTreePosition|array{phase:'planning',file_sync_patch_planner_cursor:PlannerCursor}|array{phase:'complete'}
  * @phpstan-type Cursor array{fresh_local_index_file_b64:string,position:Position}
- * @phpstan-type SyncOperation array{action:'copy'|'delete'|'replace',path:string,expected_source?:array{type:string,size:int,ctime:int},expected_base?:array{type:string,size:int,ctime:int}}
+ * @phpstan-type SyncOperation array{action:'copy'|'delete'|'replace',path:string,expected_source?:array{type:string,size:int,ctime:int},expected_base?:array{type:string,size:int,ctime:int},remote_absolute_path?:string}
  */
 final class FileSyncPatchProcessor {
     /** @var Cursor */
@@ -316,6 +316,7 @@ final class FileSyncPatchProcessor {
      * @return array|null {
      *     @type string $action          `copy`, `delete`, or `replace`.
      *     @type string $path            Local relative path selected by the patch.
+     *     @type string $remote_absolute_path Original remote path when the result index records one.
      *     @type array  $expected_source {
      *         Result index entry required by `copy` and `replace`.
      *

--- a/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
+++ b/packages/reprint-client/src/lib/index/class-pull-local-index-processor.php
@@ -29,10 +29,10 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  * them with the retained local index. It replaces retained entries inside the
  * selected roots and keeps entries outside them or across an excluded root.
  *
- * start_patch_result() copies remote type, size, ctime, and directory emptiness
- * into local coordinates. FileSyncPatchProcessor can use that index to plan
- * pre-fetch cleanup. The patch-result file is temporary planning input. Its
- * mapped entries' ctime values belong to the remote machine.
+ * start_patch_result() checks the WAL-applied remote index against the next
+ * remote index, then copies retained local metadata into local coordinates.
+ * FileSyncPatchProcessor can use that temporary index to plan cleanup after
+ * remote catch-up without comparing ctime values from different machines.
  *
  * start_next_local_index() requires the selected paths in the remote index and
  * next remote index to match in presence, type, size, and ctime. Candidate
@@ -74,7 +74,7 @@ require_once __DIR__ . '/file-sync-path-functions.php';
  * @phpstan-type MapperConfig array{filesystem_root_b64:string,original_remote_roots_b64:list<string>,resolved_path_mappings:list<array{remote_prefix_b64:string,local_prefix_b64:string}>,local_followed_symlinks_root_b64:string|null}
  * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
  * @phpstan-type Position array{phase:'mapping',remote_index_byte_offset?:int,remote_index_diff_cursor?:IndexDiffCursor,mapped_index_byte_offset:int,mapped_index_parents_byte_offset:int}|array{phase:'sorting'|'sorting_parents'|'starting_merge'}|array{phase:'merging',index_diff_cursor:IndexDiffCursor,mapped_index_parent_cursor:IndexDiffCursor,index_byte_offset:int}|array{phase:'verifying',file_sync_patch_processor_cursor:array}|array{phase:'complete'|'restart'}
- * @phpstan-type Cursor array{metadata_source:'remote_recorded'|'locally_observed',next_remote_index_file_b64:string,remote_index_file_b64:string|null,remote_index_exists:bool,retained_local_index_file_b64:string,retained_local_index_exists:bool,mapped_index_file_b64:string,mapped_index_parents_file_b64:string,index_file_b64:string,path_mapper_config:MapperConfig,included_local_index_path_roots_b64:list<string>,excluded_local_index_path_roots_b64:list<string>,verification_storage_path_b64:string,verification_include_caches:bool,position:Position}
+ * @phpstan-type Cursor array{metadata_source:'remote_recorded'|'retained_local'|'locally_observed',next_remote_index_file_b64:string,remote_index_file_b64:string|null,remote_index_exists:bool,retained_local_index_file_b64:string,retained_local_index_exists:bool,mapped_index_file_b64:string,mapped_index_parents_file_b64:string,index_file_b64:string,path_mapper_config:MapperConfig,included_local_index_path_roots_b64:list<string>,excluded_local_index_path_roots_b64:list<string>,verification_storage_path_b64:string,verification_include_caches:bool,position:Position}
  */
 final class PullLocalIndexProcessor
 {
@@ -117,33 +117,37 @@ final class PullLocalIndexProcessor
     private bool $closed = false;
 
     /**
-     * Starts a local-coordinate patch-result index using remote metadata.
+     * Starts a local-coordinate patch-result index after remote catch-up.
      *
      * @param string                  $work_directory            Existing directory for processor work files.
      * @param string                  $next_remote_index_file Immutable next remote index.
+     * @param string                  $remote_index_file WAL-applied remote index after catch-up.
      * @param string                  $retained_local_index_file Retained local index, or a missing path on the first pull.
      * @param RemoteToLocalPathMapper $path_mapper               Path mapping used by this pull.
      * @param list<string> $included_local_index_path_roots Local roots which the pull may change.
      * @param list<string> $excluded_local_index_path_roots Local roots which the pull must not affect.
+     * @param bool         $include_caches                  Whether the local scan includes default-skipped paths.
      */
     public static function start_patch_result(
         string $work_directory,
         string $next_remote_index_file,
+        string $remote_index_file,
         string $retained_local_index_file,
         RemoteToLocalPathMapper $path_mapper,
         array $included_local_index_path_roots = [""],
-        array $excluded_local_index_path_roots = []
+        array $excluded_local_index_path_roots = [],
+        bool $include_caches = false
     ): self {
         return self::start(
-            "remote_recorded", $work_directory,
+            "retained_local", $work_directory,
             $next_remote_index_file,
-            null,
+            $remote_index_file,
             $retained_local_index_file,
             $path_mapper,
             $included_local_index_path_roots,
             $excluded_local_index_path_roots,
             "",
-            false
+            $include_caches
         );
     }
 
@@ -201,6 +205,7 @@ final class PullLocalIndexProcessor
         $processor->cursor = $cursor;
         if (
             $cursor["metadata_source"] !== "remote_recorded"
+            && $cursor["metadata_source"] !== "retained_local"
             && $cursor["metadata_source"] !== "locally_observed"
         ) {
             throw new InvalidArgumentException("Pull local index cursor contains an invalid metadata source.");
@@ -244,7 +249,7 @@ final class PullLocalIndexProcessor
         if ($position["phase"] === "mapping") {
             self::require_file($processor->next_remote_index_file, "next remote index");
             try {
-                if ($cursor["metadata_source"] === "locally_observed") {
+                if ($cursor["metadata_source"] !== "remote_recorded") {
                     if ($cursor["remote_index_file_b64"] === null) {
                         throw new InvalidArgumentException(
                             "Pull local index cursor is missing its remote index."
@@ -365,7 +370,7 @@ final class PullLocalIndexProcessor
             $local_absolute_path = null;
             $local_relative_path = null;
             $path_may_change = null;
-            if ($this->cursor["metadata_source"] === "locally_observed") {
+            if ($this->cursor["metadata_source"] !== "remote_recorded") {
                 if (
                     !$this->remote_index_path_selected
                     && !$this->remote_index_diff->next_path()
@@ -405,6 +410,21 @@ final class PullLocalIndexProcessor
                     $next_remote_path_type =
                         $this->remote_index_diff
                             ->get_path_type_in_new_index();
+                    if (
+                        $path_may_change
+                        && $next_remote_path_type !== null
+                        && !$this->cursor["verification_include_caches"]
+                        && FileIndexProcessor::path_is_default_skipped(
+                            $local_relative_path
+                        )
+                    ) {
+                        throw new RuntimeException(
+                            "Cannot mirror mapped path "
+                            . base64_encode($local_relative_path)
+                            . " because the local scan omits it by default. "
+                            . "Use --include-caches or --mode=catch-up."
+                        );
+                    }
                     if ($next_remote_path_type !== null) {
                         $remote_index_entry = [
                             "path" => $remote_absolute_path,
@@ -496,6 +516,10 @@ final class PullLocalIndexProcessor
                     "size" => $remote_index_entry["size"],
                     "type" => $remote_index_entry["type"],
                 ];
+                if ($this->cursor["metadata_source"] === "retained_local") {
+                    $mapped_index_entry["remote_absolute_path"] =
+                        $remote_index_entry["path"];
+                }
                 if (array_key_exists("empty", $remote_index_entry)) {
                     $mapped_index_entry["empty"] = $remote_index_entry["empty"];
                 }
@@ -582,7 +606,7 @@ final class PullLocalIndexProcessor
                 "mapped_index_parents_byte_offset" =>
                     $mapped_index_parents_byte_offset,
             ];
-            if ($this->cursor["metadata_source"] === "locally_observed") {
+            if ($this->cursor["metadata_source"] !== "remote_recorded") {
                 $this->remote_index_path_selected =
                     $this->remote_index_diff->next_path();
                 $mapping_position[
@@ -737,12 +761,14 @@ final class PullLocalIndexProcessor
                 );
             }
         }
-        $write_retained_local_metadata =
-            $this->cursor["metadata_source"] === "locally_observed"
-            && $write_new_entry;
+        $use_retained_local_metadata =
+            $this->cursor["metadata_source"] !== "remote_recorded"
+            && $write_new_entry
+            && $old_path_type === $new_path_type;
         if (
-            $write_retained_local_metadata
-            && $old_path_type !== $new_path_type
+            $this->cursor["metadata_source"] === "locally_observed"
+            && $write_new_entry
+            && !$use_retained_local_metadata
         ) {
             return $this->restart();
         }
@@ -750,12 +776,14 @@ final class PullLocalIndexProcessor
             $index_entry = [
                 "path" => $this->index_diff->get_path(),
                 "ctime" => $write_new_entry
-                    ? ( $write_retained_local_metadata
+                    ? ( $use_retained_local_metadata
                         ? $this->index_diff->get_ctime_in_old_index()
-                        : $this->index_diff->get_ctime_in_new_index() )
+                        : ( $this->cursor["metadata_source"] === "retained_local"
+                            ? -1
+                            : $this->index_diff->get_ctime_in_new_index() ) )
                     : $this->index_diff->get_ctime_in_old_index(),
                 "size" => $write_new_entry
-                    ? ( $write_retained_local_metadata
+                    ? ( $use_retained_local_metadata
                         ? $this->index_diff->get_size_in_old_index()
                         : $this->index_diff->get_size_in_new_index() )
                     : $this->index_diff->get_size_in_old_index(),
@@ -766,6 +794,14 @@ final class PullLocalIndexProcessor
                 : $this->index_diff->get_directory_is_empty_in_old_index();
             if ($directory_is_empty !== null) {
                 $index_entry["empty"] = $directory_is_empty;
+            }
+            $remote_absolute_path =
+                $this->index_diff->get_remote_absolute_path_in_new_index();
+            if (
+                $this->cursor["metadata_source"] === "retained_local"
+                && $write_new_entry && $remote_absolute_path !== null
+            ) {
+                $index_entry["remote_absolute_path"] = $remote_absolute_path;
             }
             write_local_index_entry($this->index_handle, $index_entry);
         }
@@ -798,6 +834,15 @@ final class PullLocalIndexProcessor
     public function get_phase(): string
     {
         return $this->cursor["position"]["phase"];
+    }
+
+    /** Returns the phase whose transition requires a caller checkpoint. */
+    public function get_checkpoint_phase(): string
+    {
+        if ($this->get_phase() !== "verifying") {
+            return $this->get_phase();
+        }
+        return "verifying:" . $this->verification_processor->get_phase();
     }
 
     /** Returns `complete` or `restart` after next_step() returns false. */
@@ -895,7 +940,7 @@ final class PullLocalIndexProcessor
         }
         self::require_file($next_remote_index_file, "next remote index");
         $remote_index_exists = false;
-        if ($metadata_source === "locally_observed") {
+        if ($metadata_source !== "remote_recorded") {
             if ($remote_index_file === null) {
                 throw new LogicException(
                     "Cannot build the next local index without its remote index."
@@ -919,7 +964,7 @@ final class PullLocalIndexProcessor
         );
         $index_file = wp_join_unix_paths(
             $work_directory,
-            $metadata_source === "remote_recorded"
+            $metadata_source !== "locally_observed"
                 ? "pull_patch_result_index.jsonl"
                 : "next_local_index.jsonl"
         );
@@ -934,7 +979,7 @@ final class PullLocalIndexProcessor
         if (file_put_contents($index_file, "") !== 0) {
             throw new RuntimeException("Failed to initialize the pull local index.");
         }
-        if ($metadata_source === "locally_observed") {
+        if ($metadata_source !== "remote_recorded") {
             $position = [
                 "phase" => "mapping",
                 "remote_index_diff_cursor" => [
@@ -987,7 +1032,7 @@ final class PullLocalIndexProcessor
         $this->mapped_index_parent_reader = null;
         fclose($this->index_handle);
         $this->index_handle = null;
-        if ($this->cursor["metadata_source"] === "remote_recorded") {
+        if ($this->cursor["metadata_source"] !== "locally_observed") {
             $this->cursor["position"] = ["phase" => "complete"];
             $this->close();
             return false;

--- a/packages/reprint-client/src/lib/local-index-update-functions.php
+++ b/packages/reprint-client/src/lib/local-index-update-functions.php
@@ -7,6 +7,23 @@ use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exceptions contain CLI filesystem paths, never HTML output.
 
 /**
+ * Copies one complete index through a swap file and moves it into place.
+ *
+ * copy() streams without holding the complete index in memory. Only the
+ * final rename is atomic: interruption during copy leaves the existing
+ * index untouched and a later call overwrites the partial swap file.
+ */
+function copy_index_through_swap_file(string $source_path, string $target_path): void {
+	$swap_index = $target_path . '.swap';
+	if ( ! @copy( $source_path, $swap_index ) ) {
+		throw new \RuntimeException( 'Failed to copy the index to its swap file: ' . $swap_index );
+	}
+	if ( ! @rename( $swap_index, $target_path ) ) {
+		throw new \RuntimeException( 'Failed to move the copied index into place: ' . $target_path );
+	}
+}
+
+/**
  * Merges path mutations into the local index file:
  *
  *     current index ----\
@@ -217,11 +234,12 @@ function merge_local_index_mutations(
  * @type string $type `file`, `link`, or `dir`.
  * @type bool $empty Whether a directory has no descendant entries in
  *                         this index.
+ * @type string $remote_absolute_path Original remote path for temporary pull planning entries.
  * }
- * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool}
+ * @phpstan-return array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool,remote_absolute_path?:string}
  */
 function decode_local_index_entry( string $local_index_json_line ): array {
-	/** @var array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool} $encoded_local_index_entry */
+	/** @var array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool,remote_absolute_path?:string} $encoded_local_index_entry */
 	$encoded_local_index_entry = json_decode(
 		$local_index_json_line,
 		true,
@@ -241,6 +259,16 @@ function decode_local_index_entry( string $local_index_json_line ): array {
 	if ( array_key_exists( 'empty', $encoded_local_index_entry ) ) {
 		$local_index_entry['empty'] =
 			$encoded_local_index_entry['empty'];
+	}
+	if ( array_key_exists( 'remote_absolute_path', $encoded_local_index_entry ) ) {
+		$remote_absolute_path = base64_decode(
+			$encoded_local_index_entry['remote_absolute_path'],
+			true
+		);
+		if ( $remote_absolute_path === false ) {
+			throw new \RuntimeException( 'Invalid remote path in a local index entry.' );
+		}
+		$local_index_entry['remote_absolute_path'] = $remote_absolute_path;
 	}
 
 	return $local_index_entry;
@@ -336,6 +364,7 @@ function read_local_index_updates( $sorted_local_index_updates_handle ): \Genera
  * @type string $type `file`, `link`, or `dir`.
  * @type bool $empty Whether a directory has no descendant entries in
  *                         this index.
+ * @type string $remote_absolute_path Original remote path for temporary pull planning entries.
  * }
  */
 function write_local_index_entry(
@@ -353,6 +382,10 @@ function write_local_index_entry(
 		&& array_key_exists( 'empty', $local_index_entry )
 	) {
 		$encoded_local_index_entry['empty'] = $local_index_entry['empty'];
+	}
+	if ( array_key_exists( 'remote_absolute_path', $local_index_entry ) ) {
+		$encoded_local_index_entry['remote_absolute_path'] =
+			base64_encode( $local_index_entry['remote_absolute_path'] );
 	}
 	$local_index_json_line = json_encode(
 		                         $encoded_local_index_entry,

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -328,7 +328,8 @@ class Pull
                 $stages,
                 !empty($options['follow_symlinks']),
                 !empty($options['include_caches']),
-                $options['extra_directory'] ?? null
+                $options['extra_directory'] ?? null,
+                $options['files_pull_mode'] ?? 'mirror'
             );
             $file_selection_checkpoint_saved =
                 $command === 'pull' || $command === 'pull-files';
@@ -418,6 +419,7 @@ class Pull
                     $state = $this->client->get_state();
                     $state->follow_symlinks = !empty($options['follow_symlinks']);
                     $state->include_caches = !empty($options['include_caches']);
+                    $state->files_pull_mode = $options['files_pull_mode'] ?? 'mirror';
                     $state->extra_directory = $options['extra_directory'] ?? null;
                     $state->pull_pipeline->started_by_command = $command;
                     $state->pull_pipeline->stage_sequence = $stages;
@@ -869,13 +871,15 @@ class Pull
      * @param bool|null   $follow_symlinks Fresh lifecycle link selection, or null to retain it.
      * @param bool        $include_caches  Fresh lifecycle cache selection.
      * @param string|null $extra_directory Fresh lifecycle additional remote directory.
+     * @param string      $files_pull_mode Fresh lifecycle files-pull mode.
      */
     private function prepare_repull(
         string $command,
         array $stage_sequence = [],
         ?bool $follow_symlinks = null,
         bool $include_caches = false,
-        ?string $extra_directory = null
+        ?string $extra_directory = null,
+        string $files_pull_mode = 'mirror'
     ): void
     {
         $state_dir = $this->client->state_dir;
@@ -909,6 +913,7 @@ class Pull
                 $follow_symlinks,
                 $include_caches,
                 $extra_directory,
+                $files_pull_mode,
                 $reset_file_transfer_state,
                 $reset_file_selection_state,
                 $reset_db_state
@@ -929,6 +934,7 @@ class Pull
                         $state->follow_symlinks = $follow_symlinks;
                     }
                     $state->include_caches = $include_caches;
+                    $state->files_pull_mode = $files_pull_mode;
                     $state->extra_directory = $extra_directory;
                 }
                 if ($reset_file_transfer_state) {
@@ -976,11 +982,17 @@ class Pull
      * Lower-level commands return with completion_state="partial" when a
      * server timeout drops the connection. This loop retries automatically,
      * resetting the completion state to "in_progress" so the handler enters
-     * its resume path on the next call.
+     * its resume path on the next call. Durable files-pull cursor movement
+     * resets the retry ceiling because that partial made forward progress.
      */
     private function run_until_complete(string $stage, callable $handler): void
     {
-        for ($attempt = 0; $attempt < 1000; $attempt++) {
+        $transient_retry_attempts = 0;
+        while (true) {
+            $state = $this->client->get_state();
+            $previous_files_pull_stage =
+                $state->active_resumable_command->current_stage;
+            $previous_processor_cursor = $state->diff->processor_cursor;
             $handler();
             $state = $this->client->get_state();
             if ($state->active_resumable_command->completion_state === 'complete') {
@@ -989,13 +1001,26 @@ class Pull
             if ($state->active_resumable_command->completion_state !== 'partial') {
                 throw new RuntimeException("Stage {$stage} stopped before completing.");
             }
+            $processor_made_durable_progress =
+                $stage === 'files-pull'
+                && (
+                    $state->active_resumable_command->current_stage
+                        !== $previous_files_pull_stage
+                    || $state->diff->processor_cursor
+                        !== $previous_processor_cursor
+                );
+            if ($processor_made_durable_progress) {
+                $transient_retry_attempts = 0;
+            } elseif (++$transient_retry_attempts >= 1000) {
+                throw new RuntimeException(
+                    "Stage {$stage} kept reporting partial progress after 1000 retry attempts; aborting."
+                );
+            }
             $state->active_resumable_command->completion_state = 'in_progress';
             $this->client->save_state();
             $this->client->exit_code = 0;
             $this->progress->tick_spinner();
         }
-
-        throw new RuntimeException("Stage {$stage} kept reporting partial progress after 1000 retry attempts; aborting.");
     }
 
     /**

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Reprint\Importer\copy_index_through_swap_file;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
@@ -1391,7 +1392,7 @@ final class PushFilesSender
     {
         $fresh_local_index_file = $this->plan->get_fresh_local_index_path();
         try {
-            $this->copy_through_swap_file(
+            copy_index_through_swap_file(
                 $fresh_local_index_file,
                 $this->local_index_file
             );
@@ -1402,27 +1403,6 @@ final class PushFilesSender
         $this->state['push_plan_cursor'] = null;
         $this->state['phase'] = 'completing';
         $this->store_state($this->state);
-    }
-
-    /**
-     * Copies one complete index through a swap file and moves it into place.
-     *
-     * copy() streams without holding the complete index in memory. Only the
-     * final rename is atomic: interruption during copy leaves the existing
-     * index untouched and a later call overwrites the partial swap file.
-     *
-     * @param string $source_path Complete index to copy.
-     * @param string $target_path Final path for the copied index.
-     */
-    private function copy_through_swap_file(string $source_path, string $target_path): void
-    {
-        $swap_index = $target_path . '.swap';
-        if (!@copy($source_path, $swap_index)) {
-            throw new RuntimeException('Failed to copy the index to its swap file: ' . $swap_index);
-        }
-        if (!@rename($swap_index, $target_path)) {
-            throw new RuntimeException('Failed to move the copied index into place: ' . $target_path);
-        }
     }
 
     /**

--- a/packages/reprint-client/src/lib/state/class-file-diff-progress-state.php
+++ b/packages/reprint-client/src/lib/state/class-file-diff-progress-state.php
@@ -5,20 +5,8 @@ namespace Reprint\Importer\State;
 
 class FileDiffProgressState {
 
-    /**
-     * File-index diff cursor.
-     *
-     * @var array{
-     *     old_index_byte_offset:int,
-     *     new_index_byte_offset:int,
-     *     preceding_new_index_entry_path_b64:string|null
-     * }
-     */
-    public array $index_diff_cursor = [
-        'old_index_byte_offset' => 0,
-        'new_index_byte_offset' => 0,
-        'preceding_new_index_entry_path_b64' => null,
-    ];
+    /** @var array<string,mixed>|null Cursor for the active comparison processor. */
+    public ?array $processor_cursor = null;
 
     /** @var int Fetch-list byte offset covered by the saved diff cursor. */
     public int $fetch_list_byte_offset = 0;
@@ -30,12 +18,12 @@ class FileDiffProgressState {
     {
         $state = new self();
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
-        \reprint_assert_state_keys(
-            $data['index_diff_cursor'],
-            array_keys($state->index_diff_cursor),
-            self::class . ' index_diff_cursor'
-        );
-        $state->index_diff_cursor = $data['index_diff_cursor'];
+        if (!is_array($data['processor_cursor']) && $data['processor_cursor'] !== null) {
+            throw new \UnexpectedValueException(
+                'FileDiffProgressState processor_cursor must be an array or null.'
+            );
+        }
+        $state->processor_cursor = $data['processor_cursor'];
         $state->fetch_list_byte_offset = $data['fetch_list_byte_offset'];
         $state->pull_index_wal_byte_offset =
             $data['pull_index_wal_byte_offset'];
@@ -45,7 +33,7 @@ class FileDiffProgressState {
     public function to_array(): array
     {
         return [
-            'index_diff_cursor' => $this->index_diff_cursor,
+            'processor_cursor' => $this->processor_cursor,
             'fetch_list_byte_offset' => $this->fetch_list_byte_offset,
             'pull_index_wal_byte_offset' =>
                 $this->pull_index_wal_byte_offset,

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -51,10 +51,12 @@ class PullState
     public bool $follow_symlinks = true;
     /** Whether remote and local file indexes include cache and development paths. */
     public bool $include_caches = false;
+    /** Whether files-pull mirrors the remote tree or only catches up remote changes. */
+    public string $files_pull_mode = 'mirror';
     /** @var string|null Additional remote directory included in the file index. */
     public ?string $extra_directory = null;
-    /** @var string|null Fingerprint of the local followed symlinks root; guards resume. */
-    public ?string $local_followed_symlinks_root_fingerprint = null;
+    /** @var string|null Fingerprint of inputs which place followed remote paths locally. */
+    public ?string $followed_path_mapping_fingerprint = null;
     public string $fs_root_nonempty_behavior = 'error';
     public string $filter = 'none';
     /** @var string|null User-Agent that worked during preflight. */
@@ -128,13 +130,19 @@ class PullState
             );
         }
         $state->include_caches = $data['include_caches'];
+        if (!in_array($data['files_pull_mode'], ['mirror', 'catch-up'], true)) {
+            throw new UnexpectedValueException(
+                'PullState files_pull_mode must be mirror or catch-up.'
+            );
+        }
+        $state->files_pull_mode = $data['files_pull_mode'];
         if (!is_string($data['extra_directory']) && $data['extra_directory'] !== null) {
             throw new UnexpectedValueException(
                 'PullState extra_directory must be a string or null.'
             );
         }
         $state->extra_directory = $data['extra_directory'];
-        $state->local_followed_symlinks_root_fingerprint = $data['local_followed_symlinks_root_fingerprint'];
+        $state->followed_path_mapping_fingerprint = $data['followed_path_mapping_fingerprint'];
         $state->fs_root_nonempty_behavior = $data['fs_root_nonempty_behavior'];
         $state->filter = $data['filter'];
         $state->user_agent = $data['user_agent'];
@@ -239,8 +247,9 @@ class PullState
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
             'include_caches' => $this->include_caches,
+            'files_pull_mode' => $this->files_pull_mode,
             'extra_directory' => $this->extra_directory,
-            'local_followed_symlinks_root_fingerprint' => $this->local_followed_symlinks_root_fingerprint,
+            'followed_path_mapping_fingerprint' => $this->followed_path_mapping_fingerprint,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,
             'user_agent' => $this->user_agent,

--- a/tests/Import/CliHelpTest.php
+++ b/tests/Import/CliHelpTest.php
@@ -26,6 +26,10 @@ class CliHelpTest extends TestCase
         $this->assertStringContainsString('--include=SOURCE', $output);
         $this->assertStringNotContainsString('--only', $output);
         $this->assertStringContainsString('--exclude=SOURCE', $output);
+        $this->assertMatchesRegularExpression(
+            '/--mode=MODE.*mirror.*catch up.*default: mirror/i',
+            $output
+        );
     }
 
     public function testFilesIndexHelpNamesTheNextRemoteIndexFile(): void

--- a/tests/Import/FileIndexProtocolVersionTest.php
+++ b/tests/Import/FileIndexProtocolVersionTest.php
@@ -70,6 +70,7 @@ final class FileIndexProtocolVersionTest extends TestCase
     {
         $result = $this->runCli([
             'pull-files',
+            '--mode=catch-up',
             '--on-fs-root-nonempty=preserve-local',
         ]);
 
@@ -93,6 +94,7 @@ final class FileIndexProtocolVersionTest extends TestCase
         file_put_contents($this->protocolVersionFile, '2');
         $result = $this->runCli([
             'pull-files',
+            '--mode=catch-up',
             '--on-fs-root-nonempty=preserve-local',
         ]);
 

--- a/tests/Import/FileIndexSelectionLifecycleTest.php
+++ b/tests/Import/FileIndexSelectionLifecycleTest.php
@@ -111,6 +111,7 @@ final class FileIndexSelectionLifecycleTest extends TestCase
                     'current_stage' => 'index',
                     'remote_cursor' => null,
                 ],
+                'files_pull_mode' => 'catch-up',
                 'include_caches' => true,
                 'extra_directory' => $this->extraDirectory,
             ]
@@ -144,6 +145,7 @@ final class FileIndexSelectionLifecycleTest extends TestCase
         $this->assertIsString($importer);
         $options = [
             'command' => 'pull-files',
+            'files_pull_mode' => 'catch-up',
             'fs_root_nonempty_behavior' => 'preserve-local',
             'progress' => 'jsonl',
         ];

--- a/tests/Import/FileSyncCleanupProcessorTest.php
+++ b/tests/Import/FileSyncCleanupProcessorTest.php
@@ -155,6 +155,36 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         );
     }
 
+    public function testQueuesARemoteEmptyDirectoryMissingFromTheRetainedIndex(): void
+    {
+        mkdir($this->filesystem_root . '/selected/empty', 0755, true);
+        $work_directory = $this->work_directory('copy-empty-directory');
+        $processor = FileSyncCleanupProcessor::start(
+            $work_directory,
+            $this->filesystem_root,
+            $this->write_index('copy-empty-directory-result.jsonl', [
+                $this->entry(
+                    'selected/empty',
+                    'dir',
+                    '/remote/empty'
+                ),
+            ]),
+            $work_directory,
+            ['selected']
+        );
+
+        $operations = $this->run_to_completion_collecting_operations(
+            $processor
+        );
+
+        $this->assertDirectoryExists($this->filesystem_root . '/selected/empty');
+        $this->assertSame([[
+            'action' => 'copy',
+            'path' => 'selected/empty',
+            'remote_absolute_path' => '/remote/empty',
+        ]], $operations);
+    }
+
     /** @dataProvider exactPathTypes */
     public function testRemovesAnExactPathBeforeItsTypeChanges(
         string $local_type,
@@ -176,17 +206,28 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             $work_directory,
             $this->filesystem_root,
             $this->write_index('replace-result.jsonl', [
-                $this->entry('selected/entry', $result_type),
+                $this->entry(
+                    'selected/entry',
+                    $result_type,
+                    '/remote/entry'
+                ),
             ]),
             $work_directory,
             ['selected']
         );
 
-        $this->run_to_completion($processor);
+        $operations = $this->run_to_completion_collecting_operations(
+            $processor
+        );
 
         $this->assertFalse(file_exists($path));
         $this->assertFalse(is_link($path));
         $this->assertDirectoryExists($this->filesystem_root . '/selected');
+        $this->assertSame([[
+            'action' => 'replace',
+            'path' => 'selected/entry',
+            'remote_absolute_path' => '/remote/entry',
+        ]], $operations);
     }
 
     /** @return list<array{string,string}> */
@@ -282,17 +323,26 @@ final class FileSyncCleanupProcessorTest extends TestCase {
             $work_directory,
             $this->filesystem_root,
             $this->write_index('copy-restart-result.jsonl', [
-                $this->entry('remote.txt', 'file'),
+                $this->entry(
+                    'remote.txt',
+                    'file',
+                    '/remote/source.txt'
+                ),
             ]),
             $work_directory
         );
 
-        $this->run_to_completion($processor);
+        $operations = $this->run_to_completion_collecting_operations(
+            $processor
+        );
 
         $this->assertSame('complete', $processor->get_status());
         $this->assertFileDoesNotExist(
             $this->filesystem_root . '/remote.txt'
         );
+        $this->assertSame('/remote/source.txt', $operations[0][
+            'remote_absolute_path'
+        ]);
     }
 
     public function testChangedPendingRemovalRestartsWithoutDeletingTheNewPath(): void
@@ -714,6 +764,25 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $this->fail('File sync cleanup did not complete in 300 steps.');
     }
 
+    /** @return list<array<string,mixed>> */
+    private function run_to_completion_collecting_operations(
+        FileSyncCleanupProcessor $processor
+    ): array {
+        $operations = [];
+        for ($step = 0; $step < 300; ++$step) {
+            $has_next_step = $processor->next_step();
+            $operation = $processor->get_operation();
+            if ($operation !== null) {
+                $operations[] = $operation;
+            }
+            $processor->flush_pending_output();
+            if (!$has_next_step) {
+                return $operations;
+            }
+        }
+        $this->fail('File sync cleanup did not complete in 300 steps.');
+    }
+
     /** @return array<string,mixed> */
     private function stored_cursor(array $cursor): array
     {
@@ -740,6 +809,11 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         $lines = [];
         foreach ($entries as $entry) {
             $entry['path'] = base64_encode($entry['path']);
+            if (isset($entry['remote_absolute_path'])) {
+                $entry['remote_absolute_path'] = base64_encode(
+                    $entry['remote_absolute_path']
+                );
+            }
             $lines[] = json_encode(
                 $entry,
                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
@@ -754,7 +828,11 @@ final class FileSyncCleanupProcessorTest extends TestCase {
     }
 
     /** @return array{path:string,ctime:int,size:int,type:string,empty?:bool} */
-    private function entry(string $path, string $type): array
+    private function entry(
+        string $path,
+        string $type,
+        ?string $remote_absolute_path = null
+    ): array
     {
         $entry = [
             'path' => $path,
@@ -764,6 +842,9 @@ final class FileSyncCleanupProcessorTest extends TestCase {
         ];
         if ($type === 'dir') {
             $entry['empty'] = true;
+        }
+        if ($remote_absolute_path !== null) {
+            $entry['remote_absolute_path'] = $remote_absolute_path;
         }
         return $entry;
     }

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -459,6 +459,32 @@ final class FilesPullDiffCheckpointTest extends TestCase
         $this->assertSame(['/added.txt'], $actualFetchPaths);
     }
 
+    public function testMirrorInvalidatesAnOldRemoteRowOutsideCurrentRoots(): void
+    {
+        file_put_contents(
+            $this->pullStateDirectory . '/remote-index.jsonl',
+            '{"path":"L29sZC1yb290L3N0YWxlLnR4dA==","ctime":1,"size":1,"type":"file"}' . "\n"
+        );
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+
+        $client = $this->newClientAtDiffStage();
+        $client->get_state()->set_preflight_record([
+            'data' => ['ok' => true, 'wp_detect' => ['roots' => [['path' => '/current-root']]]],
+            'http_code' => 200,
+        ]);
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('files_pull_mode')->setValue($client, 'mirror');
+        $reflection->getMethod('compare_remote_indexes_and_build_fetch_list')
+            ->invoke($client);
+        $reflection->getProperty('pull_index_journal')->getValue($client)
+            ->apply_pending_records();
+
+        $this->assertSame([], $this->readBase64Paths(
+            $this->pullStateDirectory . '/remote-index.jsonl',
+            'path'
+        ));
+    }
+
     public function testDiffRejectsBlankRemoteIndexRecords(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.jsonl', '');
@@ -510,6 +536,7 @@ final class FilesPullDiffCheckpointTest extends TestCase
             ],
             'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
+            'files_pull_mode' => 'catch-up',
             'fs_root_nonempty_behavior' => 'preserve-local',
             'files_pull_path_selection_fingerprint' => hash(
                 'sha256',
@@ -522,6 +549,9 @@ final class FilesPullDiffCheckpointTest extends TestCase
                 ], JSON_UNESCAPED_SLASHES)
             ),
         ]);
+        ( new \ReflectionClass(\ImportClient::class) )
+            ->getProperty('files_pull_mode')
+            ->setValue($client, 'catch-up');
         return $client;
     }
 
@@ -530,9 +560,11 @@ final class FilesPullDiffCheckpointTest extends TestCase
         DiffCheckpointTestClient $client
     ): DiffCheckpointTestClient {
         $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getProperty('state')->setValue(
+        $state = $reflection->getMethod('load_state')->invoke($client);
+        $reflection->getProperty('state')->setValue($client, $state);
+        $reflection->getProperty('files_pull_mode')->setValue(
             $client,
-            $reflection->getMethod('load_state')->invoke($client)
+            $state->files_pull_mode
         );
         return $client;
     }

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -141,7 +141,7 @@ final class FilesPullLocalIndexTest extends TestCase
             ],
         ]);
 
-        $this->completeFilesPull();
+        $this->completeFilesPull(['--mode=catch-up']);
 
         $this->assertSame(
             'pulled dependency',
@@ -208,38 +208,83 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testDeltaPullUpdatesOnlyThePathsItChanges(): void
+    /** @dataProvider localDriftPullModeProvider */
+    public function testPullModeResolvesRemoteAndLocalChanges(string $mode): void
     {
-        $this->completeFilesPull();
-        file_put_contents($this->localTree . '/edited.txt', 'longer local edit');
+        $arguments = ["--mode={$mode}"];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+
+        $localEditedContents = 'longer local edit';
+        $localOnlyContents = 'local-only contents';
+        $remoteBothChangedContents = 'remote change delivered by the second pull';
+        file_put_contents($this->localTree . '/edited.txt', $localEditedContents);
         unlink($this->localTree . '/deleted.txt');
-        $pulledContents = 'remote change delivered by the second pull';
+        file_put_contents($this->localTree . '/local-only.txt', $localOnlyContents);
+        file_put_contents(
+            $this->localTree . '/' . self::PULLED_PATH,
+            'local edit before the remote also changes'
+        );
         $this->writeRemoteOverrides([
             'pulled_ctime' => self::REMOTE_CTIME + 1,
-            'pulled_contents_b64' => base64_encode($pulledContents),
+            'pulled_contents_b64' => base64_encode($remoteBothChangedContents),
             'removed_paths' => ['unchanged.txt'],
         ]);
 
-        $this->abortFilesPull();
-        $delta = $this->runFilesPull();
+        $abort = $this->runFilesPull(array_merge(['--abort'], $arguments));
+        $this->assertSame(0, $abort['exit'], $abort['output']);
+        $delta = $this->runFilesPull($arguments);
 
         $this->assertSame(0, $delta['exit'], $delta['output']);
-        $this->assertSame('longer local edit', file_get_contents($this->localTree . '/edited.txt'));
-        $this->assertSame($pulledContents, file_get_contents($this->localTree . '/' . self::PULLED_PATH));
+        $this->assertSame(
+            $remoteBothChangedContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
         $this->assertFileDoesNotExist($this->localTree . '/unchanged.txt');
 
         $diff = $this->runFilesDiff();
         $this->assertSame(0, $diff['exit'], $diff['output']);
         $records = $this->filesDiffRecords($diff['stdout']);
         $complete = array_pop($records);
+
+        if ($mode === 'mirror') {
+            $this->assertSame(
+                $this->remoteFiles['edited.txt'],
+                file_get_contents($this->localTree . '/edited.txt')
+            );
+            $this->assertSame(
+                $this->remoteFiles['deleted.txt'],
+                file_get_contents($this->localTree . '/deleted.txt')
+            );
+            $this->assertFileDoesNotExist($this->localTree . '/local-only.txt');
+            $this->assertSame([
+                'command' => 'files-diff',
+                'status' => 'complete',
+                'local_paths_to_push' => 0,
+                'local_paths_to_delete' => 0,
+            ], $complete);
+            $this->assertSame([], $records);
+            return;
+        }
+
+        $this->assertSame(
+            $localEditedContents,
+            file_get_contents($this->localTree . '/edited.txt')
+        );
+        $this->assertFileDoesNotExist($this->localTree . '/deleted.txt');
+        $this->assertSame(
+            $localOnlyContents,
+            file_get_contents($this->localTree . '/local-only.txt')
+        );
         $this->assertSame([
             'command' => 'files-diff',
             'status' => 'complete',
-            'local_paths_to_push' => 1,
+            'local_paths_to_push' => 2,
             'local_paths_to_delete' => 1,
         ], $complete);
         $this->assertSame([
             $this->expectedPushRecord('edited.txt'),
+            $this->expectedPushRecord('local-only.txt'),
             [
                 'command' => 'files-diff',
                 'action' => 'delete',
@@ -248,6 +293,13 @@ final class FilesPullLocalIndexTest extends TestCase
                 ),
             ],
         ], $records);
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function localDriftPullModeProvider(): iterable
+    {
+        yield 'catch-up keeps changes the remote did not make' => ['catch-up'];
+        yield 'mirror restores the current remote tree' => ['mirror'];
     }
 
     public function testResumeReplaysTheWALIntoTheLocalIndex(): void
@@ -347,19 +399,23 @@ final class FilesPullLocalIndexTest extends TestCase
     public static function partialPullProvider(): iterable
     {
         yield 'selected directory' => [[
+            '--mode=catch-up',
             '--include=/var/www/html/selected',
         ]];
         yield 'filtered files' => [[
+            '--mode=catch-up',
             '--filter=essential-files',
         ]];
         yield 'preserve local files' => [[
+            '--mode=catch-up',
             '--on-fs-root-nonempty=preserve-local',
         ]];
     }
 
-    public function testRemappedPullKeepsUnrelatedLocalIndexEntries(): void
+    public function testMirrorRefetchesLocallyEditedRemappedPathFromItsRemoteSource(): void
     {
         $arguments = [
+            '--mode=mirror',
             '--remap',
             '/var/www/html',
             ':fs-root:/var/www/html/remapped',
@@ -369,29 +425,31 @@ final class FilesPullLocalIndexTest extends TestCase
         $remappedUnchangedPath = $this->localIndexEntryPath(
             'remapped/unchanged.txt'
         );
-        $before = $this->readIndex(
-            $this->localIndexPath()
-        )[$remappedUnchangedPath];
-        $pulledContents = 'remapped pull change';
-        $this->writeRemoteOverrides([
-            'pulled_ctime' => self::REMOTE_CTIME + 1,
-            'pulled_contents_b64' => base64_encode($pulledContents),
-        ]);
+        $remappedUnchangedFile = $this->localTree . '/remapped/unchanged.txt';
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($remappedUnchangedFile)
+        );
+        file_put_contents(
+            $remappedUnchangedFile,
+            'local edit at the remapped destination'
+        );
 
-        $this->abortFilesPull();
+        $abort = $this->runFilesPull(array_merge(['--abort'], $arguments));
+        $this->assertSame(0, $abort['exit'], $abort['output']);
         $pull = $this->runFilesPull($arguments);
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
         $this->assertSame(
-            $pulledContents,
-            file_get_contents($this->localTree . '/remapped/' . self::PULLED_PATH)
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($remappedUnchangedFile)
         );
         $index = $this->readIndex($this->localIndexPath());
-        $this->assertSame($before, $index[$remappedUnchangedPath]);
         $this->assertArrayHasKey(
-            $this->localIndexEntryPath('remapped/' . self::PULLED_PATH),
+            $remappedUnchangedPath,
             $index
         );
+        $this->assertLocalIndexMatches('remapped/unchanged.txt');
     }
 
     public function testPulledDeletionStopsAtNestedIncludedRoot(): void
@@ -404,6 +462,7 @@ final class FilesPullLocalIndexTest extends TestCase
 
         $this->abortFilesPull();
         $pull = $this->runFilesPull([
+            '--mode=catch-up',
             '--include=/var/www/html/folder',
         ]);
 
@@ -456,6 +515,7 @@ final class FilesPullLocalIndexTest extends TestCase
             'removed_paths' => ['folder/remote-deleted.txt'],
         ]);
         $pull = $this->runFilesPull([
+            '--mode=catch-up',
             '--include=/var/www/html/folder',
             '--exclude=/var/www/html/folder/keep',
         ]);
@@ -482,6 +542,7 @@ final class FilesPullLocalIndexTest extends TestCase
     public function testPulledDeletionRemovesAnEntireRemappedSelection(): void
     {
         $arguments = [
+            '--mode=catch-up',
             '--include=/var/www/html',
             '--remap',
             '/var/www/html',
@@ -513,6 +574,7 @@ final class FilesPullLocalIndexTest extends TestCase
     public function testPulledDeletionKeepsAnotherRemapTargetBelowIt(): void
     {
         $arguments = [
+            '--mode=catch-up',
             '--remap',
             '/var/www/html/folder',
             ':fs-root:/shared',
@@ -546,6 +608,7 @@ final class FilesPullLocalIndexTest extends TestCase
     public function testPulledDeletionKeepsAnotherRemapTargetAboveIt(): void
     {
         $arguments = [
+            '--mode=catch-up',
             '--remap',
             '/var/www/html/folder',
             ':fs-root:/shared/inner',
@@ -586,7 +649,7 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->writeRemoteOverrides([
             'added_directories' => ['folder/was-empty'],
         ]);
-        $this->completeFilesPull();
+        $this->completeFilesPull(['--mode=catch-up']);
         file_put_contents(
             $this->localTree . '/folder/was-empty/local.txt',
             'local child'
@@ -599,6 +662,7 @@ final class FilesPullLocalIndexTest extends TestCase
             ],
         ]);
         $pull = $this->runFilesPull([
+            '--mode=catch-up',
             '--include=/var/www/html/folder/was-empty',
         ]);
 
@@ -636,12 +700,12 @@ final class FilesPullLocalIndexTest extends TestCase
                 'removed-tree/child.txt' => 'remote child',
             ],
         ]);
-        $this->completeFilesPull();
+        $this->completeFilesPull(['--mode=catch-up']);
         $this->assertFileExists($this->localTree . '/removed-tree/child.txt');
 
         $this->abortFilesPull();
         $this->writeRemoteOverrides([]);
-        $pull = $this->runFilesPull();
+        $pull = $this->runFilesPull(['--mode=catch-up']);
 
         $this->assertSame(0, $pull['exit'], $pull['output']);
         $this->assertDirectoryDoesNotExist($this->localTree . '/removed-tree');
@@ -659,9 +723,10 @@ final class FilesPullLocalIndexTest extends TestCase
         $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0]['local_paths_to_push']);
     }
 
-    private function completeFilesPull(): void
+    /** @param list<string> $arguments */
+    private function completeFilesPull(array $arguments = []): void
     {
-        $result = $this->runFilesPull();
+        $result = $this->runFilesPull($arguments);
         $this->assertSame(0, $result['exit'], $result['output']);
     }
 
@@ -752,12 +817,18 @@ final class FilesPullLocalIndexTest extends TestCase
      */
     private function runFilesPull(array $extraArguments = []): array
     {
-        return $this->runCli(array_merge([
-            'files-pull',
-            $this->targetUrl,
-            '--state-dir=' . $this->stateDirectory,
-            '--fs-root=' . $this->rawFileRoot,
-        ], $extraArguments));
+        for ($attempt = 0; $attempt < 100; ++$attempt) {
+            $result = $this->runCli(array_merge([
+                'files-pull',
+                $this->targetUrl,
+                '--state-dir=' . $this->stateDirectory,
+                '--fs-root=' . $this->rawFileRoot,
+            ], $extraArguments));
+            if ($result['exit'] !== 2) {
+                return $result;
+            }
+        }
+        $this->fail('files-pull did not complete after 100 bounded runs.');
     }
 
     /**

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -75,6 +75,7 @@ class FilesPullStateTest extends TestCase
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "remote_protocol_version" => PULL_PROTOCOL_VERSION,
             "follow_symlinks" => false,
+            "files_pull_mode" => "catch-up",
             "fs_root_nonempty_behavior" => "preserve-local",
         ], $state));
     }
@@ -137,6 +138,8 @@ class FilesPullStateTest extends TestCase
 
         $behaviorProp = $reflection->getProperty('fs_root_nonempty_behavior');
         $behaviorProp->setValue($client, 'preserve-local');
+        $modeProp = $reflection->getProperty('files_pull_mode');
+        $modeProp->setValue($client, 'catch-up');
 
         return [$client, $reflection];
     }
@@ -144,6 +147,32 @@ class FilesPullStateTest extends TestCase
     // ---------------------------------------------------------------
     // State transition tests
     // ---------------------------------------------------------------
+
+    public function testHighLevelPullDoesNotCountDurableMirrorStepsAsRetries(): void
+    {
+        $client = $this->makeClient();
+        $pull = ( new \ReflectionClass($client) )
+            ->getProperty('pull')
+            ->getValue($client);
+        $runs = 0;
+        $handler = function () use ($client, &$runs): void {
+            ++$runs;
+            $state = $client->get_state();
+            if ($runs > 1000) {
+                $state->active_resumable_command->completion_state = 'complete';
+                return;
+            }
+            $state->active_resumable_command->completion_state = 'partial';
+            $state->active_resumable_command->current_stage = 'mirror-index';
+            $state->diff->processor_cursor = ['step' => $runs];
+        };
+
+        ( new \ReflectionClass($pull) )
+            ->getMethod('run_until_complete')
+            ->invoke($pull, 'files-pull', $handler);
+
+        $this->assertSame(1001, $runs);
+    }
 
     /**
      * A completed files-pull should refuse to re-run.

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -218,27 +218,48 @@ class FollowedSymlinksRootTest extends TestCase
         );
     }
 
-    // ── Local followed symlinks root fingerprint guard ──
+    // ── Followed path mapping fingerprint guard ──
+
+    private function mappingFingerprint(
+        \ImportClient $client,
+        ?string $localFollowedSymlinksRoot
+    ): string {
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('local_followed_symlinks_root')->setValue(
+            $client,
+            $localFollowedSymlinksRoot
+        );
+        return $reflection->getMethod('followed_path_mapping_fingerprint')
+            ->invoke($client);
+    }
 
     private function assertGuard(\ImportClient $c, ?string $localFollowedSymlinksRoot, ?string $persistedFingerprint): void
     {
         $rc = new \ReflectionClass($c);
         $rc->getProperty('local_followed_symlinks_root')->setValue($c, $localFollowedSymlinksRoot);
-        $rc->getProperty('state')->getValue($c)->local_followed_symlinks_root_fingerprint = $persistedFingerprint;
-        $rc->getMethod('assert_local_followed_symlinks_root_unchanged')->invoke($c);
+        $rc->getProperty('state')->getValue($c)->followed_path_mapping_fingerprint = $persistedFingerprint;
+        $rc->getMethod('assert_followed_path_mapping_unchanged')->invoke($c);
     }
 
     public function testGuardRejectsChangedLocalFollowedSymlinksRoot(): void
     {
         $c = $this->newClient();
         $this->expectException(\RuntimeException::class);
-        $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-b'));
+        $this->assertGuard(
+            $c,
+            $this->root . '/.bundle-a',
+            $this->mappingFingerprint($c, $this->root . '/.bundle-b')
+        );
     }
 
     public function testGuardAllowsUnchangedLocalFollowedSymlinksRoot(): void
     {
         $c = $this->newClient();
-        $this->assertGuard($c, $this->root . '/.bundle-a', hash('sha256', $this->root . '/.bundle-a'));
+        $this->assertGuard(
+            $c,
+            $this->root . '/.bundle-a',
+            $this->mappingFingerprint($c, $this->root . '/.bundle-a')
+        );
         $this->addToAssertionCount(1); // no exception == pass
     }
 
@@ -248,7 +269,11 @@ class FollowedSymlinksRootTest extends TestCase
         // to default placement.
         $c = $this->newClient();
         $this->expectException(\RuntimeException::class);
-        $this->assertGuard($c, null, hash('sha256', $this->root . '/.bundle-a'));
+        $this->assertGuard(
+            $c,
+            null,
+            $this->mappingFingerprint($c, $this->root . '/.bundle-a')
+        );
     }
 
     public function testGuardTreatsBareFollowAndFsRootAsEquivalent(): void
@@ -256,19 +281,57 @@ class FollowedSymlinksRootTest extends TestCase
         // Bare --follow-symlinks (no explicit root) and --follow-symlinks=:fs-root:
         // fingerprint identically — both place at fs-root.
         $c = $this->newClient();
-        $this->assertGuard($c, null, hash('sha256', $this->root));
-        $this->assertGuard($c, $this->root, hash('sha256', $this->root));
+        $fingerprint = $this->mappingFingerprint($c, $this->root);
+        $this->assertGuard($c, null, $fingerprint);
+        $this->assertGuard($c, $this->root, $fingerprint);
         $this->addToAssertionCount(1); // no exception == pass
+    }
+
+    public function testGuardRejectsChangedRemoteRootsWithACustomFollowedRoot(): void
+    {
+        $client = $this->placeClient('/.bundle', ['/remote/first']);
+        $fingerprint = $this->mappingFingerprint(
+            $client,
+            $this->root . '/.bundle'
+        );
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('pull_only_files_with_path_prefixes')
+            ->setValue($client, ['/remote/second']);
+        $reflection->getProperty('export_directories_cache')
+            ->setValue($client, null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->assertGuard($client, $this->root . '/.bundle', $fingerprint);
+    }
+
+    public function testGuardAllowsChangedRemoteRootsAtTheFilesystemRoot(): void
+    {
+        $client = $this->placeClient($this->root, ['/remote/first']);
+        $fingerprint = $this->mappingFingerprint($client, $this->root);
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('pull_only_files_with_path_prefixes')
+            ->setValue($client, ['/remote/second']);
+        $reflection->getProperty('export_directories_cache')
+            ->setValue($client, null);
+
+        $this->assertGuard($client, $this->root, $fingerprint);
+        $this->addToAssertionCount(1);
     }
 
     public function testDefaultFollowedSymlinksRootFingerprintKeepsFilesystemRoot(): void
     {
         $client = $this->newRootClient();
         $fingerprint = (new \ReflectionClass($client))
-            ->getMethod('local_followed_symlinks_root_fingerprint')
+            ->getMethod('followed_path_mapping_fingerprint')
             ->invoke($client);
 
-        $this->assertSame(hash('sha256', '/'), $fingerprint);
+        $this->assertSame(
+            hash('sha256', json_encode([
+                'effective_root_b64' => base64_encode('/'),
+                'remote_roots_b64' => [],
+            ], JSON_UNESCAPED_SLASHES)),
+            $fingerprint
+        );
     }
 
     // ── Repoint routes via remap even when the target is spelled within fs-root ──

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -350,6 +350,7 @@ PHP, var_export($requestsLog, true)));
         $output = $this->runCli(array(
             'files-pull',
             $remoteReprintApiUrl,
+            '--mode=catch-up',
             '--include',
             ':wp-content:/plugins',
             '--include',
@@ -387,6 +388,7 @@ PHP, var_export($requestsLog, true)));
         $output = $this->runCli(array(
             'files-pull',
             $remoteUrl,
+            '--mode=catch-up',
             '--exclude',
             ':wp-content:/cache',
             '--exclude',

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -120,6 +120,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             ],
             "preflight" => ["data" => ["ok" => true], "http_code" => 200],
             "follow_symlinks" => false,
+            "files_pull_mode" => "catch-up",
             "fs_root_nonempty_behavior" => "preserve-local",
         ];
         \write_current_pull_state(
@@ -132,6 +133,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
         $r->getProperty('state')->setValue($client, $r->getMethod('load_state')->invoke($client));
         $r->getProperty('is_tty')->setValue($client, false);
         $r->getProperty('fs_root_nonempty_behavior')->setValue($client, 'preserve-local');
+        $r->getProperty('files_pull_mode')->setValue($client, 'catch-up');
         $r->getProperty('pull_only_files_with_path_prefixes')->setValue($client, $pull_only_files_with_path_prefixes);
         $r->getProperty('pull_excluded_files_with_path_prefixes')->setValue($client, $pull_excluded_files_with_path_prefixes);
         return [$client, $r];

--- a/tests/Import/OnlyFilesPathPrefixTest.php
+++ b/tests/Import/OnlyFilesPathPrefixTest.php
@@ -131,6 +131,7 @@ class OnlyFilesPathPrefixTest extends TestCase
             ),
             'remote_protocol_version' => PULL_PROTOCOL_VERSION,
             'follow_symlinks' => false,
+            'files_pull_mode' => 'catch-up',
             'fs_root_nonempty_behavior' => 'preserve-local',
             'filter' => 'none',
         );
@@ -378,6 +379,80 @@ class OnlyFilesPathPrefixTest extends TestCase
         );
     }
 
+    public function testRunRestoresFilesPullModeWhileFilesPullIsInProgress(): void
+    {
+        file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
+        $this->writeFilesPullState(array(
+            'files_pull_mode' => 'catch-up',
+            'files_pull_path_selection_fingerprint' =>
+                $this->pathSelectionFingerprint(array()),
+        ));
+
+        $client = $this->runFilesPull(array());
+
+        $files_pull_mode = ( new \ReflectionClass( $client ) )
+            ->getProperty('files_pull_mode')
+            ->getValue($client);
+        $this->assertSame('catch-up', $files_pull_mode);
+        $this->assertSame('catch-up', $this->readState()['files_pull_mode']);
+    }
+
+    public function testRunRejectsChangingFilesPullModeWithoutChangingState(): void
+    {
+        $this->writeFilesPullState(array('files_pull_mode' => 'catch-up'));
+        $stateBefore = file_get_contents($this->pullStateDirectory . '/state.json');
+
+        try {
+            $this->runFilesPull(array('files_pull_mode' => 'mirror'));
+            $this->fail('Expected an active files-pull to reject a mode change.');
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                'Cannot change --mode while resuming files-pull',
+                $exception->getMessage()
+            );
+        }
+        $this->assertSame(
+            $stateBefore,
+            file_get_contents($this->pullStateDirectory . '/state.json')
+        );
+    }
+
+    /** @dataProvider unsupportedMirrorOptionProvider */
+    public function testMirrorRejectsUnsupportedOptionsBeforeWritingState(
+        array $options,
+        string $message
+    ): void {
+        $stateFile = $this->pullStateDirectory . '/state.json';
+
+        try {
+            $this->runFilesPull($options);
+            $this->fail('Expected mirror to reject the unsupported option.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString($message, $exception->getMessage());
+        }
+        $this->assertFileDoesNotExist($stateFile);
+    }
+
+    /** @return iterable<string,array{array<string,mixed>,string}> */
+    public static function unsupportedMirrorOptionProvider(): iterable
+    {
+        yield 'include' => [[
+            'include' => ['/var/www/html/selected'],
+        ], 'does not accept --include'];
+        yield 'exclude' => [[
+            'exclude' => ['/var/www/html/excluded'],
+        ], 'does not accept --include, --exclude'];
+        yield 'filter' => [[
+            'filter' => 'essential-files',
+        ], 'partial --filter'];
+        yield 'caches' => [[
+            'include_caches' => true,
+        ], 'does not yet accept --include-caches'];
+        yield 'preserve local' => [[
+            'fs_root_nonempty_behavior' => 'preserve-local',
+        ], 'cannot preserve local files'];
+    }
+
     public function testRunRejectsChangingIncludeCachesWithoutChangingState(): void
     {
         file_put_contents($this->pullStateDirectory . '/remote-index.next.jsonl', '');
@@ -409,7 +484,9 @@ class OnlyFilesPathPrefixTest extends TestCase
             'include_caches' => true,
         ));
 
-        $client = $this->runFilesPull(array());
+        $client = $this->runFilesPull(array(
+            'files_pull_mode' => 'catch-up',
+        ));
 
         $include_caches = ( new \ReflectionClass( $client ) )
             ->getProperty('include_caches')
@@ -422,7 +499,10 @@ class OnlyFilesPathPrefixTest extends TestCase
     {
         $this->writeFilesPullState(array('include_caches' => true));
 
-        $this->runFilesPull(array('abort' => true));
+        $this->runFilesPull(array(
+            'abort' => true,
+            'files_pull_mode' => 'catch-up',
+        ));
 
         $this->assertFalse($this->readState()['include_caches']);
     }
@@ -671,7 +751,10 @@ class OnlyFilesPathPrefixTest extends TestCase
             'files_pull_path_selection_fingerprint' => $this->pathSelectionFingerprint(array('/var/www/html/wp-content/plugins')),
         ));
 
-        $this->runFilesPull(array('include' => array(':wp-uploads:')));
+        $this->runFilesPull(array(
+            'include' => array(':wp-uploads:'),
+            'files_pull_mode' => 'catch-up',
+        ));
 
         $state = $this->readState();
         $this->assertSame('complete', $state['active_resumable_command']['completion_state'] ?? null);

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -450,6 +450,7 @@ class PullFilterOptionTest extends TestCase
         $client->run([
             "command" => "pull-files",
             "progress" => "tty",
+            "files_pull_mode" => "catch-up",
             "only" => ["/var/www/html/wp-content/uploads/reprint-demo"],
         ]);
 
@@ -467,6 +468,7 @@ class PullFilterOptionTest extends TestCase
         $client->run([
             "command" => "pull-files",
             "filter" => "essential-files",
+            "files_pull_mode" => "catch-up",
         ]);
         ob_end_clean();
 
@@ -824,6 +826,7 @@ class PullFilterOptionTest extends TestCase
         $client->run([
             "command" => "pull",
             "filter" => "essential-files",
+            "files_pull_mode" => "catch-up",
             "runtime" => "none",
         ]);
         ob_end_clean();
@@ -863,11 +866,13 @@ class PullFilterOptionTest extends TestCase
         $client->run([
             "command" => "pull",
             "filter" => "essential-files",
+            "files_pull_mode" => "catch-up",
             "runtime" => "none",
         ]);
         $client->run([
             "command" => "pull",
             "filter" => "none",
+            "files_pull_mode" => "catch-up",
             "runtime" => "none",
         ]);
         ob_end_clean();
@@ -888,6 +893,7 @@ class PullFilterOptionTest extends TestCase
         $client->run([
             "command" => "pull",
             "filter" => "essential-files",
+            "files_pull_mode" => "catch-up",
             "flatten_to" => $flatten_to,
             "runtime" => "playground-cli",
             "start_runtime" => "none",

--- a/tests/Import/PullLocalIndexProcessorTest.php
+++ b/tests/Import/PullLocalIndexProcessorTest.php
@@ -86,20 +86,28 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $this->assertSame( (int) $a_stat['size'], $entries[0]['size']);
         $this->assertSame( (int) $z_stat['ctime'], $entries[1]['ctime']);
         $this->assertSame( (int) $z_stat['size'], $entries[1]['size']);
+        $this->assertArrayNotHasKey('remote_absolute_path', $entries[0]);
+        $this->assertArrayNotHasKey('remote_absolute_path', $entries[1]);
     }
 
-    public function testPatchResultKeepsRemoteMetadataAndEmptyDirectory(): void
+    public function testPatchResultKeepsRetainedMetadataAndRemotePaths(): void
     {
+        mkdir($this->filesystem_root . '/empty', 0700, true);
+        $this->write_file('file.txt', 'local file');
         $this->write_remote_index([
             $this->remote_entry('/remote/empty', 'dir', 0, 456, true),
             $this->remote_entry('/remote/file.txt', 'file', 123, 789),
         ]);
-        $this->write_local_index([]);
+        $empty_entry = $this->local_entry_from_path('empty');
+        $empty_entry['empty'] = true;
+        $file_entry = $this->local_entry_from_path('file.txt');
+        $this->write_local_index([$empty_entry, $file_entry]);
 
         $entries = $this->run_to_completion(
             PullLocalIndexProcessor::start_patch_result(
                 $this->work_directory,
                 $this->next_remote_index_file,
+                $this->remote_index_file,
                 $this->retained_local_index_file,
                 new RemoteToLocalPathMapper(
                     $this->filesystem_root,
@@ -111,21 +119,50 @@ final class PullLocalIndexProcessorTest extends TestCase {
 
         $this->assertSame(
             [
-                [
-                    'path' => 'empty',
-                    'ctime' => 456,
-                    'size' => 0,
-                    'type' => 'dir',
-                    'empty' => true,
+                $empty_entry + [
+                    'remote_absolute_path' => '/remote/empty',
                 ],
-                [
-                    'path' => 'file.txt',
-                    'ctime' => 789,
-                    'size' => 123,
-                    'type' => 'file',
+                $file_entry + [
+                    'remote_absolute_path' => '/remote/file.txt',
                 ],
             ],
             $entries
+        );
+    }
+
+    public function testPatchResultKeepsAMissingRemoteEmptyDirectory(): void
+    {
+        $this->write_remote_index([
+            $this->remote_entry('/remote/empty', 'dir', 0, 456, true),
+        ]);
+        $retained_entry = [
+            'path' => 'empty',
+            'ctime' => 123,
+            'size' => 0,
+            'type' => 'dir',
+            'empty' => true,
+        ];
+        $this->write_local_index([$retained_entry]);
+
+        $entries = $this->run_to_completion(
+            PullLocalIndexProcessor::start_patch_result(
+                $this->work_directory,
+                $this->next_remote_index_file,
+                $this->remote_index_file,
+                $this->retained_local_index_file,
+                new RemoteToLocalPathMapper(
+                    $this->filesystem_root,
+                    ['/remote'],
+                    ['/remote' => $this->filesystem_root]
+                )
+            )
+        );
+
+        $this->assertSame(
+            $retained_entry + [
+                'remote_absolute_path' => '/remote/empty',
+            ],
+            $entries[0]
         );
     }
 
@@ -140,6 +177,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
             PullLocalIndexProcessor::start_patch_result(
                 $this->work_directory,
                 $this->next_remote_index_file,
+                $this->remote_index_file,
                 $this->retained_local_index_file,
                 new RemoteToLocalPathMapper(
                     $this->filesystem_root,
@@ -161,6 +199,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $processor = PullLocalIndexProcessor::start_patch_result(
             $this->work_directory,
             $this->next_remote_index_file,
+            $this->remote_index_file,
             $this->retained_local_index_file,
             new RemoteToLocalPathMapper(
                 $this->filesystem_root,
@@ -292,15 +331,21 @@ final class PullLocalIndexProcessorTest extends TestCase {
 
     public function testDropsMappedEmptyDirectoryImpliedByOverlappingRemapDescendant(): void
     {
+        $this->write_file('parent-name.txt', 'parent name');
+        $this->write_file('parent/child.txt', 'child');
         $this->write_remote_index([
             $this->remote_entry('/remote/empty', 'dir', 0, 10, true),
             $this->remote_entry('/remote/interleaving.txt', 'file', 11, 11),
             $this->remote_entry('/remote/leaf.txt', 'file', 12, 12),
         ]);
-        $this->write_local_index([]);
+        $this->write_local_index([
+            $this->local_entry_from_path('parent-name.txt'),
+            $this->local_entry_from_path('parent/child.txt'),
+        ]);
         $processor = PullLocalIndexProcessor::start_patch_result(
             $this->work_directory,
             $this->next_remote_index_file,
+            $this->remote_index_file,
             $this->retained_local_index_file,
             new RemoteToLocalPathMapper(
                 $this->filesystem_root,
@@ -335,6 +380,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $processor = PullLocalIndexProcessor::start_patch_result(
             $this->work_directory,
             $this->next_remote_index_file,
+            $this->remote_index_file,
             $this->retained_local_index_file,
             new RemoteToLocalPathMapper(
                 $this->filesystem_root,
@@ -379,6 +425,7 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $processor = PullLocalIndexProcessor::start_patch_result(
             $this->work_directory,
             $this->next_remote_index_file,
+            $this->remote_index_file,
             $this->retained_local_index_file,
             new RemoteToLocalPathMapper(
                 $this->filesystem_root,
@@ -1012,6 +1059,45 @@ final class PullLocalIndexProcessorTest extends TestCase {
         $resumed = PullLocalIndexProcessor::resume($complete_cursor);
         $this->assertFalse($resumed->next_step());
         $this->assertSame('complete', $resumed->get_phase());
+        $resumed->close();
+    }
+
+    public function testTerminalStepKeepsTheLastResumableCursorForSignalSave(): void
+    {
+        $this->write_file('file.txt', 'contents');
+        $this->write_remote_index([
+            $this->remote_entry('/remote/file.txt', 'file'),
+        ]);
+        $this->write_local_index([
+            $this->local_entry_from_path('file.txt'),
+        ]);
+
+        $client = new ImportClient(
+            'http://fake.url',
+            $this->temporary_directory . '/state',
+            $this->filesystem_root
+        );
+        $take_steps = ( new ReflectionClass($client) )
+            ->getMethod('take_files_pull_local_index_steps');
+        $processor = $this->start_processor();
+        for ($batch = 0; $batch < 20; ++$batch) {
+            $has_next_step = $take_steps->invoke($client, $processor);
+            if (!$has_next_step) {
+                break;
+            }
+            $processor = PullLocalIndexProcessor::resume(
+                $client->get_state()->diff->processor_cursor
+            );
+        }
+
+        $this->assertFalse($has_next_step);
+        $saved_cursor = $client->get_state()->diff->processor_cursor;
+        $this->assertIsArray($saved_cursor);
+        $this->assertNotSame('complete', $saved_cursor['position']['phase']);
+
+        $resumed = PullLocalIndexProcessor::resume($saved_cursor);
+        $this->run_to_completion_without_closing($resumed);
+        $this->assertSame('complete', $resumed->get_status());
         $resumed->close();
     }
 

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -41,29 +41,39 @@ class PullStateTest extends TestCase
         $state->active_resumable_command->command_name = 'db-pull';
         $state->active_resumable_command->completion_state = 'complete';
         $state->pull_pipeline->started_by_command = 'pull';
-        $state->diff->index_diff_cursor = [
-            'old_index_byte_offset' => 123,
-            'new_index_byte_offset' => 456,
-            'preceding_new_index_entry_path_b64' => base64_encode(
-                '/wp-content/index.php'
-            ),
+        $state->files_pull_mode = 'catch-up';
+        $state->diff->processor_cursor = [
+            'phase' => 'planning',
+            'byte_offset' => 123,
         ];
         $state->diff->fetch_list_byte_offset = 789;
         $state->diff->pull_index_wal_byte_offset = 321;
         $state->sql_statements_counted = 99;
 
         $array = $state->to_array();
+        $restored = \PullState::from_array($array);
 
         $this->assertSame('db-pull', $array['active_resumable_command']['command_name']);
         $this->assertSame('complete', $array['active_resumable_command']['completion_state']);
         $this->assertSame('pull', $array['pull_pipeline']['started_by_command']);
+        $this->assertSame('catch-up', $array['files_pull_mode']);
+        $this->assertSame('catch-up', $restored->files_pull_mode);
         $this->assertSame(
-            $state->diff->index_diff_cursor,
-            $array['diff']['index_diff_cursor']
+            $state->diff->processor_cursor,
+            $array['diff']['processor_cursor']
         );
+        $this->assertSame($state->diff->processor_cursor, $restored->diff->processor_cursor);
         $this->assertSame(789, $array['diff']['fetch_list_byte_offset']);
         $this->assertSame(321, $array['diff']['pull_index_wal_byte_offset']);
         $this->assertSame(99, $array['sql_statements_counted']);
+    }
+
+    public function testFilesPullModeDefaultsToMirror(): void
+    {
+        $state = new \PullState();
+
+        $this->assertSame('mirror', $state->files_pull_mode);
+        $this->assertSame('mirror', $state->to_array()['files_pull_mode']);
     }
 
     public function testGetAppliesDefaultsOverVerbatimPreflight(): void
@@ -157,14 +167,32 @@ class PullStateTest extends TestCase
         \PullState::from_array($data);
     }
 
+    public function testStateRejectsInvalidFilesPullMode(): void
+    {
+        $data = ( new \PullState() )->to_array();
+        $data['files_pull_mode'] = 'combine';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'files_pull_mode must be mirror or catch-up'
+        );
+
+        \PullState::from_array($data);
+    }
+
     public function testStateRejectsDiffFieldsFromThePreviousSchema(): void
     {
         $data = (new \PullState())->to_array();
         unset(
-            $data['diff']['index_diff_cursor'],
+            $data['diff']['processor_cursor'],
             $data['diff']['fetch_list_byte_offset'],
             $data['diff']['pull_index_wal_byte_offset']
         );
+        $data['diff']['index_diff_cursor'] = [
+            'old_index_byte_offset' => 0,
+            'new_index_byte_offset' => 0,
+            'preceding_new_index_entry_path_b64' => null,
+        ];
         $data['diff']['next_remote_index_byte_offset'] = 123;
         $data['diff']['last_consumed_remote_index_entry_path'] =
             '/wp-content/index.php';
@@ -173,8 +201,8 @@ class PullStateTest extends TestCase
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage(
-            'missing fetch_list_byte_offset, index_diff_cursor, pull_index_wal_byte_offset; ' .
-            'unexpected last_consumed_remote_index_entry_path, ' .
+            'missing fetch_list_byte_offset, processor_cursor, pull_index_wal_byte_offset; ' .
+            'unexpected index_diff_cursor, last_consumed_remote_index_entry_path, ' .
             'last_processed_next_remote_index_entry_path, next_remote_index_byte_offset'
         );
 


### PR DESCRIPTION
`files-pull` now makes the local tree match the current remote tree by default. A local edit or deletion is restored when the remote path is unchanged, and a local-only path is removed. `--mode=catch-up` retains the previous delta-only behavior.

## This change

Mirror mode first applies the existing remote delta. It then reuses the local index mapper, patch planner, cleanup processor, and fetch pipeline to compare the last completed local index with a fresh local scan. Remote paths needed for replacement stay attached to their mapped local entries, so remapped files are fetched from the correct source.

The mode is saved with files-pull state and cannot change during resume. A verified local index is installed through the existing copy-and-swap path.

This first mirror mode is deliberately full-tree only. It rejects partial include, exclude, and filter selections, `--include-caches`, and `preserve-local`; those cases must use `--mode=catch-up`.

## Testing

Run an initial pull, then edit and delete remote-backed local files and add a local-only file. A second default pull should restore the remote-backed files and remove the local-only file. Repeat with `--mode=catch-up`; the three local changes should remain.
