### PR TITLE
[Docs] Explain how database migrations preserve storage engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Both packages depend on [`wp-php-toolkit/data-liberation`](https://packagist.org
 - `packages/reprint-client` — Source for the `wp-php-toolkit/reprint-client` Composer package (the CLI). `packages/reprint-client/bin/reprint-client` is the entry point for repo checkouts; Composer installs it as `vendor/bin/reprint-client`.
 - `reprint-server-wp` — WordPress plugin distribution that bundles `reprint-server`. The release ZIP keeps the legacy `reprint-exporter-wp.zip` name so upgrades land in the existing installed plugin directory.
 - `tests` — PHPUnit suite (`tests/`), Docker-based e2e scenarios (`tests/e2e/`), and PHPStan support files (`tests/phpstan/`).
-- `docs` — architecture documentation and project logos.
+- `docs` — [design choices](docs/DESIGN.md), focused design documents, and
+  project logos.
 - `bin` — build tooling (PHAR build, plugin version stamping).
 - `lib` — the `sqlite-database-integration` git submodule used by the MySQL query parser.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,32 @@
+# Design choices
+
+This document records Reprint behavior that future changes must preserve.
+
+## Database migrations preserve source storage engines
+
+A source database may contain this table:
+
+```sql
+CREATE TABLE `wp_posts` (...) ENGINE=MyISAM;
+```
+
+For a MySQL-compatible target, Reprint preserves `ENGINE=MyISAM` by writing the
+`SHOW CREATE TABLE` result into the SQL dump. The same rule applies to any
+storage-engine clause. This happens in
+[`MySQLDumpProducer::emit_create_table_statement()`](../packages/reprint-server/src/class-mysql-dump-producer.php#L349-L379).
+
+The storage engine is part of the schema. It can change full-text search
+results, locking, transactions, grouped `AUTO_INCREMENT` sequences, and
+compatibility with `MERGE` tables. Reprint preserves the source schema; it does
+not upgrade it. An engine conversion must be a separate operation that lists
+the affected tables and requires an explicit choice.
+
+The target database has the final say. Reprint sets the import session SQL mode
+without `NO_ENGINE_SUBSTITUTION`. A target that accepts MyISAM creates a MyISAM
+table. A target configured to enforce InnoDB may create an InnoDB table instead
+of rejecting the import. The target makes that substitution; Reprint does not
+rewrite the `CREATE TABLE` statement. The session settings are defined by
+[`MySQLDumpProducer::get_session_setup_sql()`](../packages/reprint-server/src/class-mysql-dump-producer.php#L430-L438).
+
+SQLite has no MyISAM or InnoDB backend, so a SQLite target must translate the
+source definition.


### PR DESCRIPTION
Documents that database migrations preserve each source storage-engine clause for MySQL-compatible targets. It also records target-server substitution, SQLite translation, and the requirement that engine conversion remain a separate, explicit operation.

The repository layout links to the new design choices document.

## Testing

Read the storage-engine section and follow its implementation links. `git diff --check` passes.