### PR TITLE
[PHP] Share remote-to-local pull path mapping

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -109,6 +109,7 @@ require_once __DIR__ . '/lib/pull/class-pull.php';
 
 // Pull index reader and the WAL for completed files-pull mutations.
 require_once __DIR__ . '/lib/pull/class-remote-index-reader.php';
+require_once __DIR__ . '/lib/pull/class-remote-to-local-path-mapper.php';
 require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
 
 /**
@@ -365,6 +366,9 @@ class ImportClient
      * the identity mapping beneath the filesystem root.
      */
     private $resolved_path_mappings = [];
+
+    /** @var RemoteToLocalPathMapper|null Resolved pull mapping for the current invocation. */
+    private $remote_to_local_path_mapper = null;
 
     /**
      * @var array<int,string> Resolved `--include` file paths: a list of real source
@@ -642,6 +646,8 @@ class ImportClient
         if ($assert_remap) {
             $this->assert_resolved_path_mappings_consistent();
         }
+
+        $this->remote_to_local_path_mapper = null;
     }
 
     /**
@@ -3695,7 +3701,7 @@ class ImportClient
             }
 
             try {
-                $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+                $local_absolute_path = $this->path_mapper()->remote_path_to_local_path(
                     $remote_absolute_path
                 );
             } catch (RuntimeException $e) {
@@ -7713,7 +7719,7 @@ class ImportClient
             return null;
         }
         try {
-            $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+            $local_absolute_path = $this->path_mapper()->remote_path_to_local_path(
                 $remote_deletion_root
             );
         } catch (RuntimeException $e) {
@@ -8823,7 +8829,7 @@ class ImportClient
 
         // Repoint to where the target's content is placed by the same pull
         // mapping used for file chunks, so the symlink does not dangle.
-        $local_absolute_target = $this->map_remote_absolute_path_to_local_absolute_path(
+        $local_absolute_target = $this->path_mapper()->remote_path_to_local_path(
             $remote_absolute_target
         );
         $local_relative_target = self::compute_relative_path(
@@ -9320,42 +9326,19 @@ class ImportClient
         return $resolved;
     }
 
-    /**
-     * Map a remote absolute path to a local absolute path under the filesystem
-     * root. Symlink traversal checks prevent writes outside the filesystem root.
-     *
-     * With --remap active, a matched remote absolute path is routed to its
-     * mapped local absolute path. An unmatched path remains nested beneath
-     * --fs-root, as in an identity pull mapping.
-     */
-    private function map_remote_absolute_path_to_local_absolute_path(
-        string $remote_absolute_path
-    ): string {
-        assert_valid_path($remote_absolute_path, "remote absolute path");
-        $local_absolute_path = null;
-        $longest_remote_prefix_length = -1;
-        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
-            $remainder = path_remainder_under($remote_absolute_path, $remote_prefix);
-            if ($remainder !== null && strlen($remote_prefix) > $longest_remote_prefix_length) {
-                $local_absolute_path = wp_join_unix_paths($local_prefix, $remainder);
-                $longest_remote_prefix_length = strlen($remote_prefix);
-            }
-        }
-        if ($local_absolute_path !== null) {
-            return $local_absolute_path;
-        }
-
-        // Following symlinks is currently the only way paths outside the original export scope reach this mapper.
-        // Use the same local followed symlinks root for copied content and rewritten symlink targets so the links do not dangle.
-        if ($this->local_followed_symlinks_root !== null
-            && !$this->path_is_within_original_export_scope($remote_absolute_path)) {
-            return wp_join_unix_paths(
-                $this->local_followed_symlinks_root,
-                $remote_absolute_path
+    /** Returns the resolved path mapper for the current files-pull options. */
+    private function path_mapper(): RemoteToLocalPathMapper
+    {
+        if ($this->remote_to_local_path_mapper === null) {
+            $this->remote_to_local_path_mapper = new RemoteToLocalPathMapper(
+                $this->filesystem_root,
+                $this->get_export_directories(),
+                $this->resolved_path_mappings,
+                $this->local_followed_symlinks_root
             );
         }
 
-        return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
+        return $this->remote_to_local_path_mapper;
     }
 
 
@@ -9395,7 +9378,7 @@ class ImportClient
             return;
         }
 
-        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path($path);
+        $local_absolute_path = $this->path_mapper()->remote_path_to_local_path($path);
 
         // Open file on first chunk
         if ($is_first) {
@@ -9596,7 +9579,7 @@ class ImportClient
             return null;
         }
 
-        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+        $local_absolute_path = $this->path_mapper()->remote_path_to_local_path(
             $remote_absolute_path
         );
 
@@ -9787,7 +9770,7 @@ class ImportClient
             return;
         }
 
