### PR TITLE
[PHP] Save db-apply statement counts in the target database

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -187,7 +187,7 @@ class ImportClient
     private const DATABASE_IMPORT_POSITION_TABLE_PREFIX = "__reprint_db_pull_progress_";
     // Change this UUID whenever the progress-table schema changes.
     private const DATABASE_IMPORT_POSITION_TABLE =
-        self::DATABASE_IMPORT_POSITION_TABLE_PREFIX . "49acb118-a97a-45c7-814d-8e670db7f6b4";
+        self::DATABASE_IMPORT_POSITION_TABLE_PREFIX . "725a0014-81eb-4827-acfb-5edb1b4f24d9";
     private const SQL_GROUP_MARKER = "-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 ";
 
     /**
@@ -6645,11 +6645,32 @@ class ImportClient
         $byte_offset = 0;
         $statements_executed = 0;
         try {
+            $target_position = $is_resume
+                ? $this->read_database_import_position(
+                    $connection,
+                    $source_hash,
+                    "db-apply",
+                )
+                : null;
+            if ($target_position !== null) {
+                $statements_executed = $target_position["statements_executed"];
+                if ($statements_executed === null) {
+                    throw new RuntimeException(
+                        "The target database has no statement count for this db-apply. " .
+                        "Run db-apply --abort to start again.",
+                    );
+                }
+            }
+
             if (
                 $is_resume
                 && $this->get_state()->active_resumable_command->current_stage === "database-cleanup"
             ) {
-                $this->finish_database_dump_file_apply($connection, $options);
+                $this->finish_database_dump_file_apply(
+                    $connection,
+                    $options,
+                    $target_position === null ? null : $statements_executed,
+                );
                 return;
             }
 
@@ -6660,14 +6681,8 @@ class ImportClient
                 $this->get_state()->active_resumable_command->current_stage = "sql";
                 $this->get_state()->active_resumable_command->remote_cursor = null;
             } else {
-                $target_position = $this->read_database_import_position(
-                    $connection,
-                    $source_hash,
-                    "db-apply",
-                );
                 if ($target_position !== null) {
                     $byte_offset = $target_position["file_byte_offset"];
-                    $statements_executed = $this->get_state()->apply->statements_executed;
                     if ($byte_offset === null) {
                         throw new RuntimeException(
                             "The target database has no db.sql byte offset for this db-apply. " .
@@ -6690,7 +6705,6 @@ class ImportClient
                 }
             }
 
-            $this->get_state()->apply->statements_executed = $statements_executed;
             $this->save_state();
 
             if ($byte_offset > 0 && $target_engine === 'mysql') {
@@ -6743,16 +6757,13 @@ class ImportClient
                     $source_hash,
                     $group["exporter_cursor"],
                     $group["byte_offset"],
+                    $statements_executed,
                     $target_engine,
                     $stmt_rewriter,
                 );
 
                 $statements_executed += $group_statement_count;
                 $byte_offset = $group["byte_offset"];
-                // The target already contains the cursor and db.sql byte offset.
-                // The local statement count is only progress information.
-                $this->get_state()->apply->statements_executed = $statements_executed;
-                $this->save_state();
 
                 $apply_fraction = $sql_file_size > 0
                     ? $byte_offset / $sql_file_size
@@ -6789,7 +6800,11 @@ class ImportClient
             // interrupted, the next process repeats cleanup instead of SQL.
             $this->get_state()->active_resumable_command->current_stage = "database-cleanup";
             $this->save_state();
-            $this->finish_database_dump_file_apply($connection, $options);
+            $this->finish_database_dump_file_apply(
+                $connection,
+                $options,
+                $statements_executed,
+            );
         } finally {
             fclose($sql_handle);
             if ($connection->inTransaction()) {
@@ -6802,12 +6817,14 @@ class ImportClient
     /**
      * Finishes idempotent target cleanup after every SQL group is committed.
      *
-     * @param DatabaseConnection $connection Open target connection.
-     * @param array $options Command options used by plugin cleanup.
+     * @param DatabaseConnection $connection          Open target connection.
+     * @param array              $options             Command options used by plugin cleanup.
+     * @param int|null           $statements_executed Exact count, or null when cleanup resumed after its target row was removed.
      */
     private function finish_database_dump_file_apply(
         DatabaseConnection $connection,
-        array $options
+        array $options,
+        ?int $statements_executed
     ): void {
         // The host analyzer declares paths_to_remove; any entry under
         // wp-content/plugins/ means that plugin will be deleted from disk
@@ -6833,26 +6850,26 @@ class ImportClient
 
         $this->remove_database_import_position_table($connection);
 
-        $statements_executed = $this->get_state()->apply->statements_executed;
         $this->get_state()->active_resumable_command->completion_state = "complete";
         $this->save_state();
-        $this->audit_log(
-            "db-apply complete | {$statements_executed} statements executed",
-            true,
-        );
-        $this->output_progress([
+        $completion_message = $statements_executed === null
+            ? "db-apply complete"
+            : "db-apply complete ({$statements_executed} statements executed)";
+        $this->audit_log($completion_message, true);
+        $completion_progress = [
             "status" => "complete",
             "phase" => "db-apply",
-            "statements_executed" => $statements_executed,
-            "message" => "db-apply complete ({$statements_executed} statements executed)",
-        ]);
+            "message" => $completion_message,
+        ];
+        if ($statements_executed !== null) {
+            $completion_progress["statements_executed"] = $statements_executed;
+        }
+        $this->output_progress($completion_progress);
         if (!$this->progress->is_mode("pipeline")) {
             // Clear the progress line before printing the final message.
             $this->progress->clear_progress_line();
         }
-        $this->progress->show_lifecycle_line(
-            "db-apply complete ({$statements_executed} statements executed)\n",
-        );
+        $this->progress->show_lifecycle_line($completion_message . "\n");
     }
 
     /**
@@ -6898,6 +6915,7 @@ class ImportClient
         string $source_hash,
         string $next_cursor,
         ?int $next_file_byte_offset,
+        ?int $statements_executed_before_group,
         string $target_engine,
         ?SqlStatementRewriter $stmt_rewriter = null
     ): int {
@@ -6912,6 +6930,9 @@ class ImportClient
                 $source_hash,
                 $next_cursor,
                 $next_file_byte_offset,
+                $statements_executed_before_group === null
+                    ? null
+                    : $statements_executed_before_group + $statement_count,
             );
             $connection->commit();
             return $statement_count;
@@ -6961,6 +6982,9 @@ class ImportClient
                 $source_hash,
                 $next_cursor,
                 $next_file_byte_offset,
+                $statements_executed_before_group === null
+                    ? null
+                    : $statements_executed_before_group + $statement_count,
             );
             $connection->commit();
             return $statement_count;
@@ -8710,6 +8734,7 @@ class ImportClient
                                         hash("sha256", $this->remote_reprint_api_url),
                                         $cursor,
                                         null,
+                                        null,
                                         'mysql',
                                     );
                                     $sql_buffer = "";
@@ -8938,7 +8963,8 @@ class ImportClient
             "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
             "`source_hash` CHAR(64) CHARACTER SET ascii NOT NULL," .
             "`source_cursor` MEDIUMTEXT NOT NULL," .
-            "`file_byte_offset` BIGINT UNSIGNED NULL" .
+            "`file_byte_offset` BIGINT UNSIGNED NULL," .
+            "`statements_executed` BIGINT UNSIGNED NULL" .
             ") ENGINE=InnoDB";
         $database->exec($create_table_sql);
     }
@@ -8963,8 +8989,9 @@ class ImportClient
      * @return array|null {
      *     The saved position, or null before the first committed group.
      *
-     *     @type string   $source_cursor    Exporter cursor after the group.
-     *     @type int|null $file_byte_offset First db.sql byte after the group marker.
+     *     @type string   $source_cursor       Exporter cursor after the group.
+     *     @type int|null $file_byte_offset    First db.sql byte after the group marker.
+     *     @type int|null $statements_executed Number of db.sql statements committed so far.
      * }
      */
     private function read_database_import_position(
@@ -8975,7 +9002,7 @@ class ImportClient
         $table = self::DATABASE_IMPORT_POSITION_TABLE;
         // No row means this target has not committed an SQL group for the
         // current import yet, so its reader starts from the beginning.
-        $query = "SELECT `source_hash`, `source_cursor`, `file_byte_offset` " .
+        $query = "SELECT `source_hash`, `source_cursor`, `file_byte_offset`, `statements_executed` " .
             "FROM `{$table}` WHERE `id` = 1";
         $result = $database->query($query);
         $row = $result->fetch(PDO::FETCH_ASSOC);
@@ -9002,9 +9029,23 @@ class ImportClient
                 );
             }
         }
