### PR TITLE
[PHP] Remove pull paths without following parent symlinks

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8088,11 +8088,32 @@ class ImportClient
     }
 
     /**
-     * Removes a remote deletion root from the mapped local filesystem.
+     * Removes a local path without traversing a symlink component.
      *
-     * @return string|null The mapped local absolute path when it is absent
-     *                     after this call, or null when it could not be removed.
+     * @return array{path:string,outcome:'absent'|'removed'|'symlink'}|null
      */
+    private function remove_local_path_without_traversing_symlinks(
+        string $local_absolute_path
+    ): ?array {
+        $removed_symlink_path = $this->remove_first_symlink_component(
+            $local_absolute_path
+        );
+        if ($removed_symlink_path !== null) {
+            return ["path" => $removed_symlink_path, "outcome" => "symlink"];
+        }
+        if (!file_exists($local_absolute_path) && !is_link($local_absolute_path)) {
+            return ["path" => $local_absolute_path, "outcome" => "absent"];
+        }
+        if (
+            $this->remove_local_absolute_path_without_following_symlinks(
+                $local_absolute_path
+            )
+        ) {
+            return ["path" => $local_absolute_path, "outcome" => "removed"];
+        }
+        return null;
+    }
+
     private function remove_remote_path_locally(
         string $remote_deletion_root
     ): ?string {
@@ -8110,17 +8131,17 @@ class ImportClient
             );
             return null;
         }
-        if (!file_exists($local_absolute_path) && !is_link($local_absolute_path)) {
-            return $local_absolute_path;
+        $removal = $this->remove_local_path_without_traversing_symlinks(
+            $local_absolute_path
+        );
+        if ($removal === null) {
+            $this->audit_log("Failed to delete: {$remote_deletion_root}", true);
+            return null;
         }
-
-        if ($this->remove_local_absolute_path_without_following_symlinks($local_absolute_path)) {
+        if ($removal["outcome"] === "removed") {
             $this->audit_log("Deleted: {$remote_deletion_root}", false);
-            return $local_absolute_path;
         }
-
-        $this->audit_log("Failed to delete: {$remote_deletion_root}", true);
-        return null;
+        return $removal["path"];
     }
 
     /**
@@ -8242,6 +8263,44 @@ class ImportClient
         }
 
         return true === @unlink($local_absolute_path);
+    }
+
+    /** Removes the first symlink component without traversing its target. */
+    private function remove_first_symlink_component(
+        string $local_absolute_path
+    ): ?string {
+        $local_relative_path = relative_path_under(
+            $local_absolute_path,
+            $this->filesystem_root
+        );
+        if ($local_relative_path === null) {
+            throw new RuntimeException(
+                "Cannot inspect a local path outside the filesystem root."
+            );
+        }
+        if ($local_relative_path === "") {
+            return null;
+        }
+
+        $local_component_path = $this->filesystem_root;
+        foreach (explode("/", $local_relative_path) as $path_component) {
+            $local_component_path = wp_join_unix_paths(
+                $local_component_path,
+                $path_component
+            );
+            if (is_link($local_component_path)) {
+                if (!@unlink($local_component_path)) {
+                    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI filesystem path, never HTML output.
+                    throw new RuntimeException(
+                        "Failed to remove a local symlink component: "
+                        . $local_component_path
+                    );
+                    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                }
+                return $local_component_path;
+            }
+        }
+        return null;
     }
 
     /**

--- a/tests/Import/PullSymlinkTest.php
+++ b/tests/Import/PullSymlinkTest.php
@@ -315,4 +315,27 @@ class PullSymlinkTest extends TestCase
         $this->assertTrue(is_link($filePath), 'File should be replaced with symlink');
         $this->assertEquals('target', readlink($filePath));
     }
+
+    public function testRemoteDeletionRemovesAParentSymlinkWithoutFollowingIt(): void
+    {
+        $outsideDirectory = $this->tempDir . '/outside';
+        mkdir($outsideDirectory);
+        file_put_contents($outsideDirectory . '/file.txt', 'outside');
+        $localSymlink = $this->tempDir . '/fs-root/link';
+        symlink($outsideDirectory, $localSymlink);
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir,
+            $this->tempDir . '/fs-root'
+        );
+
+        $removedPath = ( new \ReflectionMethod(
+            \ImportClient::class,
+            'remove_remote_path_locally'
+        ) )->invoke($client, '/link/file.txt');
+
+        $this->assertSame(realpath(dirname($localSymlink)) . '/link', $removedPath);
+        $this->assertFalse(is_link($localSymlink));
+        $this->assertFileExists($outsideDirectory . '/file.txt');
+    }
 }


### PR DESCRIPTION
Remote pull deletions now remove a parent symlink instead of traversing it.

## Example

Assume this local tree:

```text
/workspace/link -> /outside
/outside/file.txt
```

The remote index says `/link/file.txt` was deleted.

Before this PR, recursive removal inspected `/workspace/link/file.txt`. The parent component was a symlink, so that path resolved to `/outside/file.txt`. The outside file could be removed while `/workspace/link` remained.

After this PR, the pull checks each component between `/workspace` and the requested path:

```text
/workspace/link/file.txt
           ^ first symlink component
```

It removes `/workspace/link` and stops. `/outside/file.txt` remains unchanged.

The call site now uses one result for all three safe outcomes:

```php
$removal = $this->remove_local_path_without_traversing_symlinks(
    $local_absolute_path
);
```

The result says whether the path was already absent, the requested path was removed, or a parent symlink was removed. PR #633 uses the same path for locally changed files which are missing from the current remote index.

## Testing

The focused test creates a parent symlink to an outside directory, applies a remote deletion below it, and checks that the symlink is gone while the outside file remains.
