### PR TITLE
Report live URL rewrite rows that require verification

### DIFF
--- a/docs/DB-REWRITE-URLS.md
+++ b/docs/DB-REWRITE-URLS.md
@@ -66,3 +66,17 @@ https://example.com -> https://example.com/new
 The tradeoff is that a value written at the same time may still contain the old
 URL. If you need to catch every value, prevent the site from writing to the
 database while this command runs.
+
+## Rows to verify
+
+Every run creates a `db-rewrite-urls-<job-id>.jsonl` report in the same
+directory as its saved progress. The first line records the URL replacements
+and database used by the job.
+
+When the command cannot tell whether it updated a row before an interruption or
+another connection changed that row, it adds the table, primary key, and column
+hashes to the report. It does not copy the full database value into the file.
+
+The final command output tells you how many rows need verification and where to
+find the report. A reported row may already contain the intended result. Check
+it before applying another replacement.

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -12,6 +12,7 @@
 
 use Reprint\Importer\CurlTimeoutException;
 use Reprint\Importer\DatabaseUrlRewriteProcessor;
+use Reprint\Importer\DatabaseUrlRewriteReviewLog;
 use Reprint\Importer\PreserveLocalSkipException;
 use Reprint\Importer\Pull\PullFailureReportedException;
 use Reprint\Importer\State\DatabaseApplyCommandState;
@@ -5584,12 +5585,30 @@ class ImportClient
             $rewrite_state = new DatabaseUrlRewriteCommandState();
             $rewrite_state->rewrite_url = $url_mapping;
             $rewrite_state->target = $target_identity;
+            $rewrite_state->review_job_id = bin2hex(random_bytes(16));
             $this->get_state()->database_url_rewrite = $rewrite_state;
             $active_command->command_name = 'db-rewrite-urls';
             $active_command->completion_state = 'in_progress';
             $active_command->current_stage = 'database-records';
             $this->save_state();
         }
+
+        if ($rewrite_state->review_job_id === null) {
+            // An incomplete job saved before review reports were introduced
+            // receives its report ID on the first resume with this version.
+            $rewrite_state->review_job_id = bin2hex(random_bytes(16));
+            $this->save_state();
+        }
+        $review_file = wp_join_unix_paths(
+            $this->pull_state_directory,
+            "db-rewrite-urls-{$rewrite_state->review_job_id}.jsonl"
+        );
+        $review_log = new DatabaseUrlRewriteReviewLog(
+            $review_file,
+            $rewrite_state->review_job_id,
+            $url_mapping,
+            $target_identity
+        );
 
         $statement_rewriter = new SqlStatementRewriter(
             new StructuredDataUrlRewriter($url_mapping),
@@ -5643,9 +5662,17 @@ class ImportClient
                 );
             }
 
+            // The review entry must reach disk before the cursor advances.
+            // A crash between these writes replays the same pending row; the
+            // log compares its stable ID with the final complete JSONL line.
+            if (is_array($progress['row_to_verify'])) {
+                $review_log->append_row_to_verify($progress['row_to_verify']);
+            }
+
             $rewrite_state->cursor = $encoded_cursor;
             $rewrite_state->records_processed = $progress['records_processed'];
             $rewrite_state->records_changed = $progress['records_changed'];
+            $rewrite_state->records_to_verify = $progress['records_to_verify'];
             $rewrite_state->tables_started = $progress['tables_started'];
             $rewrite_state->current_table = $progress['current_table'];
             $this->save_state();
@@ -5676,8 +5703,10 @@ class ImportClient
                 'phase' => 'database-records',
                 'records_processed' => $rewrite_state->records_processed,
                 'records_changed' => $rewrite_state->records_changed,
+                'records_to_verify' => $rewrite_state->records_to_verify,
                 'tables_started' => $rewrite_state->tables_started,
                 'current_table' => $rewrite_state->current_table,
+                'review_file' => $review_file,
                 'message' => $message,
             ]);
             $this->progress->show_progress_line($message);
@@ -5697,10 +5726,13 @@ class ImportClient
         $this->save_state();
 
         $message = sprintf(
-            'db-rewrite-urls %s (%d records checked, %d changed)',
+            'db-rewrite-urls %s (%d records checked, %d changed, %d %s to verify: %s)',
             $status,
             $rewrite_state->records_processed,
-            $rewrite_state->records_changed
+            $rewrite_state->records_changed,
+            $rewrite_state->records_to_verify,
+            $rewrite_state->records_to_verify === 1 ? 'row' : 'rows',
+            $review_file
         );
         $this->audit_log($message, true);
         $this->output_progress([
@@ -5708,12 +5740,15 @@ class ImportClient
             'phase' => 'database-records',
             'records_processed' => $rewrite_state->records_processed,
             'records_changed' => $rewrite_state->records_changed,
+            'records_to_verify' => $rewrite_state->records_to_verify,
             'tables_started' => $rewrite_state->tables_started,
             'current_table' => $rewrite_state->current_table,
+            'review_file' => $review_file,
             'message' => $message,
         ], true);
         $this->progress->clear_progress_line();
         $this->progress->show_lifecycle_line($message . "\n");
+        $review_log->close();
     }
     // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
