### PR TITLE
[PHP] Add one target database API for mysqli and PDO

### DIFF
--- a/packages/reprint-client/src/lib/database/class-mysqli-database-connection.php
+++ b/packages/reprint-client/src/lib/database/class-mysqli-database-connection.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use mysqli;
+use mysqli_result;
+use mysqli_sql_exception;
+use PDOException;
+use RuntimeException;
+
+/** Presents a PDO-shaped target database API while using mysqli internally. */
+class MysqliDatabaseConnection implements DatabaseConnection {
+
+    private ?mysqli $database;
+    private bool $transaction_open = false;
+
+    public function __construct(mysqli $database)
+    {
+        $this->database = $database;
+    }
+
+    public function query(string $sql): DatabaseResult
+    {
+        return $this->run_mysqli_operation('query', function () use ($sql): DatabaseResult {
+            $result = $this->get_database()->query($sql);
+            if (!$result instanceof mysqli_result) {
+                throw $this->new_query_exception('query');
+            }
+            return new MysqliDatabaseResult($result);
+        });
+    }
+
+    public function quote(string $value): string
+    {
+        return "'" . $this->get_database()->real_escape_string($value) . "'";
+    }
+
+    public function exec(string $sql): int
+    {
+        return $this->run_mysqli_operation('statement', function () use ($sql): int {
+            $database = $this->get_database();
+            if (!$database->multi_query($sql)) {
+                throw $this->new_query_exception('statement');
+            }
+
+            $affected_rows = 0;
+            while (true) {
+                $result = $database->store_result();
+                if ($result instanceof mysqli_result) {
+                    $result->free();
+                } elseif ($database->affected_rows > 0) {
+                    $affected_rows += $database->affected_rows;
+                }
+                if ($database->errno !== 0) {
+                    throw $this->new_query_exception('statement');
+                }
+                if (!$database->more_results()) {
+                    break;
+                }
+                if (!$database->next_result()) {
+                    throw $this->new_query_exception('statement');
+                }
+            }
+            return $affected_rows;
+        });
+    }
+
+    public function execute(string $sql, array $params = []): int
+    {
+        return $this->run_mysqli_operation('prepared statement', function () use ($sql, $params): int {
+            $statement = $this->get_database()->prepare($sql);
+            if ($statement === false) {
+                throw $this->new_query_exception('prepared statement');
+            }
+
+            if ($params !== []) {
+                $values = array_values($params);
+                $types = '';
+                foreach ($values as $value) {
+                    if (is_int($value) || is_bool($value)) {
+                        $types .= 'i';
+                    } elseif (is_float($value)) {
+                        $types .= 'd';
+                    } else {
+                        $types .= 's';
+                    }
+                }
+                $arguments = [$types];
+                foreach ($values as $index => &$value) {
+                    $arguments[] = &$values[$index];
+                }
+                unset($value);
+                if (!call_user_func_array([$statement, 'bind_param'], $arguments)) {
+                    $error = $statement->error;
+                    $statement->close();
+                    // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+                    throw new PDOException('The target database could not bind a prepared statement: ' . $error);
+                }
+            }
+
+            if (!$statement->execute()) {
+                $error = $statement->error;
+                $statement->close();
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+                throw new PDOException('The target database prepared statement failed: ' . $error);
+            }
+            $affected_rows = max(0, $statement->affected_rows);
+            $statement->close();
+            return $affected_rows;
+        });
+    }
+
+    public function beginTransaction(): bool
+    {
+        $this->run_mysqli_operation('transaction', function (): void {
+            if (!$this->get_database()->begin_transaction()) {
+                throw $this->new_query_exception('transaction');
+            }
+        });
+        $this->transaction_open = true;
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        $this->run_mysqli_operation('commit', function (): void {
+            if (!$this->get_database()->commit()) {
+                throw $this->new_query_exception('commit');
+            }
+        });
+        $this->transaction_open = false;
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        $this->run_mysqli_operation('rollback', function (): void {
+            if (!$this->get_database()->rollback()) {
+                throw $this->new_query_exception('rollback');
+            }
+        });
+        $this->transaction_open = false;
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->transaction_open;
+    }
+
+    public function close(): void
+    {
+        if ($this->database === null) {
+            return;
+        }
+        $this->database->close();
+        $this->database = null;
+        $this->transaction_open = false;
+    }
+
+    private function get_database(): mysqli
+    {
+        if ($this->database === null) {
+            throw new RuntimeException('The target database connection is already closed.');
+        }
+        return $this->database;
+    }
+
+    private function new_query_exception(string $operation): PDOException
+    {
+        $database = $this->get_database();
+        return new PDOException(
+            "The target database {$operation} failed: {$database->error}",
+            $database->errno,
+        );
+    }
+
+    /**
+     * @template T
+     * @param callable():T $callback Native mysqli call.
+     * @return T
+     */
+    private function run_mysqli_operation(string $operation, callable $callback)
+    {
+        try {
+            return $callback();
+        } catch (mysqli_sql_exception $error) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException(
+                "The target database {$operation} failed: {$error->getMessage()}",
+                $error->getCode(),
+                $error,
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+    }
+}

--- a/packages/reprint-client/src/lib/database/class-mysqli-database-result.php
+++ b/packages/reprint-client/src/lib/database/class-mysqli-database-result.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use mysqli_result;
+use PDO;
+use RuntimeException;
+
+/** Adapts a mysqli result to Reprint's target database result API. */
+class MysqliDatabaseResult implements DatabaseResult {
+
+    private ?mysqli_result $result;
+
+    public function __construct(mysqli_result $result)
+    {
+        $this->result = $result;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_BOTH)
+    {
+        $row = $this->get_result()->fetch_array($this->get_mysqli_fetch_mode($mode));
+        return $row === null ? false : $row;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_BOTH): array
+    {
+        $rows = [];
+        // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Read one row per iteration.
+        while (( $row = $this->fetch($mode) ) !== false) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    public function fetchColumn(int $column = 0)
+    {
+        $row = $this->fetch(PDO::FETCH_NUM);
+        return $row === false || !array_key_exists($column, $row)
+            ? false
+            : $row[$column];
+    }
+
+    public function closeCursor(): bool
+    {
+        if ($this->result === null) {
+            return true;
+        }
+        $this->result->free();
+        $this->result = null;
+        return true;
+    }
+
+    private function get_mysqli_fetch_mode(int $mode): int
+    {
+        if ($mode === PDO::FETCH_ASSOC) {
+            return MYSQLI_ASSOC;
+        }
+        if ($mode === PDO::FETCH_NUM) {
+            return MYSQLI_NUM;
+        }
+        if ($mode === PDO::FETCH_BOTH) {
+            return MYSQLI_BOTH;
+        }
+        throw new RuntimeException('The target database result supports FETCH_ASSOC, FETCH_NUM, and FETCH_BOTH.');
+    }
+
+    private function get_result(): mysqli_result
+    {
+        if ($this->result === null) {
+            throw new RuntimeException('The database result is already closed.');
+        }
+        return $this->result;
+    }
+}

--- a/packages/reprint-client/src/lib/database/class-pdo-database-connection.php
+++ b/packages/reprint-client/src/lib/database/class-pdo-database-connection.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+/** Uses a PDO-compatible database as a Reprint target. */
+class PdoDatabaseConnection implements DatabaseConnection {
+
+    private const PREPARED_STATEMENT_CACHE_MAX = 128;
+
+    private ?PDO $query_database;
+    private ?PDO $prepared_database;
+
+    /** @var array<string,\PDOStatement> */
+    private array $prepared_statements = [];
+
+    /** @var string[] Oldest prepared statement first. */
+    private array $prepared_statement_order = [];
+
+    /**
+     * @param PDO      $query_database    Connection which accepts target SQL.
+     * @param PDO|null $prepared_database Native connection used for prepared statements.
+     */
+    public function __construct(PDO $query_database, ?PDO $prepared_database = null)
+    {
+        $this->query_database = $query_database;
+        $this->prepared_database = $prepared_database ?? $query_database;
+    }
+
+    public function query(string $sql): DatabaseResult
+    {
+        $statement = $this->get_query_database()->query($sql);
+        if ($statement === false) {
+            throw new PDOException('The target database query failed.');
+        }
+        return new PdoDatabaseResult($statement);
+    }
+
+    public function quote(string $value): string
+    {
+        $quoted = $this->get_prepared_database()->quote($value);
+        if ($quoted === false) {
+            throw new PDOException('The target database could not quote an SQL value.');
+        }
+        return $quoted;
+    }
+
+    public function exec(string $sql): int
+    {
+        $affected_rows = $this->get_query_database()->exec($sql);
+        if ($affected_rows === false) {
+            throw new PDOException('The target database statement failed.');
+        }
+        return $affected_rows;
+    }
+
+    public function execute(string $sql, array $params = []): int
+    {
+        $statement = $this->prepared_statements[$sql] ?? null;
+        if ($statement === null) {
+            $statement = $this->get_prepared_database()->prepare($sql);
+            if ($statement === false) {
+                throw new PDOException('The target database could not prepare a statement.');
+            }
+            $this->prepared_statements[$sql] = $statement;
+            $this->prepared_statement_order[] = $sql;
+            if (count($this->prepared_statement_order) > self::PREPARED_STATEMENT_CACHE_MAX) {
+                $oldest_sql = array_shift($this->prepared_statement_order);
+                if ($oldest_sql !== null) {
+                    unset($this->prepared_statements[$oldest_sql]);
+                }
+            }
+        } else {
+            $statement->closeCursor();
+        }
+
+        if (!$statement->execute($params)) {
+            throw new PDOException('The target database prepared statement failed.');
+        }
+        $affected_rows = $statement->rowCount();
+        $statement->closeCursor();
+        return $affected_rows;
+    }
+
+    public function beginTransaction(): bool
+    {
+        return $this->get_query_database()->beginTransaction();
+    }
+
+    public function commit(): bool
+    {
+        return $this->get_query_database()->commit();
+    }
+
+    public function rollBack(): bool
+    {
+        return $this->get_query_database()->rollBack();
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->get_query_database()->inTransaction();
+    }
+
+    public function close(): void
+    {
+        foreach ($this->prepared_statements as $statement) {
+            $statement->closeCursor();
+        }
+        $this->prepared_statements = [];
+        $this->prepared_statement_order = [];
+        $this->query_database = null;
+        $this->prepared_database = null;
+    }
+
+    private function get_query_database(): PDO
+    {
+        if ($this->query_database === null) {
+            throw new RuntimeException('The target database connection is already closed.');
+        }
+        return $this->query_database;
+    }
+
+    private function get_prepared_database(): PDO
+    {
+        if ($this->prepared_database === null) {
+            throw new RuntimeException('The target database connection is already closed.');
+        }
+        return $this->prepared_database;
+    }
+}

--- a/packages/reprint-client/src/lib/database/class-pdo-database-result.php
+++ b/packages/reprint-client/src/lib/database/class-pdo-database-result.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use PDO;
+use PDOStatement;
+use RuntimeException;
+
+/** Adapts a PDO statement to Reprint's target database result API. */
+class PdoDatabaseResult implements DatabaseResult {
+
+    private ?PDOStatement $statement;
+
+    public function __construct(PDOStatement $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_BOTH)
+    {
+        return $this->get_statement()->fetch($mode);
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_BOTH): array
+    {
+        return $this->get_statement()->fetchAll($mode);
+    }
+
+    public function fetchColumn(int $column = 0)
+    {
+        $row = $this->get_statement()->fetch(PDO::FETCH_NUM);
+        return $row === false || !array_key_exists($column, $row)
+            ? false
+            : $row[$column];
+    }
+
+    public function closeCursor(): bool
+    {
+        if ($this->statement === null) {
+            return true;
+        }
+        try {
+            $closed = $this->statement->closeCursor();
+        } catch (RuntimeException $error) {
+            // WP_PDO_MySQL_On_SQLite result sets are already detached from
+            // their SQLite cursor and report closeCursor() as not implemented.
+            if ($error->getMessage() !== 'Not implemented') {
+                throw $error;
+            }
+            $closed = true;
+        }
+        $this->statement = null;
+        return $closed;
+    }
+
+    private function get_statement(): PDOStatement
+    {
+        if ($this->statement === null) {
+            throw new RuntimeException('The database result is already closed.');
+        }
+        return $this->statement;
+    }
+}

--- a/packages/reprint-client/src/lib/database/interface-database-connection.php
+++ b/packages/reprint-client/src/lib/database/interface-database-connection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+/** The database operations used by Reprint's target-side commands. */
+interface DatabaseConnection {
+
+    /** Executes a query which returns rows. */
+    public function query(string $sql): DatabaseResult;
+
+    /** Quotes one string for use as an SQL literal. */
+    public function quote(string $value): string;
+
+    /**
+     * Executes SQL without bound parameters.
+     *
+     * The mysqli implementation also accepts a complete multi-statement SQL
+     * group and drains every result before returning.
+     */
+    public function exec(string $sql): int;
+
+    /**
+     * Executes one statement with positional parameters.
+     *
+     * @param array<int,mixed> $params Values for the statement's question marks.
+     */
+    public function execute(string $sql, array $params = []): int;
+
+    public function beginTransaction(): bool;
+
+    public function commit(): bool;
+
+    public function rollBack(): bool;
+
+    public function inTransaction(): bool;
+
+    /** Closes the native connection. Calling this more than once is safe. */
+    public function close(): void;
+}

--- a/packages/reprint-client/src/lib/database/interface-database-result.php
+++ b/packages/reprint-client/src/lib/database/interface-database-result.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use PDO;
+
+/** Result rows returned by a target database query. */
+interface DatabaseResult {
+
+    /** Returns the next row, or false after the last row. */
+    public function fetch(int $mode = PDO::FETCH_BOTH);
+
+    /** Returns every remaining row. */
+    public function fetchAll(int $mode = PDO::FETCH_BOTH): array;
+
+    /** Returns one column from the next row, or false after the last row. */
+    public function fetchColumn(int $column = 0);
+
+    /** Releases the result. Calling this more than once is safe. */
+    public function closeCursor(): bool;
+}

--- a/packages/reprint-client/src/lib/database/load.php
+++ b/packages/reprint-client/src/lib/database/load.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once __DIR__ . '/interface-database-result.php';
+require_once __DIR__ . '/interface-database-connection.php';
+require_once __DIR__ . '/class-pdo-database-result.php';
+require_once __DIR__ . '/class-pdo-database-connection.php';
+require_once __DIR__ . '/class-mysqli-database-result.php';
+require_once __DIR__ . '/class-mysqli-database-connection.php';

--- a/tests/Import/DatabaseConnectionTest.php
+++ b/tests/Import/DatabaseConnectionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace ImportTests;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\Database\MysqliDatabaseResult;
+use Reprint\Importer\Database\PdoDatabaseConnection;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/database/load.php';
+
+class DatabaseConnectionTest extends TestCase {
+
+    public function testPdoConnectionSupportsTheTargetDatabaseContract(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $database = new PdoDatabaseConnection(new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]));
+        $database->exec('CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT)');
+        $this->assertSame("'a''b'", $database->quote("a'b"));
+        $this->assertSame(
+            1,
+            $database->execute('INSERT INTO records (id, value) VALUES (?, ?)', [1, 'first'])
+        );
+
+        $result = $database->query('SELECT id, value FROM records');
+        $this->assertSame(['id' => 1, 'value' => 'first'], $result->fetch(PDO::FETCH_ASSOC));
+        $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
+        $this->assertTrue($result->closeCursor());
+        $this->assertTrue($result->closeCursor());
+
+        $database->beginTransaction();
+        $database->execute('UPDATE records SET value = ? WHERE id = ?', ['changed', 1]);
+        $this->assertTrue($database->inTransaction());
+        $database->rollBack();
+        $this->assertFalse($database->inTransaction());
+        $this->assertSame(
+            'first',
+            $database->query('SELECT value FROM records')->fetchColumn()
+        );
+
+        $database->execute('UPDATE records SET value = ? WHERE id = ?', ['second', 1]);
+        $this->assertSame(
+            'second',
+            $database->query('SELECT value FROM records')->fetchColumn()
+        );
+
+        $database->execute('INSERT INTO records (id, value) VALUES (?, ?)', [2, null]);
+        $this->assertNull(
+            $database->query('SELECT value FROM records WHERE id = 2')->fetchColumn()
+        );
+        $this->assertFalse(
+            $database->query('SELECT value FROM records WHERE id = 2')->fetchColumn(1)
+        );
+
+        $database->close();
+        $database->close();
+    }
+
+    public function testMysqliResultUsesTheSameFetchModes(): void
+    {
+        if (!extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli extension required');
+        }
+
+        $nativeResult = new class() extends \mysqli_result {
+            private array $rows = [
+                ['id' => 1, 'value' => 'first'],
+                ['id' => 2, 'value' => 'second'],
+            ];
+
+            public function __construct()
+            {
+            }
+
+            public function fetch_array(int $mode = MYSQLI_BOTH): array|null|false
+            {
+                $row = array_shift($this->rows);
+                if ($row === null) {
+                    return null;
+                }
+                if ($mode === MYSQLI_ASSOC) {
+                    return $row;
+                }
+                if ($mode === MYSQLI_NUM) {
+                    return array_values($row);
+                }
+                return $row + array_values($row);
+            }
+
+            public function free(): void
+            {
+                $this->rows = [];
+            }
+        };
+        $result = new MysqliDatabaseResult($nativeResult);
+
+        $this->assertSame(['id' => 1, 'value' => 'first'], $result->fetch(PDO::FETCH_ASSOC));
+        $this->assertSame([2, 'second'], $result->fetch(PDO::FETCH_NUM));
+        $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
+        $this->assertTrue($result->closeCursor());
+        $this->assertTrue($result->closeCursor());
+    }
+}

