### PR TITLE
[PHP] Move resumable copy and deletion list writing into FileSyncPlanRunner

### DIFF
--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -60,12 +60,13 @@ local relative path to a document-root-relative path.
   planning a push. Use `$fresh_local_index_file`.
 - An **index entry** records one path, type, size, and ctime. Use
   `$index_entry`.
-- A **file sync patch planner** compares a patch base index with a patch result
-  index and selects `copy`, `delete`, or `replace` operations. To make two
-  trees identical, the destination is the patch base and the source is the
-  patch result. To copy only source changes, the source snapshots from the
-  last sync and now are the patch base and result. The planner owns the index
-  diff and the active deletion roots file.
+- A **file sync patch planner** compares a patch base index with a patch head
+  index and selects `copy`, `delete`, or `replace` operations. The base is the
+  left side of the comparison. The head is the right side. To make two trees
+  identical, the destination is the patch base and the source is the patch
+  head. To copy only source changes, the source snapshots from the last sync
+  and now are the patch base and head. The planner owns the index diff and the
+  active deletion roots file.
 - The **pull index WAL** records completed pull mutations awaiting application
   to the remote and local indexes.
 - A **pull plan** lists remote absolute paths still scheduled for download or
@@ -527,7 +528,7 @@ Use these names verbatim inside `PushPlan`:
 | Fresh local index byte offset | `$fresh_local_index_byte_offset` |
 | Open fresh local index | `$fresh_local_index_handle` |
 | Combined index bytes | `$index_bytes_total` |
-| File-sync planner cursor | `file_sync_planner_cursor`, `$file_sync_planner_cursor` |
+| File-sync plan runner cursor | `file_sync_plan_runner_cursor`, `$file_sync_plan_runner_cursor` |
 | Plan progress | `get_progress()` |
 | Start index diff | `start_index_diff()` |
 | Seek an index file | `seek_index_file_to_byte_offset()`, `$index_file_handle` |