-        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path(
+        $local_absolute_path = $this->path_mapper()->remote_path_to_local_path(
             $remote_absolute_path
         );
 
@@ -9881,7 +9864,7 @@ class ImportClient
             return;
         }
 
-        $local_absolute_path = $this->map_remote_absolute_path_to_local_absolute_path($path);
+        $local_absolute_path = $this->path_mapper()->remote_path_to_local_path($path);
         $target_for_local = $this->rewrite_symlink_target_for_local_filesystem(
             $path,
             $local_absolute_path,
@@ -10142,22 +10125,6 @@ class ImportClient
             );
         }
         return $dirs;
-    }
-
-    /**
-     * Whether $path falls under one of the ORIGINAL export directories (the
-     * --include prefixes, or the base roots without --include) — i.e. it was going to
-     * be pulled anyway. Evaluated against the pre-follow scope; a followed
-     * target outside all of these is "escaping" and eligible for symlink bundling.
-     */
-    private function path_is_within_original_export_scope(string $path): bool
-    {
-        foreach ($this->get_export_directories() as $root) {
-            if (path_is_same_as_or_descendant_of($path, $root)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -1,0 +1,111 @@
+<?php
+
+use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\path_remainder_under;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Filesystem paths are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/**
+ * Maps remote absolute paths into one local filesystem tree.
+ *
+ * An explicit resolved path mapping wins first. If several mappings match,
+ * the longest remote prefix wins. An unmatched path from the original pull
+ * scope keeps its remote spelling under the local filesystem root. A followed
+ * symlink target outside that scope goes under the configured local followed
+ * symlinks root instead.
+ *
+ * Copied targets and rewritten symlink destinations both use this mapping, so
+ * a rewritten link points to the place where its target was copied.
+ *
+ * Paths remain byte strings in memory. This class does not encode them as JSON
+ * or require them to be valid UTF-8.
+ */
+final class RemoteToLocalPathMapper
+{
+    /** Local filesystem root beneath which pulled paths are written. */
+    private string $filesystem_root;
+
+    /** @var list<string> Remote absolute path roots selected before following symlinks. */
+    private array $original_remote_absolute_path_roots;
+
+    /** @var array<string,string> Remote absolute prefix to local absolute prefix. */
+    private array $resolved_path_mappings;
+
+    /** Local root for followed targets outside the original pull scope. */
+    private ?string $local_followed_symlinks_root;
+
+    /**
+     * Stores the resolved path settings used by one files pull.
+     *
+     * The caller resolves and validates these settings before constructing the
+     * mapper. Local prefixes and the followed-symlinks root must be equal to or
+     * below the filesystem root.
+     *
+     * @param string               $filesystem_root                    Local filesystem root.
+     * @param list<string>         $original_remote_absolute_path_roots Remote absolute path roots selected before following symlinks.
+     * @param array<string,string> $resolved_path_mappings             Remote absolute prefix to local absolute prefix.
+     * @param string|null          $local_followed_symlinks_root       Local root for followed targets outside the original scope.
+     */
+    public function __construct(
+        string $filesystem_root,
+        array $original_remote_absolute_path_roots,
+        array $resolved_path_mappings = [],
+        ?string $local_followed_symlinks_root = null
+    ) {
+        $this->filesystem_root = $filesystem_root;
+        $this->original_remote_absolute_path_roots = $original_remote_absolute_path_roots;
+        $this->resolved_path_mappings = $resolved_path_mappings;
+        $this->local_followed_symlinks_root = $local_followed_symlinks_root;
+    }
+
+    /**
+     * Maps one remote absolute path to its local absolute path.
+     *
+     * @param string $remote_absolute_path Remote absolute path.
+     * @return string Local absolute path under the filesystem root.
+     */
+    public function remote_path_to_local_path(string $remote_absolute_path): string
+    {
+        assert_valid_path($remote_absolute_path, "remote absolute path");
+        $local_absolute_path = null;
+        $longest_remote_prefix_length = -1;
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = path_remainder_under(
+                $remote_absolute_path,
+                $remote_prefix
+            );
+            if (
+                $remainder !== null
+                && strlen($remote_prefix) > $longest_remote_prefix_length
+            ) {
+                $local_absolute_path = wp_join_unix_paths(
+                    $local_prefix,
+                    $remainder
+                );
+                $longest_remote_prefix_length = strlen($remote_prefix);
+            }
+        }
+        if ($local_absolute_path !== null) {
+            return $local_absolute_path;
+        }
+
+        if (
+            $this->local_followed_symlinks_root !== null
+            && !path_is_same_as_or_descendant_of(
+                $remote_absolute_path,
+                $this->original_remote_absolute_path_roots
+            )
+        ) {
+            return wp_join_unix_paths(
+                $this->local_followed_symlinks_root,
+                $remote_absolute_path
+            );
+        }
+
+        return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
+    }
+}

--- a/tests/Import/FollowedSymlinksRootTest.php
+++ b/tests/Import/FollowedSymlinksRootTest.php
@@ -99,10 +99,14 @@ class FollowedSymlinksRootTest extends TestCase
 
     private function inScope(array $onlyPrefixes, string $path): bool
     {
-        $c = $this->newClient();
-        $rc = new \ReflectionClass($c);
-        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $onlyPrefixes);
-        return $rc->getMethod('path_is_within_original_export_scope')->invoke($c, $path);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->root,
+            $onlyPrefixes,
+            [],
+            $this->root . '/followed'
+        );
+
+        return $mapper->remote_path_to_local_path($path) === $this->root . $path;
     }
 
     public function testTargetUnderScopeIsInScope(): void