+
+        $statements_executed = null;
+        if ($row["statements_executed"] !== null) {
+            $statements_executed = filter_var($row["statements_executed"], FILTER_VALIDATE_INT);
+            if ($statements_executed === false || $statements_executed < 0) {
+                // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Command is a validated CLI command name.
+                throw new RuntimeException(
+                    "The target database contains an invalid statement count for {$command}. " .
+                    "Run {$command} --abort to start again.",
+                );
+                // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            }
+        }
         return [
             "source_cursor" => $row["source_cursor"],
             "file_byte_offset" => $file_byte_offset,
+            "statements_executed" => $statements_executed,
         ];
     }
 
@@ -9017,13 +9058,15 @@ class ImportClient
         DatabaseConnection $database,
         string $source_hash,
         string $next_cursor,
-        ?int $next_file_byte_offset
+        ?int $next_file_byte_offset,
+        ?int $next_statements_executed
     ): void {
         $table = self::DATABASE_IMPORT_POSITION_TABLE;
         $database->execute(
             "REPLACE INTO `{$table}` " .
-            "(`id`, `source_hash`, `source_cursor`, `file_byte_offset`) VALUES (1, ?, ?, ?)",
-            [$source_hash, $next_cursor, $next_file_byte_offset],
+            "(`id`, `source_hash`, `source_cursor`, `file_byte_offset`, `statements_executed`) " .
+            "VALUES (1, ?, ?, ?, ?)",
+            [$source_hash, $next_cursor, $next_file_byte_offset, $next_statements_executed],
         );
     }
 

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -490,8 +490,7 @@ class Pull
                         $this->client->run_db_apply($options);
                     });
                 }