--- a/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-patch-planner.php
@@ -14,10 +14,10 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
 /**
  * Plans a file-sync patch from two indexed file trees.
  *
- * The patch base index describes the state before the patch. The patch result
- * index describes the state after it. Both indexes use the same path
- * coordinates and are sorted by decoded path bytes. The caller chooses these
- * indexes based on the sync intent:
+ * The patch base and patch head indexes are the left and right sides of the
+ * comparison. Both indexes use the same path coordinates and are sorted by
+ * decoded path bytes. The caller chooses these indexes based on the sync
+ * intent:
  *
  * - To make two file trees identical, compare the current destination index
  *   with the current source index.
@@ -30,9 +30,9 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  * FileIndexDiffProcessor aligns their entries and labels each path. This
  * planner turns those labels into one operation for the current path:
  *
- * - `copy` copies the patch-result entry.
+ * - `copy` copies the patch-head entry.
  * - `delete` deletes a path from the patch base.
- * - `replace` deletes a path, then copies the patch-result entry there.
+ * - `replace` deletes a path, then copies the patch-head entry there.
  *
  * One path may need both actions. Replacing a directory tree with a file, for
  * example, deletes the tree and copies the file. The planner combines
@@ -44,7 +44,7 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  *
  * Non-empty directories have no index entry. Their descendants imply that the
  * directory exists. The planner uses the paths preceding and following the
- * current position to decide whether a missing directory still has a result
+ * current position to decide whether a missing directory still has a head
  * descendant. When a whole directory disappeared, it emits the highest
  * missing directory instead of deleting every indexed descendant.
  *
@@ -68,7 +68,7 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  *
  *     $planner = FileSyncPatchPlanner::create(
  *         $patch_base_index_file,
- *         $patch_result_index_file,
+ *         $patch_head_index_file,
  *         $active_deletion_roots_file
  *     );
  *     while ($planner->next_path()) {
@@ -80,14 +80,16 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  *     }
  *     $planner->close();
  *
- * The cursor contains everything resume() needs: both index paths, the active
- * deletion roots file, path selection, and the current byte offsets. The
- * active deletion roots file may contain bytes beyond the cursor after an
+ * The cursor contains both index paths, the active deletion roots file, path
+ * selection, and the current byte offsets. It does not contain index line
+ * decoders; pass the same decoders to resume() that were passed to create().
+ * The active deletion roots file may contain bytes beyond the cursor after an
  * interruption. resume() ignores those bytes.
  *
  * @phpstan-type IndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
- * @phpstan-type Cursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type Cursor array{patch_base_index_file:string,patch_head_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:IndexDiffCursor,active_deletion_root_byte_offset:int|null}
  * @phpstan-type ActiveDeletionRoot array{path:string,previous_byte_offset:int|null}
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool,copy_source_path?:string}
  * @phpstan-type ExpectedSource array{type:string,size:int,ctime:int}
  * @phpstan-type DeleteOperation array{action:'delete',path:string}
  * @phpstan-type CopyOperation array{action:'copy'|'replace',path:string,expected_source:ExpectedSource}
@@ -95,7 +97,7 @@ require_once __DIR__ . '/class-file-index-diff-processor.php';
  */
 final class FileSyncPatchPlanner
 {
-    /** Sorted comparison of the patch base and result indexes. */
+    /** Sorted comparison of the patch base and head indexes. */
     private FileIndexDiffProcessor $index_diff;
 
     /** @var resource Open append-only file of active deletion roots. */
@@ -116,8 +118,17 @@ final class FileSyncPatchPlanner
     /** Whether the diff processor has already selected the next path. */
     private bool $index_diff_path_selected = false;
 
+    /** Whether next_path() was attempted on this open planner. */
+    private bool $next_path_was_called = false;
+
     /** @var SyncOperation|null Operation selected for the current path. */
     private ?array $operation = null;
+
+    /** @var IndexEntry|null Complete patch-base entry for the current path. */
+    private ?array $patch_base_index_entry = null;
+
+    /** @var IndexEntry|null Complete patch-head entry for the current path. */
+    private ?array $patch_head_index_entry = null;
 
     /** Whether both indexes reached EOF. */
     private bool $complete = false;
@@ -131,19 +142,25 @@ final class FileSyncPatchPlanner
      * The active deletion roots file is replaced with an empty file. Use
      * resume() to continue from a cursor returned by get_cursor().
      *
-     * @param string       $patch_base_index_file          Tree state before the patch, or a missing path for an empty tree.
-     * @param string       $patch_result_index_file        Tree state described by the patch.
-     * @param string       $active_deletion_roots_file     State for directory deletions which cover paths not processed yet.
-     * @param list<string> $included_index_path_roots      Roots within which changes may be planned.
-     * @param list<string> $excluded_index_path_roots      Roots which changes must not affect.
+     * @param string        $patch_base_index_file         Left index in the patch comparison, or a missing path for an empty tree.
+     * @param string        $patch_head_index_file         Right index in the patch comparison.
+     * @param string        $active_deletion_roots_file    State for directory deletions which cover paths not processed yet.
+     * @param list<string>  $included_index_path_roots     Roots within which changes may be planned.
+     * @param list<string>  $excluded_index_path_roots     Roots which changes must not affect.
+     * @param callable|null $decode_patch_base_index_line  Patch-base index decoder, or null for the local decoder.
+     * @param callable|null $decode_patch_head_index_line  Patch-head index decoder, or null to reuse the base decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_base_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_head_index_line
      * @return self Open planner positioned before the first path.
      */
     public static function create(
         string $patch_base_index_file,
-        string $patch_result_index_file,
+        string $patch_head_index_file,
         string $active_deletion_roots_file,
         array $included_index_path_roots = [""],
-        array $excluded_index_path_roots = []
+        array $excluded_index_path_roots = [],
+        ?callable $decode_patch_base_index_line = null,
+        ?callable $decode_patch_head_index_line = null
     ): self {
         if (file_put_contents($active_deletion_roots_file, "") !== 0) {
             throw new RuntimeException(
@@ -153,7 +170,7 @@ final class FileSyncPatchPlanner
         return self::resume(
             [
                 "patch_base_index_file" => $patch_base_index_file,
-                "patch_result_index_file" => $patch_result_index_file,
+                "patch_head_index_file" => $patch_head_index_file,
                 "active_deletion_roots_file" => $active_deletion_roots_file,
                 "included_index_path_roots" => $included_index_path_roots,
                 "excluded_index_path_roots" => $excluded_index_path_roots,
@@ -163,7 +180,9 @@ final class FileSyncPatchPlanner
                     "preceding_new_index_entry_path_b64" => null,
                 ],
                 "active_deletion_root_byte_offset" => null,
-            ]
+            ],
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
         );
     }
 
@@ -176,19 +195,26 @@ final class FileSyncPatchPlanner
      * @param array $cursor {
      *     Cursor returned by get_cursor().
      *
-     *     @type string       $patch_base_index_file                    Tree state before the patch.
-     *     @type string       $patch_result_index_file                  Tree state described by the patch.
+     *     @type string       $patch_base_index_file                    Left index in the patch comparison.
+     *     @type string       $patch_head_index_file                    Right index in the patch comparison.
      *     @type string       $active_deletion_roots_file               State for active directory deletions.
      *     @type list<string> $included_index_path_roots                Roots within which changes may be planned.
      *     @type list<string> $excluded_index_path_roots                Roots which changes must not affect.
      *     @type array        $index_diff_cursor                        File-index diff cursor.
-     *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
+     *     @type int|null     $active_deletion_root_byte_offset         Active deletion-root offset.
      * }
      * @phpstan-param Cursor $cursor
+     * @param callable|null $decode_patch_base_index_line  Patch-base index decoder, or null for the local decoder.
+     * @param callable|null $decode_patch_head_index_line  Patch-head index decoder, or null to reuse the base decoder.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_base_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_head_index_line
      * @return self Open planner restored at the supplied cursor.
      */
-    public static function resume(array $cursor): self
-    {
+    public static function resume(
+        array $cursor,
+        ?callable $decode_patch_base_index_line = null,
+        ?callable $decode_patch_head_index_line = null
+    ): self {
         $planner = new self();
         $planner->cursor = $cursor;
         $planner->included_index_path_roots =
@@ -197,8 +223,10 @@ final class FileSyncPatchPlanner
             $cursor["excluded_index_path_roots"];
         $planner->index_diff = FileIndexDiffProcessor::resume(
             $cursor["patch_base_index_file"],
-            $cursor["patch_result_index_file"],
-            $cursor["index_diff_cursor"]
+            $cursor["patch_head_index_file"],
+            $cursor["index_diff_cursor"],
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
         );
         $planner->active_deletion_roots_handle = fopen(
             $cursor["active_deletion_roots_file"],
@@ -219,7 +247,7 @@ final class FileSyncPatchPlanner
     }
 
     /**
-     * Processes the next path found in the patch base or result index.
+     * Processes the next path found in the patch base or head index.
      *
      * True means the getters describe one processed path. False means there
      * was no path left to process. A true result may also make is_complete()
@@ -228,7 +256,10 @@ final class FileSyncPatchPlanner
     public function next_path(): bool
     {
         $this->assert_open();
+        $this->next_path_was_called = true;
         $this->operation = null;
+        $this->patch_base_index_entry = null;
+        $this->patch_head_index_entry = null;
         if ($this->complete) {
             return false;
         }
@@ -240,14 +271,20 @@ final class FileSyncPatchPlanner
             return false;
         }
         $this->index_diff_path_selected = true;
+        // The nested diff advances to its next lookahead before this method
+        // returns, so retain the complete entries for the processed path now.
+        $this->patch_base_index_entry =
+            $this->index_diff->get_entry_in_old_index();
+        $this->patch_head_index_entry =
+            $this->index_diff->get_entry_in_new_index();
 
         $index_path = $this->index_diff->get_path();
         $patch_base_path_type = $this->index_diff->get_path_type_in_old_index();
-        $patch_result_path_type = $this->index_diff->get_path_type_in_new_index();
+        $patch_head_path_type = $this->index_diff->get_path_type_in_new_index();
         $path_transition = $this->index_diff->get_path_transition();
-        $patch_result_entry_shape = $patch_result_path_type === null
+        $patch_head_entry_shape = $patch_head_path_type === null
             ? null
-            : $this->index_entry_shape($patch_result_path_type);
+            : $this->index_entry_shape($patch_head_path_type);
         $patch_base_entry_shape = $patch_base_path_type === null
             ? null
             : $this->index_entry_shape($patch_base_path_type);
@@ -283,14 +320,14 @@ final class FileSyncPatchPlanner
         if ($path_transition === "added") {
             // A NUL byte cannot occur in an index path. Use it when there is
             // no following patch-base path so the descendant test cannot match.
-            $patch_result_entry_replaces_patch_base_subtree =
+            $patch_head_entry_replaces_patch_base_subtree =
                 path_is_same_as_or_descendant_of(
                     $this->index_diff->get_following_path_in_old_index()
                         ?? "\0",
                     $index_path
                 );
             if (
-                $patch_result_entry_replaces_patch_base_subtree
+                $patch_head_entry_replaces_patch_base_subtree
                 && $this->path_may_change($index_path)
                 && !$this->active_deletion_root_covers_path($index_path)
             ) {
@@ -305,16 +342,16 @@ final class FileSyncPatchPlanner
                 $path_to_copy = $index_path;
             }
         } elseif ($path_transition === "deleted") {
-            $patch_base_empty_directory_is_implied_by_patch_result_descendant =
+            $patch_base_empty_directory_is_implied_by_patch_head_descendant =
                 $patch_base_entry_shape === "empty_directory"
-                && $this->patch_result_index_contains_path_or_descendant(
+                && $this->patch_head_index_contains_path_or_descendant(
                     $index_path,
                     $this->index_diff->get_preceding_path_in_new_index(),
                     $this->index_diff->get_following_path_in_new_index()
                 );
 
-            // Find the highest patch-base directory without a patch-result
-            // entry below it. Only the adjacent result entries can neighbor
+            // Find the highest patch-base directory without a patch-head
+            // entry below it. Only the adjacent head entries can neighbor
             // each parent in byte order, so no index rescan is needed.
             $candidate_path_to_delete = $index_path;
             $index_path_components = wp_unix_path_segments($index_path);
@@ -330,7 +367,7 @@ final class FileSyncPatchPlanner
                     ...$candidate_path_components
                 );
                 if (
-                    !$this->patch_result_index_contains_path_or_descendant(
+                    !$this->patch_head_index_contains_path_or_descendant(
                         $candidate_path,
                         $this->index_diff->get_preceding_path_in_new_index(),
                         $this->index_diff->get_following_path_in_new_index()
@@ -341,7 +378,7 @@ final class FileSyncPatchPlanner
                 }
             }
             if (
-                !$patch_base_empty_directory_is_implied_by_patch_result_descendant
+                !$patch_base_empty_directory_is_implied_by_patch_head_descendant
                 && $this->path_may_change($candidate_path_to_delete)
                 && !$this->active_deletion_root_covers_path($index_path)
             ) {
@@ -355,22 +392,22 @@ final class FileSyncPatchPlanner
                 }
             }
         } else {
-            $patch_result_entry_is_file_or_symlink =
-                $patch_result_entry_shape === "file"
-                || $patch_result_entry_shape === "symlink";
+            $patch_head_entry_is_file_or_symlink =
+                $patch_head_entry_shape === "file"
+                || $patch_head_entry_shape === "symlink";
             $patch_base_entry_is_file_or_symlink =
                 $patch_base_entry_shape === "file"
                 || $patch_base_entry_shape === "symlink";
             $empty_directory_needs_copy =
-                $patch_result_entry_shape === "empty_directory"
+                $patch_head_entry_shape === "empty_directory"
                 && $patch_base_entry_shape !== "empty_directory";
             $changed_file_or_symlink_needs_copy =
-                $patch_result_entry_is_file_or_symlink
+                $patch_head_entry_is_file_or_symlink
                 && $path_transition === "modified";
             // The diff defines modification by type, size, and ctime. Only a
-            // modified file or symlink needs its result value copied.
+            // modified file or symlink needs its patch-head value copied.
             $needs_delete =
-                $patch_result_entry_is_file_or_symlink
+                $patch_head_entry_is_file_or_symlink
                 !== $patch_base_entry_is_file_or_symlink;
             $path_may_change = $this->path_may_change($index_path);
 
@@ -395,7 +432,7 @@ final class FileSyncPatchPlanner
                 "action" => $path_to_delete === null ? "copy" : "replace",
                 "path" => $path_to_copy,
                 "expected_source" => [
-                    "type" => $patch_result_path_type,
+                    "type" => $patch_head_path_type,
                     "size" => $this->index_diff->get_size_in_new_index(),
                     "ctime" => $this->index_diff->get_ctime_in_new_index(),
                 ],
@@ -419,6 +456,25 @@ final class FileSyncPatchPlanner
         return true;
     }
 
+    /**
+     * Returns whether this planner is still at its initial position.
+     *
+     * A fresh planner is open, has not attempted a path, both index byte
+     * offsets are zero, and no active deletion root is retained.
+     */
+    public function is_positioned_before_first_path(): bool
+    {
+        if ($this->closed || $this->next_path_was_called) {
+            return false;
+        }
+
+        $index_diff_cursor = $this->cursor["index_diff_cursor"];
+        return $index_diff_cursor["old_index_byte_offset"] === 0
+            && $index_diff_cursor["new_index_byte_offset"] === 0
+            && $index_diff_cursor["preceding_new_index_entry_path_b64"] === null
+            && $this->cursor["active_deletion_root_byte_offset"] === null;
+    }
+
     /** Returns whether the last processed path exhausted both indexes. */
     public function is_complete(): bool
     {
@@ -431,7 +487,7 @@ final class FileSyncPatchPlanner
      * Null means the current path needs no operation. A `delete` operation has
      * only an action and path. A `copy` or `replace` operation also records the
      * source state expected when the operation is performed. `replace` means
-     * delete the path before copying the patch-result entry there.
+     * delete the path before copying the patch-head entry there.
      *
      * @return array|null {
      *     Current sync operation, or null.
@@ -455,18 +511,80 @@ final class FileSyncPatchPlanner
     }
 
     /**
+     * Returns the current path's complete decoded patch-base entry.
+     *
+     * Null means the current path is absent from the patch base. Fields added
+     * by the patch-base decoder remain in the returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded patch-base entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty            Optional empty-directory marker.
+     *     @type string $copy_source_path Optional source path retained from a custom decoder.
+     * }
+     * @phpstan-return IndexEntry|null
+     */
+    public function get_entry_in_patch_base_index(): ?array
+    {
+        $this->assert_open();
+        return $this->patch_base_index_entry;
+    }
+
+    /**
+     * Returns the current path's complete decoded patch-head entry.
+     *
+     * Null means the current path is absent from the patch head. Fields added
+     * by the patch-head decoder remain in the returned entry.
+     *
+     * @return array|null {
+     *     Complete decoded patch-head entry for the current path, or null.
+     *
+     *     @type string $path  Decoded path bytes.
+     *     @type string $type  `file`, `link`, or `dir`.
+     *     @type int    $size  Recorded size.
+     *     @type int    $ctime Recorded inode change time.
+     *     @type bool   $empty            Optional empty-directory marker.
+     *     @type string $copy_source_path Optional source path retained from a custom decoder.
+     * }
+     * @phpstan-return IndexEntry|null
+     */
+    public function get_entry_in_patch_head_index(): ?array
+    {
+        $this->assert_open();
+        return $this->patch_head_index_entry;
+    }
+
+    /** Returns whether the current path is inside the configured change roots. */
+    public function current_path_may_change(): bool
+    {
+        $this->assert_open();
+        $current_entry = $this->patch_head_index_entry
+            ?? $this->patch_base_index_entry;
+        if ($current_entry === null) {
+            throw new LogicException(
+                "The file sync patch planner has no current path."
+            );
+        }
+        return $this->path_may_change($current_entry["path"]);
+    }
+
+    /**
      * Returns everything needed to resume after the current path.
      *
      * @return array {
      *     Cursor for resume().
      *
-     *     @type string       $patch_base_index_file                    Tree state before the patch.
-     *     @type string       $patch_result_index_file                  Tree state described by the patch.
+     *     @type string       $patch_base_index_file                    Left index in the patch comparison.
+     *     @type string       $patch_head_index_file                    Right index in the patch comparison.
      *     @type string       $active_deletion_roots_file               State for active directory deletions.
      *     @type list<string> $included_index_path_roots                Roots within which changes may be planned.
      *     @type list<string> $excluded_index_path_roots                Roots which changes must not affect.
      *     @type array        $index_diff_cursor                        File-index diff cursor.
-     *     @type int|null     $active_deletion_root_byte_offset    Active deletion-root offset.
+     *     @type int|null     $active_deletion_root_byte_offset         Active deletion-root offset.
      * }
      * @phpstan-return Cursor
      */
@@ -498,23 +616,23 @@ final class FileSyncPatchPlanner
         $this->closed = true;
     }
 
-    /** Checks adjacent patch-result entries for a path or its descendant. */
-    private function patch_result_index_contains_path_or_descendant(
+    /** Checks adjacent patch-head entries for a path or its descendant. */
+    private function patch_head_index_contains_path_or_descendant(
         string $index_path,
-        ?string $preceding_patch_result_index_path,
-        ?string $following_patch_result_index_path
+        ?string $preceding_patch_head_index_path,
+        ?string $following_patch_head_index_path
     ): bool {
         // NUL cannot occur in an index path and cannot match either test.
-        $preceding_patch_result_index_path =
-            $preceding_patch_result_index_path ?? "\0";
-        $following_patch_result_index_path =
-            $following_patch_result_index_path ?? "\0";
+        $preceding_patch_head_index_path =
+            $preceding_patch_head_index_path ?? "\0";
+        $following_patch_head_index_path =
+            $following_patch_head_index_path ?? "\0";
 
         return path_is_same_as_or_descendant_of(
-            $preceding_patch_result_index_path,
+            $preceding_patch_head_index_path,
             $index_path
         ) || path_is_same_as_or_descendant_of(
-            $following_patch_result_index_path,
+            $following_patch_head_index_path,
             $index_path
         );
     }

--- a/packages/reprint-client/src/lib/index/class-file-sync-plan-runner.php
+++ b/packages/reprint-client/src/lib/index/class-file-sync-plan-runner.php
@@ -1,0 +1,697 @@
+<?php
+
+use function WordPress\Reprint\Exporter\relative_path_under;
+
+require_once __DIR__ . '/class-file-sync-patch-planner.php';
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Index paths are CLI/API values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reprint streaming classes use domain names.
+
+/**
+ * Materializes one file-sync plan as bounded copy and deletion list steps.
+ *
+ * The runner does not copy or delete filesystem paths. Each next_step() call
+ * processes at most one path selected by FileSyncPatchPlanner, appends its
+ * copy and deletion records, and updates the in-memory cursor. The caller
+ * flushes pending outputs before storing that cursor.
+ *
+ * Copy records use the patch-head entry's optional `copy_source_path`;
+ * otherwise they use its index path. Deletion records use the planned target
+ * path relative to the configured deletion path prefix.
+ *
+ * An optional paths-requiring-copy file is JSONL with a base64 `path` field.
+ * Its paths must be a subset of the two index paths and occur in strictly
+ * increasing byte order. A matching selected entry adds a copy only when the
+ * patch head contains that path. The runner keeps one lookahead entry and
+ * never scans forward to catch up with the planner.
+ *
+ * The cursor does not store index line decoders. Pass the same decoders to
+ * resume() that were used to create the planner passed to start().
+ *
+ * @phpstan-type IndexEntry array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,empty?:bool,copy_source_path?:string}
+ * @phpstan-type PlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
+ * @phpstan-type PlannerCursor array{patch_base_index_file:string,patch_head_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:PlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
+ * @phpstan-type PlanningPosition array{phase:'planning',file_sync_patch_planner_cursor:PlannerCursor,byte_offset_in_paths_to_copy:int,byte_offset_in_paths_to_delete:int,byte_offset_in_paths_requiring_copy:int,paths_to_copy_count:int,file_bytes_to_copy:int}
+ * @phpstan-type CompletePosition array{phase:'complete',paths_to_copy_count:int,file_bytes_to_copy:int}
+ * @phpstan-type Cursor array{paths_to_copy_file:string,paths_to_delete_file:string,deletion_path_prefix:string,paths_requiring_copy_file:string|null,position:PlanningPosition|CompletePosition}
+ * @phpstan-type StartOptions array{paths_to_copy_file:string,paths_to_delete_file:string,deletion_path_prefix:string,paths_requiring_copy_file?:string|null}
+ */
+final class FileSyncPlanRunner {
+    /** @var Cursor */
+    private array $cursor;
+
+    private FileSyncPatchPlanner $patch_planner;
+
+    /** @var resource|null */
+    private $paths_to_copy_handle = null;
+
+    /** @var resource|null */
+    private $paths_to_delete_handle = null;
+
+    /** @var resource|null */
+    private $paths_requiring_copy_handle = null;
+
+    /** Current unconsumed path from the paths-requiring-copy input. */
+    private ?string $path_requiring_copy = null;
+
+    /** Byte offset immediately after the retained paths-requiring-copy entry. */
+    private ?int $next_path_requiring_copy_byte_offset = null;
+
+    /** Whether the paths-requiring-copy input has reached EOF. */
+    private bool $paths_requiring_copy_complete = false;
+
+    private bool $closed = false;
+
+    /**
+     * Starts materializing operations from a fresh patch planner.
+     *
+     * The planner must be open and positioned before its first path. After it
+     * is passed here, the caller must not use or close it. The runner closes
+     * the planner if setup fails or when close() is called.
+     *
+     * Both output files are replaced. The optional paths-requiring-copy file
+     * is opened read-only.
+     *
+     * @param FileSyncPatchPlanner $patch_planner Fresh planner whose operations will be materialized.
+     * @param array                $options {
+     *     Plan output files and path rules.
+     *
+     *     @type string      $paths_to_copy_file        JSONL copy-plan output.
+     *     @type string      $paths_to_delete_file      NUL-delimited deletion-plan output.
+     *     @type string      $deletion_path_prefix      Index path prefix stripped from deletion targets.
+     *     @type string|null $paths_requiring_copy_file Optional. JSONL paths in strictly increasing byte order which require a patch-head copy. Default null.
+     * }
+     * @phpstan-param StartOptions $options
+     */
+    public static function start(
+        FileSyncPatchPlanner $patch_planner,
+        array $options
+    ): self {
+        $runner = new self();
+        $runner->patch_planner = $patch_planner;
+
+        try {
+            if (!$patch_planner->is_positioned_before_first_path()) {
+                throw new InvalidArgumentException(
+                    "FileSyncPlanRunner::start() requires a fresh patch planner "
+                    . "positioned before its first path; "
+                    . "is_positioned_before_first_path() returned false."
+                );
+            }
+
+            $allowed_option_names = [
+                "paths_to_copy_file",
+                "paths_to_delete_file",
+                "deletion_path_prefix",
+                "paths_requiring_copy_file",
+            ];
+            foreach (array_keys($options) as $option_name) {
+                if (!in_array($option_name, $allowed_option_names, true)) {
+                    throw new InvalidArgumentException(
+                        "FileSyncPlanRunner::start() does not accept the "
+                        . "{$option_name} option."
+                    );
+                }
+            }
+
+            foreach (
+                [
+                    "paths_to_copy_file",
+                    "paths_to_delete_file",
+                    "deletion_path_prefix",
+                ] as $required_string_option
+            ) {
+                if (!array_key_exists($required_string_option, $options)) {
+                    throw new InvalidArgumentException(
+                        "FileSyncPlanRunner::start() requires the "
+                        . "{$required_string_option} option."
+                    );
+                }
+                if (!is_string($options[$required_string_option])) {
+                    throw new InvalidArgumentException(
+                        "FileSyncPlanRunner::start() requires the "
+                        . "{$required_string_option} option to be a string; "
+                        . "received "
+                        . self::describe_observed_type(
+                            $options[$required_string_option]
+                        )
+                        . "."
+                    );
+                }
+            }
+
+            $paths_requiring_copy_file = array_key_exists(
+                "paths_requiring_copy_file",
+                $options
+            ) ? $options["paths_requiring_copy_file"] : null;
+            if (
+                $paths_requiring_copy_file !== null
+                && !is_string($paths_requiring_copy_file)
+            ) {
+                throw new InvalidArgumentException(
+                    "FileSyncPlanRunner::start() requires the "
+                    . "paths_requiring_copy_file option to be a string or null; "
+                    . "received "
+                    . self::describe_observed_type($paths_requiring_copy_file)
+                    . "."
+                );
+            }
+
+            $runner->cursor = [
+                "paths_to_copy_file" => $options["paths_to_copy_file"],
+                "paths_to_delete_file" => $options["paths_to_delete_file"],
+                "deletion_path_prefix" => $options["deletion_path_prefix"],
+                "paths_requiring_copy_file" => $paths_requiring_copy_file,
+                "position" => [
+                    "phase" => "planning",
+                    "file_sync_patch_planner_cursor" =>
+                        $patch_planner->get_cursor(),
+                    "byte_offset_in_paths_to_copy" => 0,
+                    "byte_offset_in_paths_to_delete" => 0,
+                    "byte_offset_in_paths_requiring_copy" => 0,
+                    "paths_to_copy_count" => 0,
+                    "file_bytes_to_copy" => 0,
+                ],
+            ];
+
+            $runner->open_plan_files_at_byte_offsets(0, 0, 0);
+            return $runner;
+        } catch (Throwable $throwable) {
+            $runner->close();
+            throw $throwable;
+        }
+    }
+
+    /**
+     * Returns a PHP 7.4-compatible name for one invalid option value type.
+     *
+     * @param mixed $value Invalid option value.
+     */
+    private static function describe_observed_type($value): string
+    {
+        return $value === null ? "null" : gettype($value);
+    }
+
+    /**
+     * Resumes materializing a plan at its last stored cursor.
+     *
+     * Bytes beyond the two stored output offsets are discarded. The index and
+     * paths-requiring-copy inputs must still contain the same snapshots used by
+     * start().
+     *
+     * @param array $cursor {
+     *     Cursor previously returned by get_cursor().
+     *
+     *     @type string      $paths_to_copy_file       JSONL copy-plan output path.
+     *     @type string      $paths_to_delete_file     NUL-delimited deletion-plan output path.
+     *     @type string      $deletion_path_prefix     Prefix stripped from deletion targets.
+     *     @type string|null $paths_requiring_copy_file Optional sorted required-copy input path.
+     *     @type array       $position {
+     *         Current planning or complete position.
+     *
+     *         @type string   $phase                                 `planning` or `complete`.
+     *         @type array    $file_sync_patch_planner_cursor        Planner cursor. Planning only.
+     *         @type int      $byte_offset_in_paths_to_copy          Durable copy-output offset. Planning only.
+     *         @type int      $byte_offset_in_paths_to_delete        Durable deletion-output offset. Planning only.
+     *         @type int      $byte_offset_in_paths_requiring_copy   Durable required-copy offset. Planning only.
+     *         @type int      $paths_to_copy_count                    Number of copy records.
+     *         @type int      $file_bytes_to_copy                     Combined file bytes.
+     *     }
+     * }
+     * @phpstan-param Cursor $cursor Cursor previously returned by get_cursor().
+     * @param callable|null $decode_patch_base_index_line  Decoder used to create the planner passed to start().
+     * @param callable|null $decode_patch_head_index_line  Patch-head decoder used to create that planner.
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_base_index_line
+     * @phpstan-param (callable(string):IndexEntry)|null $decode_patch_head_index_line
+     */
+    public static function resume(
+        array $cursor,
+        ?callable $decode_patch_base_index_line = null,
+        ?callable $decode_patch_head_index_line = null
+    ): self {
+        $runner = new self();
+        $runner->cursor = $cursor;
+        $position = $cursor["position"];
+        if ($position["phase"] === "complete") {
+            return $runner;
+        }
+
+        $runner->patch_planner = FileSyncPatchPlanner::resume(
+            $position["file_sync_patch_planner_cursor"],
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
+        );
+        $runner->open_plan_files_at_byte_offsets(
+            $position["byte_offset_in_paths_to_copy"],
+            $position["byte_offset_in_paths_to_delete"],
+            $position["byte_offset_in_paths_requiring_copy"]
+        );
+        return $runner;
+    }
+
+    /**
+     * Processes at most one path and appends its copy and deletion records.
+     *
+     * False means the plan is complete and remains false on later calls. The
+     * final path is written by the call which first returns false.
+     *
+     * @return bool Whether another planning step may be performed.
+     */
+    public function next_step(): bool
+    {
+        $position = $this->cursor["position"];
+        if ($position["phase"] === "complete") {
+            return false;
+        }
+        if ($this->closed) {
+            throw new LogicException(
+                "Cannot take a file sync plan runner step after close()."
+            );
+        }
+
+        if (!$this->patch_planner->next_path()) {
+            return $this->complete_plan(
+                $position["paths_to_copy_count"],
+                $position["file_bytes_to_copy"]
+            );
+        }
+
+        $patch_base_index_entry =
+            $this->patch_planner->get_entry_in_patch_base_index();
+        /** @var IndexEntry|null $patch_head_index_entry */
+        $patch_head_index_entry =
+            $this->patch_planner->get_entry_in_patch_head_index();
+        $current_path = $patch_head_index_entry["path"]
+            ?? $patch_base_index_entry["path"]
+            ?? null;
+        if ($current_path === null) {
+            throw new LogicException(
+                "The file sync patch planner processed a path without an index entry."
+            );
+        }
+
+        $path_requires_copy = false;
+        if (is_resource($this->paths_requiring_copy_handle)) {
+            $this->load_path_requiring_copy();
+            if ($this->path_requiring_copy !== null) {
+                $path_comparison = strcmp(
+                    $this->path_requiring_copy,
+                    $current_path
+                );
+                if ($path_comparison < 0) {
+                    throw new RuntimeException(
+                        "The paths-requiring-copy entry "
+                        . base64_encode($this->path_requiring_copy)
+                        . " does not match any remaining patch-index path."
+                    );
+                }
+                if ($path_comparison === 0) {
+                    $path_requires_copy =
+                        $this->patch_planner->current_path_may_change();
+                    $position["byte_offset_in_paths_requiring_copy"] =
+                        $this->next_path_requiring_copy_byte_offset;
+                    $this->path_requiring_copy = null;
+                    $this->next_path_requiring_copy_byte_offset = null;
+                }
+            }
+        }
+
+        $operation = $this->patch_planner->get_operation();
+        if ($operation !== null && $operation["action"] !== "copy") {
+            $target_relative_path = relative_path_under(
+                $operation["path"],
+                $this->cursor["deletion_path_prefix"]
+            );
+            if ($target_relative_path === null) {
+                throw new RuntimeException(
+                    "The planned deletion path "
+                    . base64_encode($operation["path"])
+                    . " is outside the deletion path prefix "
+                    . base64_encode($this->cursor["deletion_path_prefix"])
+                    . "."
+                );
+            }
+            self::write_bytes(
+                $this->paths_to_delete_handle,
+                $target_relative_path . "\0",
+                "paths-to-delete output "
+                    . $this->cursor["paths_to_delete_file"]
+            );
+        }
+
+        $operation_needs_copy =
+            $operation !== null && $operation["action"] !== "delete";
+        if (
+            ( $operation_needs_copy || $path_requires_copy )
+            && $patch_head_index_entry !== null
+        ) {
+            $source_path = $patch_head_index_entry["copy_source_path"]
+                ?? $patch_head_index_entry["path"];
+            // Base64 keeps arbitrary filesystem path bytes representable in JSON.
+            $copy_line = json_encode(
+                [
+                    "path" => base64_encode($source_path),
+                    "type" => $patch_head_index_entry["type"] === "link"
+                        ? "symlink"
+                        : ( $patch_head_index_entry["type"] === "dir"
+                            ? "directory"
+                            : "file" ),
+                    "size" => $patch_head_index_entry["size"],
+                    "ctime" => $patch_head_index_entry["ctime"],
+                ],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
+            self::write_bytes(
+                $this->paths_to_copy_handle,
+                $copy_line,
+                "paths-to-copy output "
+                    . $this->cursor["paths_to_copy_file"]
+            );
+            ++$position["paths_to_copy_count"];
+            if ($patch_head_index_entry["type"] === "file") {
+                $position["file_bytes_to_copy"] +=
+                    $patch_head_index_entry["size"];
+            }
+        }
+
+        if ($this->patch_planner->is_complete()) {
+            return $this->complete_plan(
+                $position["paths_to_copy_count"],
+                $position["file_bytes_to_copy"]
+            );
+        }
+
+        $paths_to_copy_byte_offset = ftell($this->paths_to_copy_handle);
+        $paths_to_delete_byte_offset = ftell($this->paths_to_delete_handle);
+        if (
+            !is_int($paths_to_copy_byte_offset)
+            || !is_int($paths_to_delete_byte_offset)
+        ) {
+            throw new RuntimeException(
+                "Failed to determine a file sync plan output byte offset."
+            );
+        }
+
+        $this->cursor["position"] = [
+            "phase" => "planning",
+            "file_sync_patch_planner_cursor" =>
+                $this->patch_planner->get_cursor(),
+            "byte_offset_in_paths_to_copy" => $paths_to_copy_byte_offset,
+            "byte_offset_in_paths_to_delete" => $paths_to_delete_byte_offset,
+            "byte_offset_in_paths_requiring_copy" =>
+                $position["byte_offset_in_paths_requiring_copy"],
+            "paths_to_copy_count" => $position["paths_to_copy_count"],
+            "file_bytes_to_copy" => $position["file_bytes_to_copy"],
+        ];
+        return true;
+    }
+
+    /**
+     * Returns the cursor after the latest completed step.
+     *
+     * @return array {
+     *     Cursor which may be stored and passed to resume().
+     *
+     *     @type string      $paths_to_copy_file       JSONL copy-plan output path.
+     *     @type string      $paths_to_delete_file     NUL-delimited deletion-plan output path.
+     *     @type string      $deletion_path_prefix     Prefix stripped from deletion targets.
+     *     @type string|null $paths_requiring_copy_file Optional sorted required-copy input path.
+     *     @type array       $position {
+     *         Current planning or complete position.
+     *
+     *         @type string   $phase                                 `planning` or `complete`.
+     *         @type array    $file_sync_patch_planner_cursor        Planner cursor. Planning only.
+     *         @type int      $byte_offset_in_paths_to_copy          Durable copy-output offset. Planning only.
+     *         @type int      $byte_offset_in_paths_to_delete        Durable deletion-output offset. Planning only.
+     *         @type int      $byte_offset_in_paths_requiring_copy   Durable required-copy offset. Planning only.
+     *         @type int      $paths_to_copy_count                    Number of copy records.
+     *         @type int      $file_bytes_to_copy                     Combined file bytes.
+     *     }
+     * }
+     * @phpstan-return Cursor
+     */
+    public function get_cursor(): array
+    {
+        return $this->cursor;
+    }
+
+    /** Returns whether every patch path was processed and both outputs are complete. */
+    public function is_complete(): bool
+    {
+        return $this->cursor["position"]["phase"] === "complete";
+    }
+
+    /** Returns the number of copy records. */
+    public function get_paths_to_copy_count(): int
+    {
+        return $this->cursor["position"]["paths_to_copy_count"];
+    }
+
+    /** Returns the combined file bytes to copy. */
+    public function get_file_bytes_to_copy(): int
+    {
+        return $this->cursor["position"]["file_bytes_to_copy"];
+    }
+
+    /**
+     * Returns the durable bytes consumed from both patch indexes while planning.
+     *
+     * @throws LogicException When the plan is complete and no index cursor remains.
+     */
+    public function get_index_bytes_done(): int
+    {
+        $position = $this->cursor["position"];
+        if ($position["phase"] === "complete") {
+            throw new LogicException(
+                "A completed file sync plan has no open index-diff cursor."
+            );
+        }
+
+        $index_diff_cursor =
+            $position["file_sync_patch_planner_cursor"]["index_diff_cursor"];
+        return $index_diff_cursor["old_index_byte_offset"]
+            + $index_diff_cursor["new_index_byte_offset"];
+    }
+
+    /** Flushes planner state and both plan outputs before the cursor is stored. */
+    public function flush_pending_outputs(): void
+    {
+        if (
+            is_resource($this->paths_to_copy_handle)
+            && !fflush($this->paths_to_copy_handle)
+        ) {
+            throw new RuntimeException(
+                "Failed to flush the paths-to-copy output: "
+                . $this->cursor["paths_to_copy_file"]
+            );
+        }
+        if (
+            is_resource($this->paths_to_delete_handle)
+            && !fflush($this->paths_to_delete_handle)
+        ) {
+            throw new RuntimeException(
+                "Failed to flush the paths-to-delete output: "
+                . $this->cursor["paths_to_delete_file"]
+            );
+        }
+        if (isset($this->patch_planner)) {
+            $this->patch_planner->flush_pending_outputs();
+        }
+    }
+
+    /** Closes retained planner and file handles. Repeated calls do nothing. */
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        if (isset($this->patch_planner)) {
+            $this->patch_planner->close();
+        }
+        foreach (
+            [
+                "paths_to_copy_handle",
+                "paths_to_delete_handle",
+                "paths_requiring_copy_handle",
+            ] as $handle_property
+        ) {
+            if (is_resource($this->{$handle_property})) {
+                fclose($this->{$handle_property});
+            }
+            $this->{$handle_property} = null;
+        }
+        $this->closed = true;
+    }
+
+    /** Flushes the final outputs and stores a stable complete position. */
+    private function complete_plan(
+        int $paths_to_copy_count,
+        int $file_bytes_to_copy
+    ): bool {
+        $this->assert_no_unmatched_path_requiring_copy();
+        $this->flush_pending_outputs();
+        $this->cursor["position"] = [
+            "phase" => "complete",
+            "paths_to_copy_count" => $paths_to_copy_count,
+            "file_bytes_to_copy" => $file_bytes_to_copy,
+        ];
+        return false;
+    }
+
+    /** Loads at most one paths-requiring-copy entry as retained lookahead. */
+    private function load_path_requiring_copy(): void
+    {
+        if (
+            $this->path_requiring_copy !== null
+            || $this->paths_requiring_copy_complete
+            || !is_resource($this->paths_requiring_copy_handle)
+        ) {
+            return;
+        }
+
+        $line = fgets($this->paths_requiring_copy_handle);
+        if ($line === false) {
+            if (!feof($this->paths_requiring_copy_handle)) {
+                throw new RuntimeException(
+                    "Failed to read the paths-requiring-copy input."
+                );
+            }
+            $this->paths_requiring_copy_complete = true;
+            return;
+        }
+        $next_byte_offset = ftell($this->paths_requiring_copy_handle);
+        if (!is_int($next_byte_offset)) {
+            throw new RuntimeException(
+                "Failed to determine the paths-requiring-copy byte offset."
+            );
+        }
+
+        try {
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException(
+                "Failed to decode a paths-requiring-copy entry.",
+                0,
+                $exception
+            );
+        }
+        if (!is_array($entry) || !isset($entry["path"]) || !is_string($entry["path"])) {
+            throw new RuntimeException(
+                "A paths-requiring-copy entry must contain a base64 path."
+            );
+        }
+        $path = base64_decode($entry["path"], true);
+        if ($path === false) {
+            throw new RuntimeException(
+                "A paths-requiring-copy entry contains an invalid base64 path."
+            );
+        }
+        $this->path_requiring_copy = $path;
+        $this->next_path_requiring_copy_byte_offset = $next_byte_offset;
+    }
+
+    /** Rejects a paths-requiring-copy entry beyond the completed index union. */
+    private function assert_no_unmatched_path_requiring_copy(): void
+    {
+        if (!is_resource($this->paths_requiring_copy_handle)) {
+            return;
+        }
+        $this->load_path_requiring_copy();
+        if ($this->path_requiring_copy !== null) {
+            throw new RuntimeException(
+                "The paths-requiring-copy entry "
+                . base64_encode($this->path_requiring_copy)
+                . " does not match any remaining patch-index path."
+            );
+        }
+    }
+
+    /** Opens retained plan files at the supplied durable byte offsets. */
+    private function open_plan_files_at_byte_offsets(
+        int $paths_to_copy_byte_offset,
+        int $paths_to_delete_byte_offset,
+        int $paths_requiring_copy_byte_offset
+    ): void {
+        try {
+            $this->paths_to_copy_handle = self::open_output_at_byte_offset(
+                $this->cursor["paths_to_copy_file"],
+                $paths_to_copy_byte_offset,
+                "paths-to-copy output"
+            );
+            $this->paths_to_delete_handle = self::open_output_at_byte_offset(
+                $this->cursor["paths_to_delete_file"],
+                $paths_to_delete_byte_offset,
+                "paths-to-delete output"
+            );
+            $paths_requiring_copy_file =
+                $this->cursor["paths_requiring_copy_file"];
+            if ($paths_requiring_copy_file !== null) {
+                $this->paths_requiring_copy_handle = fopen(
+                    $paths_requiring_copy_file,
+                    "rb"
+                );
+                if (
+                    !is_resource($this->paths_requiring_copy_handle)
+                    || fseek(
+                        $this->paths_requiring_copy_handle,
+                        $paths_requiring_copy_byte_offset
+                    ) !== 0
+                ) {
+                    throw new RuntimeException(
+                        "Failed to open the paths-requiring-copy input "
+                        . "{$paths_requiring_copy_file} at byte "
+                        . "{$paths_requiring_copy_byte_offset}."
+                    );
+                }
+            }
+        } catch (Throwable $throwable) {
+            $this->close();
+            throw $throwable;
+        }
+    }
+
+    /**
+     * Opens one output at its durable cursor and discards later bytes.
+     *
+     * Plan output is flushed before its cursor is stored, so a valid cursor
+     * cannot exceed the output length. A process may stop after writing output
+     * but before storing its next cursor. Truncating to the saved offset
+     * removes only that unstored tail before the plan continues.
+     *
+     * @return resource Writable output handle positioned at the cursor.
+     */
+    private static function open_output_at_byte_offset(
+        string $path,
+        int $byte_offset,
+        string $description
+    ) {
+        $handle = fopen($path, "c+b");
+        if (!is_resource($handle)) {
+            throw new RuntimeException("Failed to open the {$description}: {$path}");
+        }
+        if (
+            !ftruncate($handle, $byte_offset)
+            || fseek($handle, $byte_offset) !== 0
+        ) {
+            fclose($handle);
+            throw new RuntimeException(
+                "Failed to truncate and seek the {$description} {$path} "
+                . "to byte {$byte_offset}."
+            );
+        }
+        return $handle;
+    }
+
+    /** @param resource $handle Writable plan output. */
+    private static function write_bytes(
+        $handle,
+        string $bytes,
+        string $description
+    ): void {
+        if (fwrite($handle, $bytes) !== strlen($bytes)) {
+            throw new RuntimeException(
+                "Short write on the {$description}, is the disk full?"
+            );
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -5,7 +5,7 @@ use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
 
-require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
+require_once __DIR__ . '/../index/class-file-sync-plan-runner.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Journal failures are CLI/API values, never HTML output.
 
@@ -19,9 +19,9 @@ require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
  *
  * PushFilesSender or the files-diff command owns the caller-visible lifecycle,
  * lock, top-level phase, result, and terminal behavior. PushPlan owns
- * FileIndexProcessor, FileSyncPatchPlanner, the fresh local index, the
- * meaning of its cursor, and the two completed path lists. A caller which
- * resumes across processes stores the cursor returned by get_cursor().
+ * FileIndexProcessor, FileSyncPlanRunner, the fresh local index, the meaning
+ * of its cursor, and the two completed path lists. A caller which resumes
+ * across processes stores the cursor returned by get_cursor().
  *
  * ## Durable boundary
  *
@@ -56,18 +56,18 @@ require_once __DIR__ . '/../index/class-file-sync-patch-planner.php';
  * bytes beyond saved offsets, so an interrupted step cannot leave duplicate
  * durable entries.
  *
- * FileSyncPatchPlanner retains the next entry from each index and writes the
+ * FileSyncPlanRunner retains FileSyncPatchPlanner, both plan outputs, and the
  * active directory-deletion roots needed to suppress redundant descendant
- * deletions. PushPlan stores its cursor without unpacking it. Neither class
- * loads an index, path list, or the active deletion roots file in full.
+ * deletions. PushPlan stores the runner cursor unchanged while diffing.
+ * Neither class loads an index, path list, or the active deletion roots file
+ * in full.
  *
+ * @phpstan-import-type Cursor from FileSyncPlanRunner as FileSyncPlanRunnerCursor
  * @phpstan-type FileIndexCursor array{stack:list<array{dir:string,after:string|null}>}
  * @phpstan-type IndexingCursor array{phase:'indexing',file_index_cursor:FileIndexCursor,fresh_local_index_byte_offset:int}
  * @phpstan-type StartingDiffCursor array{phase:'starting_diff'}
- * @phpstan-type FileSyncPlannerIndexDiffCursor array{old_index_byte_offset:int,new_index_byte_offset:int,preceding_new_index_entry_path_b64:string|null}
- * @phpstan-type FileSyncPlannerCursor array{patch_base_index_file:string,patch_result_index_file:string,active_deletion_roots_file:string,included_index_path_roots:list<string>,excluded_index_path_roots:list<string>,index_diff_cursor:FileSyncPlannerIndexDiffCursor,active_deletion_root_byte_offset:int|null}
- * @phpstan-type IndexDiffCursor array{phase:'diffing',file_sync_planner_cursor:FileSyncPlannerCursor,byte_offset_in_local_paths_to_push:int,byte_offset_in_local_paths_to_delete:int,local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
- * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int|null,local_file_bytes_to_push:int|null}
+ * @phpstan-type IndexDiffCursor array{phase:'diffing',file_sync_plan_runner_cursor:FileSyncPlanRunnerCursor}
+ * @phpstan-type CompleteCursor array{phase:'complete',local_paths_to_push_count:int,local_file_bytes_to_push:int}
  * @phpstan-type PushPlanPosition IndexingCursor|StartingDiffCursor|IndexDiffCursor|CompleteCursor
  * @phpstan-type PushPlanCursor array{plan_directory:string,filesystem_root:string,local_index_file:string,document_root_local_relative_path:string,position:PushPlanPosition}
  */
@@ -112,15 +112,11 @@ class PushPlan
     /** @var FileIndexProcessor Fresh local index traversal retained during indexing. */
     private FileIndexProcessor $file_index_processor;
 
-    /** File-sync patch planner retained during the diff phase. */
-    private FileSyncPatchPlanner $patch_planner;
+    /** File-sync plan runner retained during the diff phase. */
+    private FileSyncPlanRunner $file_sync_plan_runner;
 
     /** @var resource|null Open fresh local index retained during indexing. */
     private $fresh_local_index_handle = null;
-    /** @var resource|null */
-    private $local_paths_to_push_handle = null;
-    /** @var resource|null */
-    private $local_paths_to_delete_handle = null;
     /** @var int|null Combined size of the two retained indexes during the index diff. */
     private ?int $index_bytes_total = null;
 
@@ -195,24 +191,6 @@ class PushPlan
             // Older cursors had no document-root mapping and used local relative paths unchanged.
             $cursor["document_root_local_relative_path"] = "";
         }
-        $position = $cursor["position"];
-        if (
-            ($position["phase"] === "diffing" || $position["phase"] === "complete")
-            && !array_key_exists("local_paths_to_push_count", $position)
-        ) {
-            // Keep the plan single-pass when an older cursor has no path count.
-            $position["local_paths_to_push_count"] = null;
-            $cursor["position"] = $position;
-        }
-        if (
-            ( $position["phase"] === "diffing" || $position["phase"] === "complete" )
-            && !array_key_exists("local_file_bytes_to_push", $position)
-        ) {
-            // Keep the plan single-pass when an older cursor has no file byte total.
-            $position["local_file_bytes_to_push"] = null;
-            $cursor["position"] = $position;
-        }
-
         $plan = new self(
             $cursor["plan_directory"],
             $cursor["filesystem_root"],
@@ -227,14 +205,8 @@ class PushPlan
         if ($position["phase"] === "indexing") {
             $plan->open_fresh_local_index_for_continuation();
         } elseif ($position["phase"] === "diffing") {
-            $plan->open_plan_output_files(
-                $position["byte_offset_in_local_paths_to_push"],
-                $position["byte_offset_in_local_paths_to_delete"]
-            );
-            $file_sync_planner_cursor =
-                $position["file_sync_planner_cursor"];
-            $plan->patch_planner = FileSyncPatchPlanner::resume(
-                $file_sync_planner_cursor
+            $plan->file_sync_plan_runner = FileSyncPlanRunner::resume(
+                $position["file_sync_plan_runner_cursor"]
             );
             $plan->set_index_bytes_total();
         }
@@ -282,10 +254,8 @@ class PushPlan
             return $progress;
         }
 
-        $index_diff_cursor =
-            $position["file_sync_planner_cursor"]["index_diff_cursor"];
-        $index_bytes_done = $index_diff_cursor["new_index_byte_offset"]
-            + $index_diff_cursor["old_index_byte_offset"];
+        $index_bytes_done =
+            $this->file_sync_plan_runner->get_index_bytes_done();
         $progress["index_bytes_done"] = min($index_bytes_done, $this->index_bytes_total);
         $progress["index_bytes_total"] = $this->index_bytes_total;
         return $progress;
@@ -320,14 +290,8 @@ class PushPlan
         ) {
             throw new RuntimeException("Failed to flush the fresh local index.");
         }
-        if (
-            ( is_resource($this->local_paths_to_push_handle) && !fflush($this->local_paths_to_push_handle) )
-            || ( is_resource($this->local_paths_to_delete_handle) && !fflush($this->local_paths_to_delete_handle) )
-        ) {
-            throw new RuntimeException("Failed to flush a push-plan output.");
-        }
-        if (isset($this->patch_planner)) {
-            $this->patch_planner->flush_pending_outputs();
+        if (isset($this->file_sync_plan_runner)) {
+            $this->file_sync_plan_runner->flush_pending_outputs();
         }
     }
 
@@ -495,40 +459,24 @@ class PushPlan
                 "Failed to sort the fresh local index: {$this->fresh_local_index_file}"
             );
         }
-        $this->open_plan_output_files(0, 0);
-        $this->patch_planner = FileSyncPatchPlanner::create(
+        $patch_planner = FileSyncPatchPlanner::create(
             $this->local_index_file,
             $this->fresh_local_index_file,
             $this->active_deletion_roots_file,
             [$this->document_root_local_relative_path],
             $this->get_excluded_index_path_roots()
         );
-        $this->cursor["position"] = [
-            "phase" => "diffing",
-            "file_sync_planner_cursor" => $this->patch_planner->get_cursor(),
-            "byte_offset_in_local_paths_to_push" => 0,
-            "byte_offset_in_local_paths_to_delete" => 0,
-            "local_paths_to_push_count" => 0,
-            "local_file_bytes_to_push" => 0,
-        ];
+        $this->file_sync_plan_runner = FileSyncPlanRunner::start(
+            $patch_planner,
+            [
+                "paths_to_copy_file" => $this->local_paths_to_push,
+                "paths_to_delete_file" => $this->local_paths_to_delete,
+                "deletion_path_prefix" =>
+                    $this->document_root_local_relative_path,
+            ]
+        );
+        $this->store_file_sync_plan_runner_position();
         $this->set_index_bytes_total();
-    }
-
-    /** Opens both patch-plan outputs at their durable byte offsets. */
-    private function open_plan_output_files(
-        int $byte_offset_in_local_paths_to_push,
-        int $byte_offset_in_local_paths_to_delete
-    ): void {
-        $this->local_paths_to_push_handle =
-            $this->open_push_plan_output_file_at_byte_offset(
-                $this->local_paths_to_push,
-                $byte_offset_in_local_paths_to_push
-            );
-        $this->local_paths_to_delete_handle =
-            $this->open_push_plan_output_file_at_byte_offset(
-                $this->local_paths_to_delete,
-                $byte_offset_in_local_paths_to_delete
-            );
     }
 
     /** Returns target exclusions in local-index coordinates. */
@@ -624,75 +572,31 @@ class PushPlan
      */
     private function next_index_diff_step(): bool
     {
-        /** @var IndexDiffCursor $cursor */
-        $cursor = $this->cursor["position"];
-        $local_paths_to_push_count = $cursor["local_paths_to_push_count"];
-        $local_file_bytes_to_push = $cursor["local_file_bytes_to_push"];
+        $another_step_may_be_performed =
+            $this->file_sync_plan_runner->next_step();
+        $this->store_file_sync_plan_runner_position();
+        return $another_step_may_be_performed;
+    }
 
-        if (!$this->patch_planner->next_path()) {
-            if (
-                !fflush($this->local_paths_to_push_handle)
-                || !fflush($this->local_paths_to_delete_handle)
-            ) {
-                throw new RuntimeException("Failed to flush a push-plan output.");
-            }
-            $this->patch_planner->flush_pending_outputs();
+    /** Stores the runner cursor or the completed push-plan totals. */
+    private function store_file_sync_plan_runner_position(): void
+    {
+        if ($this->file_sync_plan_runner->is_complete()) {
             $this->cursor["position"] = [
                 "phase" => "complete",
-                "local_paths_to_push_count" => $local_paths_to_push_count,
-                "local_file_bytes_to_push" => $local_file_bytes_to_push,
+                "local_paths_to_push_count" =>
+                    $this->file_sync_plan_runner->get_paths_to_copy_count(),
+                "local_file_bytes_to_push" =>
+                    $this->file_sync_plan_runner->get_file_bytes_to_copy(),
             ];
-            return false;
+            return;
         }
 
-        $operation = $this->patch_planner->get_operation();
-        if ($operation !== null) {
-            if ($operation["action"] !== "copy") {
-                $this->append_local_path_to_delete($operation["path"]);
-            }
-            if ($operation["action"] !== "delete") {
-                $this->append_local_path_to_push($operation);
-                if ($local_paths_to_push_count !== null) {
-                    ++$local_paths_to_push_count;
-                }
-                if (
-                    $local_file_bytes_to_push !== null
-                    && $operation["expected_source"]["type"] === "file"
-                ) {
-                    $local_file_bytes_to_push +=
-                        $operation["expected_source"]["size"];
-                }
-            }
-        }
-
-        $complete = $this->patch_planner->is_complete();
-        if ($complete) {
-            if (
-                !fflush($this->local_paths_to_push_handle)
-                || !fflush($this->local_paths_to_delete_handle)
-            ) {
-                throw new RuntimeException("Failed to flush a push-plan output.");
-            }
-            $this->patch_planner->flush_pending_outputs();
-        }
-        $this->cursor["position"] = $complete
-            ? [
-                "phase" => "complete",
-                "local_paths_to_push_count" => $local_paths_to_push_count,
-                "local_file_bytes_to_push" => $local_file_bytes_to_push,
-            ]
-            : [
-                "phase" => "diffing",
-                "file_sync_planner_cursor" =>
-                    $this->patch_planner->get_cursor(),
-                "byte_offset_in_local_paths_to_push" =>
-                    ftell($this->local_paths_to_push_handle),
-                "byte_offset_in_local_paths_to_delete" =>
-                    ftell($this->local_paths_to_delete_handle),
-                "local_paths_to_push_count" => $local_paths_to_push_count,
-                "local_file_bytes_to_push" => $local_file_bytes_to_push,
-            ];
-        return !$complete;
+        $this->cursor["position"] = [
+            "phase" => "diffing",
+            "file_sync_plan_runner_cursor" =>
+                $this->file_sync_plan_runner->get_cursor(),
+        ];
     }
 
     /**
@@ -704,21 +608,16 @@ class PushPlan
      */
     public function close(): void
     {
+        if ($this->closed) {
+            return;
+        }
         if (isset($this->file_index_processor)) {
             $this->file_index_processor->close();
         }
-        if (isset($this->patch_planner)) {
-            $this->patch_planner->close();
+        if (isset($this->file_sync_plan_runner)) {
+            $this->file_sync_plan_runner->close();
         }
         $this->close_fresh_local_index_handle();
-        if (is_resource($this->local_paths_to_push_handle)) {
-            fclose($this->local_paths_to_push_handle);
-        }
-        if (is_resource($this->local_paths_to_delete_handle)) {
-            fclose($this->local_paths_to_delete_handle);
-        }
-        $this->local_paths_to_push_handle = null;
-        $this->local_paths_to_delete_handle = null;
         $this->closed = true;
     }
 
@@ -731,102 +630,6 @@ class PushPlan
             fclose($this->fresh_local_index_handle);
         }
         $this->fresh_local_index_handle = null;
-    }
-
-    /**
-     * Opens one output at its durable cursor offset and discards later bytes.
-     *
-     * Plan output is flushed before its cursor is stored, so a valid cursor
-     * cannot exceed the output length. A process may stop after writing output
-     * but before storing its next cursor. Truncating to the saved offset
-     * removes only that uncommitted tail before the plan continues.
-     *
-     * @param string $push_plan_output_file Path to the push-plan output file.
-     * @param int    $byte_offset           Durable byte offset at which writing resumes.
-     * @return resource Writable output handle positioned at the durable offset.
-     */
-    private function open_push_plan_output_file_at_byte_offset(
-        string $push_plan_output_file,
-        int $byte_offset
-    )
-    {
-        $push_plan_output_file_handle = fopen($push_plan_output_file, "c+b");
-        if (!$push_plan_output_file_handle) {
-            throw new RuntimeException("Failed to open push plan output for writing: {$push_plan_output_file}");
-        }
-        if (
-            !ftruncate($push_plan_output_file_handle, $byte_offset)
-            || fseek($push_plan_output_file_handle, $byte_offset) !== 0
-        ) {
-            fclose($push_plan_output_file_handle);
-            throw new RuntimeException(
-                "Failed to truncate and seek push plan output "
-                . "{$push_plan_output_file} to byte {$byte_offset}."
-            );
-        }
-        return $push_plan_output_file_handle;
-    }
-
-    /**
-     * Appends one copy or replace operation to the JSONL push list.
-     *
-     * Base64 keeps arbitrary filesystem path bytes representable in JSON.
-     *
-     * @param array $operation {
-     *     Copy or replace operation selected by FileSyncPatchPlanner.
-     *
-     *     @type string $action          `copy` or `replace`.
-     *     @type string $path            Local relative path selected for push.
-     *     @type array  $expected_source {
-     *         Source state required when the path is pushed.
-     *
-     *         @type string $type  Expected `file`, `link`, or `dir` type.
-     *         @type int    $size  Expected size.
-     *         @type int    $ctime Expected inode change time.
-     *     }
-     * }
-     * @phpstan-param array{action:'copy'|'replace',path:string,expected_source:array{type:string,size:int,ctime:int}} $operation
-     */
-    private function append_local_path_to_push(array $operation): void {
-        $local_path_to_push_json_line = json_encode(
-            [
-                "path" => base64_encode($operation["path"]),
-                "type" => $operation["expected_source"]["type"] === "link"
-                    ? "symlink"
-                    : ( $operation["expected_source"]["type"] === "dir"
-                        ? "directory"
-                        : "file" ),
-                "size" => $operation["expected_source"]["size"],
-                "ctime" => $operation["expected_source"]["ctime"],
-            ],
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (
-            fwrite($this->local_paths_to_push_handle, $local_path_to_push_json_line)
-            !== strlen($local_path_to_push_json_line)
-        ) {
-            throw new RuntimeException("Short write on local push path list {$this->local_paths_to_push}, is the disk full?");
-        }
-    }
-
-    /**
-     * Appends one path to the NUL-delimited list of local paths to delete.
-     *
-     * @param string $path Raw filesystem path selected for deletion.
-     */
-    private function append_local_path_to_delete(string $path): void
-    {
-        $document_root_relative_path = relative_path_under(
-            $path,
-            $this->document_root_local_relative_path
-        );
-        if ($document_root_relative_path === null) {
-            return;
-        }
-        $document_root_relative_path_with_nul = $document_root_relative_path . "\0";
-        if (fwrite($this->local_paths_to_delete_handle, $document_root_relative_path_with_nul) !== strlen($document_root_relative_path_with_nul)) {
-            throw new RuntimeException("Short write on local paths to delete {$this->local_paths_to_delete}, is the disk full?");
-        }
     }
 
     /**

--- a/tests/Import/FileSyncPatchPlannerTest.php
+++ b/tests/Import/FileSyncPatchPlannerTest.php
@@ -47,7 +47,7 @@ final class FileSyncPatchPlannerTest extends TestCase
             'e-modified.txt' => $this->entry('e-modified.txt', 1),
             'f-unchanged.txt' => $this->entry('f-unchanged.txt'),
         ]);
-        $patch_result_index = $this->write_index('result.jsonl', [
+        $patch_head_index = $this->write_index('head.jsonl', [
             'a-added.txt' => $this->entry('a-added.txt', 2, 3),
             'c-empty-to-file' => $this->entry('c-empty-to-file', 2, 4),
             'd-file-to-empty' => $this->entry('d-file-to-empty', 2, 0, 'dir'),
@@ -56,7 +56,7 @@ final class FileSyncPatchPlannerTest extends TestCase
         ]);
         $planner = FileSyncPatchPlanner::create(
             $patch_base_index,
-            $patch_result_index,
+            $patch_head_index,
             $this->active_deletion_roots_file()
         );
 
@@ -76,19 +76,109 @@ final class FileSyncPatchPlannerTest extends TestCase
         $planner->close();
     }
 
-    public function testReplacesASubtreeWithOnePatchResultPath(): void
+    public function testIndependentDecodersExposeWholeEntriesBeforeAndAfterResume(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a.txt' => $this->entry('a.txt', 1),
+            'c.txt' => $this->entry('c.txt', 3, 3),
+        ]);
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'b.txt' => $this->entry('b.txt', 2, 2),
+            'c.txt' => $this->entry('c.txt', 3, 3),
+        ]);
+        $decode_patch_base_index_line = static function (string $line): array {
+            $entry = \Reprint\Importer\decode_local_index_entry($line);
+            $entry['base_marker'] = 'base:' . $entry['path'];
+            return $entry;
+        };
+        $decode_patch_head_index_line = static function (string $line): array {
+            $entry = \Reprint\Importer\decode_local_index_entry($line);
+            $entry['source_path'] = '/remote/' . $entry['path'];
+            return $entry;
+        };
+
+        $planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_head_index,
+            $this->active_deletion_roots_file(),
+            [''],
+            [],
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            [
+                'path' => 'a.txt',
+                'ctime' => 1,
+                'size' => 1,
+                'type' => 'file',
+                'base_marker' => 'base:a.txt',
+            ],
+            $planner->get_entry_in_patch_base_index()
+        );
+        $this->assertNull($planner->get_entry_in_patch_head_index());
+        $planner->flush_pending_outputs();
+        $cursor = $planner->get_cursor();
+        $planner->close();
+
+        $planner = FileSyncPatchPlanner::resume(
+            $cursor,
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
+        );
+        $this->assertTrue($planner->next_path());
+        $this->assertNull($planner->get_entry_in_patch_base_index());
+        $this->assertSame(
+            [
+                'path' => 'b.txt',
+                'ctime' => 2,
+                'size' => 2,
+                'type' => 'file',
+                'source_path' => '/remote/b.txt',
+            ],
+            $planner->get_entry_in_patch_head_index()
+        );
+
+        $this->assertTrue($planner->next_path());
+        $this->assertSame(
+            [
+                'path' => 'c.txt',
+                'ctime' => 3,
+                'size' => 3,
+                'type' => 'file',
+                'base_marker' => 'base:c.txt',
+            ],
+            $planner->get_entry_in_patch_base_index()
+        );
+        $this->assertSame(
+            [
+                'path' => 'c.txt',
+                'ctime' => 3,
+                'size' => 3,
+                'type' => 'file',
+                'source_path' => '/remote/c.txt',
+            ],
+            $planner->get_entry_in_patch_head_index()
+        );
+        $this->assertNull($planner->get_operation());
+        $this->assertTrue($planner->is_complete());
+        $planner->close();
+    }
+
+    public function testReplacesASubtreeWithOnePatchHeadPath(): void
     {
         $patch_base_index = $this->write_index('base.jsonl', [
             'tree/child.txt' => $this->entry('tree/child.txt'),
         ]);
-        $patch_result_index = $this->write_index('result.jsonl', [
+        $patch_head_index = $this->write_index('head.jsonl', [
             'tree' => $this->entry('tree', 2),
             // `-` sorts before `/`, so this sibling appears before tree/child.
             'tree-other.txt' => $this->entry('tree-other.txt', 2),
         ]);
         $planner = FileSyncPatchPlanner::create(
             $patch_base_index,
-            $patch_result_index,
+            $patch_head_index,
             $this->active_deletion_roots_file()
         );
 
@@ -110,12 +200,12 @@ final class FileSyncPatchPlannerTest extends TestCase
             'gone/nested/leaf.txt' => $this->entry('gone/nested/leaf.txt'),
             'stays.txt' => $this->entry('stays.txt'),
         ]);
-        $patch_result_index = $this->write_index('result.jsonl', [
+        $patch_head_index = $this->write_index('head.jsonl', [
             'stays.txt' => $this->entry('stays.txt'),
         ]);
         $planner = FileSyncPatchPlanner::create(
             $patch_base_index,
-            $patch_result_index,
+            $patch_head_index,
             $this->active_deletion_roots_file()
         );
 
@@ -136,7 +226,7 @@ final class FileSyncPatchPlannerTest extends TestCase
             'outside/deleted.txt' => $this->entry('outside/deleted.txt'),
             'selected/delete.txt' => $this->entry('selected/delete.txt'),
         ]);
-        $patch_result_index = $this->write_index('result.jsonl', [
+        $patch_head_index = $this->write_index('head.jsonl', [
             'outside/added.txt' => $this->entry('outside/added.txt', 2),
             'selected/excluded/added.txt' =>
                 $this->entry('selected/excluded/added.txt', 2),
@@ -145,7 +235,7 @@ final class FileSyncPatchPlannerTest extends TestCase
         ]);
         $planner = FileSyncPatchPlanner::create(
             $patch_base_index,
-            $patch_result_index,
+            $patch_head_index,
             $this->active_deletion_roots_file(),
             ['selected'],
             ['selected/excluded']
@@ -170,13 +260,13 @@ final class FileSyncPatchPlannerTest extends TestCase
         $patch_base_index = $this->write_index('base.jsonl', [
             'a/child.txt' => $this->entry('a/child.txt'),
         ]);
-        $patch_result_index = $this->write_index('result.jsonl', [
+        $patch_head_index = $this->write_index('head.jsonl', [
             'a' => $this->entry('a', 2),
             'a-other.txt' => $this->entry('a-other.txt', 2),
         ]);
         $planner = FileSyncPatchPlanner::create(
             $patch_base_index,
-            $patch_result_index,
+            $patch_head_index,
             $this->active_deletion_roots_file()
         );
 

--- a/tests/Import/FileSyncPlanRunnerTest.php
+++ b/tests/Import/FileSyncPlanRunnerTest.php
@@ -1,0 +1,693 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test classes.
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/index/class-file-sync-plan-runner.php';
+
+/** Covers durable file-sync plan outputs, required copies, and resume. */
+final class FileSyncPlanRunnerTest extends TestCase
+{
+    private string $temp_dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temp_dir = sys_get_temp_dir()
+            . '/file-sync-plan-runner-'
+            . bin2hex(random_bytes(6));
+        mkdir($this->temp_dir, 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (scandir($this->temp_dir) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                unlink($this->temp_dir . '/' . $entry);
+            }
+        }
+        rmdir($this->temp_dir);
+        parent::tearDown();
+    }
+
+    public function testWritesPushCompatibleCopyAndDeletionLists(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'b-deleted.txt' => $this->entry('b-deleted.txt', 'file', 1, 2),
+            'c-file-to-directory' => $this->entry('c-file-to-directory', 'file', 1, 3),
+            'd-directory-to-link' => $this->entry('d-directory-to-link', 'dir', 1, 0),
+            'e-link-to-file' => $this->entry('e-link-to-file', 'link', 1, 4),
+            'f-modified.txt' => $this->entry('f-modified.txt', 'file', 1, 5),
+            'g-unchanged.txt' => $this->entry('g-unchanged.txt', 'file', 1, 6),
+        ]);
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'a-added.txt' => $this->entry('a-added.txt', 'file', 2, 7),
+            'c-file-to-directory' => $this->entry('c-file-to-directory', 'dir', 2, 0),
+            'd-directory-to-link' => $this->entry('d-directory-to-link', 'link', 2, 8),
+            'e-link-to-file' => $this->entry('e-link-to-file', 'file', 2, 9),
+            'f-modified.txt' => $this->entry('f-modified.txt', 'file', 2, 10),
+            'g-unchanged.txt' => $this->entry('g-unchanged.txt', 'file', 1, 6),
+        ]);
+        $patch_planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl')
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+        ]);
+
+        $this->run_to_completion($runner);
+
+        $this->assertSame(
+            $this->copy_line('a-added.txt', 'file', 7, 2)
+                . $this->copy_line('c-file-to-directory', 'directory', 0, 2)
+                . $this->copy_line('d-directory-to-link', 'symlink', 8, 2)
+                . $this->copy_line('e-link-to-file', 'file', 9, 2)
+                . $this->copy_line('f-modified.txt', 'file', 10, 2),
+            file_get_contents($this->path('copy.jsonl'))
+        );
+        $this->assertSame(
+            "b-deleted.txt\0c-file-to-directory\0d-directory-to-link\0",
+            file_get_contents($this->path('delete'))
+        );
+        $this->assertSame(5, $runner->get_cursor()['position']['paths_to_copy_count']);
+        $this->assertSame(26, $runner->get_cursor()['position']['file_bytes_to_copy']);
+        $runner->close();
+    }
+
+    public function testUsesCopySourcePathWithoutChangingTheDeletionCoordinate(): void
+    {
+        $local_path = "target/item-\x80";
+        $copy_source_path = "/remote/item-\x81";
+        $patch_base_index = $this->write_index('base.jsonl', [
+            $local_path => $this->entry($local_path, 'dir', 1, 0),
+        ]);
+        $patch_head_index = $this->path('mapped-head.jsonl');
+        file_put_contents(
+            $patch_head_index,
+            json_encode(
+                [
+                    'mapped_path' => base64_encode($local_path),
+                    'copy_source_path' => base64_encode($copy_source_path),
+                    'type' => 'file',
+                    'size' => 4,
+                    'ctime' => 2,
+                ],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n"
+        );
+        $decode_patch_head_index_line = static function (string $line): array {
+            /** @var array{mapped_path:string,copy_source_path:string,type:'file'|'link'|'dir',size:int,ctime:int} $entry */
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            return [
+                'path' => base64_decode($entry['mapped_path'], true),
+                'copy_source_path' => base64_decode(
+                    $entry['copy_source_path'],
+                    true
+                ),
+                'type' => $entry['type'],
+                'size' => $entry['size'],
+                'ctime' => $entry['ctime'],
+            ];
+        };
+        $patch_planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl'),
+            [''],
+            [],
+            null,
+            $decode_patch_head_index_line
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => 'target',
+        ]);
+
+        $this->run_to_completion($runner);
+
+        $copy_entries = $this->read_copy_entries($this->path('copy.jsonl'));
+        $this->assertCount(1, $copy_entries);
+        $this->assertSame(
+            $copy_source_path,
+            base64_decode($copy_entries[0]['path'], true)
+        );
+        $this->assertSame("item-\x80\0", file_get_contents($this->path('delete')));
+        $runner->close();
+    }
+
+    public function testRequiredPathsAddOnlyCopiesPresentInThePatchHead(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a-base-only.txt' => $this->entry('a-base-only.txt', 'file', 1, 1),
+            'b-shared-required.txt' => $this->entry('b-shared-required.txt', 'file', 1, 2),
+            'c-shared-drift.txt' => $this->entry('c-shared-drift.txt', 'file', 1, 3),
+            'e-replaced' => $this->entry('e-replaced', 'dir', 1, 0),
+            'f-excluded.txt' => $this->entry('f-excluded.txt', 'file', 1, 1),
+        ]);
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'b-shared-required.txt' => $this->entry('b-shared-required.txt', 'file', 1, 2),
+            'c-shared-drift.txt' => $this->entry('c-shared-drift.txt', 'file', 9, 3),
+            'd-added.txt' => $this->entry('d-added.txt', 'file', 2, 4),
+            'e-replaced' => $this->entry('e-replaced', 'file', 2, 5),
+            'f-excluded.txt' => $this->entry('f-excluded.txt', 'file', 1, 1),
+        ]);
+        $paths_requiring_copy = $this->write_paths_requiring_copy(
+            'required.jsonl',
+            ['a-base-only.txt', 'b-shared-required.txt', 'f-excluded.txt']
+        );
+        $decode_without_ctime = static function (string $line): array {
+            $entry = \Reprint\Importer\decode_local_index_entry($line);
+            $entry['ctime'] = 0;
+            return $entry;
+        };
+        $patch_planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl'),
+            [''],
+            ['f-excluded.txt'],
+            $decode_without_ctime,
+            $decode_without_ctime
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+            'paths_requiring_copy_file' => $paths_requiring_copy,
+        ]);
+
+        $this->run_to_completion($runner);
+
+        $this->assertSame(
+            ['b-shared-required.txt', 'd-added.txt', 'e-replaced'],
+            $this->copy_paths($this->path('copy.jsonl'))
+        );
+        $this->assertSame(
+            "a-base-only.txt\0e-replaced\0",
+            file_get_contents($this->path('delete'))
+        );
+        $runner->close();
+    }
+
+    public function testResumeTruncatesUnstoredOutputAndRestoresRequiredLookahead(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'a.txt' => $this->entry('a.txt', 'file', 1, 1),
+            'b' => $this->entry('b', 'dir', 1, 0),
+            'c.txt' => $this->entry('c.txt', 'file', 1, 3),
+        ]);
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'a.txt' => $this->entry('a.txt', 'file', 1, 1),
+            'b' => $this->entry('b', 'file', 2, 2),
+            'c.txt' => $this->entry('c.txt', 'file', 1, 3),
+        ]);
+        $decode_patch_base_index_line = static function (string $line): array {
+            return \Reprint\Importer\decode_local_index_entry($line);
+        };
+        $decode_patch_head_index_line = static function (string $line): array {
+            $entry = \Reprint\Importer\decode_local_index_entry($line);
+            $entry['copy_source_path'] = '/remote/' . $entry['path'];
+            return $entry;
+        };
+        $patch_planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl'),
+            [''],
+            [],
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+            'paths_requiring_copy_file' =>
+                $this->write_paths_requiring_copy(
+                    'required.jsonl',
+                    ['a.txt', 'c.txt']
+                ),
+        ]);
+
+        $this->assertSame(0, $runner->get_index_bytes_done());
+        $this->assertTrue($runner->next_step());
+        $runner->flush_pending_outputs();
+        $stored_cursor = $runner->get_cursor();
+        $stored_index_bytes_done = $runner->get_index_bytes_done();
+        $this->assertGreaterThan(0, $stored_index_bytes_done);
+        $this->assertSame('planning', $stored_cursor['position']['phase']);
+        $this->assertArrayHasKey(
+            'file_sync_patch_planner_cursor',
+            $stored_cursor['position']
+        );
+        $this->assertGreaterThan(
+            0,
+            $stored_cursor['position']['byte_offset_in_paths_to_copy']
+        );
+        $this->assertSame(
+            0,
+            $stored_cursor['position']['byte_offset_in_paths_to_delete']
+        );
+        $this->assertGreaterThan(
+            0,
+            $stored_cursor['position']['byte_offset_in_paths_requiring_copy']
+        );
+        $this->assertSame(1, $stored_cursor['position']['paths_to_copy_count']);
+        $this->assertSame(1, $stored_cursor['position']['file_bytes_to_copy']);
+
+        $this->assertTrue($runner->next_step());
+        $runner->close();
+
+        $runner = FileSyncPlanRunner::resume(
+            $stored_cursor,
+            $decode_patch_base_index_line,
+            $decode_patch_head_index_line
+        );
+        $this->assertSame(
+            $stored_index_bytes_done,
+            $runner->get_index_bytes_done()
+        );
+        $this->run_to_completion($runner);
+
+        $this->assertSame(
+            ['/remote/a.txt', '/remote/b', '/remote/c.txt'],
+            $this->copy_paths($this->path('copy.jsonl'))
+        );
+        $this->assertSame("b\0", file_get_contents($this->path('delete')));
+        $this->assertSame(3, $runner->get_paths_to_copy_count());
+        $this->assertSame(6, $runner->get_file_bytes_to_copy());
+        $runner->close();
+    }
+
+    public function testRejectsARequiredCopyPathOutsideTheIndexUnion(): void
+    {
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'b.txt' => $this->entry('b.txt', 'file', 1, 1),
+        ]);
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->path('missing-base.jsonl'),
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl')
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+            'paths_requiring_copy_file' =>
+                $this->write_paths_requiring_copy(
+                    'required.jsonl',
+                    ['a-not-in-index.txt']
+                ),
+        ]);
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'does not match any remaining patch-index path'
+            );
+            $runner->next_step();
+        } finally {
+            $runner->close();
+        }
+    }
+
+    public function testStartRejectsAPlannerAfterItsFirstStepAttempt(): void
+    {
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->write_index('base.jsonl', []),
+            $this->write_index('head.jsonl', []),
+            $this->path('deletion-roots.jsonl')
+        );
+        // An empty first step leaves both index byte offsets at zero. The
+        // planner must still remember that next_path() was attempted.
+        $this->assertFalse($patch_planner->next_path());
+
+        $paths_to_copy_file = $this->path('copy.jsonl');
+        $paths_to_delete_file = $this->path('delete');
+        file_put_contents($paths_to_copy_file, "copy output before start\n");
+        file_put_contents($paths_to_delete_file, "delete output before start\n");
+
+        try {
+            FileSyncPlanRunner::start($patch_planner, [
+                'paths_to_copy_file' => $paths_to_copy_file,
+                'paths_to_delete_file' => $paths_to_delete_file,
+                'deletion_path_prefix' => '',
+            ]);
+            $this->fail('An advanced patch planner must be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'FileSyncPlanRunner::start() requires a fresh patch planner '
+                    . 'positioned before its first path; '
+                    . 'is_positioned_before_first_path() returned false.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(
+            "copy output before start\n",
+            file_get_contents($paths_to_copy_file)
+        );
+        $this->assertSame(
+            "delete output before start\n",
+            file_get_contents($paths_to_delete_file)
+        );
+        $this->assert_planner_is_closed($patch_planner);
+    }
+
+    public function testStartRejectsAResumedPartiallyAdvancedPlanner(): void
+    {
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->path('missing-base.jsonl'),
+            $this->write_index('head.jsonl', [
+                'a.txt' => $this->entry('a.txt', 'file', 1, 1),
+                'b.txt' => $this->entry('b.txt', 'file', 1, 1),
+            ]),
+            $this->path('deletion-roots.jsonl')
+        );
+        $this->assertTrue($patch_planner->next_path());
+        $cursor = $patch_planner->get_cursor();
+        $patch_planner->close();
+        $patch_planner = FileSyncPatchPlanner::resume($cursor);
+
+        $paths_to_copy_file = $this->path('copy.jsonl');
+        $paths_to_delete_file = $this->path('delete');
+        file_put_contents($paths_to_copy_file, "copy output before start\n");
+        file_put_contents($paths_to_delete_file, "delete output before start\n");
+
+        try {
+            FileSyncPlanRunner::start($patch_planner, [
+                'paths_to_copy_file' => $paths_to_copy_file,
+                'paths_to_delete_file' => $paths_to_delete_file,
+                'deletion_path_prefix' => '',
+            ]);
+            $this->fail('A partially advanced patch planner must be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'FileSyncPlanRunner::start() requires a fresh patch planner '
+                    . 'positioned before its first path; '
+                    . 'is_positioned_before_first_path() returned false.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(
+            "copy output before start\n",
+            file_get_contents($paths_to_copy_file)
+        );
+        $this->assertSame(
+            "delete output before start\n",
+            file_get_contents($paths_to_delete_file)
+        );
+        $this->assert_planner_is_closed($patch_planner);
+    }
+
+    public function testInvalidRunnerOptionsCloseTheSuppliedPlanner(): void
+    {
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->write_index('base.jsonl', []),
+            $this->write_index('head.jsonl', []),
+            $this->path('deletion-roots.jsonl')
+        );
+
+        try {
+            FileSyncPlanRunner::start($patch_planner, [
+                'paths_to_delete_file' => $this->path('delete'),
+                'deletion_path_prefix' => '',
+            ]);
+            $this->fail('Missing runner options must be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'FileSyncPlanRunner::start() requires the '
+                    . 'paths_to_copy_file option.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assert_planner_is_closed($patch_planner);
+    }
+
+    public function testStartRejectsAnUnknownOptionName(): void
+    {
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->write_index('base.jsonl', []),
+            $this->write_index('head.jsonl', []),
+            $this->path('deletion-roots.jsonl')
+        );
+
+        try {
+            FileSyncPlanRunner::start($patch_planner, [
+                'paths_to_copy_file' => $this->path('copy.jsonl'),
+                'paths_to_copy_files' => $this->path('other-copy.jsonl'),
+                'paths_to_delete_file' => $this->path('delete'),
+                'deletion_path_prefix' => '',
+            ]);
+            $this->fail('Unknown runner options must be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'FileSyncPlanRunner::start() does not accept the '
+                    . 'paths_to_copy_files option.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assert_planner_is_closed($patch_planner);
+    }
+
+    public function testCloseClosesThePatchPlanner(): void
+    {
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->write_index('base.jsonl', []),
+            $this->write_index('head.jsonl', []),
+            $this->path('deletion-roots.jsonl')
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+        ]);
+
+        $runner->close();
+        $runner->close();
+
+        $this->assert_planner_is_closed($patch_planner);
+    }
+
+    public function testRejectsAPlannedDeletionOutsideTheDeletionPrefix(): void
+    {
+        $patch_base_index = $this->write_index('base.jsonl', [
+            'site/a.txt' => $this->entry('site/a.txt', 'file', 1, 1),
+        ]);
+        $patch_planner = FileSyncPatchPlanner::create(
+            $patch_base_index,
+            $this->write_index('head.jsonl', []),
+            $this->path('deletion-roots.jsonl'),
+            ['site']
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => 'other',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'The planned deletion path '
+            . base64_encode('site')
+            . ' is outside the deletion path prefix '
+            . base64_encode('other')
+            . '.'
+        );
+        try {
+            $runner->next_step();
+        } finally {
+            $runner->close();
+        }
+    }
+
+    public function testEachStepWritesOnePathAndTerminalResumeRemainsFalse(): void
+    {
+        $patch_head_index = $this->write_index('head.jsonl', [
+            'a.txt' => $this->entry('a.txt', 'file', 1, 1),
+            'b.txt' => $this->entry('b.txt', 'file', 1, 2),
+        ]);
+        $patch_planner = FileSyncPatchPlanner::create(
+            $this->path('missing-base.jsonl'),
+            $patch_head_index,
+            $this->path('deletion-roots.jsonl')
+        );
+        $runner = FileSyncPlanRunner::start($patch_planner, [
+            'paths_to_copy_file' => $this->path('copy.jsonl'),
+            'paths_to_delete_file' => $this->path('delete'),
+            'deletion_path_prefix' => '',
+        ]);
+
+        $this->assertFalse($runner->is_complete());
+        $this->assertTrue($runner->next_step());
+        $this->assertSame(['a.txt'], $this->copy_paths($this->path('copy.jsonl')));
+        $this->assertFalse($runner->next_step());
+        $this->assertSame(
+            ['a.txt', 'b.txt'],
+            $this->copy_paths($this->path('copy.jsonl'))
+        );
+        $this->assertTrue($runner->is_complete());
+        $this->assertSame(2, $runner->get_paths_to_copy_count());
+        $this->assertSame(3, $runner->get_file_bytes_to_copy());
+        $complete_cursor = $runner->get_cursor();
+        $this->assertSame(
+            [
+                'phase' => 'complete',
+                'paths_to_copy_count' => 2,
+                'file_bytes_to_copy' => 3,
+            ],
+            $complete_cursor['position']
+        );
+        $this->assertFalse($runner->next_step());
+        $runner->close();
+        $runner->close();
+        $this->assertFalse($runner->next_step());
+
+        $runner = FileSyncPlanRunner::resume($complete_cursor);
+        $this->assertTrue($runner->is_complete());
+        $this->assertFalse($runner->next_step());
+        $runner->close();
+        $runner->close();
+    }
+
+    private function assert_planner_is_closed(
+        FileSyncPatchPlanner $patch_planner
+    ): void {
+        try {
+            $patch_planner->next_path();
+            $this->fail('The patch planner must be closed.');
+        } catch (LogicException $exception) {
+            $this->assertSame(
+                'Cannot use a closed file sync patch planner.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    private function run_to_completion(FileSyncPlanRunner $runner): void
+    {
+        while ($runner->next_step()) {
+            $runner->flush_pending_outputs();
+        }
+    }
+
+    /** @return list<array{path:string,type:string,size:int,ctime:int}> */
+    private function read_copy_entries(string $path): array
+    {
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $entries = [];
+        foreach ($lines === false ? [] : $lines as $line) {
+            /** @var array{path:string,type:string,size:int,ctime:int} $entry */
+            $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $entries[] = $entry;
+        }
+        return $entries;
+    }
+
+    /** @return list<string> */
+    private function copy_paths(string $path): array
+    {
+        return array_map(
+            static function (array $entry): string {
+                $decoded_path = base64_decode($entry['path'], true);
+                self::assertIsString($decoded_path);
+                return $decoded_path;
+            },
+            $this->read_copy_entries($path)
+        );
+    }
+
+    /** @param array<string,array{path:string,type:string,size:int,ctime:int,empty?:bool}> $entries */
+    private function write_index(string $filename, array $entries): string
+    {
+        ksort($entries, SORT_STRING);
+        $lines = [];
+        foreach ($entries as $entry) {
+            $entry['path'] = base64_encode($entry['path']);
+            $lines[] = json_encode(
+                $entry,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+        $path = $this->path($filename);
+        file_put_contents(
+            $path,
+            $lines === [] ? '' : implode("\n", $lines) . "\n"
+        );
+        return $path;
+    }
+
+    /** @param list<string> $paths */
+    private function write_paths_requiring_copy(
+        string $filename,
+        array $paths
+    ): string {
+        $lines = array_map(
+            static function (string $path): string {
+                return json_encode(
+                    ['path' => base64_encode($path)],
+                    JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                );
+            },
+            $paths
+        );
+        $path = $this->path($filename);
+        file_put_contents(
+            $path,
+            $lines === [] ? '' : implode("\n", $lines) . "\n"
+        );
+        return $path;
+    }
+
+    /** @return array{path:string,type:string,size:int,ctime:int,empty?:bool} */
+    private function entry(
+        string $path,
+        string $type,
+        int $ctime,
+        int $size
+    ): array {
+        $entry = [
+            'path' => $path,
+            'type' => $type,
+            'size' => $size,
+            'ctime' => $ctime,
+        ];
+        if ($type === 'dir') {
+            $entry['empty'] = true;
+        }
+        return $entry;
+    }
+
+    private function copy_line(
+        string $path,
+        string $type,
+        int $size,
+        int $ctime
+    ): string {
+        return json_encode(
+            [
+                'path' => base64_encode($path),
+                'type' => $type,
+                'size' => $size,
+                'ctime' => $ctime,
+            ],
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+    }
+
+    private function path(string $filename): string
+    {
+        return $this->temp_dir . '/' . $filename;
+    }
+}

--- a/tests/Import/PushPlanTest.php
+++ b/tests/Import/PushPlanTest.php
@@ -302,9 +302,9 @@ final class PushPlanTest extends TestCase
         $first_cursor = $this->planCursor();
         $this->assertSame(
             0,
-            $first_cursor['file_sync_planner_cursor'][
-                'active_deletion_root_byte_offset'
-            ]
+            $first_cursor['file_sync_plan_runner_cursor']['position'][
+                'file_sync_patch_planner_cursor'
+            ]['active_deletion_root_byte_offset']
         );
 
         $this->assertFalse($this->nextPlanStep($plan));
@@ -499,27 +499,6 @@ final class PushPlanTest extends TestCase
         $resumedPlan->close();
     }
 
-    public function testResumesCursorWrittenBeforeDocumentRootMappingAndProgressTotals(): void
-    {
-        $entries = $this->manyFileEntries(2);
-        $current = $this->writeIndex($entries);
-        $plan = $this->startPlan($current);
-
-        $this->assertTrue($this->nextPlanStep($plan));
-        $plan->close();
-
-        unset($this->cursor['document_root_local_relative_path']);
-        unset($this->cursor['position']['local_paths_to_push_count']);
-        unset($this->cursor['position']['local_file_bytes_to_push']);
-
-        $resumedPlan = $this->resumePlan();
-        $this->planToCompletion($resumedPlan);
-
-        $this->assertCount(2, $this->listPaths($this->planPath('local_paths_to_push.jsonl')));
-        $this->assertNull($this->planCursor()['local_paths_to_push_count']);
-        $this->assertNull($this->planCursor()['local_file_bytes_to_push']);
-    }
-
     public function testResumeDiscardsACompletedStepWhoseCursorWasNotStored(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(2)));
@@ -544,8 +523,12 @@ final class PushPlanTest extends TestCase
     public function testStepRetainsTheFollowingFreshLocalIndexEntryUntilClose(): void
     {
         $plan = $this->startPlan($this->writeIndex($this->manyFileEntries(3)));
-        $patch_planner_property = new ReflectionProperty(
+        $file_sync_plan_runner_property = new ReflectionProperty(
             PushPlan::class,
+            'file_sync_plan_runner'
+        );
+        $patch_planner_property = new ReflectionProperty(
+            FileSyncPlanRunner::class,
             'patch_planner'
         );
         $index_diff_property = new ReflectionProperty(
@@ -563,16 +546,19 @@ final class PushPlanTest extends TestCase
 
         $this->assertTrue($this->nextPlanStep($plan));
         $first_plan_cursor = $this->planCursor();
-        $patch_planner = $patch_planner_property->getValue($plan);
+        $file_sync_plan_runner =
+            $file_sync_plan_runner_property->getValue($plan);
+        $patch_planner =
+            $patch_planner_property->getValue($file_sync_plan_runner);
         $index_diff = $index_diff_property->getValue($patch_planner);
         $fresh_local_index_handle = $new_index_handle_property->getValue(
             $index_diff
         );
         $this->assertIsResource($fresh_local_index_handle);
         $this->assertGreaterThan(
-            $first_plan_cursor['file_sync_planner_cursor'][
-                'index_diff_cursor'
-            ]['new_index_byte_offset'],
+            $first_plan_cursor['file_sync_plan_runner_cursor']['position'][
+                'file_sync_patch_planner_cursor'
+            ]['index_diff_cursor']['new_index_byte_offset'],
             ftell($fresh_local_index_handle)
         );
         $retained_fresh_local_index_entry = $new_index_entry_property->getValue(
@@ -584,9 +570,9 @@ final class PushPlanTest extends TestCase
         $this->assertTrue($this->nextPlanStep($plan));
         $second_plan_cursor = $this->planCursor();
         $this->assertGreaterThan(
-            $second_plan_cursor['file_sync_planner_cursor'][
-                'index_diff_cursor'
-            ]['new_index_byte_offset'],
+            $second_plan_cursor['file_sync_plan_runner_cursor']['position'][
+                'file_sync_patch_planner_cursor'
+            ]['index_diff_cursor']['new_index_byte_offset'],
             ftell($fresh_local_index_handle)
         );
         $this->assertPathCounts(2, 0);
@@ -620,33 +606,51 @@ final class PushPlanTest extends TestCase
         $this->assertSame('', $cursor['document_root_local_relative_path']);
         $this->assertSame([
             'phase',
-            'file_sync_planner_cursor',
-            'byte_offset_in_local_paths_to_push',
-            'byte_offset_in_local_paths_to_delete',
-            'local_paths_to_push_count',
-            'local_file_bytes_to_push',
+            'file_sync_plan_runner_cursor',
         ], array_keys($cursor['position']));
+        $runner_cursor = $cursor['position']['file_sync_plan_runner_cursor'];
         $this->assertSame([
-            'patch_base_index_file',
-            'patch_result_index_file',
-            'active_deletion_roots_file',
-            'included_index_path_roots',
-            'excluded_index_path_roots',
-            'index_diff_cursor',
-            'active_deletion_root_byte_offset',
-        ], array_keys($cursor['position']['file_sync_planner_cursor']));
-        $this->assertSame(1, $cursor['position']['local_paths_to_push_count']);
-        $this->assertSame(1, $cursor['position']['local_file_bytes_to_push']);
+            'paths_to_copy_file',
+            'paths_to_delete_file',
+            'deletion_path_prefix',
+            'paths_requiring_copy_file',
+            'position',
+        ], array_keys($runner_cursor));
+        $this->assertSame(
+            1,
+            $runner_cursor['position']['paths_to_copy_count']
+        );
+        $this->assertSame(
+            1,
+            $runner_cursor['position']['file_bytes_to_copy']
+        );
         $this->assertSame(
             filesize($this->planPath('local_paths_to_push.jsonl')),
-            $cursor['position']['byte_offset_in_local_paths_to_push']
+            $runner_cursor['position']['byte_offset_in_paths_to_copy']
         );
         $this->assertSame(
             filesize($this->planPath('local_paths_to_delete')),
-            $cursor['position']['byte_offset_in_local_paths_to_delete']
+            $runner_cursor['position']['byte_offset_in_paths_to_delete']
+        );
+        $file_sync_plan_runner_property = new ReflectionProperty(
+            PushPlan::class,
+            'file_sync_plan_runner'
+        );
+        $this->assertSame(
+            $file_sync_plan_runner_property->getValue($plan)->get_cursor(),
+            $runner_cursor
         );
         $this->assertFileDoesNotExist($this->planPath('cursor.json'));
         $plan->close();
+
+        $resumed_plan = PushPlan::resume($cursor);
+        $this->assertSame(
+            $runner_cursor,
+            $file_sync_plan_runner_property
+                ->getValue($resumed_plan)
+                ->get_cursor()
+        );
+        $resumed_plan->close();
     }
 
     public function testCursorKeepsTheFilesystemRootSlash(): void


### PR DESCRIPTION
Moves resume-safe copy and deletion list writing out of `PushPlan` so mirror pulls can use the same planning code.

## This change

`FileSyncPatchPlanner` compares two indexes. The patch base is the left side of the comparison. The patch head is the right side. If the base contains `old.txt` and the head contains `new.txt`, the planner reports `delete old.txt` and `copy new.txt`.

`FileSyncPlanRunner` turns those operations into durable files. It writes `new.txt` to the JSONL copy list and writes `old.txt\0` to the NUL-delimited deletion list. It does not change the filesystem.

`PushPlan` still scans the local filesystem and sorts the fresh local index. It now creates a fresh `FileSyncPatchPlanner` and passes that planner to `FileSyncPlanRunner`. The planner receives the two indexes, selected roots, active deletion-roots file, and index decoders. The runner receives named settings for the files it writes, the deletion path prefix, and the optional paths which require a copy.

Each `next_step()` call processes at most one planner path. The runner cursor records the planner position and both output byte offsets after the last completed step. If the process stops after writing a row but before the caller stores the new cursor, `resume()` truncates that unstored output tail and writes the row again.

`PushPlan` stores the full runner cursor as one nested value and passes it directly to `FileSyncPlanRunner::resume()`. This PR changes that in-progress cursor layout directly. Old flat `PushPlan` diff cursors are not translated and must be restarted.

## Follow-up

#633 needs to write remote absolute paths to its fetch list while keeping deletions in local relative coordinates. Its patch-head decoder can retain a separate `copy_source_path`, while the runner applies the deletion path prefix only to deletion records. This PR prepares that use; #633 does not call the runner yet.

## Testing

Tests cover exact copy and deletion output, one-path steps, interruption and resume, planner lifecycle checks, arbitrary path bytes, separate local and remote path coordinates, and PHP 7.4 compatibility.
