### PR TITLE
db-rewrite-urls: Skip tables without primary keys

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -5650,6 +5650,23 @@ class ImportClient
             $rewrite_state->current_table = $progress['current_table'];
             $this->save_state();
 
+            if ($progress['skipped_table'] !== null) {
+                $skip_message = sprintf(
+                    'Skipping %s because it has no primary key.',
+                    $progress['skipped_table']
+                );
+                $this->audit_log($skip_message, false);
+                $this->output_progress([
+                    'type' => 'warning',
+                    'phase' => 'database-records',
+                    'reason' => 'missing_primary_key',
+                    'table' => $progress['skipped_table'],
+                    'message' => $skip_message,
+                ], true);
+                $this->progress->clear_progress_line();
+                $this->progress->show_lifecycle_line($skip_message . "\n");
+            }
+
             $message = sprintf(
                 '%s records checked, %s changed',
                 number_format($rewrite_state->records_processed),

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
@@ -32,6 +32,7 @@ class DatabaseUrlRewriteProcessor {
     private int $records_changed;
     private int $tables_started;
     private ?string $current_table;
+    private ?string $skipped_table = null;
     private bool $complete = false;
 
     /**
@@ -95,6 +96,7 @@ class DatabaseUrlRewriteProcessor {
      */
     public function next_step(): bool
     {
+        $this->skipped_table = null;
         if ($this->complete) {
             return false;
         }
@@ -107,6 +109,10 @@ class DatabaseUrlRewriteProcessor {
                 $this->complete = true;
                 return false;
             }
+            if ($this->row_reader->get_current_primary_key_columns() === []) {
+                $this->skip_current_table();
+                return true;
+            }
             $this->reader_phase = self::READER_PHASE_NEXT_RECORD;
             return true;
         }
@@ -118,10 +124,15 @@ class DatabaseUrlRewriteProcessor {
                     'The saved db-rewrite-urls record is missing. Use --abort.'
                 );
             }
+            $primary_key_columns = $this->row_reader->get_current_primary_key_columns();
+            if ($primary_key_columns === []) {
+                $this->skip_current_table();
+                return true;
+            }
             $this->rewrite_record(
                 $this->row_reader->get_current_table(),
                 $record,
-                $this->row_reader->get_current_primary_key_columns()
+                $primary_key_columns
             );
             $this->row_reader->clear_current_record();
             $this->reader_phase = self::READER_PHASE_NEXT_RECORD;
@@ -135,6 +146,13 @@ class DatabaseUrlRewriteProcessor {
 
         $this->reader_phase = self::READER_PHASE_NEXT_TABLE;
         return true;
+    }
+
+    private function skip_current_table(): void
+    {
+        $this->skipped_table = $this->row_reader->get_current_table();
+        $this->row_reader->clear_current_record();
+        $this->reader_phase = self::READER_PHASE_NEXT_TABLE;
     }
 
     /**
@@ -171,6 +189,7 @@ class DatabaseUrlRewriteProcessor {
      *     @type int         $records_changed  Records changed by this lifecycle.
      *     @type int         $tables_started   Tables in which a record was processed.
      *     @type string|null $current_table    Table containing the last processed record.
+     *     @type string|null $skipped_table    Table skipped by the latest step for lacking a primary key.
      * }
      */
     public function get_progress(): array
@@ -180,6 +199,7 @@ class DatabaseUrlRewriteProcessor {
             'records_changed' => $this->records_changed,
             'tables_started' => $this->tables_started,
             'current_table' => $this->current_table,
+            'skipped_table' => $this->skipped_table,
         ];
     }
 