-                $stmts = $state->apply->statements_executed;
-                $this->print_done($stage, $stmts > 0 ? number_format($stmts) . " statements" : null);
+                $this->print_done($stage);
                 break;
 
             case 'flat-docroot':

--- a/packages/reprint-client/src/lib/state/class-database-apply-command-state.php
+++ b/packages/reprint-client/src/lib/state/class-database-apply-command-state.php
@@ -9,12 +9,6 @@ namespace Reprint\Importer\State;
  */
 class DatabaseApplyCommandState {
 
-    /** @var int SQL statements successfully executed. */
-    public int $statements_executed = 0;
-
-    /** @var int Bytes read from db.sql. */
-    public int $bytes_read = 0;
-
     /** @var array<string,string>|null URL rewrite map selected for db-apply. */
     public ?array $rewrite_url = null;
 
@@ -46,8 +40,6 @@ class DatabaseApplyCommandState {
     {
         $state = new self();
         \reprint_assert_state_keys($data, array_keys($state->to_array()), self::class);
-        $state->statements_executed = $data['statements_executed'];
-        $state->bytes_read = $data['bytes_read'];
         $state->rewrite_url = $data['rewrite_url'];
         $state->target_engine = $data['target_engine'];
         $state->target_db = $data['target_db'];
@@ -63,8 +55,6 @@ class DatabaseApplyCommandState {
     public function to_array(): array
     {
         return [
-            'statements_executed' => $this->statements_executed,
-            'bytes_read' => $this->bytes_read,
             'rewrite_url' => $this->rewrite_url,
             'target_engine' => $this->target_engine,
             'target_db' => $this->target_db,

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -474,7 +474,7 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertSame(strtoupper(bin2hex($bytes)), $rows[0]['hex_value']);
     }
 
-    public function testSqlitePragmasDoNotChangeProgressCounters(): void
+    public function testSqliteApplyDoesNotStoreTargetProgressInStateJson(): void
     {
         $remoteReprintApiUrl = 'https://old-site.example.com/?reprint-api';
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
@@ -526,7 +526,7 @@ class NewSiteUrlSqliteTest extends TestCase
             true
         );
         $this->assertSame('complete', $state['active_resumable_command']['completion_state']);
-        $this->assertSame(3, $state['apply']['statements_executed']);
-        $this->assertSame(0, $state['apply']['bytes_read']);
+        $this->assertArrayNotHasKey('statements_executed', $state['apply']);
+        $this->assertArrayNotHasKey('bytes_read', $state['apply']);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -132,7 +132,6 @@ class PullFilterFakeClient extends \ImportClient
         $state->active_resumable_command->command_name = "db-apply";
         $state->active_resumable_command->completion_state = "complete";
         $state->active_resumable_command->current_stage = null;
-        $state->apply->statements_executed = 42;
         $this->save_state();
     }
 }
@@ -687,7 +686,8 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('pull-db', $state["pull_pipeline"]["started_by_command"]);
         $this->assertSame('db-apply', $state["pull_pipeline"]["last_completed_stage"]);
         $this->assertSame('db-apply', $state["active_resumable_command"]["command_name"]);
-        $this->assertSame(42, $state["apply"]["statements_executed"]);
+        $this->assertArrayNotHasKey("statements_executed", $state["apply"]);
+        $this->assertArrayNotHasKey("bytes_read", $state["apply"]);
     }
 
     public function testPullDbRejectsConflictingInProgressPullFiles(): void

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -23,8 +23,6 @@ class PullStateTest extends TestCase
             'last_completed_stage' => 'preflight',
             'has_completed_once' => false,
         ];
-        $data['apply']['statements_executed'] = 12;
-        $data['apply']['bytes_read'] = 34;
         $data['apply']['target_engine'] = 'sqlite';
         $state = \PullState::from_array($data);
 
@@ -32,7 +30,8 @@ class PullStateTest extends TestCase
         $this->assertSame('partial', $state->active_resumable_command->completion_state);
         $this->assertSame('preflight', $state->pull_pipeline->last_completed_stage);
         $this->assertSame(['preflight', 'files-pull'], $state->pull_pipeline->stage_sequence);
-        $this->assertSame(12, $state->apply->statements_executed);
+        $this->assertArrayNotHasKey('statements_executed', $state->apply->to_array());
+        $this->assertArrayNotHasKey('bytes_read', $state->apply->to_array());
     }
 
     public function testStateRoundTripsToPersistedArraySchema(): void