@@ -12677,6 +12712,8 @@ if (
                 "\n" .
                 "Resumes from the last saved record cursor and reports records\n" .
                 "checked, records changed, tables started, and the current table.\n" .
+                "Each job also writes a JSONL report listing rows whose update\n" .
+                "result must be verified after an interruption or concurrent change.\n" .
                 "Tables containing records must have a primary key. --fs-root is\n" .
                 "not used.\n",
             "extra" =>

--- a/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
+++ b/packages/reprint-client/src/lib/state/class-database-url-rewrite-command-state.php
@@ -15,6 +15,9 @@ class DatabaseUrlRewriteCommandState {
     /** @var int Database records changed by this lifecycle. */
     public int $records_changed = 0;
 
+    /** @var int Database records whose update result must be verified. */
+    public int $records_to_verify = 0;
+
     /** @var int Tables in which at least one record was processed. */
     public int $tables_started = 0;
 
@@ -27,17 +30,27 @@ class DatabaseUrlRewriteCommandState {
     /** @var array<string,mixed>|null Database identity fixed for this lifecycle. */
     public ?array $target = null;
 
+    /** @var string|null Identifier used in this lifecycle's review report filename. */
+    public ?string $review_job_id = null;
+
     public static function from_array(array $data): self
     {
         $state = new self();
+        // State written before review reports were introduced has neither key.
+        $data += [
+            'records_to_verify' => 0,
+            'review_job_id' => null,
+        ];
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
         $state->cursor = $data['cursor'];
         $state->records_processed = $data['records_processed'];
         $state->records_changed = $data['records_changed'];
+        $state->records_to_verify = $data['records_to_verify'];
         $state->tables_started = $data['tables_started'];
         $state->current_table = $data['current_table'];
         $state->rewrite_url = $data['rewrite_url'];
         $state->target = $data['target'];
+        $state->review_job_id = $data['review_job_id'];
         return $state;
     }
 
@@ -47,10 +60,12 @@ class DatabaseUrlRewriteCommandState {
             'cursor' => $this->cursor,
             'records_processed' => $this->records_processed,
             'records_changed' => $this->records_changed,
+            'records_to_verify' => $this->records_to_verify,
             'tables_started' => $this->tables_started,
             'current_table' => $this->current_table,
             'rewrite_url' => $this->rewrite_url,
             'target' => $this->target,
+            'review_job_id' => $this->review_job_id,
         ];
     }
 }

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-processor.php
@@ -30,9 +30,12 @@ class DatabaseUrlRewriteProcessor {
     private string $reader_phase = self::READER_PHASE_NEXT_TABLE;
     private int $records_processed;
     private int $records_changed;
+    private int $records_to_verify;
     private int $tables_started;
     private ?string $current_table;
     private ?string $skipped_table = null;
+    /** @var array<string,mixed>|null */
+    private ?array $row_to_verify = null;
     private bool $complete = false;
 
     /**
@@ -82,6 +85,7 @@ class DatabaseUrlRewriteProcessor {
         }
         $this->records_processed = (int) ( $cursor['records_processed'] ?? 0 );
         $this->records_changed = (int) ( $cursor['records_changed'] ?? 0 );
+        $this->records_to_verify = (int) ( $cursor['records_to_verify'] ?? 0 );
         $this->tables_started = (int) ( $cursor['tables_started'] ?? 0 );
         $this->current_table = isset($cursor['current_table'])
             ? (string) $cursor['current_table']
@@ -97,6 +101,7 @@ class DatabaseUrlRewriteProcessor {
     public function next_step(): bool
     {
         $this->skipped_table = null;
+        $this->row_to_verify = null;
         if ($this->complete) {
             return false;
         }
@@ -163,6 +168,7 @@ class DatabaseUrlRewriteProcessor {
      *     @type string      $reader_phase    Next reader action.
      *     @type int         $records_processed Records whose rewrite decision is complete.
      *     @type int         $records_changed  Records changed by this lifecycle.
+     *     @type int         $records_to_verify Records whose update result could not be confirmed.
      *     @type int         $tables_started   Tables in which a record was processed.
      *     @type string|null $current_table    Table containing the last processed record.
      *     @type bool        $complete         Whether the processor is terminal.
@@ -175,6 +181,7 @@ class DatabaseUrlRewriteProcessor {
             'reader_phase' => $this->reader_phase,
             'records_processed' => $this->records_processed,
             'records_changed' => $this->records_changed,
+            'records_to_verify' => $this->records_to_verify,
             'tables_started' => $this->tables_started,
             'current_table' => $this->current_table,
             'complete' => $this->complete,
@@ -187,9 +194,11 @@ class DatabaseUrlRewriteProcessor {
      *
      *     @type int         $records_processed Records whose rewrite decision is complete.
      *     @type int         $records_changed  Records changed by this lifecycle.
+     *     @type int         $records_to_verify Records whose update result could not be confirmed.
      *     @type int         $tables_started   Tables in which a record was processed.
      *     @type string|null $current_table    Table containing the last processed record.
      *     @type string|null $skipped_table    Table skipped by the latest step for lacking a primary key.
+     *     @type array|null  $row_to_verify    Selected row whose conditional update changed no rows.
      * }
      */
     public function get_progress(): array
@@ -197,9 +206,11 @@ class DatabaseUrlRewriteProcessor {
         return [
             'records_processed' => $this->records_processed,
             'records_changed' => $this->records_changed,
+            'records_to_verify' => $this->records_to_verify,
             'tables_started' => $this->tables_started,
             'current_table' => $this->current_table,
             'skipped_table' => $this->skipped_table,
+            'row_to_verify' => $this->row_to_verify,
         ];
     }
 
@@ -231,7 +242,25 @@ class DatabaseUrlRewriteProcessor {
         }
 
         if ($changes !== []) {
-            $this->update_record($table, $record, $primary_key_columns, $changes);
+            if (!$this->update_record($table, $record, $primary_key_columns, $changes)) {
+                $primary_key = [];
+                foreach ($primary_key_columns as $column) {
+                    $primary_key[$column] = $record[$column];
+                }
+                $columns = [];
+                foreach ($changes as $column => $rewritten_value) {
+                    $columns[$column] = [
+                        'original_sha256' => hash('sha256', (string) $record[$column]),
+                        'intended_sha256' => hash('sha256', $rewritten_value),
+                    ];
+                }
+                $this->row_to_verify = [
+                    'table' => $table,
+                    'primary_key' => $primary_key,
+                    'columns' => $columns,
+                ];
+                ++$this->records_to_verify;
+            }
             ++$this->records_changed;
         }
         ++$this->records_processed;
@@ -251,7 +280,7 @@ class DatabaseUrlRewriteProcessor {
         array $record,
         array $primary_key_columns,
         array $changes
-    ): void {
+    ): bool {
         $set_parts = [];
         $where_parts = [];
         $params = [];
@@ -290,6 +319,13 @@ class DatabaseUrlRewriteProcessor {
         // cursor was saved, or that the selected values changed or disappeared.
         // These cases cannot be distinguished for overlapping URL mappings.
         // Complete the pending decision without rewriting the current bytes.
+        $rows_changed = $statement->rowCount();
+        if ($rows_changed > 1) {
+            throw new RuntimeException(
+                "The primary-key update for {$table} changed {$rows_changed} records instead of at most one."
+            );
+        }
+        return $rows_changed === 1;
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-review-log.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-database-url-rewrite-review-log.php
@@ -1,0 +1,314 @@
+<?php
+declare(strict_types=1);
+
+namespace Reprint\Importer;
+
+use RuntimeException;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI errors contain local paths, never HTML.
+
+/**
+ * Appends rows whose live URL rewrite result could not be confirmed.
+ *
+ * One process writes a job file at a time. A stable row ID and a comparison
+ * with the final complete line make replay after an interrupted append
+ * idempotent without rescanning the file.
+ */
+class DatabaseUrlRewriteReviewLog {
+
+    private string $path;
+    private string $job_id;
+
+    /** @var resource|null */
+    private $handle;
+
+    /** @var array<string,mixed>|null */
+    private ?array $last_record = null;
+
+    /**
+     * @param array<string,string> $rewrite_url URL replacements for this job.
+     * @param array<string,mixed>  $target      Database identity without its password.
+     */
+    public function __construct(
+        string $path,
+        string $job_id,
+        array $rewrite_url,
+        array $target
+    ) {
+        if (preg_match('/^[a-f0-9]{32}$/', $job_id) !== 1) {
+            throw new RuntimeException('The db-rewrite-urls review job ID is invalid.');
+        }
+
+        $this->path = $path;
+        $this->job_id = $job_id;
+        $handle = fopen($path, 'c+b');
+        if ($handle === false) {
+            throw new RuntimeException("Failed to open the db-rewrite-urls review file: {$path}");
+        }
+        $this->handle = $handle;
+
+        try {
+            if (!flock($this->handle, LOCK_EX)) {
+                throw new RuntimeException("Failed to lock the db-rewrite-urls review file: {$path}");
+            }
+            if (!chmod($path, 0600)) {
+                throw new RuntimeException("Failed to restrict the db-rewrite-urls review file: {$path}");
+            }
+
+            $this->remove_incomplete_final_line();
+            $header = [
+                'type' => 'job',
+                'version' => 1,
+                'job_id' => $job_id,
+                'command' => 'db-rewrite-urls',
+                'rewrite_url' => array_map(
+                    static function (string $from, string $to): array {
+                        return [
+                            'from' => $from,
+                            'to' => $to,
+                        ];
+                    },
+                    array_keys($rewrite_url),
+                    array_values($rewrite_url)
+                ),
+                'target' => $target,
+            ];
+
+            if ($this->file_size() === 0) {
+                $this->append_record($header);
+            } else {
+                rewind($this->handle);
+                $header_line = fgets($this->handle);
+                $saved_header = is_string($header_line)
+                    ? json_decode(rtrim($header_line, "\r\n"), true)
+                    : null;
+                if ($saved_header !== $header) {
+                    throw new RuntimeException(
+                        "The db-rewrite-urls review file does not match the saved job: {$path}"
+                    );
+                }
+            }
+            $this->last_record = $this->read_last_complete_record();
+        } catch (\Throwable $throwable) {
+            $this->close();
+            throw $throwable;
+        }
+    }
+
+    /**
+     * @param array $row {
+     *     Row whose conditional update changed no records.
+     *
+     *     @type string $table       Database table name.
+     *     @type array  $primary_key Primary-key values keyed by column name.
+     *     @type array  $columns     Original and intended SHA-256 hashes keyed by column name.
+     * }
+     * @return bool Whether a new line was appended.
+     */
+    public function append_row_to_verify(array $row): bool
+    {
+        $primary_key = [];
+        foreach ($row['primary_key'] as $column => $value) {
+            $primary_key[$column] = $this->format_database_value($value);
+        }
+        $record_without_id = [
+            'type' => 'row_to_verify',
+            'reason' => 'conditional_update_changed_no_rows',
+            'table' => $row['table'],
+            'primary_key' => $primary_key,
+            'columns' => $row['columns'],
+        ];
+        $record_id = hash(
+            'sha256',
+            $this->job_id . "\n" . $this->encode_record($record_without_id)
+        );
+        if (
+            ( $this->last_record['type'] ?? null ) === 'row_to_verify'
+            && ( $this->last_record['id'] ?? null ) === $record_id
+        ) {
+            return false;
+        }
+
+        $this->append_record([
+            'type' => 'row_to_verify',
+            'id' => $record_id,
+            'reason' => 'conditional_update_changed_no_rows',
+            'table' => $row['table'],
+            'primary_key' => $primary_key,
+            'columns' => $row['columns'],
+        ]);
+        return true;
+    }
+
+    public function close(): void
+    {
+        if (!is_resource($this->handle)) {
+            $this->handle = null;
+            return;
+        }
+        flock($this->handle, LOCK_UN);
+        fclose($this->handle);
+        $this->handle = null;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /** @param mixed $value */
+    private function format_database_value($value): array
+    {
+        if ($value === null) {
+            return ['type' => 'null'];
+        }
+        if (is_int($value)) {
+            return [
+                'type' => 'integer',
+                'value' => $value,
+            ];
+        }
+        if (is_float($value)) {
+            return [
+                'type' => 'float',
+                'value' => $value,
+            ];
+        }
+        if (is_string($value) && preg_match('//u', $value) === 1) {
+            return [
+                'type' => 'string',
+                'value' => $value,
+            ];
+        }
+        if (is_string($value)) {
+            return [
+                'type' => 'bytes',
+                'base64' => base64_encode($value),
+            ];
+        }
+        throw new RuntimeException(
+            'Cannot record a db-rewrite-urls primary-key value of type ' . gettype($value) . '.'
+        );
+    }
+
+    /** @param array<string,mixed> $record */
+    private function append_record(array $record): void
+    {
+        $line = $this->encode_record($record) . "\n";
+        fseek($this->handle, 0, SEEK_END);
+        $offset = 0;
+        $length = strlen($line);
+        while ($offset < $length) {
+            $bytes_written = fwrite($this->handle, substr($line, $offset));
+            if ($bytes_written === false || $bytes_written === 0) {
+                throw new RuntimeException(
+                    "Failed to append the db-rewrite-urls review file: {$this->path}"
+                );
+            }
+            $offset += $bytes_written;
+        }
+        if (!fflush($this->handle)) {
+            throw new RuntimeException(
+                "Failed to flush the db-rewrite-urls review file: {$this->path}"
+            );
+        }
+        if (function_exists('fsync') && !fsync($this->handle)) {
+            throw new RuntimeException(
+                "Failed to sync the db-rewrite-urls review file: {$this->path}"
+            );
+        }
+        $this->last_record = $record;
+    }
+
+    /** @param array<string,mixed> $record */
+    private function encode_record(array $record): string
+    {
+        $encoded = json_encode($record, JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            throw new RuntimeException(
+                'Failed to encode a db-rewrite-urls review record: ' . json_last_error_msg()
+            );
+        }
+        return $encoded;
+    }
+
+    private function remove_incomplete_final_line(): void
+    {
+        $size = $this->file_size();
+        if ($size === 0) {
+            return;
+        }
+        fseek($this->handle, -1, SEEK_END);
+        if (fread($this->handle, 1) === "\n") {
+            return;
+        }
+
+        $last_newline = $this->find_last_newline_offset($size);
+        $complete_size = $last_newline === null ? 0 : $last_newline + 1;
+        if (!ftruncate($this->handle, $complete_size) || !fflush($this->handle)) {
+            throw new RuntimeException(
+                "Failed to discard an incomplete db-rewrite-urls review line: {$this->path}"
+            );
+        }
+        if (function_exists('fsync') && !fsync($this->handle)) {
+            throw new RuntimeException(
+                "Failed to sync the repaired db-rewrite-urls review file: {$this->path}"
+            );
+        }
+    }
+
+    /** @return array<string,mixed>|null */
+    private function read_last_complete_record(): ?array
+    {
+        $size = $this->file_size();
+        if ($size === 0) {
+            return null;
+        }
+
+        $previous_newline = $this->find_last_newline_offset($size - 1);
+        $start = $previous_newline === null ? 0 : $previous_newline + 1;
+        $length = $size - 1 - $start;
+        fseek($this->handle, $start);
+        $line = $length > 0 ? fread($this->handle, $length) : '';
+        $record = is_string($line) ? json_decode($line, true) : null;
+        if (!is_array($record)) {
+            throw new RuntimeException(
+                "The final db-rewrite-urls review line is invalid: {$this->path}"
+            );
+        }
+        return $record;
+    }
+
+    private function find_last_newline_offset(int $before_offset): ?int
+    {
+        $position = $before_offset;
+        while ($position > 0) {
+            $length = min(4096, $position);
+            $position -= $length;
+            fseek($this->handle, $position);
+            $chunk = fread($this->handle, $length);
+            if (!is_string($chunk)) {
+                throw new RuntimeException(
+                    "Failed to read the db-rewrite-urls review file: {$this->path}"
+                );
+            }
+            $newline = strrpos($chunk, "\n");
+            if ($newline !== false) {
+                return $position + $newline;
+            }
+        }
+        return null;
+    }
+
+    private function file_size(): int
+    {
+        fseek($this->handle, 0, SEEK_END);
+        $size = ftell($this->handle);
+        if ($size === false) {
+            throw new RuntimeException(
+                "Failed to inspect the db-rewrite-urls review file: {$this->path}"
+            );
+        }
+        return $size;
+    }
+}

--- a/packages/reprint-client/src/lib/url-rewrite/load.php
+++ b/packages/reprint-client/src/lib/url-rewrite/load.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/class-fast-insert-scanner.php';
 require_once __DIR__ . '/class-sqlite-prepared-insert-builder.php';
 require_once __DIR__ . '/class-cautious-url-base-rewrite-mapping.php';
 require_once __DIR__ . '/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php';
+require_once __DIR__ . '/class-database-url-rewrite-review-log.php';
 
 // Scans structured block markup and uses the cautious processor for opaque tokens.
 require_once __DIR__ . '/class-structured-block-markup-url-processor.php';

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -79,7 +79,18 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
         $this->assertSame(6, $state['database_url_rewrite']['records_processed']);
         $this->assertSame(2, $state['database_url_rewrite']['records_changed']);
+        $this->assertSame(0, $state['database_url_rewrite']['records_to_verify']);
         $this->assertNotEmpty($state['database_url_rewrite']['cursor']);
+        $this->assertMatchesRegularExpression(
+            '/^[a-f0-9]{32}$/',
+            $state['database_url_rewrite']['review_job_id']
+        );
+        $report_file = $client->pull_state_directory . '/db-rewrite-urls-'
+            . $state['database_url_rewrite']['review_job_id'] . '.jsonl';
+        $this->assertFileExists($report_file);
+        $report_lines = file($report_file, FILE_IGNORE_NEW_LINES);
+        $this->assertCount(1, $report_lines);
+        $this->assertSame('job', json_decode($report_lines[0], true)['type']);
     }
 
     public function testInterruptedCommandResumesWithoutUpdatingARecordTwice(): void
@@ -497,6 +508,16 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         );
         $resumed_processor->next_step();
 
+        $row_to_verify = $resumed_processor->get_progress()['row_to_verify'];
+        $this->assertSame('wp_posts', $row_to_verify['table']);
+        $this->assertSame(['ID' => 1], $row_to_verify['primary_key']);
+        $this->assertSame([
+            'post_content' => [
+                'original_sha256' => hash('sha256', 'https://old.example/one'),
+                'intended_sha256' => hash('sha256', 'https://new.example/one'),
+            ],
+        ], $row_to_verify['columns']);
+
         $sqlite = new \PDO('sqlite:' . $this->database_path);
         $this->assertSame(
             'https://new.example/one',
@@ -508,6 +529,7 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         );
         $this->assertSame(1, $resumed_processor->get_progress()['records_processed']);
         $this->assertSame(1, $resumed_processor->get_progress()['records_changed']);
+        $this->assertSame(1, $resumed_processor->get_progress()['records_to_verify']);
     }
 
     public function testProcessorAdvancesPastADeletedPendingRecord(): void
@@ -592,6 +614,7 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         $state->cursor = '{"state":"emit_row"}';
         $state->records_processed = 12;
         $state->records_changed = 4;
+        $state->records_to_verify = 2;
         $state->tables_started = 3;
         $state->current_table = 'wp_posts';
         $state->rewrite_url = ['https://old.example' => 'https://new.example'];
@@ -600,11 +623,23 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
             'db' => 'wp_test',
             'sqlite_path' => '/tmp/wordpress.sqlite',
         ];
+        $state->review_job_id = '0123456789abcdef0123456789abcdef';
 
         $this->assertSame(
             $state->to_array(),
             DatabaseUrlRewriteCommandState::from_array($state->to_array())->to_array()
         );
+    }
+
+    public function testStateLoadsAJobSavedBeforeReviewReportsWereAdded(): void
+    {
+        $legacy_state = ( new DatabaseUrlRewriteCommandState() )->to_array();
+        unset($legacy_state['records_to_verify'], $legacy_state['review_job_id']);
+
+        $state = DatabaseUrlRewriteCommandState::from_array($legacy_state);
+
+        $this->assertSame(0, $state->records_to_verify);
+        $this->assertNull($state->review_job_id);
     }
 
     private function create_database(): void

