### PR TITLE
[PHP] Let file sync callers decide shared path copies

### DIFF
--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -80,12 +80,14 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  *     }
  *     $planner->close();
  *
- * The cursor contains everything resume() needs: both index paths, the active
- * deletion roots file, path selection, and the current byte offsets. The
- * active deletion roots file may contain bytes beyond the cursor after an
- * interruption. resume() ignores those bytes.
+ * The cursor contains both index paths, the active deletion roots file, path
+ * selection, and the current byte offsets. It does not store optional line
+ * decoders; pass the same decoders to resume(). The active deletion roots file
+ * may contain bytes beyond the cursor after an interruption. resume() ignores
+ * those bytes.
  *
  * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool}
  * @phpstan-type Cursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
  * @phpstan-type ActiveDeletionRoot array{path:string,previous_byte_offset:int|null}
  * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
@@ -119,6 +121,12 @@ final class FileSyncPatchPlanner
     /** @var SyncOperation|null Operation selected for the current path. */
     private ?array $operation = null;
 
+    /** @var IndexEntry|null Complete patch-base entry for the current path. */
+    private ?array $patch_base_index_entry = null;
+
+    /** @var IndexEntry|null Complete patch-result entry for the current path. */
+    private ?array $patch_result_index_entry = null;
+
     /** Whether both indexes reached EOF. */
     private bool $complete = false;
 
@@ -136,6 +144,10 @@ final class FileSyncPatchPlanner
      * @param string       $active_deletion_roots_file     State for directory deletions which cover paths not processed yet.
      * @param list<string> $included_index_path_roots      Roots within which changes may be planned.
      * @param list<string> $excluded_index_path_roots      Roots which changes must not affect.
+     * @param callable|null $decode_patch_base_index_line   Patch-base decoder, or null for the local decoder.
+     * @param callable|null $decode_patch_result_index_line Patch-result decoder, or null to reuse the patch-base decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_base_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_result_index_line
      * @return self Open planner positioned before the first path.
      */
     public static function create(
@@ -143,7 +155,9 @@ final class FileSyncPatchPlanner
         string $patch_result_index_file,
         string $active_deletion_roots_file,
         array $included_index_path_roots = [""],
-        array $excluded_index_path_roots = []
+        array $excluded_index_path_roots = [],
+        ?callable $decode_patch_base_index_line = null,
+        ?callable $decode_patch_result_index_line = null
     ): self {
         if (file_put_contents($active_deletion_roots_file, "") !== 0) {
             throw new RuntimeException(
@@ -163,7 +177,9 @@ final class FileSyncPatchPlanner
                     "preceding_new_index_entry_path_b64" => null,
                 ],
                 "active_deletion_root_byte_offset" => null,
-            ]
+            ],
+            $decode_patch_base_index_line,
+            $decode_patch_result_index_line
         );
     }
 
@@ -172,6 +188,8 @@ final class FileSyncPatchPlanner
      *
      * Both index files must still contain the same snapshots used by create().
      * The active deletion roots file must still belong to this plan.
+     * The cursor does not store the line decoders, so the caller must pass the
+     * same decoders again when resuming.
      *
      * @param array $cursor {
      *     Cursor returned by get_cursor().
@@ -185,10 +203,17 @@ final class FileSyncPatchPlanner
      *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
      * }
      * @phpstan-param Cursor $cursor
+     * @param callable|null $decode_patch_base_index_line   Patch-base decoder, or null for the local decoder.
+     * @param callable|null $decode_patch_result_index_line Patch-result decoder, or null to reuse the patch-base decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_base_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_result_index_line
      * @return self Open planner restored at the supplied cursor.
      */