@@ -122,67 +126,57 @@ class FollowedSymlinksRootTest extends TestCase
      * @param array<int,string> $scopePrefixes Original export scope (--include prefixes).
      * @param array<string,string> $remapRules source => absolute target.
      */
-    private function placeClient(?string $followedSymlinksRootSub, array $scopePrefixes, array $remapRules = []): \ImportClient
+    private function placeMapper(?string $followedSymlinksRootSub, array $scopePrefixes, array $remapRules = []): \RemoteToLocalPathMapper
     {
-        $c = $this->newClient();
-        $rc = new \ReflectionClass($c);
-        $rc->getProperty('local_followed_symlinks_root')->setValue($c, $followedSymlinksRootSub === null ? null : $this->root . $followedSymlinksRootSub);
-        $rc->getProperty('pull_only_files_with_path_prefixes')->setValue($c, $scopePrefixes);
-        $rc->getProperty('resolved_path_mappings')->setValue($c, $remapRules);
-        return $c;
-    }
-
-    private function place(\ImportClient $c, string $path): string
-    {
-        return (new \ReflectionClass($c))->getMethod('map_remote_absolute_path_to_local_absolute_path')->invoke($c, $path);
+        return new \RemoteToLocalPathMapper(
+            $this->root,
+            $scopePrefixes,
+            $remapRules,
+            $followedSymlinksRootSub === null
+                ? null
+                : $this->root . $followedSymlinksRootSub
+        );
     }
 
     public function testEscapingTargetRoutesIntoLocalFollowedSymlinksRoot(): void
     {
-        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html']);
+        $mapper = $this->placeMapper('/.followed-symlinks-root', ['/var/www/html']);
         $this->assertSame(
             $this->root . '/.followed-symlinks-root/tmp/shared/foo/style.css',
-            $this->place($c, '/tmp/shared/foo/style.css')
+            $mapper->remote_path_to_local_path('/tmp/shared/foo/style.css')
         );
     }
 
     public function testInScopePathDoesNotUseLocalFollowedSymlinksRoot(): void
     {
-        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html']);
+        $mapper = $this->placeMapper('/.followed-symlinks-root', ['/var/www/html']);
         $this->assertSame(
             $this->root . '/var/www/html/index.php',
-            $this->place($c, '/var/www/html/index.php')
+            $mapper->remote_path_to_local_path('/var/www/html/index.php')
         );
     }
 
     public function testDefaultPlacementWhenNoLocalFollowedSymlinksRoot(): void
     {
-        $c = $this->placeClient(null, []);
+        $mapper = $this->placeMapper(null, []);
         $this->assertSame(
             $this->root . '/tmp/shared/foo/style.css',
-            $this->place($c, '/tmp/shared/foo/style.css')
+            $mapper->remote_path_to_local_path('/tmp/shared/foo/style.css')
         );
     }
 
     public function testFilesystemRootPlacementKeepsOneLeadingSlash(): void
     {
-        $client = $this->newRootClient();
-        $reflection = new \ReflectionClass($client);
-        $reflection->getProperty('pull_only_files_with_path_prefixes')->setValue($client, []);
-
+        $mapper = new \RemoteToLocalPathMapper('/', []);
         $this->assertSame(
             '/tmp/shared/foo/style.css',
-            $this->place($client, '/tmp/shared/foo/style.css')
+            $mapper->remote_path_to_local_path('/tmp/shared/foo/style.css')
         );
 
-        $reflection->getProperty('local_followed_symlinks_root')->setValue($client, '/');
-        $reflection->getProperty('pull_only_files_with_path_prefixes')->setValue(
-            $client,
-            ['/var/www/html']
-        );
+        $mapper = new \RemoteToLocalPathMapper('/', ['/var/www/html'], [], '/');
         $this->assertSame(
             '/tmp/shared/foo/style.css',
-            $this->place($client, '/tmp/shared/foo/style.css')
+            $mapper->remote_path_to_local_path('/tmp/shared/foo/style.css')
         );
     }
 
