### PR TITLE
[PHP] Send file-fetch paths as base64 records

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -125,7 +125,7 @@ require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
  * multipart structure, header names, endpoint parameters, response format)
  * would break an older export plugin.
  */
-define('PULL_PROTOCOL_VERSION', 1);
+define('PULL_PROTOCOL_VERSION', 2);
 
 register_shutdown_function(function () {
     $error = error_get_last();
@@ -2693,7 +2693,16 @@ class ImportClient
             if ($tmp === false) {
                 continue;
             }
-            file_put_contents($tmp, json_encode($dir_files, JSON_UNESCAPED_SLASHES));
+            $encoded_files = [];
+            foreach ($dir_files as $remote_absolute_path) {
+                $encoded_files[] = [
+                    "path" => base64_encode($remote_absolute_path),
+                ];
+            }
+            file_put_contents(
+                $tmp,
+                json_encode($encoded_files, JSON_UNESCAPED_SLASHES)
+            );
 
             $post_data = [
                 "file_list" => new \CURLFile($tmp, "application/json", "file_list"),
@@ -8287,8 +8296,8 @@ class ImportClient
             fseek($handle, $offset);
         }
 
-        // The output is a temp file containing a JSON array of paths, e.g.
-        // ["/wp-content/uploads/photo.jpg","/wp-content/themes/flavor/style.css"]
+        // The output is a temp file containing a JSON array of base64 path
+        // records. Paths are arbitrary bytes and cannot appear directly in JSON.
         // This file gets uploaded as the request body for the file_fetch endpoint.
         $tmp = tempnam(sys_get_temp_dir(), "file-fetch-");
         if ($tmp === false) {
@@ -8304,9 +8313,7 @@ class ImportClient
 
         // Read lines from the fetch list (one JSON entry per line) and
         // accumulate them into the JSON array until we approach the size limit.
-        // The fetch list supports two formats:
-        //   - A bare JSON string:   "/path/to/file"
-        //   - A JSON object:        {"path": "<base64-encoded path>"}
+        // Each fetch-list entry is a JSON object whose path is base64 encoded.
         $bytes = 0;
         $entries = 0;
         $first = true;
@@ -8325,25 +8332,20 @@ class ImportClient
                 continue;
             }
             $decoded = json_decode($line, true);
-            if (is_string($decoded)) {
-                $path = $decoded;
-            } elseif (is_array($decoded) && isset($decoded["path"])) {
-                $path = base64_decode($decoded["path"]);
-            } else {
+            if (
+                !is_array($decoded)
+                || !isset($decoded["path"])
+                || !is_string($decoded["path"])
+                || $decoded["path"] === ""
+            ) {
                 continue;
             }
-            if (!is_string($path) || $path === "") {
-                continue;
-            }
-            $json_path = json_encode(
-                $path,
-                JSON_UNESCAPED_SLASHES,
+            $json_entry = json_encode(
+                ["path" => $decoded["path"]],
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
             );
-            if ($json_path === false) {
-                continue;
-            }
             $prefix = $first ? "" : ",";
-            $chunk = $prefix . $json_path;
+            $chunk = $prefix . $json_entry;
             $needed = $bytes + strlen($chunk) + 1; // +1 for closing bracket
 
             // Would this entry push us over the limit?

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -31,7 +31,7 @@ if (!ob_get_level()) {
  * protocol (cursor encoding, multipart structure, header names, endpoint
  * parameters, response format) would break an older importer.
  */
-define('EXPORT_PROTOCOL_VERSION', 1);
+define('EXPORT_PROTOCOL_VERSION', 2);
 
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);
@@ -2936,7 +2936,7 @@ function emit_file_index_error(
 }
 
 /**
- * Streams files from a client-provided path list (uploaded as JSON).
+ * Streams files from client-provided base64 path records uploaded as JSON.
  */
 function endpoint_file_fetch(
     array $config,
@@ -2972,14 +2972,25 @@ function endpoint_file_fetch(
     $decoded = json_decode($raw, true);
     if (!is_array($decoded)) {
         throw new InvalidArgumentException(
-            "file_list must be a JSON array of paths"
+            "file_list must be a JSON array of base64 path records"
         );
     }
     $paths = [];
-    foreach ($decoded as $path) {
-        if (!is_string($path) || $path === "") {
-            continue;
+    foreach ($decoded as $entry_index => $entry) {
+        $encoded_path = null;
+        if (is_array($entry)) {
+            $encoded_path = $entry["path"] ?? null;
         }
+        $path = is_string($encoded_path)
+            ? base64_decode($encoded_path, true)
+            : false;
+        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error, never HTML output.
+        if (!is_string($path) || $path === "") {
+            throw new InvalidArgumentException(
+                "file_list entry {$entry_index} must contain a nonempty base64 path"
+            );
+        }
+        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         $paths[] = $path;
     }
 

--- a/tests/FileFetchCompressionTest.php
+++ b/tests/FileFetchCompressionTest.php
@@ -35,6 +35,33 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertStringContainsString('pretend-jpeg-bytes', $stdout);
     }
 
+    public function testFileFetchRejectsRawJsonPaths(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-server/src/export.php';
+        $siteDir = $this->tempDir . '/site';
+        mkdir($siteDir, 0755, true);
+        $listPath = $this->tempDir . '/file-list.json';
+        file_put_contents(
+            $listPath,
+            json_encode([$siteDir . '/file.txt'], JSON_THROW_ON_ERROR)
+        );
+        $budget = new ResourceBudget(
+            microtime(true),
+            10,
+            128 * 1024 * 1024,
+            0.9
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'file_list entry 0 must contain a nonempty base64 path'
+        );
+        endpoint_file_fetch([
+            'directory' => $siteDir,
+            'file_list_path' => $listPath,
+        ], $budget);
+    }
+
     public function testFileFetchUsesGzipForTextOnlyPaths(): void
     {
         $siteDir = $this->tempDir . '/site';
@@ -340,7 +367,16 @@ final class FileFetchCompressionTest extends TestCase
     private function runFileFetch(string $siteDir, array $paths): string
     {
         $listPath = $this->tempDir . '/file-list.json';
-        file_put_contents($listPath, json_encode($paths, JSON_THROW_ON_ERROR));
+        $encodedPaths = array_map(
+            static function (string $path): array {
+                return ['path' => base64_encode($path)];
+            },
+            $paths
+        );
+        file_put_contents(
+            $listPath,
+            json_encode($encodedPaths, JSON_THROW_ON_ERROR)
+        );
 
         $configPath = $this->tempDir . '/config.json';
         file_put_contents($configPath, json_encode([

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -313,6 +313,58 @@ class FetchListProgressTest extends TestCase
         $this->assertSame(10, $batch['entries']);
         $this->assertSame(0, $batch['offset']);
         $this->assertGreaterThan(0, $batch['next_offset']);
+        $this->assertSame(
+            array_map(
+                static function (int $index): array {
+                    return [
+                        'path' => base64_encode("/file-{$index}.txt"),
+                    ];
+                },
+                range(0, 9)
+            ),
+            json_decode(
+                file_get_contents($batch['file']),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        if (file_exists($batch['file'])) {
+            @unlink($batch['file']);
+        }
+    }
+
+    public function testPrepareFetchBatchPreservesArbitraryPathBytes()
+    {
+        $listFile = $this->pullStateDirectory . '/fetch-list.jsonl';
+        $encodedPath = base64_encode("/binary-\xff.txt");
+        file_put_contents(
+            $listFile,
+            json_encode(["path" => $encodedPath], JSON_THROW_ON_ERROR) . "\n"
+        );
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $batch = $reflection->getMethod('prepare_fetch_batch')
+            ->invoke($client, $listFile, 0);
+
+        $this->assertNotNull($batch);
+        $this->assertSame(
+            [["path" => $encodedPath]],
+            json_decode(
+                file_get_contents($batch['file']),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )
+        );
 
         if (file_exists($batch['file'])) {
             @unlink($batch['file']);

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -104,6 +104,38 @@ final class FilesPullLocalIndexTest extends TestCase
         ]], $this->filesDiffRecords($diff['stdout']));
     }
 
+    public function testFilesPullTransfersAPathContainingInvalidUtf8Bytes(): void
+    {
+        $path = "binary-\xff.txt";
+        $probePath = $this->rawFileRoot . '/probe-' . $path;
+        if (@file_put_contents($probePath, 'probe') === false) {
+            $this->markTestSkipped(
+                'This filesystem does not accept invalid UTF-8 path bytes.'
+            );
+        }
+        unlink($probePath);
+        $contents = 'binary path contents';
+        $this->writeRemoteOverrides([
+            'added_files_b64' => [[
+                'path_b64' => base64_encode($path),
+                'contents_b64' => base64_encode($contents),
+            ]],
+        ]);
+
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(0, $pull['exit'], $pull['output']);
+        $this->assertFileExists($this->localTree . '/' . $path);
+        $this->assertSame(
+            $contents,
+            file_get_contents($this->localTree . '/' . $path)
+        );
+        $this->assertArrayHasKey(
+            $this->localIndexEntryPath($path),
+            $this->readIndex($this->localIndexPath())
+        );
+    }
+
     public function testEmptyInitialPullCreatesAnEmptyLocalIndex(): void
     {
         $this->writeRemoteOverrides([
@@ -741,12 +773,21 @@ foreach (($overrides['removed_paths'] ?? array()) as $removed_path) {
 foreach (($overrides['added_files'] ?? array()) as $path => $contents) {
     $remote_files[$path] = $contents;
 }
-$added_directories = array_fill_keys(
-    $overrides['added_directories'] ?? array(),
-    true
-);
 $added_files = array_fill_keys(
     array_keys($overrides['added_files'] ?? array()),
+    true
+);
+foreach (($overrides['added_files_b64'] ?? array()) as $encoded_file) {
+    $path = base64_decode($encoded_file['path_b64'] ?? '', true);
+    $contents = base64_decode($encoded_file['contents_b64'] ?? '', true);
+    if (!is_string($path) || $path === '' || !is_string($contents)) {
+        continue;
+    }
+    $remote_files[$path] = $contents;
+    $added_files[$path] = true;
+}
+$added_directories = array_fill_keys(
+    $overrides['added_directories'] ?? array(),
     true
 );
 $remote_index = array();
@@ -850,10 +891,19 @@ if ($endpoint === 'file_index') {
         isset($_FILES['file_list']['tmp_name'])
         && is_file($_FILES['file_list']['tmp_name'])
     ) {
-        $requested_paths = array_fill_keys(
-            json_decode((string) file_get_contents($_FILES['file_list']['tmp_name']), true),
+        $requested_paths = array();
+        $file_list = json_decode(
+            (string) file_get_contents($_FILES['file_list']['tmp_name']),
             true
         );
+        foreach ($file_list as $entry) {
+            $path = is_array($entry)
+                ? base64_decode($entry['path'] ?? '', true)
+                : false;
+            if (is_string($path) && $path !== '') {
+                $requested_paths[$path] = true;
+            }
+        }
     }
     $parts = array();
     foreach ($remote_index as $path => $entry) {

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -394,7 +394,9 @@ async function ensureFileBenchSite() {
 }
 
 async function runFileFetchScenario({ stage, site, filePath, params = {}, details = {} }) {
-    const fileListJson = JSON.stringify([filePath]);
+    const fileListJson = JSON.stringify([{
+        path: Buffer.from(filePath).toString('base64'),
+    }]);
     const formData = new FormData();
     formData.append(
         'file_list',

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -614,7 +614,7 @@ export function clearHookState(siteName) {
 }
 
 /**
- * Make a file_fetch request with a file_list upload.
+ * Make a file_fetch request with a base64 path record file_list upload.
  * Uses multipart/form-data to upload the file list as a file.
  */
 export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
@@ -625,7 +625,9 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
         url.searchParams.set(k, String(v));
     }
 
-    const fileListJson = JSON.stringify(filePaths);
+    const fileListJson = JSON.stringify(filePaths.map(path => ({
+        path: Buffer.from(path).toString('base64'),
+    })));
 
     // Create form data with file upload
     const formData = new FormData();

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     assertRemoteIndexEntryCount, assertSiteMirror,
-    fsRootDir,
+    fsRootDir, PHP_BINARY,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -92,7 +92,12 @@ describe('Import: Unicode Paths', () => {
 
     it('file hashes match source', () => {
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
-        assertTreesMatch(getSiteDir(site), importedRoot);
+        // Playground's mounted filesystem replaces invalid filename bytes.
+        // Native PHP tests cover that path, so compare the remaining tree here.
+        const exclude = PHP_BINARY.endsWith('/playground-php.sh')
+            ? ['test-data/invalid']
+            : [];
+        assertTreesMatch(getSiteDir(site), importedRoot, { exclude });
     });
 
     it('accounted for at least 3000 remote index entries', () => {


### PR DESCRIPTION
`file_fetch` now carries requested paths as base64 records, so a filename containing arbitrary bytes can reach the server without being placed directly in JSON text.

## Background

The fetch list already stored paths safely as base64. Before this PR, the client decoded each path and built a second JSON document containing the raw path:

```json
["/var/www/html/photo.jpg"]
```

That works for normal text. It cannot represent a path such as `/var/www/html/binary-\xff.txt`, because JSON strings must contain valid UTF-8. The client skipped that path while building the request.

## This change

The request now keeps the path encoded:

```json
[{"path":"L3Zhci93d3cvaHRtbC9iaW5hcnkt/y50eHQ="}]
```

The server strictly decodes each `path` before reading the file. Runtime-file requests and direct file-fetch helpers use the same record. Raw JSON path strings are rejected. The pull and export protocol versions move to 2 because the request body changed; this PR does not add an old-format parser.

## Testing

Focused tests check the exact request body, preserve a path containing invalid UTF-8 bytes through batch creation, reject the old raw-string form, retain file-fetch compression behavior, and run files-pull against a local HTTP endpoint. The HTTP filesystem test runs the raw-byte filename on Linux and skips platforms that reject such names. Playground's mounted filesystem rewrites invalid filename bytes, so its tree comparison excludes that one path while still checking every other file.
