### PR TITLE
[PHP] Compare file indexes with separate decoders

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
+++ b/packages/reprint-client/src/lib/index/class-file-index-diff-processor.php
@@ -18,8 +18,10 @@ require_once __DIR__ . '/../local-index-update-functions.php';
  * link, or directory, its size, its inode change time (ctime), and, for some
  * directories, whether it was empty. Both indexes must use the same path
  * coordinate system; paths may be local relative paths or remote absolute paths.
- * Each physical line must decode to one entry. A decoder cannot filter lines;
- * blank or invalid records must throw.
+ * Each physical line must decode to one entry. The two indexes may use separate
+ * decoders, and decoder-specific fields remain available through
+ * `get_entry_in_old_index()` and `get_entry_in_new_index()`. A decoder cannot
+ * filter lines; blank or invalid records must throw.
  *
  * This processor opens two such lists:
  *
@@ -126,8 +128,11 @@ final class FileIndexDiffProcessor
     /** @var resource|null Stream containing the ending tree. */
     private $new_index_handle = null;
 
-    /** @var callable(string):IndexEntry Decodes one JSONL index line. */
-    private $decode_index_line;
+    /** @var callable(string):IndexEntry Decodes one old-index JSONL line. */
+    private $decode_old_index_line;
+
+    /** @var callable(string):IndexEntry Decodes one new-index JSONL line. */
+    private $decode_new_index_line;
 
     /** @var IndexEntry|null Unconsumed old entry, which may be current or following. */
     private ?array $old_index_entry = null;
@@ -163,16 +168,19 @@ final class FileIndexDiffProcessor
      * equivalent to an empty tree. The new file describes the ending tree and
      * must be readable. Both files remain open until `close()`.
      *
-     * @param string        $old_index_file  Old index, or a missing path for an empty index.
-     * @param string        $new_index_file  New index.
-     * @param callable|null $decode_index_line Decoder for one JSONL line. Null uses the local decoder.
+     * @param string        $old_index_file       Old index, or a missing path for an empty index.
+     * @param string        $new_index_file       New index.
+     * @param callable|null $decode_index_line    Old-index decoder, or null for the local decoder.
+     * @param callable|null $decode_new_index_line New-index decoder, or null to reuse the old-index decoder.
      * @phpstan-param (callable(string):IndexEntry)|null $decode_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_new_index_line
      * @return self Open processor positioned before either index's first path.
      */
     public static function create(
         string $old_index_file,
         string $new_index_file,
-        ?callable $decode_index_line = null
+        ?callable $decode_index_line = null,
+        ?callable $decode_new_index_line = null
     ): self {
         return self::resume(
             $old_index_file,
@@ -182,7 +190,8 @@ final class FileIndexDiffProcessor
                 "new_index_byte_offset" => 0,
                 "preceding_new_index_entry_path_b64" => null,
             ],
-            $decode_index_line
+            $decode_index_line,
+            $decode_new_index_line
         );
     }
 
@@ -197,8 +206,8 @@ final class FileIndexDiffProcessor
      * The caller must provide the same immutable index contents used to produce
      * the cursor. This method restores positions; it does not fingerprint the
      * files or check that they still describe the same snapshots.
-     * The cursor does not store the line decoder, so the caller must pass the
-     * same decoder again when resuming.
+     * The cursor does not store the line decoders, so the caller must pass the
+     * same decoders again when resuming.
      *
      * @param string $old_index_file Old index, or a missing path for an empty index.
      * @param string $new_index_file New index.
@@ -210,22 +219,27 @@ final class FileIndexDiffProcessor
      *     @type string|null $preceding_new_index_entry_path_b64 New-index path before the next position.
      * }
      * @phpstan-param Cursor $cursor