@@ -190,15 +184,15 @@ class FollowedSymlinksRootTest extends TestCase
     // (/shared/wp-content) must not move the in-scope subtree.
     public function testAncestorEscapingRootLeavesInScopeContentInPlace(): void
     {
-        $c = $this->placeClient('/.followed-symlinks-root', ['/shared/wp-content']);
+        $mapper = $this->placeMapper('/.followed-symlinks-root', ['/shared/wp-content']);
         $this->assertSame(
             $this->root . '/shared/wp-content/plugins/foo.php',
-            $this->place($c, '/shared/wp-content/plugins/foo.php'),
+            $mapper->remote_path_to_local_path('/shared/wp-content/plugins/foo.php'),
             'in-scope content must not use the local followed symlinks root'
         );
         $this->assertSame(
             $this->root . '/.followed-symlinks-root/shared/other/bar.php',
-            $this->place($c, '/shared/other/bar.php'),
+            $mapper->remote_path_to_local_path('/shared/other/bar.php'),
             'genuinely escaping content uses the local followed symlinks root'
         );
     }
@@ -207,10 +201,10 @@ class FollowedSymlinksRootTest extends TestCase
     // and the symlink repoint (which share this seam) agree — no dangling link.
     public function testRemapWinsOverBundle(): void
     {
-        $c = $this->placeClient('/.followed-symlinks-root', ['/var/www/html'], ['/escaped' => $this->root . '/x']);
+        $mapper = $this->placeMapper('/.followed-symlinks-root', ['/var/www/html'], ['/escaped' => $this->root . '/x']);
         $this->assertSame(
             $this->root . '/x/foo',
-            $this->place($c, '/escaped/foo'),
+            $mapper->remote_path_to_local_path('/escaped/foo'),
             'remap target wins; the path does not use the local followed symlinks root'
         );
     }

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -14,8 +14,8 @@ use function WordPress\Reprint\Exporter\trim_right_slash;
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
 /**
- * --remap: the single write seam (map_remote_absolute_path_to_local_absolute_path)
- * routes remote absolute paths to local absolute paths and leaves the rest nested.
+ * RemoteToLocalPathMapper routes remote absolute paths to local absolute paths
+ * and leaves unmatched paths nested beneath the filesystem root.
  */
 class RemapSeamTest extends TestCase
 {
@@ -66,21 +66,19 @@ class RemapSeamTest extends TestCase
         (new \ReflectionClass($c))->getProperty($p)->setValue($c, $v);
     }
 