@@ -193,12 +213,6 @@ class DatabaseUrlRewriteProcessor {
         array $primary_key_columns
     ): void
     {
-        if ($primary_key_columns === []) {
-            throw new RuntimeException(
-                "Cannot rewrite URLs in {$table} because it has records but no primary key."
-            );
-        }
-
         $changes = [];
         foreach ($record as $column => $value) {
             if (!is_string($value)) {

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -285,18 +285,95 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         $this->assertSame(6, $complete_state['database_url_rewrite']['records_processed']);
     }
 
-    public function testRejectsLiveTableRowsWithoutAPrimaryKey(): void
+    public function testSkipsTablesWithoutAPrimaryKeyAndContinues(): void
     {
         $database = new \PDO('sqlite:' . $this->database_path);
         $database->exec('CREATE TABLE wp_unkeyed (content TEXT NOT NULL)');
         $database->exec("INSERT INTO wp_unkeyed VALUES ('https://old.example/unkeyed')");
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'Cannot rewrite URLs in wp_unkeyed because it has records but no primary key.'
+        $database->exec(
+            'CREATE TABLE zz_after_unkeyed (id INTEGER PRIMARY KEY, content TEXT NOT NULL)'
+        );
+        $database->exec(
+            "INSERT INTO zz_after_unkeyed VALUES (1, 'https://old.example/after-unkeyed')"
         );
 
-        $this->new_client()->run($this->command_options());
+        $client = $this->new_client();
+        $client->run($this->command_options());
+
+        $this->assertSame(
+            'https://old.example/unkeyed',
+            $database->query('SELECT content FROM wp_unkeyed')->fetchColumn()
+        );
+        $this->assertSame(
+            'https://new.example/after-unkeyed',
+            $database->query('SELECT content FROM zz_after_unkeyed')->fetchColumn()
+        );
+        $this->assertSame(
+            'complete',
+            $this->read_state($client)['active_resumable_command']['completion_state']
+        );
+        $this->assertStringContainsString(
+            'Skipping wp_unkeyed because it has no primary key.',
+            (string) file_get_contents($this->temp_dir . '/audit.log')
+        );
+    }
+
+    public function testResumesPastAPendingRecordFromAnUnkeyedTable(): void
+    {
+        $sqlite = new \PDO('sqlite:' . $this->database_path);
+        $sqlite->exec('CREATE TABLE wp_unkeyed (content TEXT NOT NULL)');
+        $sqlite->exec("INSERT INTO wp_unkeyed VALUES ('https://old.example/unkeyed')");
+        $sqlite->exec(
+            'CREATE TABLE zz_after_unkeyed (id INTEGER PRIMARY KEY, content TEXT NOT NULL)'
+        );
+        $sqlite->exec(
+            "INSERT INTO zz_after_unkeyed VALUES (1, 'https://old.example/after-unkeyed')"
+        );
+
+        $database = $this->open_mysql_on_sqlite_database();
+        $reader = new \WordPress\DataLiberation\DatabaseRowsReader(
+            $database,
+            ['batch_size' => 1]
+        );
+        $reader->initialize_tables_to_process();
+        do {
+            $this->assertTrue($reader->move_to_next_table());
+        } while ($reader->get_current_table() !== 'wp_unkeyed');
+        $this->assertTrue($reader->next_record());
+
+        $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(
+            $database,
+            new \SqlStatementRewriter(
+                new \StructuredDataUrlRewriter([
+                    'https://old.example' => 'https://new.example',
+                ]),
+                'wp_'
+            ),
+            [
+                'reader_cursor' => $reader->get_cursor_state(),
+                'reader_phase' => 'process_record',
+                'records_processed' => 3,
+                'records_changed' => 2,
+                'tables_started' => 1,
+                'current_table' => 'wp_posts',
+                'complete' => false,
+            ]
+        );
+
+        $this->assertTrue($processor->next_step());
+        $this->assertSame('wp_unkeyed', $processor->get_progress()['skipped_table']);
+        do {
+            $has_more_steps = $processor->next_step();
+        } while ($has_more_steps);
+
+        $this->assertSame(
+            'https://old.example/unkeyed',
+            $sqlite->query('SELECT content FROM wp_unkeyed')->fetchColumn()
+        );
+        $this->assertSame(
+            'https://new.example/after-unkeyed',
+            $sqlite->query('SELECT content FROM zz_after_unkeyed')->fetchColumn()
+        );
     }
 
     public function testSqliteMetadataQuotesATableNameContainingSqlPunctuation(): void


### PR DESCRIPTION
`db-rewrite-urls` now leaves tables without primary keys unchanged, reports each skipped table, and continues rewriting the remaining database.

A table without a primary key has no stable record cursor, so the command cannot safely update it record by record. It now saves the table skip as a bounded step and emits:

```json
{"type":"warning","phase":"database-records","reason":"missing_primary_key","table":"wp_unkeyed","message":"Skipping wp_unkeyed because it has no primary key."}
```

The same rule handles a lifecycle resumed from a pending unkeyed record saved by the earlier command version.

## Example

```bash
php reprint.phar db-rewrite-urls \
  --state-dir=/path/to/reprint-state \
  --rewrite-url https://old.example https://new.example
```

Rows in unkeyed tables keep their original values. Keyed tables after them are still rewritten.

## Testing

The command test places an unkeyed table before a keyed table and confirms the skip warning, unchanged unkeyed value, rewritten later value, and completed lifecycle. A second test resumes a pending unkeyed record and continues to the following table.