--- a/tests/Import/SqliteSqlGroupImporterTest.php
+++ b/tests/Import/SqliteSqlGroupImporterTest.php
@@ -86,43 +86,24 @@ class SqliteSqlGroupImporterTest extends TestCase
             ],
         ]);
 
-        $sqlitePath = $this->sqlitePath;
         $firstApply = new class(
             $this->remoteUrl,
             $this->tempDir,
-            $this->tempDir . '/fs-root',
-            $sqlitePath
+            $this->tempDir . '/fs-root'
         ) extends \ImportClient {
-            private string $sqlitePath;
             private bool $stopped = false;
 
-            public function __construct(
-                string $remoteUrl,
-                string $stateDirectory,
-                string $filesystemRoot,
-                string $sqlitePath
-            ) {
-                parent::__construct($remoteUrl, $stateDirectory, $filesystemRoot);
-                $this->sqlitePath = $sqlitePath;
-            }
-
-            public function save_state(): void
+            public function output_progress(array $data, bool $force = false): void
             {
-                if (!$this->stopped && file_exists($this->sqlitePath)) {
-                    $database = new \PDO('sqlite:' . $this->sqlitePath);
-                    $statement = $database->query(
-                        'SELECT "attempts", "finished" FROM "import_probe" WHERE "id" = 1'
-                    );
-                    $row = $statement->fetch(\PDO::FETCH_ASSOC);
-                    $statement->closeCursor();
-                    unset($statement, $database);
-                    if ( (int) $row['attempts'] === 100 && (int) $row['finished'] === 0 ) {
-                        $this->stopped = true;
-                        throw new \RuntimeException('Stop after the first committed SQL group.');
-                    }
+                parent::output_progress($data, $force);
+                if (
+                    !$this->stopped
+                    && ( $data['phase'] ?? null ) === 'db-apply'
+                    && ( $data['statements_executed'] ?? null ) === 100
+                ) {
+                    $this->stopped = true;
+                    throw new \RuntimeException('Stop after the first committed SQL group.');
                 }
-
-                parent::save_state();
             }
         };
         $pullStateDirectory = $firstApply->pull_state_directory;
@@ -145,18 +126,20 @@ class SqliteSqlGroupImporterTest extends TestCase
         );
         $sqlite = new \PDO('sqlite:' . $this->sqlitePath);
         $position = $sqlite->query(
-            "SELECT `source_cursor`, `file_byte_offset` " .
-            "FROM `__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4`"
+            "SELECT `source_cursor`, `file_byte_offset`, `statements_executed` " .
+            "FROM `__reprint_db_pull_progress_725a0014-81eb-4827-acfb-5edb1b4f24d9`"
         )->fetch(\PDO::FETCH_ASSOC);
         $this->assertIsArray($position);
         $this->assertGreaterThan(0, (int) $position['file_byte_offset']);