--- a/tests/e2e/tests/import-59-target-database-connections.test.js
+++ b/tests/e2e/tests/import-59-target-database-connections.test.js
@@ -1,0 +1,129 @@
+/**
+ * The target database classes run the same query, prepared statement, and
+ * transaction flow through mysqli and the MySQL-on-SQLite PDO driver.
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Target database connection classes', () => {
+    const projectRoot = join(import.meta.dirname, '..', '..', '..');
+    const phpBinary = process.env.PHP_BINARY || 'php';
+
+    it('uses the same operations through mysqli and SQLite', () => {
+        const script = String.raw`
+            require $argv[1] . '/packages/reprint-client/src/lib/database/load.php';
+            require $argv[1] . '/lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php';
+
+            use Reprint\Importer\Database\MysqliDatabaseConnection;
+            use Reprint\Importer\Database\PdoDatabaseConnection;
+
+            function run_contract($database) {
+                $database->exec('DROP TABLE IF EXISTS reprint_connection_contract');
+                $database->exec(
+                    'CREATE TABLE reprint_connection_contract (' .
+                    'id BIGINT NOT NULL PRIMARY KEY, value TEXT NOT NULL)'
+                );
+                $quoted = $database->quote("a'b");
+                $quoted_result = $database->query("SELECT {$quoted}");
+                $quoted_value = $quoted_result->fetchColumn();
+                $quoted_result->closeCursor();
+                if ($quoted_value !== "a'b") {
+                    throw new RuntimeException('The target quoted an SQL value incorrectly.');
+                }
+                $null_result = $database->query('SELECT NULL');
+                if ($null_result->fetchColumn() !== null) {
+                    throw new RuntimeException('The target changed SQL NULL into another value.');
+                }
+                $null_result->closeCursor();
+
+                $duplicate_columns = $database->query(
+                    'SELECT 1 AS duplicate_value, 2 AS duplicate_value'
+                );
+                $duplicate_values = $duplicate_columns->fetch(PDO::FETCH_NUM);
+                if (array_map('intval', $duplicate_values) !== array(1, 2)) {
+                    throw new RuntimeException('Numeric results lost a duplicate-named column.');
+                }
+                $duplicate_columns->closeCursor();
+                $database->execute(
+                    'INSERT INTO reprint_connection_contract (id, value) VALUES (?, ?)',
+                    array(1, 'first')
+                );
+                $row = $database->query(
+                    'SELECT id, value FROM reprint_connection_contract WHERE id = 1'
+                )->fetch(PDO::FETCH_ASSOC);
+                if ((int) $row['id'] !== 1 || $row['value'] !== 'first') {
+                    throw new RuntimeException('The target query returned the wrong row.');
+                }
+
+                $database->beginTransaction();
+                $database->execute(
+                    'UPDATE reprint_connection_contract SET value = ? WHERE id = ?',
+                    array('changed', 1)
+                );
+                $database->rollBack();
+                $value = $database->query(
+                    'SELECT value FROM reprint_connection_contract WHERE id = 1'
+                )->fetchColumn();
+                if ($value !== 'first') {
+                    throw new RuntimeException('The target rollback did not restore the row.');
+                }
+
+                $database->execute(
+                    'UPDATE reprint_connection_contract SET value = ? WHERE id = ?',
+                    array('second', 1)
+                );
+                $value = $database->query(
+                    'SELECT value FROM reprint_connection_contract WHERE id = 1'
+                )->fetchColumn();
+                if ($value !== 'second') {
+                    throw new RuntimeException('The target could not reuse a prepared statement.');
+                }
+
+                try {
+                    $database->exec('SELECT * FROM reprint_table_which_does_not_exist');
+                    throw new RuntimeException('The target accepted invalid SQL.');
+                } catch (PDOException $error) {
+                    // Both native drivers expose SQL failures through the same type.
+                }
+
+                $database->exec('DROP TABLE reprint_connection_contract');
+                $database->close();
+            }
+
+            mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+            $mysqli = new mysqli('127.0.0.1', 'e2e_admin', 'e2e_password', 'mysql');
+            $mysqli->set_charset('utf8mb4');
+            $mysql_database = new MysqliDatabaseConnection($mysqli);
+            $mysql_database->exec('SELECT 1; SELECT 2');
+            $drained_result = $mysql_database->query('SELECT 3');
+            if ((int) $drained_result->fetchColumn() !== 3) {
+                throw new RuntimeException('The MySQL adapter did not drain its SQL group.');
+            }
+            $drained_result->closeCursor();
+            run_contract($mysql_database);
+
+            $sqlite = new WP_PDO_MySQL_On_SQLite(
+                'mysql-on-sqlite:path=:memory:;dbname=wp',
+                null,
+                null,
+                array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION)
+            );
+            run_contract(new PdoDatabaseConnection(
+                $sqlite,
+                $sqlite->get_connection()->get_pdo()
+            ));
+        `;
+
+        const output = execFileSync(phpBinary, ['-r', script, projectRoot], {
+            encoding: 'utf8',
+            env: { ...process.env },
+        });
+        assert.equal(output, '');
+    });
+});


### PR DESCRIPTION
Adds one small database API for Reprint's target-side commands. It lets command code run the same query, prepared statement, and transaction calls whether the native connection is `mysqli` or PDO-compatible.

Today the client has two target drivers:

- MySQL uses `MysqliDatabaseConnection` over `ext-mysqli`.
- SQLite uses `PdoDatabaseConnection` over WordPress's `WP_PDO_MySQL_On_SQLite` driver, plus its native SQLite PDO connection for prepared statements.

Both implement `DatabaseConnection`. Their query results implement `DatabaseResult`, so callers also do not need to distinguish `mysqli_result` from `PDOStatement`.

## Creating a connection

Load the database API once:

```php
require_once __DIR__ . '/lib/database/load.php';

use Reprint\Importer\Database\MysqliDatabaseConnection;
use Reprint\Importer\Database\PdoDatabaseConnection;
```

For MySQL, create the normal `mysqli` connection and wrap it:

```php
$mysqli = new mysqli($host, $user, $password, $database_name, $port);
$mysqli->set_charset('utf8mb4');

$database = new MysqliDatabaseConnection($mysqli);
```

For a normal PDO connection, pass that connection directly:

```php
$pdo = new PDO('sqlite:/path/to/database.sqlite', null, null, [
    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
]);

$database = new PdoDatabaseConnection($pdo);
```

Reprint's SQLite target uses WordPress's MySQL-on-SQLite driver for exported MySQL SQL and its native SQLite PDO connection for prepared statements:

```php
$mysql_on_sqlite = new WP_PDO_MySQL_On_SQLite(
    "mysql-on-sqlite:path={$path};dbname={$database_name}",
    null,
    null,
    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
);
$sqlite_pdo = $mysql_on_sqlite->get_connection()->get_pdo();

$database = new PdoDatabaseConnection($mysql_on_sqlite, $sqlite_pdo);
```

The first argument receives MySQL-style dump SQL. The optional second argument is used for prepared statements.

## Using the connection

A caller can read rows without knowing which driver is underneath:

```php
$result = $database->query(
    "SELECT option_value FROM wp_options WHERE option_name = 'siteurl'"
);
$row = $result->fetch(PDO::FETCH_ASSOC);
$result->closeCursor();
```

The same applies to prepared statements and transactions:

```php
$database->beginTransaction();
$database->execute(
    'UPDATE wp_options SET option_value = ? WHERE option_name = ?',
    [$new_url, 'siteurl'],
);
$database->commit();
```

`MysqliDatabaseConnection::exec()` uses `mysqli::multi_query()` and drains every result before returning. This is needed by the follow-up import flow, which executes a complete exporter SQL group before saving its next position. `PdoDatabaseConnection` keeps a bounded prepared-statement cache because SQLite imports repeat the same INSERT shape many times.

## Later drivers

This API does not lock Reprint to these two native drivers.

PDO MySQL can use the existing `PdoDatabaseConnection` if we decide to support it. The target connection factory would choose that adapter when `pdo_mysql` is available. Command code would stay unchanged. We would still add a real MySQL integration test before calling that path supported, especially for multi-statement SQL groups and transaction handling.

`$wpdb` can also be supported by adding a `WpdbDatabaseConnection` and matching result adapter. Command code would again stay unchanged. That adapter would need to handle `$wpdb`'s placeholder syntax, transaction state, and row fetching without loading a large result into memory. This PR does not add that adapter because no current command needs it.

## Scope

This PR only adds the interfaces, the `mysqli` and PDO-compatible implementations, and their tests. It does not change any importer command or the source exporter. #654 uses these classes throughout the client-side target database flow.

## Testing

The shared contract runs against real MariaDB and SQLite targets. It covers plain SQL, positional parameters, result fetching, rollback, repeated prepared statements, and closing connections more than once.

Stack: this PR → #654
