### PR TITLE
[PHP] Cover files-pull mirror convergence and restart boundaries

### DIFF
--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -2,12 +2,37 @@
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
 // phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match the existing importer test class style.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Test-only client and interruption exception live with their test.
 
 namespace ImportTests;
 
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/** Stops after the replacement fetch list is published but before its stage is saved. */
+final class SimulatedStopBeforeMirrorFetchStageSave extends \RuntimeException
+{
+}
+
+/** Stops files-pull at the publication boundary selected by the test. */
+final class MirrorFetchPublicationTestClient extends \ImportClient
+{
+    public bool $throw_before_fetch_stage_save = false;
+
+    public function save_state(): void
+    {
+        if (
+            $this->throw_before_fetch_stage_save
+            && $this->get_state()->active_resumable_command->current_stage
+                === 'fetch'
+        ) {
+            $this->throw_before_fetch_stage_save = false;
+            throw new SimulatedStopBeforeMirrorFetchStageSave();
+        }
+        parent::save_state();
+    }
+}
 
 /**
  * The local index used by files-pull, files-push, and files-diff.
@@ -248,6 +273,445 @@ final class FilesPullLocalIndexTest extends TestCase
                 ),
             ],
         ], $records);
+    }
+
+    public function testMirrorRestoresLocalChangesAndRemovesLocalOnlyPaths(): void
+    {
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+
+        $samePath = $this->localTree . '/unchanged.txt';
+        $sameCtime = filectime($samePath);
+        $this->assertIsInt($sameCtime);
+        while (time() <= $sameCtime) {
+            usleep(20000);
+        }
+        file_put_contents($samePath, 'edit');
+        $this->assertSame(4, filesize($samePath));
+
+        $localTypeChange = $this->localTree . '/edited.txt';
+        unlink($localTypeChange);
+        mkdir($localTypeChange);
+        file_put_contents($localTypeChange . '/local-child.txt', 'local');
+
+        unlink($this->localTree . '/deleted.txt');
+        $localOnlyRoot = $this->localTree . '/local-only';
+        mkdir($localOnlyRoot . '/nested', 0700, true);
+        file_put_contents($localOnlyRoot . '/nested/file.txt', 'local');
+        $localOnlySibling = $this->localTree . '/folder/local-only.txt';
+        file_put_contents($localOnlySibling, 'local sibling');
+
+        $pulledContents = 'remote change delivered by mirror';
+        file_put_contents(
+            $this->localTree . '/' . self::PULLED_PATH,
+            'local change to the same remote-changed path'
+        );
+        $this->writeRemoteOverrides([
+            'pulled_ctime' => self::REMOTE_CTIME + 1,
+            'pulled_contents_b64' => base64_encode($pulledContents),
+        ]);
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame('same', file_get_contents($samePath));
+        $this->assertFileExists($localTypeChange);
+        $this->assertFalse(is_dir($localTypeChange));
+        $this->assertSame(
+            $this->remoteFiles['edited.txt'],
+            file_get_contents($localTypeChange)
+        );
+        $this->assertSame(
+            $this->remoteFiles['deleted.txt'],
+            file_get_contents($this->localTree . '/deleted.txt')
+        );
+        $this->assertSame(
+            $pulledContents,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $this->assertDirectoryDoesNotExist($localOnlyRoot);
+        $this->assertFileDoesNotExist($localOnlySibling);
+        $this->assertSame(
+            $this->remoteFiles['folder/remote-deleted.txt'],
+            file_get_contents(
+                $this->localTree . '/folder/remote-deleted.txt'
+            )
+        );
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testInitialMirrorConvergesANonemptyLocalTree(): void
+    {
+        mkdir($this->localTree . '/local-only', 0700, true);
+        file_put_contents(
+            $this->localTree . '/local-only/file.txt',
+            'local only'
+        );
+        file_put_contents($this->localTree . '/unchanged.txt', 'local');
+
+        $mirror = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree . '/local-only');
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+        $this->assertSame(
+            $this->remoteFiles['edited.txt'],
+            file_get_contents($this->localTree . '/edited.txt')
+        );
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testMirrorWithAnEmptyRemoteIndexRemovesTheLocalTree(): void
+    {
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        file_put_contents($this->localTree . '/local-only.txt', 'local');
+        $this->writeRemoteOverrides([
+            'removed_paths' => array_merge(
+                array_keys($this->remoteFiles),
+                [self::PULLED_PATH]
+            ),
+        ]);
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree);
+        $this->assertSame([], $this->readIndex($this->localIndexPath()));
+    }
+
+    /**
+     * @dataProvider mirrorIncompatibleOptionProvider
+     * @param list<string> $arguments
+     */
+    public function testMirrorRejectsPartialPathSelectionBeforeStarting(
+        array $arguments
+    ): void
+    {
+        $mirror = $this->runFilesPull(
+            array_merge(['--mode=mirror'], $arguments)
+        );
+
+        $this->assertSame(1, $mirror['exit'], $mirror['output']);
+        $this->assertStringContainsString(
+            '--mode=mirror requires a full pull',
+            $mirror['output']
+        );
+        $savedState = json_decode(
+            file_get_contents($this->pullStateDirectory . '/state.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('catch-up', $savedState['files_pull_mode']);
+        $this->assertNull(
+            $savedState['active_resumable_command']['command_name']
+        );
+    }
+
+    /** @return iterable<string,array{list<string>}> */
+    public static function mirrorIncompatibleOptionProvider(): iterable
+    {
+        yield 'included path' => [[
+            '--include=/var/www/html/selected',
+        ]];
+        yield 'excluded path' => [[
+            '--exclude=/var/www/html/ignored',
+        ]];
+        yield 'default skipped paths' => [[
+            '--include-caches',
+        ]];
+        yield 'partial filter' => [[
+            '--filter=essential-files',
+        ]];
+        yield 'preserved local paths' => [[
+            '--on-fs-root-nonempty=preserve-local',
+        ]];
+    }
+
+    public function testMirrorRejectsAStateDirectoryInsideTheFilesystemRoot(): void
+    {
+        $mirror = $this->runCli([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->rawFileRoot . '/state-inside',
+            '--fs-root=' . $this->rawFileRoot,
+            '--mode=mirror',
+        ]);
+
+        $this->assertSame(1, $mirror['exit'], $mirror['output']);
+        $this->assertStringContainsString(
+            '--mode=mirror requires --state-dir to be outside --fs-root.',
+            $mirror['output']
+        );
+    }
+
+    public function testMirrorUsesRemotePathsAfterLocalRemapping(): void
+    {
+        $arguments = [
+            '--mode=mirror',
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/var/www/html/remapped',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+
+        $remappedRoot = $this->localTree . '/remapped';
+        file_put_contents($remappedRoot . '/unchanged.txt', 'local edit');
+        unlink($remappedRoot . '/deleted.txt');
+        mkdir($remappedRoot . '/local-only', 0700, true);
+        file_put_contents(
+            $remappedRoot . '/local-only/file.txt',
+            'local only'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($remappedRoot . '/unchanged.txt')
+        );
+        $this->assertSame(
+            $this->remoteFiles['deleted.txt'],
+            file_get_contents($remappedRoot . '/deleted.txt')
+        );
+        $this->assertDirectoryDoesNotExist($remappedRoot . '/local-only');
+
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0][
+            'local_paths_to_push'
+        ]);
+        $this->assertSame(0, $this->filesDiffRecords($diff['stdout'])[0][
+            'local_paths_to_delete'
+        ]);
+    }
+
+    public function testMirrorRestartsAnInterruptedLocalIndexStage(): void
+    {
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->abortFilesPull();
+
+        $localOnlyRoot = $this->localTree . '/many-local-only-files';
+        $this->createManyLocalOnlyFiles($localOnlyRoot);
+
+        [$process, $pipes] = $this->startCliProcess([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+            '--mode=mirror',
+        ]);
+        $freshLocalIndex = $this->pullStateDirectory
+            . '/mirror-plan/fresh-local-index.jsonl';
+        $deadline = microtime(true) + 10;
+        $savedStage = null;
+        while (microtime(true) < $deadline) {
+            clearstatcache(true, $freshLocalIndex);
+            $savedState = json_decode(
+                (string) file_get_contents(
+                    $this->pullStateDirectory . '/state.json'
+                ),
+                true
+            );
+            $savedStage = is_array($savedState)
+                ? $savedState['active_resumable_command']['current_stage'] ?? null
+                : null;
+            if (
+                $savedStage === 'local-index'
+                && is_file($freshLocalIndex)
+                && filesize($freshLocalIndex) > 0
+            ) {
+                break;
+            }
+            usleep(1000);
+        }
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+        $this->assertSame('local-index', $savedStage);
+        $this->assertFileExists($freshLocalIndex);
+        $this->assertGreaterThan(0, filesize($freshLocalIndex));
+
+        $modeChange = $this->runFilesPull(['--mode=catch-up']);
+        $this->assertSame(1, $modeChange['exit'], $modeChange['output']);
+        $this->assertStringContainsString(
+            'Cannot change --mode after files-pull starts.',
+            $modeChange['output']
+        );
+
+        $resumed = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertDirectoryDoesNotExist($localOnlyRoot);
+        $this->assertSame(
+            'complete',
+            json_decode(
+                file_get_contents($this->pullStateDirectory . '/state.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )['active_resumable_command']['completion_state']
+        );
+    }
+
+    public function testMirrorRestartsAfterAnInterruptedLocalDeletionPass(): void
+    {
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->abortFilesPull();
+
+        $localOnlyRoot = $this->localTree . '/many-local-only-files';
+        $this->createManyLocalOnlyFiles($localOnlyRoot);
+
+        [$process, $pipes] = $this->startCliProcess([
+            'files-pull',
+            $this->targetUrl,
+            '--state-dir=' . $this->stateDirectory,
+            '--fs-root=' . $this->rawFileRoot,
+            '--mode=mirror',
+        ]);
+        $walPath = $this->pullStateDirectory . '/index.wal';
+        $deadline = microtime(true) + 10;
+        $savedStage = null;
+        while (microtime(true) < $deadline) {
+            clearstatcache(true, $walPath);
+            $savedState = json_decode(
+                (string) file_get_contents(
+                    $this->pullStateDirectory . '/state.json'
+                ),
+                true
+            );
+            $savedStage = is_array($savedState)
+                ? $savedState['active_resumable_command']['current_stage'] ?? null
+                : null;
+            if (
+                $savedStage === 'mirror'
+                && is_file($walPath)
+                && filesize($walPath) > 0
+            ) {
+                break;
+            }
+            usleep(1000);
+        }
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+        $this->assertSame('mirror', $savedStage);
+        $this->assertFileExists($walPath);
+        $this->assertGreaterThan(0, filesize($walPath));
+
+        $resumed = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertDirectoryDoesNotExist($localOnlyRoot);
+        $diff = $this->runFilesDiff();
+        $this->assertSame(0, $diff['exit'], $diff['output']);
+        $this->assertSame([[
+            'command' => 'files-diff',
+            'status' => 'complete',
+            'local_paths_to_push' => 0,
+            'local_paths_to_delete' => 0,
+        ]], $this->filesDiffRecords($diff['stdout']));
+    }
+
+    public function testMirrorResumesAfterPublishingTheFetchListBeforeSavingItsStage(): void
+    {
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->abortFilesPull();
+
+        file_put_contents($this->localTree . '/unchanged.txt', 'local edit');
+        mkdir($this->localTree . '/local-only');
+        file_put_contents(
+            $this->localTree . '/local-only/file.txt',
+            'local only'
+        );
+
+        $client = new MirrorFetchPublicationTestClient(
+            $this->targetUrl,
+            $this->stateDirectory,
+            $this->rawFileRoot,
+            'files-pull'
+        );
+        $client->throw_before_fetch_stage_save = true;
+        $processLock = new \ReprintProcessLock($this->stateDirectory);
+        ob_start();
+        try {
+            $client->run([
+                'command' => 'files-pull',
+                'files_pull_mode' => 'mirror',
+            ], $processLock);
+            $this->fail(
+                'Expected files-pull to stop before saving the fetch stage.'
+            );
+        } catch (SimulatedStopBeforeMirrorFetchStageSave $error) {
+            $this->assertSame(
+                'mirror',
+                json_decode(
+                    file_get_contents(
+                        $this->pullStateDirectory . '/state.json'
+                    ),
+                    true,
+                    512,
+                    JSON_THROW_ON_ERROR
+                )['active_resumable_command']['current_stage']
+            );
+        } finally {
+            $processLock->close();
+            ob_end_clean();
+        }
+
+        $this->assertFileExists(
+            $this->pullStateDirectory . '/fetch-list.jsonl'
+        );
+        $this->assertFileDoesNotExist(
+            $this->pullStateDirectory . '/fetch-list.next.jsonl'
+        );
+
+        $resumed = $this->runFilesPull(['--mode=mirror']);
+
+        $this->assertSame(0, $resumed['exit'], $resumed['output']);
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+        $this->assertDirectoryDoesNotExist($this->localTree . '/local-only');
+        $this->assertSame(
+            'complete',
+            json_decode(
+                file_get_contents($this->pullStateDirectory . '/state.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )['active_resumable_command']['completion_state']
+        );
     }
 
     public function testResumeReplaysTheWALIntoTheLocalIndex(): void
@@ -515,6 +979,22 @@ final class FilesPullLocalIndexTest extends TestCase
         ]);
     }
 
+    private function createManyLocalOnlyFiles(string $directory): void
+    {
+        mkdir($directory, 0700, true);
+        for ($index = 0; $index < 5000; ++$index) {
+            file_put_contents(
+                $directory . '/' . str_pad(
+                    (string) $index,
+                    5,
+                    '0',
+                    STR_PAD_LEFT
+                ),
+                'local'
+            );
+        }
+    }
+
     private function assertLocalIndexMatches(string $path): void
     {
         $stat = lstat($this->localTree . '/' . $path);
@@ -741,12 +1221,12 @@ foreach (($overrides['removed_paths'] ?? array()) as $removed_path) {
 foreach (($overrides['added_files'] ?? array()) as $path => $contents) {
     $remote_files[$path] = $contents;
 }
-$added_directories = array_fill_keys(
-    $overrides['added_directories'] ?? array(),
-    true
-);
 $added_files = array_fill_keys(
     array_keys($overrides['added_files'] ?? array()),
+    true
+);
+$added_directories = array_fill_keys(
+    $overrides['added_directories'] ?? array(),
     true
 );
 $remote_index = array();

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -479,6 +479,47 @@ class PullFilterOptionTest extends TestCase
         $this->assertSame('essential-files', $state["filter"]);
     }
 
+    public function testPullFilesPassesMirrorModeToTheFileStage(): void
+    {
+        $client = $this->makeClient();
+
+        ob_start();
+        $client->run([
+            "command" => "pull-files",
+            "files_pull_mode" => "mirror",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->files_pull_runs);
+        $this->assertSame('mirror', $state['files_pull_mode']);
+        $this->assertSame(
+            'files-pull',
+            $state['pull_pipeline']['last_completed_stage']
+        );
+    }
+
+    public function testPullPassesMirrorModeToTheFileStage(): void
+    {
+        $client = $this->makeClient();
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "files_pull_mode" => "mirror",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame(1, $client->files_pull_runs);
+        $this->assertSame('mirror', $state['files_pull_mode']);
+        $this->assertSame(
+            'db-apply',
+            $state['pull_pipeline']['last_completed_stage']
+        );
+    }
+
     public function testPullFilesDoesNotAdvancePastFailedPreflight(): void
     {
         $client = new PullFailingPreflightFakeClient($this->stateDir, $this->filesystem_root);

--- a/tests/Import/PullStateTest.php
+++ b/tests/Import/PullStateTest.php
@@ -69,6 +69,29 @@ class PullStateTest extends TestCase
         $this->assertSame('mirror', \PullState::from_array($array)->files_pull_mode);
     }
 
+    public function testStateDefaultsAnOlderMissingFilesPullModeToCatchUp(): void
+    {
+        $array = ( new \PullState() )->to_array();
+        unset($array['files_pull_mode']);
+
+        $this->assertSame(
+            'catch-up',
+            \PullState::from_array($array)->files_pull_mode
+        );
+    }
+
+    public function testStateRejectsAnUnknownFilesPullMode(): void
+    {
+        $array = ( new \PullState() )->to_array();
+        $array['files_pull_mode'] = 'partial';
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'PullState files_pull_mode must be mirror or catch-up.'
+        );
+        \PullState::from_array($array);
+    }
+
     public function testGetAppliesDefaultsOverVerbatimPreflight(): void
     {
         $state = new \PullState();

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -151,6 +151,9 @@
     },
     "budgeted-mysql-sql-groups": {
       "port": 8129
+    },
+    "files-pull-mirror": {
+      "port": 8130
     }
   }
 }

--- a/tests/e2e/tests/import-59-files-pull-mirror.test.js
+++ b/tests/e2e/tests/import-59-files-pull-mirror.test.js
@@ -1,0 +1,357 @@
+/**
+ * Test 59: files-pull mirror and catch-up modes
+ *
+ * Uses the real CLI and HTTP endpoint to check the difference between the two
+ * modes. Mirror restores the current remote tree after local changes. Catch-up
+ * keeps those same local changes when the remote index did not change.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    unlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+    assertTreesMatch,
+    cleanupTempDir,
+    clearHookState,
+    createTempDir,
+    fsRootDir,
+    getSiteDir,
+    getSiteSecret,
+    getSiteUrl,
+    pullStateDirectory,
+    removeTestHooks,
+    runImporter,
+    writeHookState,
+    writeTestHooks,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, () => {
+    const site = 'files-pull-mirror';
+    let mirrorTempDir;
+    let catchUpTempDir;
+    let nonemptyMirrorTempDir;
+    let remappedMirrorTempDir;
+
+    const remoteConflictFile = join(
+        getSiteDir(site),
+        'test-data',
+        'local-and-remote-change.txt',
+    );
+    const remoteDeletedFile = join(
+        getSiteDir(site),
+        'test-data',
+        'deleted-remotely.txt',
+    );
+    const remoteAddedFile = join(
+        getSiteDir(site),
+        'test-data',
+        'added-remotely.txt',
+    );
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                writeFileSync(
+                    join(siteDir, 'test-data', 'local-and-remote-change.txt'),
+                    'initial remote content\n',
+                );
+                writeFileSync(
+                    join(siteDir, 'test-data', 'deleted-remotely.txt'),
+                    'present before remote deletion\n',
+                );
+            },
+        });
+        mirrorTempDir = createTempDir('e2e-files-pull-mirror');
+        catchUpTempDir = createTempDir('e2e-files-pull-catch-up');
+        nonemptyMirrorTempDir = createTempDir('e2e-files-pull-mirror-nonempty');
+        remappedMirrorTempDir = createTempDir('e2e-files-pull-mirror-remapped');
+        clearHookState(site);
+        removeTestHooks(site);
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(mirrorTempDir);
+        cleanupTempDir(catchUpTempDir);
+        cleanupTempDir(nonemptyMirrorTempDir);
+        cleanupTempDir(remappedMirrorTempDir);
+        writeRemoteFile(remoteConflictFile, 'initial remote content\n');
+        writeRemoteFile(remoteDeletedFile, 'present before remote deletion\n');
+        removeRemotePath(remoteAddedFile);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    function localSiteRoot(tempDir) {
+        return join(fsRootDir(tempDir), getSiteDir(site));
+    }
+
+    function changeLocalTree(localRoot) {
+        writeFileSync(join(localRoot, 'test-data', 'hello.txt'), 'local edit\n');
+        unlinkSync(join(localRoot, 'test-data', 'subdir', 'nested', 'deep.txt'));
+        mkdirSync(join(localRoot, 'test-data', 'local-only'), { recursive: true });
+        writeFileSync(
+            join(localRoot, 'test-data', 'local-only', 'debug.log'),
+            'local only\n',
+        );
+    }
+
+    function writeRemoteFile(path, contents) {
+        execFileSync('sudo', ['tee', path], {
+            input: contents,
+            stdio: ['pipe', 'ignore', 'pipe'],
+        });
+    }
+
+    function removeRemotePath(path) {
+        execFileSync('sudo', ['rm', '-rf', path]);
+    }
+
+    function runFilesPull(tempDir, mode, options = {}) {
+        return runImporter(importUrl(), tempDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            timeout: 180000,
+            wallTimeout: 240000,
+            ...options,
+            extraArgs: [`--mode=${mode}`, ...(options.extraArgs || [])],
+        });
+    }
+
+    function resetCompletedFilesPull(tempDir) {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--abort'],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `Failed to start the next files-pull\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+    }
+
+    it('downloads the same remote tree in both modes', () => {
+        for (const [tempDir, mode] of [
+            [mirrorTempDir, 'mirror'],
+            [catchUpTempDir, 'catch-up'],
+        ]) {
+            const result = runFilesPull(tempDir, mode);
+            assert.equal(
+                result.exitCode,
+                0,
+                `${mode} initial pull failed\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+            );
+            assertTreesMatch(getSiteDir(site), localSiteRoot(tempDir));
+        }
+    });
+
+    it('replaces an existing local tree during the first mirror', () => {
+        const localRoot = localSiteRoot(nonemptyMirrorTempDir);
+        mkdirSync(join(localRoot, 'test-data', 'local-only'), { recursive: true });
+        writeFileSync(join(localRoot, 'test-data', 'hello.txt'), 'old local content\n');
+        writeFileSync(
+            join(localRoot, 'test-data', 'local-only', 'debug.log'),
+            'local only\n',
+        );
+
+        const result = runFilesPull(nonemptyMirrorTempDir, 'mirror');
+        assert.equal(
+            result.exitCode,
+            0,
+            `Initial nonempty mirror failed\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+        assertTreesMatch(getSiteDir(site), localRoot);
+    });
+
+    it('resumes an interrupted mirror and restores the current remote tree', () => {
+        resetCompletedFilesPull(mirrorTempDir);
+        changeLocalTree(localSiteRoot(mirrorTempDir));
+
+        writeTestHooks(site, [
+            'function test_hook_during_dir_scan($dir, &$entries) {',
+            "    $state_file = '/srv/e2e-sites/.e2e-hook-state-files-pull-mirror';",
+            "    $state = file_exists($state_file) ? json_decode(file_get_contents($state_file), true) : [];",
+            "    $count = ($state['scan_count'] ?? 0) + 1;",
+            "    $state['scan_count'] = $count;",
+            '    file_put_contents($state_file, json_encode($state));',
+            '    if ($count === 5) {',
+            '        exit(1);',
+            '    }',
+            '}',
+        ].join('\n'));
+        writeHookState(site, { scan_count: 0 });
+
+        const interrupted = runFilesPull(mirrorTempDir, 'mirror', {
+            autoResume: false,
+        });
+        assert.equal(
+            interrupted.exitCode,
+            2,
+            `Expected an interrupted mirror pull\nstderr: ${interrupted.stderr}\nstdout: ${interrupted.stdout}`,
+        );
+
+        const interruptedState = JSON.parse(readFileSync(
+            join(pullStateDirectory(mirrorTempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
+        assert.equal(interruptedState.active_resumable_command.current_stage, 'index');
+        assert.equal(interruptedState.active_resumable_command.completion_state, 'partial');
+
+        removeTestHooks(site);
+        const resumed = runFilesPull(mirrorTempDir, 'mirror');
+        assert.equal(
+            resumed.exitCode,
+            0,
+            `Mirror resume failed\nstderr: ${resumed.stderr}\nstdout: ${resumed.stdout}`,
+        );
+
+        assertTreesMatch(getSiteDir(site), localSiteRoot(mirrorTempDir));
+        assert.ok(
+            !existsSync(join(localSiteRoot(mirrorTempDir), 'test-data', 'local-only')),
+            'Mirror should remove the local-only directory',
+        );
+    });
+
+    it('catch-up keeps local changes when the remote index did not change', () => {
+        resetCompletedFilesPull(catchUpTempDir);
+        changeLocalTree(localSiteRoot(catchUpTempDir));
+
+        const result = runFilesPull(catchUpTempDir, 'catch-up');
+        assert.equal(
+            result.exitCode,
+            0,
+            `Catch-up pull failed\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+
+        const localRoot = localSiteRoot(catchUpTempDir);
+        assert.equal(
+            readFileSync(join(localRoot, 'test-data', 'hello.txt'), 'utf-8'),
+            'local edit\n',
+        );
+        assert.ok(
+            !existsSync(join(localRoot, 'test-data', 'subdir', 'nested', 'deep.txt')),
+            'Catch-up should keep the local deletion',
+        );
+        assert.equal(
+            readFileSync(
+                join(localRoot, 'test-data', 'local-only', 'debug.log'),
+                'utf-8',
+            ),
+            'local only\n',
+        );
+    });
+
+    it('mirrors remote paths into a remapped local root', () => {
+        const remapArgs = [
+            '--remap',
+            ':abspath:',
+            ':fs-root:/site',
+        ];
+        const remappedLocalRoot = join(fsRootDir(remappedMirrorTempDir), 'site');
+
+        const initial = runFilesPull(remappedMirrorTempDir, 'mirror', {
+            extraArgs: remapArgs,
+        });
+        assert.equal(
+            initial.exitCode,
+            0,
+            `Initial remapped mirror failed\nstderr: ${initial.stderr}\nstdout: ${initial.stdout}`,
+        );
+        assertTreesMatch(getSiteDir(site), remappedLocalRoot);
+
+        resetCompletedFilesPull(remappedMirrorTempDir);
+        changeLocalTree(remappedLocalRoot);
+        const repeated = runFilesPull(remappedMirrorTempDir, 'mirror', {
+            extraArgs: remapArgs,
+        });
+        assert.equal(
+            repeated.exitCode,
+            0,
+            `Repeated remapped mirror failed\nstderr: ${repeated.stderr}\nstdout: ${repeated.stdout}`,
+        );
+        assertTreesMatch(getSiteDir(site), remappedLocalRoot);
+    });
+
+    it('applies remote additions, deletions, and conflicts on both modes', () => {
+        resetCompletedFilesPull(mirrorTempDir);
+        resetCompletedFilesPull(catchUpTempDir);
+
+        const mirrorLocalRoot = localSiteRoot(mirrorTempDir);
+        const catchUpLocalRoot = localSiteRoot(catchUpTempDir);
+        const mirrorConflictPath = join(
+            mirrorLocalRoot,
+            'test-data',
+            'local-and-remote-change.txt',
+        );
+        rmSync(mirrorConflictPath);
+        mkdirSync(mirrorConflictPath);
+        writeFileSync(join(mirrorConflictPath, 'local-child.txt'), 'local directory\n');
+        writeFileSync(
+            join(catchUpLocalRoot, 'test-data', 'local-and-remote-change.txt'),
+            'conflicting local content\n',
+        );
+        writeFileSync(
+            join(mirrorLocalRoot, 'test-data', 'deleted-remotely.txt'),
+            'locally edited before remote deletion\n',
+        );
+        writeFileSync(
+            join(catchUpLocalRoot, 'test-data', 'deleted-remotely.txt'),
+            'locally edited before remote deletion\n',
+        );
+
+        writeRemoteFile(remoteConflictFile, 'new content from remote\n');
+        removeRemotePath(remoteDeletedFile);
+        writeRemoteFile(remoteAddedFile, 'new remote file\n');
+
+        for (const [tempDir, mode] of [
+            [mirrorTempDir, 'mirror'],
+            [catchUpTempDir, 'catch-up'],
+        ]) {
+            const result = runFilesPull(tempDir, mode);
+            assert.equal(
+                result.exitCode,
+                0,
+                `${mode} remote-delta pull failed\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+            );
+
+            const localRoot = localSiteRoot(tempDir);
+            const conflictPath = join(
+                localRoot,
+                'test-data',
+                'local-and-remote-change.txt',
+            );
+            assert.ok(lstatSync(conflictPath).isFile());
+            assert.equal(readFileSync(conflictPath, 'utf-8'), 'new content from remote\n');
+            assert.ok(
+                !existsSync(join(localRoot, 'test-data', 'deleted-remotely.txt')),
+                `${mode} should apply the remote deletion`,
+            );
+            assert.equal(
+                readFileSync(join(localRoot, 'test-data', 'added-remotely.txt'), 'utf-8'),
+                'new remote file\n',
+            );
+        }
+
+        assertTreesMatch(getSiteDir(site), mirrorLocalRoot);
+        assert.equal(
+            readFileSync(
+                join(catchUpLocalRoot, 'test-data', 'local-only', 'debug.log'),
+                'utf-8',
+            ),
+            'local only\n',
+            'Catch-up should still keep a local-only path after applying remote changes',
+        );
+    });
+});


### PR DESCRIPTION
Adds regression coverage for files-pull mirror mode after #633.

The HTTP-backed tests cover an initial nonempty local tree, an empty remote index, same-size local edits, local type changes, local deletions restored from remote, local-only removals, remote changes, path remapping, and options which mirror mode rejects.

The interruption tests stop during the local index scan, during the local deletion pass, and after the replacement fetch list has moved into place but before the next stage is saved. Each resumed pull must finish with an empty files-diff result. Pull pipeline tests also confirm that `pull-files` and `pull` pass mirror mode to their file stage, and PullState tests cover its default and invalid values.

A new E2E test runs the real CLI against the real HTTP endpoint. It covers an empty and an existing local tree, local edits and deletions, local-only paths, remote additions and deletions, simultaneous local and remote changes, a local directory replaced by a remote file, a remapped local root, and an interrupted remote-index request followed by resume. The same local changes are also run through catch-up mode so the test checks the intended difference: mirror restores the current remote tree, while catch-up keeps local changes when the remote index did not change but still applies later remote changes.

Arbitrary filename bytes remain covered by #652. Parent-symlink removal remains tracked separately in #650.

## Testing

The focused PHPUnit suite passes with 64 tests and 650 assertions. The E2E test is exercised by the repository's PHP-version and Playground CLI matrices.