+        $this->assertSame(100, (int) $position['statements_executed']);
         unset($sqlite);
 
         $localState = json_decode(
             file_get_contents($pullStateDirectory . '/state.json'),
             true
         );
-        $this->assertSame(0, $localState['apply']['bytes_read']);
+        $this->assertArrayNotHasKey('bytes_read', $localState['apply']);
+        $this->assertArrayNotHasKey('statements_executed', $localState['apply']);
         $this->assertNull($localState['active_resumable_command']['remote_cursor']);
 
         $this->runApply(new \ImportClient(
@@ -169,12 +152,97 @@ class SqliteSqlGroupImporterTest extends TestCase
             ['attempts' => 100, 'finished' => 1],
             $this->readProbe()
         );
+        $completedState = json_decode(
+            file_get_contents($pullStateDirectory . '/state.json'),
+            true
+        );
+        $this->assertArrayNotHasKey('bytes_read', $completedState['apply']);
+        $this->assertArrayNotHasKey('statements_executed', $completedState['apply']);
         $sqlite = new \PDO('sqlite:' . $this->sqlitePath);
         $positionTables = $sqlite->query(
             "SELECT COUNT(*) FROM sqlite_master " .
             "WHERE type = 'table' AND name LIKE '__reprint_db_pull_progress_%'"
         )->fetchColumn();
         $this->assertSame(0, (int) $positionTables);
+    }
+
+    public function testFinishesCleanupAfterTheTargetPositionWasRemoved(): void
+    {
+        $this->writeGroups([
+            [
+                'sql' => "UPDATE `import_probe` SET `attempts` = `attempts` + 1 WHERE `id` = 1;\n",
+                'cursor' => ['current_table' => 'import_probe'],
+            ],
+        ]);
+
+        $firstApply = new class(
+            $this->remoteUrl,
+            $this->tempDir,
+            $this->tempDir . '/fs-root'
+        ) extends \ImportClient {
+            private bool $stopped = false;
+
+            public function save_state(): void
+            {
+                $command = $this->get_state()->active_resumable_command;
+                if (
+                    !$this->stopped
+                    && $command->current_stage === 'database-cleanup'
+                    && $command->completion_state === 'complete'
+                ) {
+                    $this->stopped = true;
+                    throw new \RuntimeException(
+                        'Stop after removing the target position and before saving completion.'
+                    );
+                }
+
+                parent::save_state();
+            }
+        };
+        $pullStateDirectory = $firstApply->pull_state_directory;
+
+        try {
+            $this->runApply($firstApply);
+            $this->fail('The first db-apply should stop during final cleanup.');
+        } catch (\RuntimeException $error) {
+            $this->assertSame(
+                'Stop after removing the target position and before saving completion.',
+                $error->getMessage()
+            );
+        }
+        unset($firstApply, $error);
+        gc_collect_cycles();
+
+        $sqlite = new \PDO('sqlite:' . $this->sqlitePath);
+        $positionTables = $sqlite->query(
+            "SELECT COUNT(*) FROM sqlite_master " .
+            "WHERE type = 'table' AND name LIKE '__reprint_db_pull_progress_%'"
+        )->fetchColumn();
+        $this->assertSame(0, (int) $positionTables);
+        unset($sqlite);
+
+        $stoppedState = json_decode(
+            file_get_contents($pullStateDirectory . '/state.json'),
+            true
+        );
+        $this->assertSame('in_progress', $stoppedState['active_resumable_command']['completion_state']);
+        $this->assertSame('database-cleanup', $stoppedState['active_resumable_command']['current_stage']);
+        $this->assertArrayNotHasKey('bytes_read', $stoppedState['apply']);
+        $this->assertArrayNotHasKey('statements_executed', $stoppedState['apply']);
+        $this->assertSame(1, $this->readProbe()['attempts']);
+
+        $this->runApply(new \ImportClient(
+            $this->remoteUrl,
+            $this->tempDir,
+            $this->tempDir . '/fs-root'
+        ));
+
+        $completedState = json_decode(
+            file_get_contents($pullStateDirectory . '/state.json'),
+            true
+        );
+        $this->assertSame('complete', $completedState['active_resumable_command']['completion_state']);
+        $this->assertSame(1, $this->readProbe()['attempts']);
     }
 
     public function testRefusesATamperedUnfinishedStageBeforeExecutingSql(): void

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -29,7 +29,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
     );
     const applyCursorTable = 'zy_db_apply_cursor_rows';
     const sqlModeTable = 'zz_session_setup_sql_mode';
