### PR TITLE
[PHP] Record local-only pull index deletions

### DIFF
--- a/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
+++ b/packages/reprint-client/src/lib/pull/class-pull-index-journal.php
@@ -362,6 +362,26 @@ class PullIndexJournal
     }
 
     /**
+     * Adds a `-` record after mirror removes a local-only path.
+     *
+     * @param string $local_absolute_path Local path already removed.
+     * @throws RuntimeException When the record cannot be appended.
+     */
+    public function record_local_deletion(string $local_absolute_path): void
+    {
+        $local_relative_path = $this->local_relative_path_from_local_absolute_path(
+            $local_absolute_path
+        );
+        if ($local_relative_path === null) {
+            return;
+        }
+        $this->write_record([
+            "op" => "-",
+            "local_relative_path_b64" => base64_encode($local_relative_path),
+        ]);
+    }
+
+    /**
      * Adds a `-` record which changes only the remote index.
      *
      * The record has no `local_relative_path_b64`, so the local index does not
@@ -775,6 +795,19 @@ class PullIndexJournal
                 throw new RuntimeException("Invalid pull index WAL line format.");
             }
             $pull_index_wal_operation = $pull_index_wal_record["op"] ?? null;
+            if (
+                $pull_index_wal_operation === "-"
+                && !array_key_exists(
+                    "remote_absolute_path_b64",
+                    $pull_index_wal_record
+                )
+                && array_key_exists(
+                    "local_relative_path_b64",
+                    $pull_index_wal_record
+                )
+            ) {
+                continue;
+            }
             $remote_absolute_path_base64 =
                 $pull_index_wal_record["remote_absolute_path_b64"] ?? null;
             if (

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -117,6 +117,34 @@ final class PullIndexWalTest extends TestCase
         $journal->remove_empty_wal();
     }
 
+    public function testLocalOnlyDeletionChangesOnlyTheLocalIndex(): void
+    {
+        mkdir($this->fileRoot . '/site');
+        $localAbsolutePath = $this->fileRoot . '/site/local-only.txt';
+        file_put_contents($localAbsolutePath, 'hello');
+        $localAbsolutePath = realpath($localAbsolutePath);
+        $this->assertIsString($localAbsolutePath);
+        $journal = $this->journal($this->client());
+        $journal->record_remote_upsert(
+            '/site/local-only.txt',
+            42,
+            5,
+            'file',
+            $localAbsolutePath
+        );
+        $journal->apply_pending_records();
+
+        unlink($localAbsolutePath);
+        $journal->record_local_deletion($localAbsolutePath);
+        $journal->apply_pending_records();
+
+        $this->assertSame(
+            ['/site/local-only.txt'],
+            $this->remoteIndexEntryPaths()
+        );
+        $this->assertSame([], $this->readLocalIndex());
+    }
+
     public function testUpsertingFileDoesNotCreateParentDirectoryEntries(): void
     {
         $journal = $this->journal($this->client());


### PR DESCRIPTION
The pull index journal can now record a deletion which changes the retained local index without changing the remote index.

## Example

Suppose `/workspace/debug.log` was created locally after the last pull. Mirror removes it because the current remote index has no `debug.log`.

Before this PR, the deletion API required both paths:

```php
$journal->record_successful_deletion(
    '/srv/site/debug.log',
    '/workspace/debug.log'
);
```

That call would claim a remote path was deleted and would remove it from the retained remote index. There is no correct remote path in this example because `debug.log` never existed remotely.

After this PR, mirror can record exactly what happened:

```php
$journal->record_local_deletion('/workspace/debug.log');
```

The WAL row contains only the local path:

```json
{"op":"-","local_relative_path_b64":"ZGVidWcubG9n"}
```

Local-index replay removes `debug.log`. Remote-index replay sees that no remote path is present and leaves the remote index unchanged.

## Testing

The focused test starts with separate local and remote index rows, records a local-only deletion, applies the WAL, and checks that the local index changes while the remote index stays byte-for-byte unchanged.