-    private function clientWithRules(array $rules): \ImportClient
+    private function mapperWithRules(array $rules): \RemoteToLocalPathMapper
     {
-        $c = new \ImportClient('https://src.example/export.php', $this->stateDir, $this->fsRoot);
-        $this->set($c, 'resolved_path_mappings', $rules);
-        return $c;
+        return new \RemoteToLocalPathMapper($this->root, [], $rules);
     }
 
     public function testRemoteAbsolutePathMapsToLocalAbsolutePath(): void
     {
-        $c = $this->clientWithRules(array(
+        $mapper = $this->mapperWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
-            '/var/www/html/wp-content/plugins/woo/woo.php',
-        ));
+        $local_absolute_path = $mapper->remote_path_to_local_path(
+            '/var/www/html/wp-content/plugins/woo/woo.php'
+        );
         $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local_absolute_path);
     }
 
@@ -89,13 +87,13 @@ class RemapSeamTest extends TestCase
         // Two nested remote prefixes; the deeper (more specific) one has the
         // shorter local prefix. It must still win — specificity is ranked by
         // remote-prefix length, not local-prefix length.
-        $c = $this->clientWithRules(array(
+        $mapper = $this->mapperWithRules(array(
             '/srv/wp-content' => $this->root . '/archive-of-everything',
             '/srv/wp-content/plugins' => $this->root . '/p',
         ));
-        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
-            '/srv/wp-content/plugins/woo/woo.php',
-        ));
+        $local_absolute_path = $mapper->remote_path_to_local_path(
+            '/srv/wp-content/plugins/woo/woo.php'
+        );
         $this->assertSame($this->root . '/p/woo/woo.php', $local_absolute_path);
     }
 