-    const progressTable = '__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4';
+    const progressTable = '__reprint_db_pull_progress_725a0014-81eb-4827-acfb-5edb1b4f24d9';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
     const importerPath = process.env.IMPORTER_PATH
@@ -251,11 +251,13 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
                 const hookState = readHookState(site);
                 try {
                     const [[savedPosition]] = await targetMonitor.query(
-                        'SELECT source_cursor, file_byte_offset FROM `' + progressTable + '` WHERE id = 1'
+                        'SELECT source_cursor, file_byte_offset, statements_executed '
+                        + 'FROM `' + progressTable + '` WHERE id = 1'
                     );
                     savedCursor = savedPosition?.source_cursor ?? null;
                     if (savedPosition) {
                         assert.equal(savedPosition.file_byte_offset, null);
+                        assert.equal(savedPosition.statements_executed, null);
                     }
                 } catch (error) {
                     if (error?.code !== 'ER_NO_SUCH_TABLE') {
@@ -368,6 +370,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
         let rowsVisibleBeforeKill = null;
         let cursorSavedBeforeKill = null;
         let fileByteOffsetSavedBeforeKill = null;
+        let statementsExecutedSavedBeforeKill = null;
         const targetMonitor = await createMysqlConnection(targetDb);
 
         try {
@@ -389,10 +392,12 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
                     );
                     if (Number(savedPosition.positionCount) === 1) {
                         const [[savedCursor]] = await targetMonitor.query(
-                            'SELECT source_cursor, file_byte_offset FROM `' + progressTable + '` WHERE id = 1'
+                            'SELECT source_cursor, file_byte_offset, statements_executed '
+                            + 'FROM `' + progressTable + '` WHERE id = 1'
                         );
                         cursorSavedBeforeKill = savedCursor.source_cursor;
                         fileByteOffsetSavedBeforeKill = Number(savedCursor.file_byte_offset);
+                        statementsExecutedSavedBeforeKill = Number(savedCursor.statements_executed);
                         const [[visibleRows]] = await targetMonitor.query(
                             `SELECT COUNT(*) AS rowCount FROM \`${applyCursorTable}\``
                         );
@@ -417,6 +422,10 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
             fileByteOffsetSavedBeforeKill,
             expectedFileByteOffset,
             'MySQL did not save the byte immediately after the matching db.sql marker',
+        );
+        assert.ok(
+            statementsExecutedSavedBeforeKill > 0,
+            'MySQL did not save the statement count with the db.sql position',
         );
         assert.ok(
             rowsVisibleBeforeKill < 301,
@@ -454,8 +463,8 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
                 join(pullStateDirectory(fileTempDir, importUrl()), 'state.json'),
                 'utf8',
             ));
-            assert.equal(completedState.apply.bytes_read, 0, 'db-apply copied the MySQL byte offset into local state');
-            assert.ok(completedState.apply.statements_executed > 0, 'db-apply did not save the statement count');
+            assert.equal('bytes_read' in completedState.apply, false, 'db-apply copied the MySQL byte offset into local state');
+            assert.equal('statements_executed' in completedState.apply, false, 'db-apply copied the statement count into local state');
             assert.equal(completedState.active_resumable_command.remote_cursor, null);
 
             const [[remainingProgressTable]] = await targetConnection.query(

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -29,7 +29,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     const myisamSourceTable = 'ab_target_cursor_myisam_rows';
     const unkeyedMyisamSourceTable = 'ac_target_cursor_unkeyed_myisam_rows';
     const afterUnkeyedSourceTable = 'ad_after_unkeyed_myisam_rows';
-    const progressTable = '__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4';
+    const progressTable = '__reprint_db_pull_progress_725a0014-81eb-4827-acfb-5edb1b4f24d9';
     const previousProgressTable = '__reprint_db_pull_progress_11111111-2222-4333-8444-555555555555';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
@@ -222,7 +222,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             );
             assert.deepEqual(
                 targetColumns.map(column => column.COLUMN_NAME),
-                ['id', 'source_hash', 'source_cursor', 'file_byte_offset'],
+                ['id', 'source_hash', 'source_cursor', 'file_byte_offset', 'statements_executed'],
             );
             const [[previousTable]] = await targetConnection.query(
                 'SELECT COUNT(*) AS tableCount FROM INFORMATION_SCHEMA.TABLES '
@@ -282,12 +282,14 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                             `SELECT COUNT(*) AS rowCount FROM \`${table}\``
                         );
                         const [[savedPosition]] = await interruptedTarget.query(
-                            `SELECT source_cursor, file_byte_offset FROM \`${progressTable}\` WHERE id = 1`
+                            'SELECT source_cursor, file_byte_offset, statements_executed '
+                            + `FROM \`${progressTable}\` WHERE id = 1`
                         );
                         importedRowCount = Number(importedRows.rowCount);
                         savedSourceCursor = savedPosition?.source_cursor ?? null;
                         if (savedPosition) {
                             assert.equal(savedPosition.file_byte_offset, null);
+                            assert.equal(savedPosition.statements_executed, null);
                         }
                         const expectedRowsArePresent = completedRowCount === null
                             ? importedRowCount > 0 && importedRowCount < 600


### PR DESCRIPTION
File-based `db-apply` now restores its exact statement count from the target database after a process stops.

For example, the target may commit this SQL group:

```text
imported rows
cursor = C100
db.sql byte offset = 48,210
statement count = 100
```

The PHP process may then stop before writing `state.json`. The next process already resumes the SQL at `C100`, but the old local counter starts too low and the final message reports the wrong number.

This adds `statements_executed` to the existing import-position row used by MySQL and SQLite. Each file-based SQL group saves its cursor, file offset, and cumulative statement count in the same target transaction as the imported SQL. It does not add another database write. Direct MySQL `db-pull` stores `NULL` because that path does not report an exact cumulative count.

`state.json` no longer stores `apply.bytes_read` or `apply.statements_executed`. The running PHP process keeps the count in memory. A replacement process reads the count from the target database. If the process stops after final cleanup has already removed the target row, all SQL is complete; the next process finishes cleanup and reports completion without inventing a number.

The SQLite tests stop after the target commits 100 statements, confirm that the disk JSON contains no apply cursor, offset, or count, and resume at 101. Another test stops after the target row is removed but before completion is saved, then confirms cleanup can finish without applying SQL again. The MySQL E2E tests check that file-based apply stores a count while direct output stores `NULL`.