-    public static function resume(array $cursor): self
-    {
+    public static function resume(
+        array $cursor,
+        ?callable $decode_patch_base_index_line = null,
+        ?callable $decode_patch_result_index_line = null
+    ): self {
         $planner = new self();
         $planner->cursor = $cursor;
         $planner->included_index_path_roots =
@@ -198,7 +223,9 @@ final class FileSyncPatchPlanner
         $planner->index_diff = FileIndexDiffProcessor::resume(
             $cursor["patch_base_index_file"],
             $cursor["patch_result_index_file"],
-            $cursor["index_diff_cursor"]
+            $cursor["index_diff_cursor"],
+            $decode_patch_base_index_line,
+            $decode_patch_result_index_line
         );
         $planner->active_deletion_roots_handle = fopen(
             $cursor["active_deletion_roots_file"],
@@ -229,6 +256,8 @@ final class FileSyncPatchPlanner
     {
         $this->assert_open();
         $this->operation = null;
+        $this->patch_base_index_entry = null;
+        $this->patch_result_index_entry = null;
         if ($this->complete) {
             return false;
         }
@@ -240,6 +269,11 @@ final class FileSyncPatchPlanner
             return false;
         }
         $this->index_diff_path_selected = true;
+
+        $this->patch_base_index_entry =
+            $this->index_diff->get_entry_in_old_index();
+        $this->patch_result_index_entry =
+            $this->index_diff->get_entry_in_new_index();
 
         $index_path = $this->index_diff->get_path();
         $patch_base_path_type = $this->index_diff->get_path_type_in_old_index();
@@ -396,8 +430,8 @@ final class FileSyncPatchPlanner
                 "path" => $path_to_copy,
                 "expected_source" => [
                     "type" => $patch_result_path_type,
-                    "size" => $this->index_diff->get_size_in_new_index(),
-                    "ctime" => $this->index_diff->get_ctime_in_new_index(),
+                    "size" => $this->patch_result_index_entry["size"],
+                    "ctime" => $this->patch_result_index_entry["ctime"],
                 ],
             ];
         } elseif ($path_to_delete !== null) {
@@ -433,6 +467,12 @@ final class FileSyncPatchPlanner
      * source state expected when the operation is performed. `replace` means
      * delete the path before copying the patch-result entry there.
      *
+     * When both indexes contain the same path shape, the optional decision
+     * overrides whether that shared path needs a copy. Null keeps the type,
+     * size, and ctime comparison used by default. Additions, deletions, and
+     * paths whose shapes differ are unchanged by this decision.
+     *
+     * @param bool|null $shared_path_needs_copy Whether a shared path needs copying, or null to compare its index metadata.
      * @return array|null {
      *     Current sync operation, or null.
      *
@@ -448,10 +488,92 @@ final class FileSyncPatchPlanner
      * }
      * @phpstan-return SyncOperation|null
      */
-    public function get_operation(): ?array
+    public function get_operation(?bool $shared_path_needs_copy = null): ?array
     {
         $this->assert_open();
-        return $this->operation;
+        if (
+            $shared_path_needs_copy === null
+            || $this->patch_base_index_entry === null
+            || $this->patch_result_index_entry === null
+        ) {
+            return $this->operation;
+        }
+
+        $patch_base_entry_shape = $this->index_entry_shape(
+            $this->patch_base_index_entry["type"]
+        );
+        $patch_result_entry_shape = $this->index_entry_shape(
+            $this->patch_result_index_entry["type"]
+        );
+        if ($patch_base_entry_shape !== $patch_result_entry_shape) {
+            return $this->operation;
+        }
+        if (
+            !$shared_path_needs_copy
+            || !$this->path_may_change(
+                $this->patch_result_index_entry["path"]
+            )
+        ) {
+            return null;
+        }
+
+        return [
+            "action" => "copy",
+            "path" => $this->patch_result_index_entry["path"],
+            "expected_source" => [
+                "type" => $this->patch_result_index_entry["type"],
+                "size" => $this->patch_result_index_entry["size"],
+                "ctime" => $this->patch_result_index_entry["ctime"],
+            ],
+        ];
+    }
+
+    /**
+     * Returns the complete patch-base entry for the current path, when present.
+     *
+     * A retained patch-base lookahead entry is not returned for a current path
+     * found only in the patch-result index. Decoder-added fields remain in the
+     * returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded patch-base entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty Optional empty-directory marker.
+     * }
+     * @phpstan-return IndexEntry|null
+     */
+    public function get_entry_in_patch_base_index(): ?array
+    {
+        $this->assert_open();
+        return $this->patch_base_index_entry;
+    }
+
+    /**
+     * Returns the complete patch-result entry for the current path, when present.
+     *
+     * A retained patch-result lookahead entry is not returned for a current
+     * path found only in the patch-base index. Decoder-added fields remain in
+     * the returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded patch-result entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty Optional empty-directory marker.
+     * }
+     * @phpstan-return IndexEntry|null
+     */
+    public function get_entry_in_patch_result_index(): ?array
+    {
+        $this->assert_open();
+        return $this->patch_result_index_entry;
     }
 
     /**

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -308,6 +308,17 @@ class PushPlan
     }
 
     /**
+     * Returns the plan-owned deletion-root work file for later patch planning.
+     *
+     * The path remains available after a completed plan is closed, so another
+     * planner can reuse the existing work file instead of creating one.
+     */
+    public function get_active_deletion_roots_path(): string
+    {
+        return $this->active_deletion_roots_file;
+    }
+
+    /**
      * Flushes plan files before the owner persists the current cursor.
      *
      * A later process truncates bytes beyond that cursor before appending.

--- a/tests/Import/FileSyncPatchPlannerTest.php
+++ b/tests/Import/FileSyncPatchPlannerTest.php
@@ -165,6 +165,237 @@ final class FileSyncPatchPlannerTest extends TestCase
         $planner->close();
     }
 
+    public function testSharedPathCopyDecisionCanOverrideTheIndexDiff(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'modified.txt' => $this->entry('modified.txt', 1),
+            'symlink-modified' => $this->entry('symlink-modified', 1, 1, 'link'),
+            'unchanged.txt' => $this->entry('unchanged.txt'),
+            'z-empty-dir' => $this->entry('z-empty-dir', 1, 0, 'dir'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'modified.txt' => $this->entry('modified.txt', 2),
+            'symlink-modified' => $this->entry('symlink-modified', 2, 1, 'link'),
+            'unchanged.txt' => $this->entry('unchanged.txt'),
+            'z-empty-dir' => $this->entry('z-empty-dir', 1, 0, 'dir'),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('copy', 'modified.txt', 'file', 1, 2),
+            $planner->get_operation()
+        );
+        $this->assertNull($planner->get_operation(false));
+        $this->assertSame(
+            $this->copy_operation('copy', 'modified.txt', 'file', 1, 2),
+            $planner->get_operation(true)
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('copy', 'symlink-modified', 'link', 1, 2),
+            $planner->get_operation()
+        );
+        $this->assertNull($planner->get_operation(false));
+        $this->assertSame(
+            $this->copy_operation('copy', 'symlink-modified', 'link', 1, 2),
+            $planner->get_operation(true)
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertNull($planner->get_operation());
+        $this->assertNull($planner->get_operation(false));
+        $this->assertSame(
+            $this->copy_operation('copy', 'unchanged.txt', 'file', 1, 1),
+            $planner->get_operation(true)
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertNull($planner->get_operation());
+        $this->assertNull($planner->get_operation(false));
+        $this->assertSame(
+            $this->copy_operation('copy', 'z-empty-dir', 'dir', 0, 1),
+            $planner->get_operation(true)
+        );
+        $planner->close();
+    }
+
+    public function testSharedPathCopyDecisionDoesNotSuppressStructuralOperations(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'b-deleted.txt' => $this->entry('b-deleted.txt'),
+            'c-dir-to-file' => $this->entry('c-dir-to-file', 1, 0, 'dir'),
+            'd-file-to-dir' => $this->entry('d-file-to-dir'),
+            'e-file-to-link' => $this->entry('e-file-to-link'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'a-added.txt' => $this->entry('a-added.txt', 2),
+            'c-dir-to-file' => $this->entry('c-dir-to-file', 2),
+            'd-file-to-dir' => $this->entry('d-file-to-dir', 2, 0, 'dir'),
+            'e-file-to-link' => $this->entry('e-file-to-link', 2, 1, 'link'),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file()
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('copy', 'a-added.txt', 'file', 1, 2),
+            $planner->get_operation(false)
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->delete_operation('b-deleted.txt'),
+            $planner->get_operation(false)
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('replace', 'c-dir-to-file', 'file', 1, 2),
+            $planner->get_operation(false)
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('replace', 'd-file-to-dir', 'dir', 0, 2),
+            $planner->get_operation(false)
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            $this->copy_operation('copy', 'e-file-to-link', 'link', 1, 2),
+            $planner->get_operation(false)
+        );
+        $planner->close();
+    }
+
+    public function testExposesCompleteEntriesFromIndependentDecoders(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'shared.txt' => $this->entry('shared.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'shared.txt' => $this->entry('shared.txt', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file(),
+            [''],
+            [],
+            $this->decoder_with_source('base'),
+            $this->decoder_with_source('result')
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            'base',
+            $planner->get_entry_in_patch_base_index()['source'] ?? null
+        );
+        $this->assertSame(
+            'result',
+            $planner->get_entry_in_patch_result_index()['source'] ?? null
+        );
+        $planner->close();
+    }
+
+    public function testEntryGettersDoNotExposeFollowingLookahead(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a-old.txt' => $this->entry('a-old.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'b-new.txt' => $this->entry('b-new.txt', 2),
+        ]);
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file(),
+            [''],
+            [],
+            $this->decoder_with_source('base'),
+            $this->decoder_with_source('result')
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            'a-old.txt',
+            $planner->get_entry_in_patch_base_index()['path'] ?? null
+        );
+        $this->assertNull($planner->get_entry_in_patch_result_index());
+
+        $this->assertTrue($planner->next_path());
+        $this->assertNull($planner->get_entry_in_patch_base_index());
+        $this->assertSame(
+            'b-new.txt',
+            $planner->get_entry_in_patch_result_index()['path'] ?? null
+        );
+        $planner->close();
+    }
+
+    public function testResumeUsesTheSameIndependentDecoders(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a-old.txt' => $this->entry('a-old.txt'),
+        ]);
+        $patch_result_index = $this->write_index('result.jsonl', [
+            'b-new.txt' => $this->entry('b-new.txt', 2),
+        ]);
+        $decode_patch_base_index_line = $this->decoder_with_source('base');
+        $decode_patch_result_index_line = $this->decoder_with_source('result');
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_result_index,
+            $this->active_deletion_roots_file(),
+            [''],
+            [],
+            $decode_patch_base_index_line,
+            $decode_patch_result_index_line
+        );
+
+        $this->assertTrue($planner->next_path());
+        $planner->flush_pending_outputs();
+        $cursor = $planner->get_cursor();
+        $this->assertSame(
+            [
+                'patch_base_index_file',
+                'patch_result_index_file',
+                'active_deletion_roots_file',
+                'included_index_path_roots',
+                'excluded_index_path_roots',
+                'index_diff_cursor',
+                'active_deletion_root_byte_offset',
+            ],
+            array_keys($cursor)
+        );
+        $this->assertSame(
+            [
+                'old_index_byte_offset',
+                'new_index_byte_offset',
+                'preceding_new_index_entry_path_b64',
+            ],
+            array_keys($cursor['index_diff_cursor'])
+        );
+        $planner->close();
+
+        $resumed_planner = FileSyncPatchPlanner::resume(
+            $cursor,
+            $decode_patch_base_index_line,
+            $decode_patch_result_index_line
+        );
+        $this->assertTrue($resumed_planner->next_path());
+        $this->assertNull($resumed_planner->get_entry_in_patch_base_index());
+        $this->assertSame(
+            'result',
+            $resumed_planner->get_entry_in_patch_result_index()['source'] ?? null
+        );
+        $resumed_planner->close();
+    }
+
     public function testResumeKeepsAnActiveDeletionRootAcrossASibling(): void
     {
         $patch_base_index = $this->write_index('base.jsonl', [
@@ -278,6 +509,18 @@ final class FileSyncPatchPlannerTest extends TestCase
             $entry['empty'] = true;
         }
         return $entry;
+    }
+
+    /**
+     * @return callable(string):array{path:string,ctime:int,size:int,type:'file'|'link'|'dir',empty?:bool,source:string}
+     */
+    private function decoder_with_source(string $source): callable
+    {
+        return static function (string $line) use ($source): array {
+            $entry = \Reprint\Importer\decode_local_index_entry($line);
+            $entry['source'] = $source;
+            return $entry;
+        };
     }
 
     private function active_deletion_roots_file(): string

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -68,6 +68,17 @@ final class PushPlanTest extends TestCase
         $this->assertPathCounts(0, 0);
     }
 
+    public function testExposesTheActiveDeletionRootsWorkFile(): void
+    {
+        $plan = $this->startPlan();
+        $this->planToCompletion($plan);
+
+        $this->assertSame(
+            $this->planDirectory() . '/deleted_directories_stack.jsonl',
+            $plan->get_active_deletion_roots_path()
+        );
+    }
+
     public function testStartRequiresTheCallerToCreateThePlanDirectory(): void
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
`PushPlan` and files-pull mirror need different answers for the same shared path. For example, `PushPlan` decides whether `uploads/a.jpg` changed from two local type, size, and ctime records. Mirror compares a fresh local entry with a mapped remote entry, whose ctime came from another machine, and uses a separate retained-to-fresh local plan to know whether the local path changed.

This PR keeps tree-shape decisions in `FileSyncPatchPlanner`: additions, deletions, collapsed subtree deletions, and type replacements still produce the same operations. For a path with the same shape in both indexes, the caller may now say whether that path needs copying. That includes an empty directory whose retained local-index row must be restored. Passing `null` keeps the existing type, size, and ctime comparison, so `PushPlan` behavior and its cursor remain unchanged.

The planner also accepts a separate decoder for each index and exposes the complete current entries, including decoder-added fields. A resumed planner must receive the same decoders; they are deliberately not added to the cursor. `PushPlan` exposes its existing active-deletion-roots work-file path so #633 can reuse that closed scratch file instead of creating another artifact.

This sits on #636, which provides the same independent-decoder and complete-entry API at the lower `FileIndexDiffProcessor` layer. The follow-up in #633 will replace its local-versus-mapped-remote classification loop with this planner.

## Testing

```sh
cd tests
../vendor/bin/phpunit Import/FileIndexDiffProcessorTest.php Import/FileSyncPatchPlannerTest.php Import/PushPlanTest.php
composer analyze -- --memory-limit=1G
git diff --check
```
