### PR TITLE
[PHP] Exclude earlier MySQL import position tables

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -176,8 +176,10 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const MYSQL_IMPORT_PROGRESS_TABLE_PREFIX = "__reprint_db_pull_progress_";
     // Change this UUID whenever the progress-table schema changes.
-    private const MYSQL_IMPORT_PROGRESS_TABLE = "__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4";
+    private const MYSQL_IMPORT_PROGRESS_TABLE =
+        self::MYSQL_IMPORT_PROGRESS_TABLE_PREFIX . "49acb118-a97a-45c7-814d-8e670db7f6b4";
     private const MYSQL_SQL_GROUP_MARKER = "-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 ";
 
     /**
@@ -8389,7 +8391,7 @@ class ImportClient
         try {
             if ($mode === "mysql") {
                 $this->audit_log(
-                    "SKIPPING SOURCE TABLE IF PRESENT | " . self::MYSQL_IMPORT_PROGRESS_TABLE,
+                    "SKIPPING SOURCE TABLES IF PRESENT | " . self::MYSQL_IMPORT_PROGRESS_TABLE_PREFIX . "*",
                     true,
                 );
             }

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -12,6 +12,9 @@ use PDO;
  */
 class DatabaseRowsReader {
 
+    /** Prefix shared by every schema version of Reprint's internal MySQL progress table. */
+    private const MYSQL_IMPORT_PROGRESS_TABLE_PREFIX = "__reprint_db_pull_progress_";
+
 
     /** @var mixed PDO or a PDO-compatible adapter. */
     private $db;
@@ -571,7 +574,7 @@ class DatabaseRowsReader {
     }
 
     /**
-     * Discovers BASE TABLEs and excludes views.
+     * Discovers BASE TABLEs and excludes views and Reprint progress tables.
      *
      * @TODO: Paginate databases with millions of tables.
      */
@@ -582,7 +585,10 @@ class DatabaseRowsReader {
         $row = $statement->fetch(PDO::FETCH_ASSOC);
         while ($row !== false) {
             $values = array_values($row);
-            $excluded = false;
+            $excluded = isset($values[0]) && stripos(
+                $values[0],
+                self::MYSQL_IMPORT_PROGRESS_TABLE_PREFIX
+            ) === 0;
             foreach ($this->exclude_tables as $excluded_table) {
                 if (isset($values[0]) && strcasecmp($values[0], $excluded_table) === 0) {
                     $excluded = true;

--- a/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
+++ b/tests/MySQLDumpProducer/DatabaseRowsReaderTest.php
@@ -7,10 +7,13 @@ use WordPress\DataLiberation\DatabaseRowsReader;
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 class DatabaseRowsReaderTest extends MySQLDumpProducerTestBase {
 
-    public function testExcludesRequestedTablesWhenDiscoveringSourceTables(): void
+    public function testExcludesRequestedAndReprintProgressTablesWhenDiscoveringSourceTables(): void
     {
         $this->pdo->exec('CREATE TABLE included_table (id INT PRIMARY KEY)');
         $this->pdo->exec('CREATE TABLE skipped_table (id INT PRIMARY KEY)');
+        $this->pdo->exec(
+            'CREATE TABLE `__reprint_db_pull_progress_another_schema` (id INT PRIMARY KEY)'
+        );
 
         $reader = new DatabaseRowsReader(
             $this->pdo,
@@ -25,6 +28,7 @@ class DatabaseRowsReaderTest extends MySQLDumpProducerTestBase {
 
         $this->assertContains('included_table', $tables);
         $this->assertNotContains('skipped_table', $tables);
+        $this->assertNotContains('__reprint_db_pull_progress_another_schema', $tables);
     }
 
     public function testReturnsStructuredRecordsWithoutFormattingSql(): void

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -28,6 +28,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     const sourceTable = 'aa_target_cursor_rows';
     const myisamSourceTable = 'ab_target_cursor_myisam_rows';
     const progressTable = '__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4';
+    const previousProgressTable = '__reprint_db_pull_progress_11111111-2222-4333-8444-555555555555';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
     const importerPath = process.env.IMPORTER_PATH
@@ -185,15 +186,18 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
         const sourceConnection = await createMysqlConnection(getDbName(site));
         const targetConnection = await createMysqlConnection(targetDb);
         const sourceProgressTable = progressTable.toUpperCase();
+        const sourcePreviousProgressTable = previousProgressTable.toUpperCase();
         try {
-            await sourceConnection.query(
-                `CREATE TABLE \`${sourceProgressTable}\` (`
-                + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
-                + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
-            );
-            await sourceConnection.query(
-                `INSERT INTO \`${sourceProgressTable}\` (id, note) VALUES (1, 'source row')`
-            );
+            for (const table of [sourceProgressTable, sourcePreviousProgressTable]) {
+                await sourceConnection.query(
+                    `CREATE TABLE \`${table}\` (`
+                    + '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, '
+                    + '`note` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
+                );
+                await sourceConnection.query(
+                    `INSERT INTO \`${table}\` (id, note) VALUES (1, 'source row')`
+                );
+            }
 
             const preflight = runImporter(importUrl(), collisionDir, 'preflight', {
                 secret: getSiteSecret(site),
@@ -207,7 +211,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             assert.equal(result.exitCode, 0, result.stderr + result.stdout);
             assert.match(
                 readAuditLog(collisionDir),
-                new RegExp(`SKIPPING SOURCE TABLE IF PRESENT .*${progressTable}`),
+                /SKIPPING SOURCE TABLES IF PRESENT .*__reprint_db_pull_progress_\*/,
             );
 
             const [targetColumns] = await targetConnection.query(
@@ -219,8 +223,16 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                 targetColumns.map(column => column.COLUMN_NAME),
                 ['id', 'source_hash', 'source_cursor', 'file_byte_offset'],
             );
+            const [[previousTable]] = await targetConnection.query(
+                'SELECT COUNT(*) AS tableCount FROM INFORMATION_SCHEMA.TABLES '
+                + 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                [targetDb, previousProgressTable],
+            );
+            assert.equal(Number(previousTable.tableCount), 0);
         } finally {
-            await sourceConnection.query(`DROP TABLE IF EXISTS \`${sourceProgressTable}\``);
+            for (const table of [sourceProgressTable, sourcePreviousProgressTable]) {
+                await sourceConnection.query(`DROP TABLE IF EXISTS \`${table}\``);
+            }
             await sourceConnection.end();
             await targetConnection.end();
             cleanupTempDir(collisionDir);


### PR DESCRIPTION
Stops later database pulls from copying any earlier Reprint MySQL import-position table as site data.

## Background

Reprint gives its internal progress table a new UUID when the table schema changes:

```text
__reprint_db_pull_progress_<schema UUID>
```

A completed import leaves that table in the target database. If that target is later used as a source, a new Reprint version knows its current UUID but may not know every older UUID. The old internal table could then be copied into the next target as ordinary site data.

## This change

Source table discovery excludes every table whose name starts with `__reprint_db_pull_progress_`. The client still sends the current exact table name in `skip_tables` for a server which does not yet have the prefix rule.

The unit test uses an arbitrary progress-table suffix. The MySQL E2E test uses a different UUID and checks that neither it nor the current table is copied.

## Testing

Rely on CI for the MySQL tests.
