### PR TITLE
[PHP] Build remote indexes in mapped local path order

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
+++ b/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
@@ -1,0 +1,316 @@
+<?php
+
+use function Reprint\Importer\sort_index_file;
+use function WordPress\Reprint\Exporter\path_is_descendant_of;
+use function WordPress\Reprint\Exporter\relative_path_under;
+
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Filesystem paths are CLI values, never HTML output.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Importer classes use unprefixed domain names.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Importer classes place braces on the following line.
+
+/** Builds the current remote index in mapped local path order. */
+final class MappedRemoteIndexBuilder
+{
+    /**
+     * Rebuilds, sorts, and validates one mapped remote index.
+     *
+     * The output is disposable until this method returns. A caller may rebuild
+     * it from the immutable remote index after interruption.
+     *
+     * @param array $options {
+     *     Inputs and output for the mapped index.
+     *
+     *     @type string                  $remote_index_file        Completed remote index.
+     *     @type string                  $mapped_remote_index_file Output in mapped local order.
+     *     @type string                  $filesystem_root          Local filesystem root.
+     *     @type RemoteToLocalPathMapper $path_mapper              Remote-to-local path mapper.
+     * }
+     */
+    public static function build(array $options): void
+    {
+        $allowed_options = [
+            "remote_index_file",
+            "mapped_remote_index_file",
+            "filesystem_root",
+            "path_mapper",
+        ];
+        $unknown_options = array_diff(array_keys($options), $allowed_options);
+        if ($unknown_options !== []) {
+            throw new InvalidArgumentException(
+                "Unknown mapped remote-index option: " . reset($unknown_options)
+            );
+        }
+        foreach (
+            ["remote_index_file", "mapped_remote_index_file", "filesystem_root"]
+            as $string_option
+        ) {
+            if (
+                !isset($options[$string_option])
+                || !is_string($options[$string_option])
+                || $options[$string_option] === ""
+            ) {
+                $observed_type = gettype($options[$string_option] ?? null);
+                throw new InvalidArgumentException(
+                    "Mapped remote-index option {$string_option} must be a non-empty string; "
+                    . "received {$observed_type}."
+                );
+            }
+        }
+        if (
+            !isset($options["path_mapper"])
+            || !( $options["path_mapper"] instanceof RemoteToLocalPathMapper )
+        ) {
+            $observed_type = gettype($options["path_mapper"] ?? null);
+            throw new InvalidArgumentException(
+                "Mapped remote-index option path_mapper must be a RemoteToLocalPathMapper; "
+                . "received {$observed_type}."
+            );
+        }
+
+        /** @var string $remote_index_file */
+        $remote_index_file = $options["remote_index_file"];
+        /** @var string $mapped_remote_index_file */
+        $mapped_remote_index_file = $options["mapped_remote_index_file"];
+        /** @var string $filesystem_root */
+        $filesystem_root = $options["filesystem_root"];
+        /** @var RemoteToLocalPathMapper $path_mapper */
+        $path_mapper = $options["path_mapper"];
+
+        $remote_index_reader = new RemoteIndexReader($remote_index_file);
+        $mapped_index_handle = fopen($mapped_remote_index_file, "wb");
+        if (!is_resource($mapped_index_handle)) {
+            throw new RuntimeException(
+                "Failed to create the mapped remote index: {$mapped_remote_index_file}."
+            );
+        }
+        try {
+            $remote_index_reader->open();
+            $remote_entry = $remote_index_reader->next_entry();
+            while ($remote_entry !== null) {
+                self::write_mapped_entry(
+                    $mapped_index_handle,
+                    $remote_entry,
+                    $filesystem_root,
+                    $path_mapper
+                );
+                $remote_entry = $remote_index_reader->next_entry();
+            }
+            if (!fflush($mapped_index_handle)) {
+                throw new RuntimeException(
+                    "Failed to flush the mapped remote index: {$mapped_remote_index_file}."
+                );
+            }
+        } finally {
+            $remote_index_reader->close();
+            fclose($mapped_index_handle);
+        }
+
+        if (!sort_index_file($mapped_remote_index_file)) {
+            throw new RuntimeException(
+                "Failed to sort the mapped remote index: {$mapped_remote_index_file}."
+            );
+        }
+        self::assert_no_path_collisions($mapped_remote_index_file);
+    }
+
+    /**
+     * Decodes one mapped remote entry for a local-path index merge.
+     *
+     * @return array {
+     *     @type string $path             Local relative path.
+     *     @type string $type             file, link, or dir.
+     *     @type int    $ctime            Always zero; clocks are not compared.
+     *     @type int    $size             Remote size.
+     *     @type string $copy_source_path Remote absolute path.
+     * }
+     * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,copy_source_path:string}
+     */
+    public static function decode_index_line(string $line): array
+    {
+        $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        $encoded_mapping = is_array($entry) ? $entry["path"] ?? null : null;
+        $mapping = is_string($encoded_mapping)
+            ? base64_decode($encoded_mapping, true)
+            : false;
+        $separator = is_string($mapping) ? strpos($mapping, "/") : false;
+        $local_relative_path = $separator === false
+            ? false
+            : @hex2bin(substr($mapping, 0, $separator));
+        $remote_absolute_path = $separator === false
+            ? false
+            : @hex2bin(substr($mapping, $separator + 1));
+        $type = is_array($entry) ? $entry["type"] ?? null : null;
+        if (
+            !is_string($local_relative_path)
+            || $local_relative_path === ""
+            || !is_string($remote_absolute_path)
+            || $remote_absolute_path === ""
+            || !in_array($type, ["file", "dir", "link"], true)
+        ) {
+            throw new RuntimeException("Invalid mapped remote-index entry.");
+        }
+        return [
+            "path" => $local_relative_path,
+            "type" => $type,
+            "ctime" => 0,
+            "size" => (int) ( $entry["size"] ?? 0 ),
+            "copy_source_path" => $remote_absolute_path,
+        ];
+    }
+
+    /** @param resource $mapped_index_handle */
+    private static function write_mapped_entry(
+        $mapped_index_handle,
+        array $remote_entry,
+        string $filesystem_root,
+        RemoteToLocalPathMapper $path_mapper
+    ): void {
+        $remote_absolute_path = $remote_entry["path"];
+        $local_relative_path = relative_path_under(
+            $path_mapper->remote_path_to_local_path($remote_absolute_path),
+            $filesystem_root
+        );
+        if ($local_relative_path === null) {
+            throw new RuntimeException(
+                "Mapped remote path is outside the filesystem root: {$remote_absolute_path}."
+            );
+        }
+        if ($local_relative_path === "") {
+            if ($remote_entry["type"] !== "dir") {
+                throw new RuntimeException(
+                    "A remote path cannot replace the filesystem root: {$remote_absolute_path}."
+                );
+            }
+            return;
+        }
+
+        $mapped_key = bin2hex($local_relative_path)
+            . "/"
+            . bin2hex($remote_absolute_path);
+        $line = json_encode(
+            [
+                "path" => base64_encode($mapped_key),
+                "ctime" => 0,
+                "size" => $remote_entry["size"],
+                "type" => $remote_entry["type"],
+            ],
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+        ) . "\n";
+        if (fwrite($mapped_index_handle, $line) !== strlen($line)) {
+            throw new RuntimeException("Failed to write the mapped remote index.");
+        }
+    }
+
+    /** Rejects remote paths which map to the same local path or below one. */
+    private static function assert_no_path_collisions(
+        string $mapped_remote_index_file
+    ): void {
+        $mapped_index_handle = fopen($mapped_remote_index_file, "rb");
+        if (!is_resource($mapped_index_handle)) {
+            throw new RuntimeException(
+                "Failed to validate the mapped remote index: {$mapped_remote_index_file}."
+            );
+        }
+        $collision_stack_file = $mapped_remote_index_file . ".collision-stack";
+        $collision_stack_handle = fopen($collision_stack_file, "w+b");
+        if (!is_resource($collision_stack_handle)) {
+            fclose($mapped_index_handle);
+            throw new RuntimeException(
+                "Failed to create the mapped-path collision stack: {$collision_stack_file}."
+            );
+        }
+        $preceding_local_path = null;
+        /** @var array{path:string,record_offset:int,previous_record_offset:int|null}|null $active_mapped_path */
+        $active_mapped_path = null;
+        $collision_stack_byte_offset = 0;
+        try {
+            $line = fgets($mapped_index_handle);
+            while ($line !== false) {
+                $local_path = self::decode_index_line($line)["path"];
+                if ($local_path === $preceding_local_path) {
+                    throw new RuntimeException(
+                        "Remote paths map to the same local path: {$local_path}."
+                    );
+                }
+                while ($active_mapped_path !== null) {
+                    $mapped_path = $active_mapped_path["path"];
+                    if (path_is_descendant_of($local_path, $mapped_path)) {
+                        throw new RuntimeException(
+                            "A remote path maps below another remote path: "
+                            . "{$local_path} is below {$mapped_path}."
+                        );
+                    }
+                    if (strcmp($local_path, $mapped_path . "/") <= 0) {
+                        break;
+                    }
+                    $previous_record_offset =
+                        $active_mapped_path["previous_record_offset"];
+                    if ($previous_record_offset === null) {
+                        $active_mapped_path = null;
+                        continue;
+                    }
+                    if (
+                        fseek($collision_stack_handle, $previous_record_offset) !== 0
+                    ) {
+                        throw new RuntimeException(
+                            "Failed to seek in the mapped-path collision stack."
+                        );
+                    }
+                    $stack_line = fgets($collision_stack_handle);
+                    $stack_record = is_string($stack_line)
+                        ? json_decode($stack_line, true, 512, JSON_THROW_ON_ERROR)
+                        : null;
+                    $stack_path = is_array($stack_record)
+                        ? base64_decode($stack_record["path_b64"] ?? "", true)
+                        : false;
+                    if (!is_string($stack_path)) {
+                        throw new RuntimeException(
+                            "Invalid mapped-path collision stack record."
+                        );
+                    }
+                    $active_mapped_path = [
+                        "path" => $stack_path,
+                        "record_offset" => $previous_record_offset,
+                        "previous_record_offset" =>
+                            $stack_record["previous_record_offset"] ?? null,
+                    ];
+                }
+                $stack_line = json_encode(
+                    [
+                        "path_b64" => base64_encode($local_path),
+                        "previous_record_offset" =>
+                            $active_mapped_path["record_offset"] ?? null,
+                    ],
+                    JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                ) . "\n";
+                if (
+                    fseek($collision_stack_handle, $collision_stack_byte_offset) !== 0
+                    || fwrite($collision_stack_handle, $stack_line)
+                        !== strlen($stack_line)
+                ) {
+                    throw new RuntimeException(
+                        "Failed to write the mapped-path collision stack."
+                    );
+                }
+                $active_mapped_path = [
+                    "path" => $local_path,
+                    "record_offset" => $collision_stack_byte_offset,
+                    "previous_record_offset" =>
+                        $active_mapped_path["record_offset"] ?? null,
+                ];
+                $collision_stack_byte_offset += strlen($stack_line);
+                $preceding_local_path = $local_path;
+                $line = fgets($mapped_index_handle);
+            }
+            if (!feof($mapped_index_handle)) {
+                throw new RuntimeException(
+                    "Failed to read the mapped remote index: {$mapped_remote_index_file}."
+                );
+            }
+        } finally {
+            fclose($mapped_index_handle);
+            fclose($collision_stack_handle);
+            @unlink($collision_stack_file);
+        }
+    }
+}