-     * @param callable|null $decode_index_line Decoder for one JSONL line. Null uses the local decoder.
+     * @param callable|null $decode_index_line    Old-index decoder, or null for the local decoder.
+     * @param callable|null $decode_new_index_line New-index decoder, or null to reuse the old-index decoder.
      * @phpstan-param (callable(string):IndexEntry)|null $decode_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_new_index_line
      * @return self Open processor restored at the supplied continuation boundary.
      */
     public static function resume(
         string $old_index_file,
         string $new_index_file,
         array $cursor,
-        ?callable $decode_index_line = null
+        ?callable $decode_index_line = null,
+        ?callable $decode_new_index_line = null
     ): self {
         $processor = new self();
         $processor->cursor = $cursor;
-        $processor->decode_index_line = $decode_index_line
+        $processor->decode_old_index_line = $decode_index_line
             ?? static function (string $line): array {
                 return decode_local_index_entry($line);
             };
+        $processor->decode_new_index_line = $decode_new_index_line
+            ?? $processor->decode_old_index_line;
         if (is_file($old_index_file)) {
             $processor->old_index_handle = @fopen($old_index_file, "rb");
             if (!is_resource($processor->old_index_handle)) {
@@ -300,13 +314,15 @@ final class FileIndexDiffProcessor
         }
         if (!$this->old_index_entry_loaded) {
             $this->old_index_entry = $this->read_next_index_entry(
-                $this->old_index_handle
+                $this->old_index_handle,
+                $this->decode_old_index_line
             );
             $this->old_index_entry_loaded = true;
         }
         if (!$this->new_index_entry_loaded) {
             $this->new_index_entry = $this->read_next_index_entry(
-                $this->new_index_handle
+                $this->new_index_handle,
+                $this->decode_new_index_line
             );
             $this->new_index_entry_loaded = true;
         }
@@ -402,7 +418,7 @@ final class FileIndexDiffProcessor
      */
     public function get_path_type_in_old_index(): ?string
     {
-        $entry = $this->get_old_index_entry_for_current_path();
+        $entry = $this->get_entry_in_old_index();
         return $entry["type"] ?? null;
     }
 
@@ -415,7 +431,7 @@ final class FileIndexDiffProcessor
      */
     public function get_path_type_in_new_index(): ?string
     {
-        $entry = $this->get_new_index_entry_for_current_path();
+        $entry = $this->get_entry_in_new_index();
         return $entry["type"] ?? null;
     }
 
@@ -472,7 +488,7 @@ final class FileIndexDiffProcessor
      */
     public function get_directory_is_empty_in_old_index(): ?bool
     {
-        $entry = $this->get_old_index_entry_for_current_path();
+        $entry = $this->get_entry_in_old_index();
         return $entry["empty"] ?? null;
     }
 
@@ -485,7 +501,7 @@ final class FileIndexDiffProcessor
      */
     public function get_directory_is_empty_in_new_index(): ?bool
     {
-        $entry = $this->get_new_index_entry_for_current_path();
+        $entry = $this->get_entry_in_new_index();
         return $entry["empty"] ?? null;
     }
 
@@ -606,11 +622,22 @@ final class FileIndexDiffProcessor
      *
      * The retained old entry may instead be the path following a current path
      * found only in the new index. In that case this method returns null rather
-     * than exposing the unrelated retained entry.
+     * than exposing the unrelated retained entry. Any additional fields from
+     * the old-index decoder remain in the returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded old-index entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty Optional empty-directory marker.
+     * }
      *
      * @phpstan-return IndexEntry|null
      */
-    private function get_old_index_entry_for_current_path(): ?array
+    public function get_entry_in_old_index(): ?array
     {
         $this->assert_current_path();
         return $this->current_path_found_in === "new"
@@ -623,11 +650,22 @@ final class FileIndexDiffProcessor
      *
      * The retained new entry may instead be the path following a current path
      * found only in the old index. In that case this method returns null rather
-     * than exposing the unrelated retained entry.
+     * than exposing the unrelated retained entry. Any additional fields from
+     * the new-index decoder remain in the returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded new-index entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty Optional empty-directory marker.
+     * }
      *
      * @phpstan-return IndexEntry|null
      */
-    private function get_new_index_entry_for_current_path(): ?array
+    public function get_entry_in_new_index(): ?array
     {
         $this->assert_current_path();
         return $this->current_path_found_in === "old"
@@ -642,7 +680,7 @@ final class FileIndexDiffProcessor
      */
     private function get_required_old_index_entry(): array
     {
-        $entry = $this->get_old_index_entry_for_current_path();
+        $entry = $this->get_entry_in_old_index();
         if ($entry === null) {
             throw new LogicException("The current path has no old-index entry.");
         }
@@ -656,7 +694,7 @@ final class FileIndexDiffProcessor
      */
     private function get_required_new_index_entry(): array
     {
-        $entry = $this->get_new_index_entry_for_current_path();
+        $entry = $this->get_entry_in_new_index();
         if ($entry === null) {
             throw new LogicException("The current path has no new-index entry.");
         }
@@ -669,10 +707,15 @@ final class FileIndexDiffProcessor
      * The file handle advances when a line is read, but the public cursor does
      * does not advance until `next_path()` moves past the current path.
      *
-     * @param resource|null $index_handle Open index or null for an empty index.
+     * @param resource|null $index_handle      Open index or null for an empty index.
+     * @param callable      $decode_index_line Decoder for this index.
+     * @phpstan-param callable(string):IndexEntry $decode_index_line
      * @phpstan-return IndexEntry|null
      */
-    private function read_next_index_entry($index_handle): ?array
+    private function read_next_index_entry(
+        $index_handle,
+        callable $decode_index_line
+    ): ?array
     {
         if (!is_resource($index_handle)) {
             return null;
@@ -684,7 +727,7 @@ final class FileIndexDiffProcessor
             }
             return null;
         }
-        $index_entry = ( $this->decode_index_line )($line);
+        $index_entry = $decode_index_line($line);
         if (!is_array($index_entry)) {
             throw new UnexpectedValueException(
                 "The file-index decoder returned " . gettype($index_entry)

--- a/tests/Import/FileIndexDiffProcessorTest.php
+++ b/tests/Import/FileIndexDiffProcessorTest.php
@@ -305,6 +305,155 @@ final class FileIndexDiffProcessorTest extends TestCase
         $processor->close();
     }
 
+    public function testIndependentDecodersExposeCompleteCurrentEntries(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('b-old-only.txt', 10),
+            $this->entry('c-shared.txt', 20),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('a-new-only.txt', 30),
+            $this->entry('c-shared.txt', 40),
+        ]);
+        $old_decoder = static function (string $line): array {
+            $entry = Reprint\Importer\decode_local_index_entry($line);
+            $entry['decoded_from'] = 'old';
+            return $entry;
+        };
+        $new_decoder = static function (string $line): array {
+            $entry = Reprint\Importer\decode_local_index_entry($line);
+            $entry['decoded_from'] = 'new';
+            return $entry;
+        };
+        $processor = FileIndexDiffProcessor::create(
+            $old_index_file,
+            $new_index_file,
+            $old_decoder,
+            $new_decoder
+        );
+
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('a-new-only.txt', $processor->get_path());
+        $this->assertNull($processor->get_entry_in_old_index());
+        $this->assertSame(
+            [
+                'path' => 'a-new-only.txt',
+                'ctime' => 30,
+                'size' => 1,
+                'type' => 'file',
+                'decoded_from' => 'new',
+            ],
+            $processor->get_entry_in_new_index()
+        );
+
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('b-old-only.txt', $processor->get_path());
+        $this->assertSame(
+            [
+                'path' => 'b-old-only.txt',
+                'ctime' => 10,
+                'size' => 1,
+                'type' => 'file',
+                'decoded_from' => 'old',
+            ],
+            $processor->get_entry_in_old_index()
+        );
+        $this->assertNull($processor->get_entry_in_new_index());
+
+        $this->assertTrue($processor->next_path());
+        $this->assertSame('c-shared.txt', $processor->get_path());
+        $this->assertSame(
+            'old',
+            $processor->get_entry_in_old_index()['decoded_from'] ?? null
+        );
+        $this->assertSame(
+            'new',
+            $processor->get_entry_in_new_index()['decoded_from'] ?? null
+        );
+        $processor->close();
+    }
+
+    public function testOneDecoderStillDecodesBothIndexes(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('shared.txt', 10),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('shared.txt', 20),
+        ]);
+        $decoder = static function (string $line): array {
+            $entry = Reprint\Importer\decode_local_index_entry($line);
+            $entry['decoder'] = 'shared';
+            return $entry;
+        };
+        $processor = FileIndexDiffProcessor::create(
+            $old_index_file,
+            $new_index_file,
+            $decoder
+        );
+
+        $this->assertTrue($processor->next_path());
+        $this->assertSame(
+            'shared',
+            $processor->get_entry_in_old_index()['decoder'] ?? null
+        );
+        $this->assertSame(
+            'shared',
+            $processor->get_entry_in_new_index()['decoder'] ?? null
+        );
+        $processor->close();
+    }
+
+    public function testNewDecoderOverridesTheDefaultDecoderAcrossResume(): void
+    {
+        $old_index_file = $this->write_index('old.jsonl', [
+            $this->entry('a-old-only.txt'),
+            $this->entry('c-shared.txt'),
+        ]);
+        $new_index_file = $this->write_index('new.jsonl', [
+            $this->entry('b-new-only.txt'),
+            $this->entry('c-shared.txt'),
+        ]);
+        $new_decoder = static function (string $line): array {
+            $entry = Reprint\Importer\decode_local_index_entry($line);
+            $entry['decoded_from'] = 'new';
+            return $entry;
+        };
+        $processor = FileIndexDiffProcessor::create(
+            $old_index_file,
+            $new_index_file,
+            null,
+            $new_decoder
+        );
+        $this->assertTrue($processor->next_path());
+        $this->assertTrue($processor->next_path());
+        $cursor = $processor->get_cursor();
+        $processor->close();
+
+        $resumed_processor = FileIndexDiffProcessor::resume(
+            $old_index_file,
+            $new_index_file,
+            $cursor,
+            null,
+            $new_decoder
+        );
+        $this->assertTrue($resumed_processor->next_path());
+        $this->assertSame('b-new-only.txt', $resumed_processor->get_path());
+        $this->assertNull($resumed_processor->get_entry_in_old_index());
+        $this->assertSame(
+            'new',
+            $resumed_processor->get_entry_in_new_index()['decoded_from'] ?? null
+        );
+        $this->assertTrue($resumed_processor->next_path());
+        $this->assertSame('c-shared.txt', $resumed_processor->get_path());
+        $old_entry = $resumed_processor->get_entry_in_old_index();
+        $new_entry = $resumed_processor->get_entry_in_new_index();
+        $this->assertIsArray($old_entry);
+        $this->assertArrayNotHasKey('decoded_from', $old_entry);
+        $this->assertSame('new', $new_entry['decoded_from'] ?? null);
+        $resumed_processor->close();
+    }
+
     public function testMissingNewIndexIsRejected(): void
     {
         $old_index_file = $this->write_index('old.jsonl', []);


### PR DESCRIPTION
`FileIndexDiffProcessor` can now align two sorted file indexes that need different line decoders and let the caller read the complete decoded entry from either index.

## Example

A mirror pull compares a fresh local index with a mapped remote index. Their decoders may produce these entries for the same file:

```php
$fresh_local_entry = [
    "path" => "wp-content/uploads/photo.jpg",
    "type" => "file",
    "size" => 123,
    "ctime" => 456,
];

$mapped_remote_entry = [
    "path" => "wp-content/uploads/photo.jpg",
    "type" => "file",
    "size" => 123,
    "ctime" => 987,
    "remote_absolute_path" => "/srv/site/wp-content/uploads/photo.jpg",
];
```

The processor aligns both entries by the local relative `path`. The mirror pull also needs `remote_absolute_path` so it knows which remote file to fetch.

Before this PR, one decoder was applied to both index files. The public API also exposed only selected fields such as type, size, and ctime. A caller could not decode the mapped remote index separately and then read its remote absolute path.

This PR adds an optional decoder for the new index and public getters for both complete current entries:

```php
$diff = FileIndexDiffProcessor::create(
    $fresh_local_index_file,
    $mapped_remote_index_file,
    null,
    $decode_mapped_remote_index_line
);

while ($diff->next_path()) {
    $fresh_local_entry = $diff->get_entry_in_old_index();
    $mapped_remote_entry = $diff->get_entry_in_new_index();
}
```

The existing third decoder argument still handles both indexes when no fourth argument is given. When the current path exists in only one index, the getter for the other index returns `null`. It does not return the processor's retained lookahead entry. Fields added by a decoder remain available in the returned entry.

A resumed processor must receive the same decoders again. The cursor format does not change.

Both decoders must return valid index entries. After decoding, both files must use the same path names and must still be sorted by those paths.

#633 builds the mapped remote index used in this example. This PR only adds the shared comparison API that it needs.

## Possible follow-up

An `IndexReader` could keep one index file, its decoder, and its byte-offset reading behavior together. `FileIndexDiffProcessor` could then receive two readers instead of two file paths and two decoder arguments:

```php
$diff = FileIndexDiffProcessor::create(
    new IndexReader($fresh_local_index_file),
    new IndexReader(
        $mapped_remote_index_file,
        $decode_mapped_remote_index_line
    )
);
```

This would keep each file beside the decoder that understands it. Other index processors could then use the same reading API. This larger API change is outside this PR.

## Testing

`FileIndexDiffProcessorTest` covers separate decoders for old-only, new-only, and shared paths; decoder-added fields; the existing shared-decoder behavior; and resuming with a separate new-index decoder.