@@ -103,33 +101,47 @@ class RemapSeamTest extends TestCase
     {
         // A local absolute prefix that is the filesystem root: files land directly at the root,
         // no double slash.
-        $c = $this->clientWithRules(array(
+        $mapper = $this->mapperWithRules(array(
             '/var/www/html/wp-content' => $this->root,
         ));
-        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
-            '/var/www/html/wp-content/plugins/woo/woo.php',
-        ));
+        $local_absolute_path = $mapper->remote_path_to_local_path(
+            '/var/www/html/wp-content/plugins/woo/woo.php'
+        );
         $this->assertSame($this->root . '/plugins/woo/woo.php', $local_absolute_path);
     }
 
     public function testOutOfScopePathFallsBackToNestedIdentity(): void
     {
-        $c = $this->clientWithRules(array(
+        $mapper = $this->mapperWithRules(array(
             '/var/www/html/wp-content' => $this->root . '/wp-content',
         ));
-        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
-            '/var/www/html/wp-admin/index.php',
-        ));
+        $local_absolute_path = $mapper->remote_path_to_local_path(
+            '/var/www/html/wp-admin/index.php'
+        );
         $this->assertSame($this->root . '/var/www/html/wp-admin/index.php', $local_absolute_path);
     }
 
     public function testNoRulesIsLegacyMapping(): void
     {
-        $c = $this->clientWithRules(array());
-        $local_absolute_path = $this->call($c, 'map_remote_absolute_path_to_local_absolute_path', array(
-            '/var/www/html/wp-content/x.txt',
-        ));
+        $mapper = $this->mapperWithRules(array());
+        $local_absolute_path = $mapper->remote_path_to_local_path(
+            '/var/www/html/wp-content/x.txt'
+        );
         $this->assertSame($this->root . '/var/www/html/wp-content/x.txt', $local_absolute_path);
+    }
+
+    public function testMappingPreservesArbitraryPathBytes(): void
+    {
+        $remote_prefix = "/var/www/html/content-\xff";
+        $local_prefix = $this->root . "/content-\xfe";
+        $mapper = $this->mapperWithRules(array(
+            $remote_prefix => $local_prefix,
+        ));
+
+        $this->assertSame(
+            $local_prefix . "/file-\xfd.txt",
+            $mapper->remote_path_to_local_path($remote_prefix . "/file-\xfd.txt")
+        );
     }
 
     /**
@@ -339,7 +351,11 @@ class RemapSeamTest extends TestCase
 
     public function testNextRemoteIndexMatchesFilesystemRootAndPathBoundaries(): void
     {
-        $client = $this->clientWithRules(array());
+        $client = new \ImportClient(
+            'https://src.example/export.php',
+            $this->stateDir,
+            $this->fsRoot
+        );
         $next_remote_index_file = $this->tempDir . '/remote-index.next.jsonl';
         file_put_contents(
             $next_remote_index_file,


### PR DESCRIPTION
`files-pull` now uses one `RemoteToLocalPathMapper` for every remote-absolute to local-absolute path conversion.

## Example

Assume the remote site stores WordPress at `/var/www/html`, the local filesystem root is `/workspace`, and the pull remaps remote `wp-content` to local `/workspace/wp-content`:

```php
$mapper = new RemoteToLocalPathMapper(
    '/workspace',
    ['/var/www/html'],
    [
        '/var/www/html/wp-content' => '/workspace/wp-content',
    ]
);

$mapper->remote_path_to_local_path(
    '/var/www/html/wp-content/plugins/akismet/akismet.php'
);
// /workspace/wp-content/plugins/akismet/akismet.php

$mapper->remote_path_to_local_path('/var/www/html/wp-admin/index.php');
// /workspace/var/www/html/wp-admin/index.php
```

The explicit `wp-content` rule wins for the first path. The second path has no explicit rule, so it keeps its remote spelling below the filesystem root. If several rules match, the longest remote prefix wins.

## Before and after

Before this PR, these rules lived inside one large private `ImportClient` method:

```php
$local_absolute_path =
    $this->map_remote_absolute_path_to_local_absolute_path(
        $remote_absolute_path
    );
```

Only `ImportClient` could use that code. Building another local-coordinate view of remote paths required copying the rules or adding more work to `ImportClient`.

After this PR, existing pull paths use the mapper directly:

```php
$local_absolute_path = $this->path_mapper()->remote_path_to_local_path(
    $remote_absolute_path
);
```

The mapper is used when files are written, remote deletions are applied, fetch resume paths are checked, and symlink targets are rewritten. PR #643 uses the same class to build a local-path-sorted view of a completed remote index.

The extraction does not change path placement. It preserves longest-prefix matching, path-boundary checks, followed-symlink placement, filesystem root `/`, and arbitrary filename bytes.

## Testing

The focused tests cover direct remaps, deeper-prefix selection, paths without a remap, followed targets inside and outside the original pull scope, filesystem root `/`, arbitrary filename bytes, file application, deletion, and symlink rewriting.