--- a/tests/Import/DatabaseUrlRewriteReviewLogTest.php
+++ b/tests/Import/DatabaseUrlRewriteReviewLogTest.php
@@ -1,0 +1,109 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\DatabaseUrlRewriteReviewLog;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+class DatabaseUrlRewriteReviewLogTest extends TestCase {
+
+    private string $temp_dir;
+    private string $report_path;
+    private string $job_id = '0123456789abcdef0123456789abcdef';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temp_dir = sys_get_temp_dir() . '/reprint-url-review-' . uniqid('', true);
+        mkdir($this->temp_dir, 0755, true);
+        $this->report_path = $this->temp_dir . '/review.jsonl';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->report_path)) {
+            unlink($this->report_path);
+        }
+        rmdir($this->temp_dir);
+        parent::tearDown();
+    }
+
+    public function testReopenSkipsTheSameFinalRowAndRepairsAPartialLine(): void
+    {
+        $row = $this->row_to_verify(42);
+        $log = $this->open_log();
+        $this->assertTrue($log->append_row_to_verify($row));
+        $log->close();
+        $complete_contents = file_get_contents($this->report_path);
+
+        $log = $this->open_log();
+        $this->assertFalse($log->append_row_to_verify($row));
+        $log->close();
+        $this->assertSame($complete_contents, file_get_contents($this->report_path));
+
+        file_put_contents($this->report_path, '{"type":"row_to_', FILE_APPEND);
+        $log = $this->open_log();
+        $this->assertFalse($log->append_row_to_verify($row));
+        $log->close();
+        $this->assertSame($complete_contents, file_get_contents($this->report_path));
+    }
+
+    public function testWritesAReadableHeaderAndBytePreservingPrimaryKeys(): void
+    {
+        $log = $this->open_log();
+        $row = $this->row_to_verify(7);
+        $row['primary_key'] = [
+            'integer_id' => 7,
+            'binary_id' => "\xff\x00",
+        ];
+        $this->assertTrue($log->append_row_to_verify($row));
+        $log->close();
+
+        $lines = array_map(
+            static fn (string $line): array => json_decode($line, true),
+            file($this->report_path, FILE_IGNORE_NEW_LINES)
+        );
+        $this->assertSame([
+            ['from' => 'https://old.example', 'to' => 'https://new.example'],
+        ], $lines[0]['rewrite_url']);
+        $this->assertSame($this->job_id, $lines[0]['job_id']);
+        $this->assertSame([
+            'integer_id' => ['type' => 'integer', 'value' => 7],
+            'binary_id' => ['type' => 'bytes', 'base64' => '/wA='],
+        ], $lines[1]['primary_key']);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $lines[1]['id']);
+        $this->assertSame(0600, fileperms($this->report_path) & 0777);
+    }
+
+    private function open_log(): DatabaseUrlRewriteReviewLog
+    {
+        return new DatabaseUrlRewriteReviewLog(
+            $this->report_path,
+            $this->job_id,
+            ['https://old.example' => 'https://new.example'],
+            [
+                'engine' => 'sqlite',
+                'sqlite_path' => '/tmp/wordpress.sqlite',
+                'db' => 'wordpress',
+            ]
+        );
+    }
+
+    /** @return array<string,mixed> */
+    private function row_to_verify(int $id): array
+    {
+        return [
+            'table' => 'wp_posts',
+            'primary_key' => ['ID' => $id],
+            'columns' => [
+                'post_content' => [
+                    'original_sha256' => hash('sha256', 'https://old.example'),
+                    'intended_sha256' => hash('sha256', 'https://new.example'),
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/e2e/tests/import-57-db-rewrite-urls-crash-report.test.js
+++ b/tests/e2e/tests/import-57-db-rewrite-urls-crash-report.test.js
@@ -1,0 +1,342 @@
+/**
+ * Test 57: Live database URL rewrite crash report.
+ *
+ * Five consecutive CLI processes are killed while MySQL is applying five
+ * different rows. The server finishes each one-row UPDATE, but the process
+ * cannot save its cursor. The final process resumes the job and must report
+ * each row whose result could not be distinguished from a concurrent change.
+ * The same sequence runs against InnoDB and MyISAM.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    createTempDir, cleanupTempDir, createMysqlConnection, PHP_BINARY,
+} from '../lib/test-helpers.js';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+const IMPORTER_PATH = process.env.IMPORTER_PATH || join(
+    PROJECT_ROOT,
+    'packages',
+    'reprint-client',
+    'bin',
+    'reprint-client',
+);
+
+// Playground PHP runs inside the Node process and cannot be killed as a
+// separate PHP process. The native PHP matrix covers these real crashes.
+const describeWithProcessCrashes = PHP_BINARY.includes('playground-php.sh')
+    ? describe.skip
+    : describe;
+
+for (const engine of ['InnoDB', 'MyISAM']) {
+    describeWithProcessCrashes(
+        `Import: db-rewrite-urls ${engine} crash report`,
+        { timeout: 300000 },
+        () => {
+            const engineName = engine.toLowerCase();
+            const databaseName = `e2e_db_rewrite_crash_57_${engineName}`;
+            const contentTable = 'rewrite_content';
+            const rowCount = 5;
+            const sourceUrl = `https://${engineName}-source.example.test`;
+            const targetUrl = `https://${engineName}-target.example.test`;
+            const duplicateTargetUrl = `https://${engineName}-processed-twice.example.test`;
+            const lockPrefix = `reprint-e2e-57-${engineName}-`;
+            let tempDir;
+            let runningProcess = null;
+
+            beforeAll(async () => {
+                tempDir = createTempDir(`e2e-db-rewrite-crash-${engineName}`);
+                const connection = await createMysqlConnection();
+                await connection.query(`DROP DATABASE IF EXISTS \`${databaseName}\``);
+                await connection.query(`CREATE DATABASE \`${databaseName}\``);
+                await connection.query(
+                    `CREATE TABLE \`${databaseName}\`.\`${contentTable}\` (` +
+                    '`id` int NOT NULL, ' +
+                    '`content` text NOT NULL, ' +
+                    '`secondary_content` text NOT NULL, ' +
+                    '`untouched` varbinary(16) NOT NULL, ' +
+                    `PRIMARY KEY (\`id\`)) ENGINE=${engine}`
+                );
+
+                for (let id = 1; id <= rowCount; id++) {
+                    await connection.query(
+                        `INSERT INTO \`${databaseName}\`.\`${contentTable}\` ` +
+                        '(`id`, `content`, `secondary_content`, `untouched`) VALUES (?, ?, ?, ?)',
+                        [
+                            id,
+                            originalContent(id),
+                            originalSecondaryContent(id),
+                            untouchedBytes(id),
+                        ],
+                    );
+                }
+
+                // The named lock tells the test that MySQL is inside the
+                // UPDATE. MySQL then sleeps long enough for SIGKILL to arrive.
+                // The server finishes the statement after the client process
+                // disappears, leaving the saved cursor on the selected row.
+                await connection.query(
+                    `CREATE TRIGGER \`${databaseName}\`.\`pause_rewrite_update\` ` +
+                    `BEFORE UPDATE ON \`${databaseName}\`.\`${contentTable}\` ` +
+                    'FOR EACH ROW SET @reprint_pause = IF(' +
+                    `GET_LOCK(CONCAT('${lockPrefix}', NEW.\`id\`), 0) = 1, ` +
+                    `SLEEP(2) + RELEASE_LOCK(CONCAT('${lockPrefix}', NEW.\`id\`)), 0)`
+                );
+                await connection.end();
+            });
+
+            afterAll(async () => {
+                if (runningProcess && runningProcess.exitCode === null) {
+                    const child = runningProcess;
+                    child.kill('SIGKILL');
+                    await new Promise(resolve => child.once('close', resolve));
+                }
+                cleanupTempDir(tempDir);
+                const connection = await createMysqlConnection();
+                await connection.query(`DROP DATABASE IF EXISTS \`${databaseName}\``);
+                await connection.end();
+            });
+
+            it('reports five interrupted rows without changing their bytes twice', async () => {
+                const controlConnection = await createMysqlConnection(databaseName);
+
+                for (let id = 1; id <= rowCount; id++) {
+                    const process = startRewrite(id === 1 ? [
+                        '--target-engine=mysql',
+                        '--target-host=127.0.0.1',
+                        '--target-user=e2e_admin',
+                        '--target-pass=e2e_password',
+                        `--target-db=${databaseName}`,
+                        '--rewrite-url', sourceUrl, targetUrl,
+                        '--rewrite-url', targetUrl, duplicateTargetUrl,
+                    ] : [
+                        '--target-pass=e2e_password',
+                    ]);
+
+                    await waitForNamedLock(controlConnection, `${lockPrefix}${id}`);
+                    assert.equal(
+                        process.child.kill('SIGKILL'),
+                        true,
+                        `Expected to kill the process while updating row ${id}`,
+                    );
+                    const crashed = await waitForCompletion(process, 30000);
+                    assert.equal(crashed.exitCode, null);
+                    assert.equal(crashed.signal, 'SIGKILL');
+
+                    await waitForCommittedContent(controlConnection, id);
+                }
+
+                await controlConnection.end();
+
+                const finalProcess = startRewrite([
+                    '--target-pass=e2e_password',
+                ]);
+                const completed = await waitForCompletion(finalProcess, 120000);
+                assert.equal(
+                    completed.exitCode,
+                    0,
+                    `Expected resume to complete\nstdout: ${completed.stdout}\n` +
+                    `stderr: ${completed.stderr}`,
+                );
+
+                const reportPath = findReportPath();
+                const reportLines = readFileSync(reportPath, 'utf8')
+                    .trimEnd()
+                    .split('\n')
+                    .map(line => JSON.parse(line));
+                assert.equal(reportLines.length, rowCount + 1);
+
+                const [header, ...rowsToVerify] = reportLines;
+                assert.deepEqual(
+                    header.rewrite_url,
+                    [
+                        { from: sourceUrl, to: targetUrl },
+                        { from: targetUrl, to: duplicateTargetUrl },
+                    ],
+                );
+                assert.equal(header.type, 'job');
+                assert.equal(header.command, 'db-rewrite-urls');
+                assert.equal(header.version, 1);
+                assert.match(header.job_id, /^[a-f0-9]{32}$/);
+
+                assert.equal(new Set(rowsToVerify.map(row => row.id)).size, rowCount);
+                for (let id = 1; id <= rowCount; id++) {
+                    const row = rowsToVerify[id - 1];
+                    assert.equal(row.type, 'row_to_verify');
+                    assert.equal(row.reason, 'conditional_update_changed_no_rows');
+                    assert.equal(row.table, contentTable);
+                    assert.deepEqual(row.primary_key, {
+                        id: { type: 'integer', value: id },
+                    });
+                    assert.deepEqual(row.columns, {
+                        content: {
+                            original_sha256: sha256(originalContent(id)),
+                            intended_sha256: sha256(rewrittenContent(id)),
+                        },
+                        secondary_content: {
+                            original_sha256: sha256(originalSecondaryContent(id)),
+                            intended_sha256: sha256(rewrittenSecondaryContent(id)),
+                        },
+                    });
+                }
+
+                assert.match(completed.stdout, /5 rows? to verify/);
+                const progressRecords = completed.stdout
+                    .trimEnd()
+                    .split('\n')
+                    .map(line => JSON.parse(line));
+                const finalProgress = progressRecords.find(
+                    record => record.records_to_verify === rowCount
+                );
+                assert.equal(finalProgress.review_file, reportPath);
+
+                const connection = await createMysqlConnection(databaseName);
+                const [rows] = await connection.query(
+                    `SELECT \`id\`, \`content\`, \`secondary_content\`, \`untouched\` ` +
+                    `FROM \`${contentTable}\` ORDER BY \`id\``
+                );
+                const [tableCheck] = await connection.query(
+                    `CHECK TABLE \`${contentTable}\``
+                );
+                await connection.end();
+
+                assert.equal(tableCheck.at(-1).Msg_text, 'OK');
+                assert.equal(rows.length, rowCount);
+                for (let id = 1; id <= rowCount; id++) {
+                    const row = rows[id - 1];
+                    assert.equal(row.id, id);
+                    assert.equal(row.content.toString(), rewrittenContent(id));
+                    assert.equal(
+                        row.secondary_content.toString(),
+                        rewrittenSecondaryContent(id),
+                    );
+                    assert.deepEqual(row.untouched, untouchedBytes(id));
+                    assert.doesNotMatch(row.content.toString(), /processed-twice/);
+                    assert.doesNotMatch(row.secondary_content.toString(), /processed-twice/);
+                }
+            });
+
+            function originalContent(id) {
+                return `${sourceUrl}/content/${id}`;
+            }
+
+            function rewrittenContent(id) {
+                return `${targetUrl}/content/${id}`;
+            }
+
+            function originalSecondaryContent(id) {
+                return `before-${id} ${sourceUrl}/secondary/${id} after-${id}`;
+            }
+
+            function rewrittenSecondaryContent(id) {
+                return `before-${id} ${targetUrl}/secondary/${id} after-${id}`;
+            }
+
+            function untouchedBytes(id) {
+                return Buffer.from([0, id, 255, 82, 69, 80, 82, 73, 78, 84]);
+            }
+
+            function statePath() {
+                return join(tempDir, 'db-rewrite-urls', 'pull', 'state.json');
+            }
+
+            function findReportPath() {
+                assert.equal(existsSync(statePath()), true);
+                const pullDirectory = join(tempDir, 'db-rewrite-urls', 'pull');
+                const reportNames = readdirSync(pullDirectory).filter(
+                    name => /^db-rewrite-urls-[a-f0-9]{32}\.jsonl$/.test(name)
+                );
+                assert.equal(reportNames.length, 1);
+                return join(pullDirectory, reportNames[0]);
+            }
+
+            function startRewrite(extraArgs) {
+                const child = spawn(PHP_BINARY, [
+                    IMPORTER_PATH,
+                    'db-rewrite-urls',
+                    `--state-dir=${tempDir}`,
+                    '--progress=jsonl',
+                    ...extraArgs,
+                ], {
+                    env: { ...process.env },
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+                runningProcess = child;
+
+                let stdout = '';
+                let stderr = '';
+                child.stdout.on('data', chunk => { stdout += chunk.toString(); });
+                child.stderr.on('data', chunk => { stderr += chunk.toString(); });
+
+                const completion = new Promise((resolve, reject) => {
+                    child.once('error', reject);
+                    child.once('close', (exitCode, signal) => {
+                        if (runningProcess === child) {
+                            runningProcess = null;
+                        }
+                        resolve({ exitCode, signal, stdout, stderr });
+                    });
+                });
+
+                return { child, completion };
+            }
+
+            async function waitForNamedLock(connection, lockName) {
+                const deadline = Date.now() + 60000;
+                while (Date.now() < deadline) {
+                    const [[row]] = await connection.query(
+                        'SELECT IS_USED_LOCK(?) AS connection_id',
+                        [lockName],
+                    );
+                    if (row.connection_id !== null) {
+                        return;
+                    }
+                    if (
+                        runningProcess?.exitCode !== null ||
+                        runningProcess?.signalCode !== null
+                    ) {
+                        break;
+                    }
+                    await sleep(5);
+                }
+                throw new Error(`Expected MySQL to start the UPDATE guarded by ${lockName}`);
+            }
+
+            async function waitForCommittedContent(connection, id) {
+                const deadline = Date.now() + 30000;
+                while (Date.now() < deadline) {
+                    const [[row]] = await connection.query(
+                        `SELECT \`content\` FROM \`${contentTable}\` WHERE \`id\` = ?`,
+                        [id],
+                    );
+                    if (row?.content?.toString() === rewrittenContent(id)) {
+                        return;
+                    }
+                    await sleep(10);
+                }
+                throw new Error(`Expected MySQL to commit the interrupted UPDATE for row ${id}`);
+            }
+
+            async function waitForCompletion(process, timeoutMilliseconds) {
+                return Promise.race([
+                    process.completion,
+                    sleep(timeoutMilliseconds).then(() => {
+                        process.child.kill('SIGKILL');
+                        throw new Error(
+                            `db-rewrite-urls did not exit within ${timeoutMilliseconds}ms`
+                        );
+                    }),
+                ]);
+            }
+
+            function sha256(value) {
+                return createHash('sha256').update(value).digest('hex');
+            }
+        },
+    );
+}


### PR DESCRIPTION
`db-rewrite-urls` now writes a JSONL report for rows whose update result cannot be confirmed after the process dies.

## Background

MySQL may finish a row update after the PHP process has been killed, but before the command saves its next cursor. On resume, the same conditional update changes zero rows. That can mean the earlier update committed, or that another connection changed the row.

## This change

Each job creates `db-rewrite-urls-<job-id>.jsonl` beside its saved progress. The first line records the URL mappings and password-free database target. A zero-row conditional update appends the table, typed primary key, and hashes of the original and intended column values before the cursor advances. Full database values are not copied into the report.

A stable row ID prevents the final line from being appended twice. Resume also removes an incomplete final line before continuing.

Example completion:

```
db-rewrite-urls complete (5 records checked, 5 changed, 5 rows to verify: /path/to/db-rewrite-urls-<job-id>.jsonl)
```

## Testing

The E2E test sends `SIGKILL` to five consecutive CLI processes while MySQL is executing five different row updates, then resumes the job. It checks the complete JSONL report, every rewritten database value, untouched binary bytes, and `CHECK TABLE`.

The same five-crash sequence passes with InnoDB and MyISAM. Focused PHPUnit, PHP compatibility, PHPCS, PHPStan, and `git diff --check` also pass.