### PR TITLE
[PHP] Skip existing rows when replaying database inserts

### DIFF
--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -234,7 +234,7 @@ class MySQLDumpProducer
         );
 
         $header = "INSERT INTO " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . " ({$column_list}) VALUES\n";
-        $this->current_statement_size = strlen($header);
+        $this->current_statement_size = strlen($header) + strlen($this->get_insert_replay_clause()) + 1;
 
         $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
         $first_row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
@@ -258,7 +258,7 @@ class MySQLDumpProducer
         $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
-            $sql = $header . $first_row_sql . ";";
+            $sql = $this->finish_insert_statement($header . $first_row_sql);
             $this->current_sql_fragment = $sql;
             $this->current_statement_size = 0;
             if ($has_oversized) {
@@ -268,7 +268,7 @@ class MySQLDumpProducer
                 $this->state = self::STATE_NEXT_TABLE;
             }
         } elseif ($has_oversized) {
-            $sql = $header . $first_row_sql . ";";
+            $sql = $this->finish_insert_statement($header . $first_row_sql);
             $this->current_sql_fragment = $sql;
             $this->current_statement_size = 0;
             $this->state_after_oversized = self::STATE_START_INSERT;
@@ -312,7 +312,7 @@ class MySQLDumpProducer
         $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
-            $this->current_sql_fragment = $row_sql . ";";
+            $this->current_sql_fragment = $this->finish_insert_statement($row_sql);
             $this->current_statement_size = 0;
             if ($has_oversized) {
                 $this->state_after_oversized = self::STATE_NEXT_TABLE;
@@ -321,7 +321,7 @@ class MySQLDumpProducer
                 $this->state = self::STATE_NEXT_TABLE;
             }
         } elseif ($has_oversized) {
-            $this->current_sql_fragment = $row_sql . ";";
+            $this->current_sql_fragment = $this->finish_insert_statement($row_sql);
             $this->current_statement_size = 0;
             $this->state_after_oversized = self::STATE_START_INSERT;
             $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
@@ -335,7 +335,7 @@ class MySQLDumpProducer
     /** Finishes an INSERT batch at its bounded row limit. */
     private function finish_insert_batch($sql, $has_oversized)
     {
-        $this->current_sql_fragment = $sql . ";";
+        $this->current_sql_fragment = $this->finish_insert_statement($sql);
         $this->current_statement_size = 0;
         if ($has_oversized) {
             $this->state_after_oversized = self::STATE_START_INSERT;
@@ -343,6 +343,27 @@ class MySQLDumpProducer
         } else {
             $this->state = self::STATE_START_INSERT;
         }
+    }
+
+    /** Adds the duplicate-row behavior and terminates an INSERT statement. */
+    private function finish_insert_statement($sql)
+    {
+        return $sql . $this->get_insert_replay_clause() . ";";
+    }
+
+    /**
+     * Returns a no-op update for rows already written by a stopped INSERT.
+     *
+     * MyISAM can keep a complete prefix of a multi-row INSERT when the query
+     * stops. Repeating that INSERT should skip the existing rows and write the
+     * missing rows. Assigning any inserted column to itself handles a simple
+     * or composite key without hiding invalid values behind INSERT IGNORE.
+     */
+    private function get_insert_replay_clause()
+    {
+        $first_column = $this->row_reader->get_current_column_names()[0];
+        $quoted_column = $this->row_reader->quote_identifier($first_column);
+        return "\nON DUPLICATE KEY UPDATE {$quoted_column} = {$quoted_column}";
     }
 
     /**

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -358,6 +358,9 @@ class MySQLDumpProducer
      * stops. Repeating that INSERT should skip the existing rows and write the
      * missing rows. Assigning any inserted column to itself handles a simple
      * or composite key without hiding invalid values behind INSERT IGNORE.
+     * MySQL can also detect an enforced UNIQUE key whose columns are NOT NULL.
+     * A nullable UNIQUE key cannot identify an existing row because MySQL
+     * permits more than one row whose unique-key value contains NULL.
      */
     private function get_insert_replay_clause()
     {
@@ -407,9 +410,11 @@ class MySQLDumpProducer
     }
 
     /**
-     * Emits SET statements that disable constraint checks and set a strict SQL mode.
+     * Emits SET statements that configure constraint checks and set a strict SQL mode.
      * These are restored in emit_sql_footer(). Without disabling FK checks, tables
      * that reference each other would need to be imported in dependency order.
+     * Unique checks stay enabled because replayed INSERT statements use unique
+     * keys to recognize rows which are already present.
      *
      * The SQL_MODE explicitly omits NO_ZERO_DATE, NO_ZERO_IN_DATE, and NO_ENGINE_SUBSTITUTION.
      *
@@ -451,7 +456,7 @@ class MySQLDumpProducer
     /** Returns the connection settings required before executing dump SQL. */
     public static function get_session_setup_sql()
     {
-        return "SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;\n" .
+        return "SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=1;\n" .
             "SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;\n" .
             // @TODO: Restore STRICT_TRANS_TABLES
             "SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO';\n" .

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -234,7 +234,7 @@ class MySQLDumpProducer
         );
 
         $header = "INSERT INTO " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . " ({$column_list}) VALUES\n";
-        $this->current_statement_size = strlen($header) + strlen($this->get_insert_replay_clause()) + 1;
+        $this->current_statement_size = strlen($header) + strlen($this->on_duplicate_key()) + 1;
 
         $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
         $first_row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
@@ -258,7 +258,7 @@ class MySQLDumpProducer
         $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
-            $sql = $this->finish_insert_statement($header . $first_row_sql);
+            $sql = $header . $first_row_sql . $this->on_duplicate_key() . ';';
             $this->current_sql_fragment = $sql;
             $this->current_statement_size = 0;
             if ($has_oversized) {
@@ -268,7 +268,7 @@ class MySQLDumpProducer
                 $this->state = self::STATE_NEXT_TABLE;
             }
         } elseif ($has_oversized) {
-            $sql = $this->finish_insert_statement($header . $first_row_sql);
+            $sql = $header . $first_row_sql . $this->on_duplicate_key() . ';';
             $this->current_sql_fragment = $sql;
             $this->current_statement_size = 0;
             $this->state_after_oversized = self::STATE_START_INSERT;
@@ -312,7 +312,7 @@ class MySQLDumpProducer
         $has_next_row = $this->row_reader->next_record();
 
         if (!$has_next_row) {
-            $this->current_sql_fragment = $this->finish_insert_statement($row_sql);
+            $this->current_sql_fragment = $row_sql . $this->on_duplicate_key() . ';';
             $this->current_statement_size = 0;
             if ($has_oversized) {
                 $this->state_after_oversized = self::STATE_NEXT_TABLE;
@@ -321,7 +321,7 @@ class MySQLDumpProducer
                 $this->state = self::STATE_NEXT_TABLE;
             }
         } elseif ($has_oversized) {
-            $this->current_sql_fragment = $this->finish_insert_statement($row_sql);
+            $this->current_sql_fragment = $row_sql . $this->on_duplicate_key() . ';';
             $this->current_statement_size = 0;
             $this->state_after_oversized = self::STATE_START_INSERT;
             $this->state = self::STATE_EMIT_OVERSIZED_UPDATE;
@@ -335,7 +335,7 @@ class MySQLDumpProducer
     /** Finishes an INSERT batch at its bounded row limit. */
     private function finish_insert_batch($sql, $has_oversized)
     {
-        $this->current_sql_fragment = $this->finish_insert_statement($sql);
+        $this->current_sql_fragment = $sql . $this->on_duplicate_key() . ';';
         $this->current_statement_size = 0;
         if ($has_oversized) {
             $this->state_after_oversized = self::STATE_START_INSERT;
@@ -343,12 +343,6 @@ class MySQLDumpProducer
         } else {
             $this->state = self::STATE_START_INSERT;
         }
-    }
-
-    /** Adds the duplicate-row behavior and terminates an INSERT statement. */
-    private function finish_insert_statement($sql)
-    {
-        return $sql . $this->get_insert_replay_clause() . ";";
     }
 
     /**
@@ -362,7 +356,7 @@ class MySQLDumpProducer
      * A nullable UNIQUE key cannot identify an existing row because MySQL
      * permits more than one row whose unique-key value contains NULL.
      */
-    private function get_insert_replay_clause()
+    private function on_duplicate_key()
     {
         $first_column = $this->row_reader->get_current_column_names()[0];
         $quoted_column = $this->row_reader->quote_identifier($first_column);

--- a/tests/MySQLDumpProducer/BasicDumpTest.php
+++ b/tests/MySQLDumpProducer/BasicDumpTest.php
@@ -81,10 +81,11 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
             INSERT INTO replay_rows VALUES
             (1, 1, 'first'),
             (1, 2, 'second'),
-            (1, 3, 'third')
+            (1, 3, 'third'),
+            (1, 4, 'fourth')
         ");
 
-        $sql = $this->getDumpSQL(['batch_size' => 3]);
+        $sql = $this->getDumpSQL(['batch_size' => 4]);
         $this->assertSame(
             1,
             preg_match('/INSERT INTO `replay_rows`.*?;/s', $sql, $matches)
@@ -95,19 +96,86 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         );
 
         $this->pdo->exec('TRUNCATE TABLE replay_rows');
-        // MyISAM keeps the first two rows when the third row stops this statement.
-        try {
-            $this->pdo->exec("
-                INSERT INTO replay_rows VALUES
-                (1, 1, 'first'),
-                (1, 2, 'second'),
-                (1, 1, 'duplicate'),
-                (1, 3, 'third')
-            ");
-            $this->fail('The setup query should stop at its duplicate composite key.');
-        } catch (PDOException $error) {
-            $this->assertSame('23000', $error->getCode());
+
+        $host = getenv('DB_HOST') ?: 'localhost';
+        $user = getenv('DB_USER') ?: 'root';
+        $pass = getenv('DB_PASS') ?: '';
+        $dsn = "mysql:host={$host};charset=utf8mb4";
+        $query = "
+            INSERT INTO replay_rows VALUES
+            (1, 1, 'first'),
+            (1, 2, 'second'),
+            (1, IF(SLEEP(30) = 0, 3, 1), 'third'),
+            (1, 4, 'fourth')
+        ";
+        $child_code = <<<'PHP'
+$pdo = new PDO(
+    $argv[1],
+    $argv[2],
+    $argv[3],
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+$pdo->exec('USE `' . str_replace('`', '``', $argv[4]) . '`');
+echo $pdo->query('SELECT CONNECTION_ID()')->fetchColumn(), "\n";
+flush();
+try {
+    $pdo->exec(base64_decode($argv[5]));
+    exit(2);
+} catch (PDOException $error) {
+    fwrite(STDERR, $error->getMessage());
+    exit(0);
+}
+PHP;
+        $pipes = [];
+        $command = [
+            PHP_BINARY,
+            '-r',
+            $child_code,
+            $dsn,
+            $user,
+            $pass,
+            $this->dbName,
+            base64_encode($query),
+        ];
+        $process = proc_open(
+            $command,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+
+        $connection_id_line = fgets($pipes[1]);
+        $this->assertNotFalse($connection_id_line);
+        $connection_id = (int) trim($connection_id_line);
+        $deadline = microtime(true) + 10;
+        $state = null;
+        do {
+            $state = $this->pdo->query(
+                "SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = {$connection_id}"
+            )->fetchColumn();
+            if ('User sleep' === $state) {
+                break;
+            }
+            usleep(10000);
+        } while (microtime(true) < $deadline);
+
+        if ('User sleep' !== $state) {
+            $this->pdo->exec("KILL CONNECTION {$connection_id}");
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+            $this->fail('The MyISAM INSERT did not reach its interruption point.');
         }
+
+        // KILL QUERY makes SLEEP() return 1. That repeats row 1's key, so
+        // MyISAM stops after the first two rows instead of finishing the batch.
+        $this->pdo->exec("KILL QUERY {$connection_id}");
+        $child_error = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $this->assertSame(0, proc_close($process), $child_error);
+        $this->assertStringContainsString('1062', $child_error);
 
         $this->assertSame(
             ['1:1', '1:2'],
@@ -119,10 +187,50 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         $this->pdo->exec($matches[0]);
 
         $this->assertSame(
-            ['1:1:first', '1:2:second', '1:3:third'],
+            ['1:1:first', '1:2:second', '1:3:third', '1:4:fourth'],
             $this->pdo->query(
                 "SELECT CONCAT(site_id, ':', row_id, ':', value) " .
                 'FROM replay_rows ORDER BY site_id, row_id'
+            )->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
+    public function testUniqueKeyChecksStayEnabledForReplay(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE unique_replay_rows (
+                site_id INT NOT NULL,
+                row_id INT NOT NULL,
+                value VARCHAR(100) NOT NULL,
+                UNIQUE KEY replay_row (site_id, row_id)
+            ) ENGINE=InnoDB
+        ");
+        $this->pdo->exec("
+            INSERT INTO unique_replay_rows VALUES
+            (1, 1, 'first'),
+            (1, 2, 'second'),
+            (1, 3, 'third')
+        ");
+
+        $sql = $this->getDumpSQL(['batch_size' => 3]);
+        $this->assertStringContainsString('UNIQUE_CHECKS=1', $sql);
+        $this->assertSame(
+            1,
+            preg_match('/INSERT INTO `unique_replay_rows`.*?;/s', $sql, $matches)
+        );
+
+        $this->pdo->exec('TRUNCATE TABLE unique_replay_rows');
+        $this->pdo->exec("INSERT INTO unique_replay_rows VALUES (1, 1, 'first')");
+        $this->pdo->exec('SET UNIQUE_CHECKS=0');
+        $this->pdo->exec(\WordPress\DataLiberation\MySQLDumpProducer::get_session_setup_sql());
+        $this->assertSame(1, (int) $this->pdo->query('SELECT @@UNIQUE_CHECKS')->fetchColumn());
+        $this->pdo->exec($matches[0]);
+
+        $this->assertSame(
+            ['1:1:first', '1:2:second', '1:3:third'],
+            $this->pdo->query(
+                "SELECT CONCAT(site_id, ':', row_id, ':', value) " .
+                'FROM unique_replay_rows ORDER BY site_id, row_id'
             )->fetchAll(PDO::FETCH_COLUMN)
         );
     }

--- a/tests/MySQLDumpProducer/BasicDumpTest.php
+++ b/tests/MySQLDumpProducer/BasicDumpTest.php
@@ -67,6 +67,66 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         $this->assertSQLContains('19.99', $sql);
     }
 
+    public function testMyIsamInsertFillsRowsMissingAfterAStoppedQuery(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE replay_rows (
+                site_id INT NOT NULL,
+                row_id INT NOT NULL,
+                value VARCHAR(100) NOT NULL,
+                PRIMARY KEY (site_id, row_id)
+            ) ENGINE=MyISAM
+        ");
+        $this->pdo->exec("
+            INSERT INTO replay_rows VALUES
+            (1, 1, 'first'),
+            (1, 2, 'second'),
+            (1, 3, 'third')
+        ");
+
+        $sql = $this->getDumpSQL(['batch_size' => 3]);
+        $this->assertSame(
+            1,
+            preg_match('/INSERT INTO `replay_rows`.*?;/s', $sql, $matches)
+        );
+        $this->assertStringContainsString(
+            'ON DUPLICATE KEY UPDATE `site_id` = `site_id`;',
+            $matches[0]
+        );
+
+        $this->pdo->exec('TRUNCATE TABLE replay_rows');
+        // MyISAM keeps the first two rows when the third row stops this statement.
+        try {
+            $this->pdo->exec("
+                INSERT INTO replay_rows VALUES
+                (1, 1, 'first'),
+                (1, 2, 'second'),
+                (1, 1, 'duplicate'),
+                (1, 3, 'third')
+            ");
+            $this->fail('The setup query should stop at its duplicate composite key.');
+        } catch (PDOException $error) {
+            $this->assertSame('23000', $error->getCode());
+        }
+
+        $this->assertSame(
+            ['1:1', '1:2'],
+            $this->pdo->query(
+                "SELECT CONCAT(site_id, ':', row_id) FROM replay_rows ORDER BY site_id, row_id"
+            )->fetchAll(PDO::FETCH_COLUMN)
+        );
+
+        $this->pdo->exec($matches[0]);
+
+        $this->assertSame(
+            ['1:1:first', '1:2:second', '1:3:third'],
+            $this->pdo->query(
+                "SELECT CONCAT(site_id, ':', row_id, ':', value) " .
+                'FROM replay_rows ORDER BY site_id, row_id'
+            )->fetchAll(PDO::FETCH_COLUMN)
+        );
+    }
+
     public function testMultipleTables(): void
     {
         // Create multiple tables
@@ -207,9 +267,7 @@ class BasicDumpTest extends MySQLDumpProducerTestBase
         // Export with batch size of 100
         $sql = $this->getDumpSQL(['batch_size' => 100]);
 
-        // Count semicolons in INSERT statements (one per batch)
-        // Each batch ends with ); so we should have 5 batches
-        $batchCount = substr_count($sql, ');');
+        $batchCount = $this->countInsertStatements($sql);
         $this->assertEquals(5, $batchCount, 'Should have 5 batches (500 rows / 100 per batch)');
 
         // Verify round-trip - all 500 rows should be imported

--- a/tests/MySQLDumpProducer/EdgeCasesTest.php
+++ b/tests/MySQLDumpProducer/EdgeCasesTest.php
@@ -634,7 +634,7 @@ class EdgeCasesTest extends MySQLDumpProducerTestBase
 
         $sql = $this->getDumpSQL();
         // Should NOT use UPDATE+CONCAT
-        $this->assertStringNotContainsString('UPDATE', $sql);
+        $this->assertStringNotContainsString('UPDATE `t` SET', $sql);
 
         $importPdo = $this->executeDumpInNewDatabase($sql);
         $imported = $importPdo->query("SELECT v FROM t WHERE id = 1")->fetchColumn();

--- a/tests/MySQLDumpProducer/EdgeCasesTest.php
+++ b/tests/MySQLDumpProducer/EdgeCasesTest.php
@@ -541,7 +541,7 @@ class EdgeCasesTest extends MySQLDumpProducerTestBase
         while ($producer->next_sql_fragment()) {
             $frag = $producer->get_sql_fragment();
             $fragments[] = $frag;
-            if (strpos($frag, ');') !== false) {
+            if (strpos($frag, 'INSERT INTO `t`') === 0) {
                 break;
             }
         }
@@ -938,7 +938,7 @@ class EdgeCasesTest extends MySQLDumpProducerTestBase
         while ($producer->next_sql_fragment()) {
             $frag = $producer->get_sql_fragment();
             $fragments[] = $frag;
-            if (strpos($frag, ');') !== false) {
+            if (strpos($frag, 'INSERT INTO `t`') === 0) {
                 break;
             }
         }

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -30,8 +30,8 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         // Use a large max_statement_size so nothing gets split
         $sql = $this->getDumpSQL(['max_statement_size' => 1024 * 1024]);
 
-        // Should not contain UPDATE statements
-        $this->assertStringNotContainsString('UPDATE', $sql);
+        // Should not contain an oversized-value UPDATE statement.
+        $this->assertStringNotContainsString('UPDATE `small_data` SET', $sql);
 
         // Round-trip test
         $importPdo = $this->executeDumpInNewDatabase($sql);
@@ -59,7 +59,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = $this->getDumpSQL(['max_statement_size' => 10 * 1024]);
 
         // Should contain UPDATE statements with CONCAT
-        $this->assertStringContainsString('UPDATE', $sql);
+        $this->assertStringContainsString('UPDATE `large_data` SET', $sql);
         $this->assertStringContainsString('CONCAT', $sql);
 
         // Round-trip test
@@ -91,7 +91,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = $this->getDumpSQL(['max_statement_size' => 10 * 1024]);
 
         // Should contain UPDATE statements
-        $this->assertStringContainsString('UPDATE', $sql);
+        $this->assertStringContainsString('UPDATE `large_text` SET', $sql);
 
         // Round-trip test
         $importPdo = $this->executeDumpInNewDatabase($sql);
@@ -123,7 +123,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = $this->getDumpSQL(['max_statement_size' => 20 * 1024]);
 
         // Both large columns should trigger updates
-        $updateCount = substr_count($sql, 'UPDATE');
+        $updateCount = substr_count($sql, 'UPDATE `multi_large` SET');
         $this->assertGreaterThan(1, $updateCount, 'Should have multiple UPDATE statements');
 
         // Round-trip test
@@ -252,7 +252,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = $this->getDumpSQL(['max_statement_size' => 10 * 1024]);
 
         // UPDATE statements should use composite WHERE clause
-        $this->assertStringContainsString('UPDATE', $sql);
+        $this->assertStringContainsString('UPDATE `composite_pk` SET', $sql);
         $this->assertStringContainsString('tenant_id', $sql);
         $this->assertStringContainsString('item_id', $sql);
 
@@ -641,7 +641,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
 
         // The PK value should appear in UPDATE WHERE clauses
         // It should NOT be split
-        $this->assertStringContainsString('UPDATE', $sql);
+        $this->assertStringContainsString('UPDATE `varchar_pk` SET', $sql);
 
         // Round-trip test
         $importPdo = $this->executeDumpInNewDatabase($sql);

--- a/tests/MySQLDumpProducer/ReentrancyTest.php
+++ b/tests/MySQLDumpProducer/ReentrancyTest.php
@@ -500,7 +500,7 @@ class ReentrancyTest extends MySQLDumpProducerTestBase
             $fragments[] = $sql;
 
             // Stop after first INSERT batch (5 rows)
-            if (strpos($sql, ");") !== false) {
+            if (strpos($sql, 'INSERT INTO `resume_test`') === 0) {
                 break;
             }
         }
@@ -699,8 +699,8 @@ class ReentrancyTest extends MySQLDumpProducerTestBase
             $sql = $producer->get_sql_fragment();
             $fragments[] = $sql;
 
-            // Stop right after finishing table_a (when we see semicolon for last INSERT)
-            if (strpos($sql, ");") !== false && strpos($sql, "a_10") !== false) {
+            // Stop right after finishing table_a's only INSERT batch.
+            if (strpos($sql, 'INSERT INTO `table_a`') === 0) {
                 break;
             }
         }


### PR DESCRIPTION
A MyISAM multi-row `INSERT` can stop after writing some complete rows. This makes each generated `INSERT` safe to repeat when the table has a primary key or a non-null unique key.

## Example

Suppose Reprint sends:

```sql
INSERT INTO `posts` (`id`, `title`) VALUES
    (1, 'First'),
    (2, 'Second'),
    (3, 'Third');
```

If MySQL stops the query after writing row 2, MyISAM keeps rows 1 and 2. Repeating the plain statement fails immediately because row 1 already exists.

This PR generates:

```sql
INSERT INTO `posts` (`id`, `title`) VALUES
    (1, 'First'),
    (2, 'Second'),
    (3, 'Third')
ON DUPLICATE KEY UPDATE `id` = `id`;
```

Rows 1 and 2 take the no-op update path. Row 3 is inserted. MySQL finds the existing row from the table's complete key, so a composite key works. The assignment only satisfies MySQL's required syntax; the producer does not need to know which columns make up the key.

The dump now keeps `UNIQUE_CHECKS` enabled. This is required when a table relies on a secondary unique key instead of a primary key. It can cost some bulk-import speed, but disabling the check would let the storage engine assume that no duplicate unique values exist. A unique key containing `NULL` still cannot identify a row because MySQL permits more than one such value. A table with no usable key also has no way to recognize an existing row.

This deliberately does not use `INSERT IGNORE`. Invalid values and other SQL errors remain errors instead of being changed into warnings.

This PR only changes generated `INSERT` statements. It does not change where `db-pull` resumes. Oversized values that use later `UPDATE ... CONCAT()` statements still need their own repeatable form. The duplicate path uses MySQL's normal update behavior, so an update trigger can run when an existing row is found; normal replacement dumps drop and recreate the table before inserting rows.

## Testing

The regression test starts a four-row MyISAM statement on a separate connection. It waits until the statement reaches a slow third row, sends `KILL QUERY`, and confirms that MyISAM kept only the first two rows. It then runs the generated statement and confirms that the existing rows stay unchanged while the missing rows are added.

A second test starts with `UNIQUE_CHECKS=0`, applies the dump's session setup, and confirms that a table with only a composite non-null unique key can replay an existing row and insert the missing rows.
