### PR TITLE
Document db-rewrite-urls interruption and concurrency behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 * `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
 * `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
-* `db-rewrite-urls` — Rewrites URLs in an existing MySQL or SQLite database one primary-keyed record at a time. It saves a record cursor after each bounded step and resumes without scanning completed records again.
+* `db-rewrite-urls` — Rewrites URLs directly in an existing MySQL or SQLite database. You can stop it and continue later. See [Rewrite URLs in a live database](docs/DB-REWRITE-URLS.md).
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
 * `pull-metadata` — Prints pull lifecycle and source-site metadata as JSON. The remote Reprint API URL selects the pull state; no network calls are made.
 * `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).

--- a/docs/DB-REWRITE-URLS.md
+++ b/docs/DB-REWRITE-URLS.md
@@ -1,0 +1,68 @@
+# Rewrite URLs in a live database
+
+Use `db-rewrite-urls` to replace URLs in an existing MySQL or SQLite database.
+The command works directly on the database. It does not export or re-import a
+SQL file.
+
+It updates one row at a time and saves its place as it goes. It does not lock a
+whole table for the duration of the command.
+
+## Run the command
+
+```bash
+php reprint.phar db-rewrite-urls \
+  --state-dir=/path/to/reprint-state \
+  --rewrite-url https://old.example https://new.example
+```
+
+Add another `--rewrite-url FROM TO` for each additional replacement.
+
+The command uses the database previously saved by `db-apply`. You can use the
+`--target-*` options to choose a different database.
+
+You do not need to pass a remote Reprint API URL when the state directory has
+one saved remote. If it has no saved remote, the command uses local state. This
+command does not use `--fs-root`.
+
+## Stop and resume
+
+Press `Ctrl+C` once to stop safely when PHP PCNTL is available. The command
+finishes the current row, saves its place, and exits. Run the same command again
+to continue.
+
+If the process crashes or is killed, run the same command again. The command
+checks the row it was working on:
+
+* If the row was not updated, it updates it after resuming.
+* If the row was already updated, it moves on without replacing the URL again.
+
+This assumes that completed database writes survived the crash and no other
+connection changed the same row at that moment. A power, host, or database
+failure may have different results.
+
+While a run is incomplete, keep using the same URL replacements and database.
+To discard the saved place and start over with different settings, use
+`--abort`.
+
+## Tables without primary keys
+
+A primary key lets the command identify each row and remember where to resume.
+If a table has no primary key, the command warns you, leaves that table
+unchanged, and continues with the next table. It also records the skipped table
+in the audit log.
+
+## Changes made by the site while the command runs
+
+The site may change or delete a row after the command reads it. The command will
+not overwrite that newer change. It leaves the row alone and moves on.
+
+This protects a row from being replaced twice. That matters when the new URL
+contains the old URL, for example:
+
+```text
+https://example.com -> https://example.com/new
+```
+
+The tradeoff is that a value written at the same time may still contain the old
+URL. If you need to catch every value, prevent the site from writing to the
+database while this command runs.


### PR DESCRIPTION
Adds a guide for people who use `db-rewrite-urls` and links to it from the README.

The guide answers the practical questions: how to run the command, which database it uses, how to stop and resume it, and what happens when a table has no primary key.

It also explains one important limit. If the site changes a row while the command is working on it, the command leaves that row alone rather than risk replacing its URL twice. The old URL may remain in that row, so pause database writes when every value must be changed.

## Testing

Follow the example command and check that the README link opens the new guide.