### PR TITLE
[PHP] Share FileIndexProcessor entry writing

### DIFF
--- a/packages/reprint-client/src/lib/local-index-update-functions.php
+++ b/packages/reprint-client/src/lib/local-index-update-functions.php
@@ -3,6 +3,7 @@
 namespace Reprint\Importer;
 
 use function WordPress\Reprint\Exporter\path_is_same_as_or_descendant_of;
+use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exceptions contain CLI filesystem paths, never HTML output.
 
@@ -321,6 +322,60 @@ function read_local_index_updates( $sorted_local_index_updates_handle ): \Genera
 	if ( ! feof( $sorted_local_index_updates_handle ) ) {
 		throw new \RuntimeException( 'Failed to read an index-update entry.' );
 	}
+}
+
+/**
+ * Converts and writes one absolute-path FileIndexProcessor entry.
+ *
+ * @param resource $local_index_output_handle Open local index output.
+ * @param array    $file_index_processor_entry {
+ *     Indexed filesystem entry.
+ *
+ *     @type string $path  Local absolute path.
+ *     @type int    $ctime Indexed change timestamp.
+ *     @type int    $size  Indexed size.
+ *     @type string $type  file, link, dir, or other.
+ *     @type bool   $empty Whether a directory has no indexed descendants.
+ * }
+ * @param string $filesystem_root Local filesystem root.
+ */
+function write_file_index_processor_entry_to_local_index(
+	$local_index_output_handle,
+	array $file_index_processor_entry,
+	string $filesystem_root
+): void {
+	if (
+		$file_index_processor_entry['type'] === 'other'
+		|| (
+			$file_index_processor_entry['type'] === 'dir'
+			&& ! array_key_exists( 'empty', $file_index_processor_entry )
+		)
+	) {
+		throw new \RuntimeException(
+			'Could not index the local path: '
+			. base64_encode( $file_index_processor_entry['path'] )
+			. '.'
+		);
+	}
+	$local_relative_path = relative_path_under(
+		$file_index_processor_entry['path'],
+		$filesystem_root
+	);
+	if ( $local_relative_path === null ) {
+		throw new \LogicException(
+			'File index path is outside the filesystem root.'
+		);
+	}
+	$local_index_entry = [
+		'path'  => $local_relative_path,
+		'ctime' => $file_index_processor_entry['ctime'],
+		'size'  => $file_index_processor_entry['size'],
+		'type'  => $file_index_processor_entry['type'],
+	];
+	if ( $file_index_processor_entry['type'] === 'dir' ) {
+		$local_index_entry['empty'] = $file_index_processor_entry['empty'];
+	}
+	write_local_index_entry( $local_index_output_handle, $local_index_entry );
 }
 
 /**

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -1,6 +1,7 @@
 <?php
 
 use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\write_file_index_processor_entry_to_local_index;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Reprint\Exporter\relative_path_under;
 use function WordPress\Reprint\Exporter\trim_right_slash;
@@ -422,7 +423,11 @@ class PushPlan
         switch ($this->file_index_processor->get_step_status()) {
             case FileIndexProcessor::STATUS_INDEXED:
                 foreach ($this->file_index_processor->get_index_entries() as $file_index_processor_entry) {
-                    $this->append_fresh_local_index_entry($file_index_processor_entry);
+                    write_file_index_processor_entry_to_local_index(
+                        $this->fresh_local_index_handle,
+                        $file_index_processor_entry,
+                        $this->filesystem_root
+                    );
                 }
                 break;
 
@@ -505,60 +510,6 @@ class PushPlan
         if (is_int($fresh_local_index_bytes) && is_int($local_index_bytes)) {
             $this->index_bytes_total = $fresh_local_index_bytes
                 + $local_index_bytes;
-        }
-    }
-
-    /**
-     * Appends one FileIndexProcessor entry in the JSONL format consumed by the
-     * index diff.
-     *
-     * @param array<string,mixed> $file_index_processor_entry Filesystem path details from FileIndexProcessor.
-     */
-    private function append_fresh_local_index_entry(array $file_index_processor_entry): void
-    {
-        if ($file_index_processor_entry["type"] === "other") {
-            throw new RuntimeException(
-                "Cannot push the unsupported local path: "
-                . base64_encode($file_index_processor_entry["path"])
-                . "."
-            );
-        }
-        if (
-            $file_index_processor_entry["type"] === "dir"
-            && !array_key_exists("empty", $file_index_processor_entry)
-        ) {
-            throw new RuntimeException(
-                "Could not inspect the local directory: "
-                . base64_encode($file_index_processor_entry["path"])
-                . "."
-            );
-        }
-
-        $local_relative_path = relative_path_under(
-            $file_index_processor_entry["path"],
-            $this->filesystem_root
-        );
-        if ($local_relative_path === null) {
-            throw new LogicException("File index path is outside the filesystem root.");
-        }
-        $fresh_local_index_entry = [
-            "path" => base64_encode($local_relative_path),
-            "ctime" => $file_index_processor_entry["ctime"],
-            "size" => $file_index_processor_entry["size"],
-            "type" => $file_index_processor_entry["type"],
-        ];
-        if ($file_index_processor_entry["type"] === "dir") {
-            $fresh_local_index_entry["empty"] = $file_index_processor_entry["empty"];
-        }
-        $fresh_local_index_json_line = json_encode(
-            $fresh_local_index_entry,
-            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
-        ) . "\n";
-        if (
-            fwrite($this->fresh_local_index_handle, $fresh_local_index_json_line)
-            !== strlen($fresh_local_index_json_line)
-        ) {
-            throw new RuntimeException("Failed to write a fresh local index entry.");
         }
     }
 


### PR DESCRIPTION
`FileIndexProcessor` entries can now be written to the local-index JSONL format through one shared function.

## Example

`FileIndexProcessor` reports absolute local paths:

```php
$entry = [
    'path' => '/workspace/wp-config.php',
    'ctime' => 1723800000,
    'size' => 3210,
    'type' => 'file',
];
```

The local index stores the same path relative to the filesystem root:

```json
{"path":"d3AtY29uZmlnLnBocA==","ctime":1723800000,"size":3210,"type":"file"}
```

The caller now writes that conversion with:

```php
write_file_index_processor_entry_to_local_index(
    $local_index_handle,
    $entry,
    '/workspace'
);
```

## Before and after

Before this PR, `PushPlan` contained a private method which validated the processor entry, made its path relative, copied its metadata, encoded its path, encoded the JSON row, and wrote it.

After this PR, that conversion lives beside the other local-index functions. `PushPlan` calls the shared writer and removes its private serializer. PR #633 uses the same function while computing the current local index for mirror mode.

The writer still rejects unsupported path types, directories without an `empty` marker, and paths outside the filesystem root. Directory entries keep their `empty` value.

## Testing

The existing `PushPlanTest` suite checks that fresh local indexes, copy plans, deletion plans, arbitrary path bytes, and resume cursors remain unchanged.
