### PR TITLE
[PHP] Mirror paths changed locally or remotely

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -31,6 +31,8 @@ use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
 use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\write_file_index_processor_entry_to_local_index;
+use function Reprint\Importer\write_local_index_entry;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_segments;
 use function WordPress\Reprint\Exporter\assert_valid_path;
@@ -110,6 +112,7 @@ require_once __DIR__ . '/lib/pull/class-pull.php';
 // Pull index reader and the WAL for completed files-pull mutations.
 require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
 require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
+require_once __DIR__ . '/lib/pull/class-mapped-remote-index-builder.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
 
 /**
@@ -250,8 +253,14 @@ class ImportClient
      */
     private $next_remote_index_file;
 
+    /** @var string Current remote index sorted by mapped local relative path. */
+    private $mapped_remote_index_file;
+
     /** @var string Path to pull/fetch-list.jsonl — files to download, computed by comparing the next remote index with the remote index. */
     private $fetch_list_file;
+
+    /** @var string Unpublished mirror replacement for the fetch list. */
+    private $next_fetch_list_file;
 
     /** @var string Path to audit.log — append-only log of every operation for debugging. */
     private $audit_log_file;
@@ -322,6 +331,9 @@ class ImportClient
      * with no source).
      */
     private $include_caches = false;
+
+    /** @var string `mirror` or `catch-up`. */
+    private $files_pull_mode = "catch-up";
 
     /**
      * @var string Controls behavior when the filesystem root is non-empty at pull start.
@@ -503,8 +515,12 @@ class ImportClient
             wp_join_unix_paths($this->pull_state_directory, "index.wal");
         $this->next_remote_index_file =
             wp_join_unix_paths($this->pull_state_directory, "remote-index.next.jsonl");
+        $this->mapped_remote_index_file =
+            wp_join_unix_paths($this->pull_state_directory, "remote-index.local-map.jsonl");
         $this->fetch_list_file =
             wp_join_unix_paths($this->pull_state_directory, "fetch-list.jsonl");
+        $this->next_fetch_list_file =
+            wp_join_unix_paths($this->pull_state_directory, "fetch-list.next.jsonl");
         $this->audit_log_file = wp_join_unix_paths($this->state_dir, "audit.log");
         $this->volatile_files_file = wp_join_unix_paths($this->pull_state_directory, "volatile-files.json");
         $this->progress_file = wp_join_unix_paths($this->state_dir, "progress.json");
@@ -932,6 +948,74 @@ class ImportClient
         if ($command === "pull-metadata") {
             $this->run_pull_metadata();
             return;
+        }
+
+        if (in_array($command, ["pull", "pull-files", "files-pull"], true)) {
+            $requested_files_pull_mode = $options["files_pull_mode"] ?? null;
+            if (
+                $requested_files_pull_mode !== null
+                && !in_array($requested_files_pull_mode, ["mirror", "catch-up"], true)
+            ) {
+                throw new InvalidArgumentException(
+                    // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI option value, never HTML.
+                    "Invalid --mode value: {$requested_files_pull_mode}. Valid values: mirror, catch-up"
+                );
+            }
+            $saved_files_pull_mode = $this->get_state()->files_pull_mode;
+            if (
+                !$abort
+                && $requested_files_pull_mode !== null
+                && $requested_files_pull_mode !== $saved_files_pull_mode
+                && $this->get_state()->active_resumable_command->command_name === "files-pull"
+            ) {
+                throw new RuntimeException(
+                    "Cannot change --mode after files-pull starts. Use --abort first."
+                );
+            }
+            $this->files_pull_mode =
+                $requested_files_pull_mode ?? $saved_files_pull_mode;
+
+            $effective_filter = $options["filter"]
+                ?? $this->get_state()->filter
+                ?? "none";
+            $effective_nonempty_behavior = $options["fs_root_nonempty_behavior"]
+                ?? $this->get_state()->fs_root_nonempty_behavior
+                ?? "error";
+            if (
+                !$abort
+                && $this->files_pull_mode === "mirror"
+                && (
+                    !empty($options["include"] ?? $options["only"] ?? [])
+                    || !empty($options["exclude"] ?? [])
+                    || $this->include_caches
+                    || $effective_filter !== "none"
+                    || $effective_nonempty_behavior === "preserve-local"
+                )
+            ) {
+                throw new InvalidArgumentException(
+                    "--mode=mirror requires a full pull without --include, --exclude, "
+                    . "--include-caches, a partial --filter, or "
+                    . "--on-fs-root-nonempty=preserve-local."
+                );
+            }
+            $absolute_state_directory = realpath_with_missing_tail(
+                $this->state_dir[0] === "/"
+                    ? $this->state_dir
+                    : wp_join_unix_paths(getcwd() ?: "/", $this->state_dir)
+            );
+            if (
+                !$abort
+                && $this->files_pull_mode === "mirror"
+                && relative_path_under(
+                    $absolute_state_directory,
+                    $this->filesystem_root
+                ) !== null
+            ) {
+                throw new InvalidArgumentException(
+                    "--mode=mirror requires --state-dir to be outside --fs-root."
+                );
+            }
+            $this->get_state()->files_pull_mode = $this->files_pull_mode;
         }
 
         // Persist follow_symlinks in state so it survives across invocations.
@@ -2377,6 +2461,18 @@ class ImportClient
             @unlink($this->next_remote_index_file);
             $this->audit_log("FILE DELETE | {$this->next_remote_index_file}");
         }
+        foreach (
+            [$this->mapped_remote_index_file, $this->next_fetch_list_file]
+            as $mirror_work_file
+        ) {
+            if (file_exists($mirror_work_file)) {
+                @unlink($mirror_work_file);
+                $this->audit_log("FILE DELETE | {$mirror_work_file}");
+            }
+        }
+        $this->remove_local_plan_directory(
+            wp_join_unix_paths($this->pull_state_directory, "mirror-plan")
+        );
         if (file_exists($this->fetch_list_file)) {
             @unlink($this->fetch_list_file);
             $this->audit_log("FILE DELETE | {$this->fetch_list_file}");
@@ -3113,7 +3209,12 @@ class ImportClient
             // Starting fresh — validate that the filesystem root is empty.
             // A delta sync ($is_delta) naturally has a non-empty filesystem root
             // because we put those files there during the initial sync.
-            if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
+            if (
+                $this->files_pull_mode === "catch-up"
+                && !$is_empty
+                && !$is_delta
+                && $this->fs_root_nonempty_behavior === 'error'
+            ) {
                 throw new RuntimeException(
                     "Filesystem root is not empty and no cursor found. " .
                         "Either clear the filesystem root, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
@@ -3179,6 +3280,7 @@ class ImportClient
             $this->pull_index_journal->open();
         }
 
+        $starting_diff_stage = false;
         if ($stage === "index") {
             $complete = $this->fetch_next_remote_index();
             if (!$complete) {
@@ -3195,6 +3297,29 @@ class ImportClient
                 }
             }
             $this->sort_next_remote_index_file();
+            if ($this->files_pull_mode === "mirror") {
+                $stage = "local-index";
+                $this->get_state()->active_resumable_command->current_stage = $stage;
+                $this->pull_index_journal->close();
+                $this->save_state();
+            } else {
+                $starting_diff_stage = true;
+            }
+        }
+
+        if ($stage === "local-index") {
+            $this->ensure_local_index_exists();
+            MappedRemoteIndexBuilder::build([
+                "remote_index_file" => $this->next_remote_index_file,
+                "mapped_remote_index_file" => $this->mapped_remote_index_file,
+                "filesystem_root" => $this->filesystem_root,
+                "path_mapper" => $this->path_mapper(),
+            ]);
+            $this->build_files_pull_mirror_local_changes();
+            $starting_diff_stage = true;
+        }
+
+        if ($starting_diff_stage) {
             $this->get_state()->active_resumable_command->current_stage = "diff";
             $this->get_state()->diff = new FileDiffProgressState();
             $this->pull_index_journal->close();
@@ -3208,6 +3333,8 @@ class ImportClient
             $stage = "diff";
         }
 
+        $starting_mirror_stage = false;
+        $starting_fetch_stage = false;
         if ($stage === "diff") {
             $complete = $this->compare_remote_indexes_and_build_fetch_list();
             if (!$complete) {
@@ -3216,6 +3343,26 @@ class ImportClient
                 return;
             }
 
+            if ($this->files_pull_mode === "mirror") {
+                $stage = "mirror";
+                $this->get_state()->active_resumable_command->current_stage = $stage;
+                $this->save_state();
+                $starting_mirror_stage = true;
+            } else {
+                $starting_fetch_stage = true;
+            }
+        }
+
+        if ($stage === "mirror") {
+            if ($starting_mirror_stage) {
+                $this->pull_index_journal->open();
+            }
+            $this->build_files_pull_mirror_fetch_list();
+            $this->pull_index_journal->flush();
+            $starting_fetch_stage = true;
+        }
+
+        if ($starting_fetch_stage) {
             $has_files_to_fetch =
                 file_exists($this->fetch_list_file) &&
                 filesize($this->fetch_list_file) > 0;
@@ -3225,6 +3372,9 @@ class ImportClient
             // startup applies any pending WAL before it resumes the fetch list.
             $this->save_state();
             $this->pull_index_journal->apply_pending_records();
+            $this->remove_local_plan_directory(
+                wp_join_unix_paths($this->pull_state_directory, "mirror-plan")
+            );
 
             // In pull mode, finalize the scanning line with a checkmark
             // and start the download progress on a fresh line.
@@ -3305,6 +3455,183 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    /** Saves the local-before to local-now changes before remote work begins. */
+    private function build_files_pull_mirror_local_changes(): void
+    {
+        $plan_directory = wp_join_unix_paths(
+            $this->pull_state_directory,
+            "mirror-plan"
+        );
+        $this->remove_local_plan_directory($plan_directory);
+        if (!mkdir($plan_directory, 0755, true)) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI filesystem path, never HTML output.
+            throw new RuntimeException(
+                "Failed to create the mirror plan directory: {$plan_directory}."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+        $fresh_local_index_file = wp_join_unix_paths(
+            $plan_directory,
+            "fresh-local-index.jsonl"
+        );
+        $fresh_local_index_handle = fopen($fresh_local_index_file, "wb");
+        if (!is_resource($fresh_local_index_handle)) {
+            throw new RuntimeException("Failed to create the fresh local index.");
+        }
+        $file_index_processor = FileIndexProcessor::start(
+            [$this->filesystem_root],
+            $this->filesystem_root,
+            false,
+            false,
+            $plan_directory
+        );
+        try {
+            while ($file_index_processor->next_index_step()) {
+                $status = $file_index_processor->get_step_status();
+                if ($status === FileIndexProcessor::STATUS_DIRECTORY_ERROR) {
+                    $error = $file_index_processor->get_directory_error();
+                    throw new RuntimeException(
+                        $error["message"] . ": " . base64_encode($error["path"]) . "."
+                    );
+                }
+                if ($status === FileIndexProcessor::STATUS_INDEXED) {
+                    foreach ($file_index_processor->get_index_entries() as $entry) {
+                        write_file_index_processor_entry_to_local_index(
+                            $fresh_local_index_handle,
+                            $entry,
+                            $this->filesystem_root
+                        );
+                    }
+                }
+            }
+            if (!fflush($fresh_local_index_handle)) {
+                throw new RuntimeException("Failed to flush the fresh local index.");
+            }
+        } finally {
+            $file_index_processor->close();
+            fclose($fresh_local_index_handle);
+        }
+        if (!sort_index_file($fresh_local_index_file)) {
+            throw new RuntimeException("Failed to sort the fresh local index.");
+        }
+
+        $changed_local_paths_file = wp_join_unix_paths(
+            $plan_directory,
+            "changed-local-paths.jsonl"
+        );
+        $changed_local_paths_handle = fopen($changed_local_paths_file, "wb");
+        if (!is_resource($changed_local_paths_handle)) {
+            throw new RuntimeException("Failed to create the changed local paths index.");
+        }
+        $local_index_diff = FileIndexDiffProcessor::create(
+            $this->local_index_file,
+            $fresh_local_index_file
+        );
+        try {
+            while ($local_index_diff->next_path()) {
+                if ($local_index_diff->get_path_transition() === "unchanged") {
+                    continue;
+                }
+                $entry = $local_index_diff->get_entry_in_new_index()
+                    ?? $local_index_diff->get_entry_in_old_index();
+                if ($entry === null) {
+                    throw new LogicException("A changed local path has no local index entry.");
+                }
+                write_local_index_entry($changed_local_paths_handle, $entry);
+            }
+            if (!fflush($changed_local_paths_handle)) {
+                throw new RuntimeException("Failed to flush the changed local paths index.");
+            }
+        } finally {
+            $local_index_diff->close();
+            fclose($changed_local_paths_handle);
+        }
+    }
+
+    /** Adds the saved local changes to the completed remote-diff fetch list. */
+    private function build_files_pull_mirror_fetch_list(): void
+    {
+        $plan_directory = wp_join_unix_paths($this->pull_state_directory, "mirror-plan");
+        $changed_local_paths_file = wp_join_unix_paths(
+            $plan_directory,
+            "changed-local-paths.jsonl"
+        );
+        if (file_exists($this->fetch_list_file)) {
+            if (!copy($this->fetch_list_file, $this->next_fetch_list_file)) {
+                throw new RuntimeException("Failed to copy the remote-diff fetch list.");
+            }
+        } elseif (file_put_contents($this->next_fetch_list_file, "") !== 0) {
+            throw new RuntimeException("Failed to create the mirror fetch list.");
+        }
+
+        $next_fetch_list_handle = fopen($this->next_fetch_list_file, "ab");
+        if (!is_resource($next_fetch_list_handle)) {
+            throw new RuntimeException("Failed to open the mirror fetch list.");
+        }
+        $decode_mapped_entry = static function (string $line): array {
+            return MappedRemoteIndexBuilder::decode_index_line($line);
+        };
+        $changed_path_diff = FileIndexDiffProcessor::create(
+            $changed_local_paths_file,
+            $this->mapped_remote_index_file,
+            null,
+            $decode_mapped_entry
+        );
+        try {
+            while ($changed_path_diff->next_path()) {
+                $local_entry = $changed_path_diff->get_entry_in_old_index();
+                if ($local_entry === null) {
+                    continue;
+                }
+                $remote_entry = $changed_path_diff->get_entry_in_new_index();
+                if ($remote_entry !== null) {
+                    /** @var array{copy_source_path:string} $remote_entry */
+                    $this->append_to_fetch_list(
+                        $remote_entry["copy_source_path"],
+                        $next_fetch_list_handle
+                    );
+                    continue;
+                }
+
+                $local_relative_path = $local_entry["path"];
+                $local_absolute_path = wp_join_unix_paths(
+                    $this->filesystem_root,
+                    $local_relative_path
+                );
+                if (
+                    !$this->remove_local_absolute_path_without_following_symlinks(
+                        $local_absolute_path
+                    )
+                ) {
+                    throw new RuntimeException(
+                        "Failed to remove a local path absent from the current remote index."
+                    );
+                }
+                $this->pull_index_journal->record_local_deletion($local_absolute_path);
+                $local_parent_path = dirname($local_absolute_path);
+                while (
+                    $local_parent_path !== $this->filesystem_root
+                    && @rmdir($local_parent_path)
+                ) {
+                    $local_parent_path = dirname($local_parent_path);
+                }
+            }
+            if (!fflush($next_fetch_list_handle)) {
+                throw new RuntimeException("Failed to flush the mirror fetch list.");
+            }
+        } finally {
+            $changed_path_diff->close();
+            fclose($next_fetch_list_handle);
+        }
+
+        if (!sort_index_file($this->next_fetch_list_file)) {
+            throw new RuntimeException("Failed to sort the mirror fetch list.");
+        }
+        if (!rename($this->next_fetch_list_file, $this->fetch_list_file)) {
+            throw new RuntimeException("Failed to publish the mirror fetch list.");
+        }
     }
 
     /** Creates an empty local index when files-pull recorded no local paths. */
@@ -12335,6 +12662,16 @@ if (
             'help' => 'Follow symlinks, consolidating escaping (out-of-scope) targets into DIR ' .
                 '(a :fs-root: path or an absolute path within --fs-root), nested by source path. ' .
                 'Bare --follow-symlinks is equivalent to --follow-symlinks=:fs-root:.',
+            'commands' => ['pull', 'pull-files', 'files-pull'],
+        ],
+        [
+            'name' => 'mode',
+            'type' => 'value',
+            'target' => 'files_pull_mode',
+            'placeholder' => 'MODE',
+            'valid_values' => ['catch-up', 'mirror'],
+            'help' => 'File pull mode (catch-up|mirror)',
+            'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'files-pull'],
         ],
         [

--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -362,6 +362,26 @@ class PullIndexJournal
     }
 
     /**
+     * Adds a `-` record after mirror removes a local-only path.
+     *
+     * @param string $local_absolute_path Local path already removed.
+     * @throws RuntimeException When the record cannot be appended.
+     */
+    public function record_local_deletion(string $local_absolute_path): void
+    {
+        $local_relative_path = $this->local_relative_path_from_local_absolute_path(
+            $local_absolute_path
+        );
+        if ($local_relative_path === null) {
+            return;
+        }
+        $this->write_record([
+            "op" => "-",
+            "local_relative_path_b64" => base64_encode($local_relative_path),
+        ]);
+    }
+
+    /**
      * Adds a `-` record which changes only the remote index.
      *
      * The record has no `local_relative_path_b64`, so the local index does not
@@ -775,6 +795,19 @@ class PullIndexJournal
                 throw new RuntimeException("Invalid pull index WAL line format.");
             }
             $pull_index_wal_operation = $pull_index_wal_record["op"] ?? null;
+            if (
+                $pull_index_wal_operation === "-"
+                && !array_key_exists(
+                    "remote_absolute_path_b64",
+                    $pull_index_wal_record
+                )
+                && array_key_exists(
+                    "local_relative_path_b64",
+                    $pull_index_wal_record
+                )
+            ) {
+                continue;
+            }
             $remote_absolute_path_base64 =
                 $pull_index_wal_record["remote_absolute_path_b64"] ?? null;
             if (

--- a/packages/reprint-client/src/lib/state/class-pull-state.php
+++ b/packages/reprint-client/src/lib/state/class-pull-state.php
@@ -50,6 +50,8 @@ class PullState
     /** @var string|null Webhost detected during preflight. */
     public ?string $webhost = null;
     public bool $follow_symlinks = true;
+    /** The selected files-pull mode. */
+    public string $files_pull_mode = 'catch-up';
     /** @var string|null Fingerprint of the local followed symlinks root; guards resume. */
     public ?string $local_followed_symlinks_root_fingerprint = null;
     public string $fs_root_nonempty_behavior = 'error';
@@ -115,6 +117,7 @@ class PullState
     public static function from_array(array $data): self
     {
         $state = new self();
+        $data += ['files_pull_mode' => 'catch-up'];
         reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->active_resumable_command = ResumableCommandCheckpointState::from_array($data['active_resumable_command']);
         $state->preflight = $data['preflight'];
@@ -122,6 +125,12 @@ class PullState
         $state->version = $data['version'];
         $state->webhost = $data['webhost'];
         $state->follow_symlinks = $data['follow_symlinks'];
+        if (!in_array($data['files_pull_mode'], ['mirror', 'catch-up'], true)) {
+            throw new UnexpectedValueException(
+                'PullState files_pull_mode must be mirror or catch-up.'
+            );
+        }
+        $state->files_pull_mode = $data['files_pull_mode'];
         $state->local_followed_symlinks_root_fingerprint = $data['local_followed_symlinks_root_fingerprint'];
         $state->fs_root_nonempty_behavior = $data['fs_root_nonempty_behavior'];
         $state->filter = $data['filter'];
@@ -227,6 +236,7 @@ class PullState
             'version' => $this->version,
             'webhost' => $this->webhost,
             'follow_symlinks' => $this->follow_symlinks,
+            'files_pull_mode' => $this->files_pull_mode,
             'local_followed_symlinks_root_fingerprint' => $this->local_followed_symlinks_root_fingerprint,
             'fs_root_nonempty_behavior' => $this->fs_root_nonempty_behavior,
             'filter' => $this->filter,

--- a/tests/Import/FilesPullMirrorDiffTest.php
+++ b/tests/Import/FilesPullMirrorDiffTest.php
@@ -1,0 +1,202 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match existing importer tests.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\write_local_index_entry;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+final class FilesPullMirrorDiffTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/mirror-diff-' . bin2hex(random_bytes(5));
+        mkdir($this->root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove($this->root);
+    }
+
+    public function testUsesRemoteFilesChangedInEitherIndexDiff(): void
+    {
+        $client = $this->client();
+        $same = $client->filesystem_root . '/same.txt';
+        $localOnlyRoot = $client->filesystem_root . '/local-only';
+        $localOnly = $localOnlyRoot . '/sub/file.txt';
+        $remoteDeleted = $client->filesystem_root . '/remote-deleted.txt';
+        file_put_contents($same, 'same');
+        mkdir(dirname($localOnly), 0755, true);
+        file_put_contents($localOnly, 'local');
+        file_put_contents($remoteDeleted, 'same');
+        $sameStat = lstat($same);
+        $remoteDeletedStat = lstat($remoteDeleted);
+        $this->assertIsArray($sameStat);
+        $this->assertIsArray($remoteDeletedStat);
+
+        $this->writeIndex($this->path($client, 'local_index_file'), [
+            ['path' => 'deleted.txt', 'ctime' => 1, 'size' => 7, 'type' => 'file'],
+            [
+                'path' => 'remote-deleted.txt',
+                'ctime' => $remoteDeletedStat['ctime'],
+                'size' => 4,
+                'type' => 'file',
+            ],
+            ['path' => 'same.txt', 'ctime' => $sameStat['ctime'] - 1, 'size' => 4, 'type' => 'file'],
+        ]);
+        $this->writeMappedIndex($client, [
+            ['deleted.txt', '/remote/deleted.txt', 'file', 7],
+            ['same.txt', '/remote/same.txt', 'file', 4],
+        ]);
+        $this->writeFetchList($client, [
+            '/remote/remote-change.txt',
+            '/remote/same.txt',
+        ]);
+
+        $buildLocalChanges = new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_local_changes'
+        );
+        $buildFetchList = new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_fetch_list'
+        );
+        $buildLocalChanges->invoke($client);
+        unlink($remoteDeleted); // The remote diff owns this later removal.
+        $buildFetchList->invoke($client);
+        $journal = ( new \ReflectionProperty(
+            \ImportClient::class,
+            'pull_index_journal'
+        ) )->getValue($client);
+        $journal->flush();
+        $journal->apply_pending_records();
+        // A stopped mirror stage may have published its list but not saved fetch.
+        $buildFetchList->invoke($client);
+        $journal->flush();
+
+        $this->assertSame([
+            '/remote/deleted.txt',
+            '/remote/remote-change.txt',
+            '/remote/same.txt',
+        ], $this->readFetchList($client));
+        $this->assertDirectoryDoesNotExist($localOnlyRoot);
+        $this->assertSame([
+            [
+                'op' => '-',
+                'local_relative_path_b64' => base64_encode(
+                    'local-only/sub/file.txt'
+                ),
+            ],
+        ], $this->readJsonLines($this->path($client, 'pull_index_wal_path')));
+    }
+
+    private function client(): \ImportClient
+    {
+        return new \ImportClient(
+            'https://src.example/export.php',
+            $this->root . '/state-' . bin2hex(random_bytes(2)),
+            $this->root . '/files-' . bin2hex(random_bytes(2))
+        );
+    }
+
+    /** @param list<array{path:string,ctime:int,size:int,type:string}> $entries */
+    private function writeIndex(string $path, array $entries): void
+    {
+        $handle = fopen($path, 'wb');
+        $this->assertIsResource($handle);
+        foreach ($entries as $entry) {
+            write_local_index_entry($handle, $entry);
+        }
+        fclose($handle);
+    }
+
+    /** @param list<array{0:string,1:string,2:string,3:int}> $entries */
+    private function writeMappedIndex(\ImportClient $client, array $entries): void
+    {
+        $lines = '';
+        foreach ($entries as [$localPath, $remotePath, $type, $size]) {
+            $lines .= json_encode([
+                'path' => base64_encode(
+                    bin2hex($localPath) . '/' . bin2hex($remotePath)
+                ),
+                'ctime' => 0,
+                'size' => $size,
+                'type' => $type,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        }
+        $path = $this->path($client, 'mapped_remote_index_file');
+        file_put_contents($path, $lines);
+        $this->assertTrue(sort_index_file($path));
+    }
+
+    /** @param list<string> $remotePaths */
+    private function writeFetchList(\ImportClient $client, array $remotePaths): void
+    {
+        $lines = '';
+        foreach ($remotePaths as $remotePath) {
+            $lines .= json_encode(
+                ['path' => base64_encode($remotePath)],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
+        }
+        file_put_contents($this->path($client, 'fetch_list_file'), $lines);
+    }
+
+    /** @return list<string> */
+    private function readFetchList(\ImportClient $client): array
+    {
+        return array_map(
+            static fn(array $entry): string => base64_decode($entry['path'], true),
+            $this->readJsonLines($this->path($client, 'fetch_list_file'))
+        );
+    }
+
+    /** @return list<array<string,mixed>> */
+    private function readJsonLines(string $path): array
+    {
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertIsArray($lines);
+        return array_map(
+            static fn(string $line): array => json_decode(
+                $line,
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            ),
+            $lines
+        );
+    }
+
+    private function path(\ImportClient $client, string $property): string
+    {
+        return ( new \ReflectionProperty(
+            \ImportClient::class,
+            $property
+        ) )->getValue($client);
+    }
+
+    private function remove(string $path): void
+    {
+        if (!is_dir($path) || is_link($path)) {
+            if (file_exists($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -117,6 +117,34 @@ final class PullIndexWalTest extends TestCase
         $journal->remove_empty_wal();
     }
 
+    public function testLocalOnlyDeletionChangesOnlyTheLocalIndex(): void
+    {
+        mkdir($this->fileRoot . '/site');
+        $localAbsolutePath = $this->fileRoot . '/site/local-only.txt';
+        file_put_contents($localAbsolutePath, 'hello');
+        $localAbsolutePath = realpath($localAbsolutePath);
+        $this->assertIsString($localAbsolutePath);
+        $journal = $this->journal($this->client());
+        $journal->record_remote_upsert(
+            '/site/local-only.txt',
+            42,
+            5,
+            'file',
+            $localAbsolutePath
+        );
+        $journal->apply_pending_records();
+
+        unlink($localAbsolutePath);
+        $journal->record_local_deletion($localAbsolutePath);
+        $journal->apply_pending_records();
+
+        $this->assertSame(
+            ['/site/local-only.txt'],
+            $this->remoteIndexEntryPaths()
+        );
+        $this->assertSame([], $this->readLocalIndex());
+    }
+
     public function testUpsertingFileDoesNotCreateParentDirectoryEntries(): void
     {
         $journal = $this->journal($this->client());

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -51,6 +51,7 @@ class PullStateTest extends TestCase
         $state->diff->fetch_list_byte_offset = 789;
         $state->diff->pull_index_wal_byte_offset = 321;
         $state->sql_statements_counted = 99;
+        $state->files_pull_mode = 'mirror';
 
         $array = $state->to_array();
 
@@ -64,6 +65,8 @@ class PullStateTest extends TestCase
         $this->assertSame(789, $array['diff']['fetch_list_byte_offset']);
         $this->assertSame(321, $array['diff']['pull_index_wal_byte_offset']);
         $this->assertSame(99, $array['sql_statements_counted']);
+        $this->assertSame('mirror', $array['files_pull_mode']);
+        $this->assertSame('mirror', \PullState::from_array($array)->files_pull_mode);
     }
 
     public function testGetAppliesDefaultsOverVerbatimPreflight(): void


### PR DESCRIPTION
`files-pull --mode=mirror` now downloads the current remote version of every path changed locally or remotely, and removes a locally changed path which is missing from the current remote index.

## Usage

```bash
php reprint.phar files-pull "$URL" \
    --state-dir="$STATE_DIR" \
    --fs-root="$FS_ROOT" \
    --secret="$SECRET" \
    --mode=mirror
```

Mirror requires the complete file selection and a state directory outside the filesystem root. `catch-up` remains the default in this PR.

## Before and after

Suppose `same.txt` contained `remote` after the last pull. It is then edited locally to contain `local edit`, while the remote file and remote index stay unchanged.

Before this PR, `files-pull` only compared the retained and current remote indexes:

```text
remote before: same.txt = remote
remote now:    same.txt = remote
remote diff:   unchanged
fetch list:    empty
local result:  local edit remains
```

With mirror mode, the local comparison also selects the path:

```text
local before:  same.txt = remote
local now:     same.txt = local edit
local diff:    changed
current remote contains same.txt
fetch list:    /remote/same.txt
local result:  remote is restored
```

A locally added `debug.log` follows the other branch:

```text
local diff:    debug.log was added
current remote has no debug.log
mirror action: remove local debug.log
```

## Data flow

Mirror uses the existing index and diff pieces in both directions:

```text
local index ----\
                 FileIndexDiffProcessor -> changed local paths --\
fresh local ----/                                                 \
                                                                   +--> fetch current remote files
remote index ---\                                                 /
                 FileIndexDiffProcessor -> remote fetch paths ---/
next remote ----/
```

After both index comparisons finish, mirror joins the changed local paths with the mapped current remote index. A matching remote entry adds its remote absolute path to the fetch list. A missing remote entry removes the local path and records a local-only index deletion. Sorting the combined candidates makes a path changed on both sides appear once.

## What stays unchanged

The remote-index request, file fetch protocol, file chunk handling, and fetch resume cursor are unchanged. Local mirror preparation is derived work. If it stops, it starts that local preparation again from the completed ordinary remote index. The existing remote diff and file fetch keep their current resume behavior.

## Out of scope

This PR does not define what happens when a mapped local path traverses a parent symlink to a path outside the filesystem root. #650 tracks that decision separately.

## Testing

The focused mirror test covers a same-size local edit, a local deletion restored from remote, a remote-only change, a duplicate candidate, a local-only subtree, the local-only WAL row, and replay after the replacement fetch list was already published. Existing diff checkpoint, pull journal, mapped-index, push-plan, and state suites also pass.