--- a/tests/Import/MappedRemoteIndexBuilderTest.php
+++ b/tests/Import/MappedRemoteIndexBuilderTest.php
@@ -1,0 +1,146 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match existing importer tests.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php';
+
+final class MappedRemoteIndexBuilderTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/mapped-index-' . bin2hex(random_bytes(5));
+        mkdir($this->root . '/files', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove($this->root);
+    }
+
+    public function testBuildsTheRemoteIndexInMappedLocalOrder(): void
+    {
+        $remoteIndex = $this->root . '/remote.jsonl';
+        $mappedIndex = $this->root . '/mapped.jsonl';
+        $this->writeRemoteIndex($remoteIndex, ['/remote/a', '/remote/b']);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->root . '/files',
+            ['/remote'],
+            [
+                '/remote/a' => $this->root . '/files/z',
+                '/remote/b' => $this->root . '/files/a',
+            ]
+        );
+
+        \MappedRemoteIndexBuilder::build([
+            'remote_index_file' => $remoteIndex,
+            'mapped_remote_index_file' => $mappedIndex,
+            'filesystem_root' => $this->root . '/files',
+            'path_mapper' => $mapper,
+        ]);
+
+        $this->assertSame([
+            ['path' => 'a', 'source' => '/remote/b'],
+            ['path' => 'z', 'source' => '/remote/a'],
+        ], array_map(
+            static function (string $line): array {
+                $entry = \MappedRemoteIndexBuilder::decode_index_line($line);
+                return [
+                    'path' => $entry['path'],
+                    'source' => $entry['copy_source_path'],
+                ];
+            },
+            file($mappedIndex, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
+        ));
+        $this->assertFileDoesNotExist($mappedIndex . '.collision-stack');
+    }
+
+    /**
+     * @dataProvider collisionProvider
+     * @param array<string,string> $mappings
+     */
+    public function testRejectsMappedPathCollisions(
+        array $mappings,
+        string $message
+    ): void {
+        $remoteIndex = $this->root . '/remote.jsonl';
+        $remotePaths = array_keys($mappings);
+        $this->writeRemoteIndex($remoteIndex, $remotePaths);
+        $resolvedMappings = [];
+        foreach ($mappings as $remotePath => $localPath) {
+            $resolvedMappings[$remotePath] = $this->root . '/files/' . $localPath;
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($message);
+        \MappedRemoteIndexBuilder::build([
+            'remote_index_file' => $remoteIndex,
+            'mapped_remote_index_file' => $this->root . '/mapped.jsonl',
+            'filesystem_root' => $this->root . '/files',
+            'path_mapper' => new \RemoteToLocalPathMapper(
+                $this->root . '/files',
+                ['/remote'],
+                $resolvedMappings
+            ),
+        ]);
+    }
+
+    /** @return iterable<string,array{array<string,string>,string}> */
+    public static function collisionProvider(): iterable
+    {
+        yield 'same path' => [[
+            '/remote/a' => 'same',
+            '/remote/b' => 'same',
+        ], 'Remote paths map to the same local path'];
+        yield 'ancestor before lexical sibling' => [[
+            '/remote/a' => 'x',
+            '/remote/b' => 'x-other',
+            '/remote/c' => 'x/child',
+        ], 'x/child is below x'];
+    }
+
+    public function testRejectsUnknownOptions(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown mapped remote-index option: remote_file');
+        \MappedRemoteIndexBuilder::build(['remote_file' => 'index.jsonl']);
+    }
+
+    /** @param list<string> $remotePaths */
+    private function writeRemoteIndex(string $path, array $remotePaths): void
+    {
+        $lines = '';
+        foreach ($remotePaths as $remotePath) {
+            $lines .= json_encode([
+                'path' => base64_encode($remotePath),
+                'ctime' => 1,
+                'size' => 1,
+                'type' => 'file',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+        }
+        file_put_contents($path, $lines);
+    }
+
+    private function remove(string $path): void
+    {
+        if (!is_dir($path) || is_link($path)) {
+            if (file_exists($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
A completed remote file index can now be rebuilt in mapped local-path order before mirror planning starts.

## Example

Assume the completed remote index is sorted like this:

```text
/srv/a/photo.jpg
/srv/z/config.php
```

The pull settings map those paths like this:

```text
/srv/a  -> /workspace/z
/srv/z  -> /workspace/a
```

Remote order and local order are now different. The mapped index must contain:

```text
local a/config.php  -> copy from /srv/z/config.php
local z/photo.jpg   -> copy from /srv/a/photo.jpg
```

The builder is used with named inputs:

```php
MappedRemoteIndexBuilder::build([
    'remote_index_file' => $remote_index_file,
    'mapped_remote_index_file' => $mapped_remote_index_file,
    'filesystem_root' => '/workspace',
    'path_mapper' => $path_mapper,
]);
```

`decode_index_line()` returns the mapped local path as `path` and the original remote absolute path as `copy_source_path`. A later local-path merge can therefore compare `a/config.php` while still asking the remote site for `/srv/z/config.php`.

## Before and after

Before this PR, there was no reusable way to produce this index. Mirror code had to map rows while the remote index was still arriving, which tied local mapping work to the network download and its cursor.

After this PR, the ordinary remote index finishes first and remains unchanged. The builder reads that completed file, writes a disposable mapped index, sorts it by local path, and checks it for collisions. If local mapping stops, the mapped file can be rebuilt without downloading the remote index again.

The collision check also rejects configurations such as these before local files change:

```text
/srv/a -> /workspace/shared
/srv/b -> /workspace/shared
```

It rejects both equal mapped paths and cases where one mapped file path would become another mapped path's parent. The collision stack is kept on disk instead of loading the index into memory.

## Testing

The focused tests cover reversed remote/local order, remote source preservation, equal-path collisions, parent/child collisions across lexical siblings, unknown options, and collision-stack cleanup.
