### PR TITLE
[PHP] Mirror only the selected files-pull paths

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3623,7 +3623,7 @@ class ImportClient
                 if (
                     (
                         !$this->include_caches
-                        && $this->is_default_skipped_local_absolute_path(
+                        && $this->local_path_requires_include_caches(
                             $local_absolute_path,
                             $local_relative_path
                         )
@@ -3672,8 +3672,16 @@ class ImportClient
         }
     }
 
-    /** Whether the local path spells a default-skipped path before or after remapping. */
-    private function is_default_skipped_local_absolute_path(
+    /**
+     * Checks whether mirroring this local path requires --include-caches.
+     *
+     * Unless --include-caches is set, the file index omits generated caches,
+     * version-control metadata, OS metadata, and editor scratch files. A remap
+     * may place one of those paths under a different local name, so this checks
+     * both the path relative to --fs-root and every matching remote path before
+     * allowing its removal.
+     */
+    private function local_path_requires_include_caches(
         string $local_absolute_path,
         string $local_relative_path
     ): bool {
@@ -9777,20 +9785,24 @@ class ImportClient
     }
 
     /**
-     * Whether a path is selected by the active --include and --exclude prefixes.
+     * Checks whether a remote or local path passes --include and --exclude.
      *
-     * The exporter has already applied --include to entries in the next remote
-     * index, including followed symlink targets outside an --include prefix. Other
-     * paths are checked against --include locally. An included root itself is not
-     * selected because the next remote index lists its contents, not the root
-     * entry. Exclusions always win.
+     * The server has already applied --include to current remote index entries,
+     * including followed symlink targets outside an include prefix. Locally
+     * discovered paths still need that include check. Mirror supplies local
+     * prefixes for those paths because remapping has changed their coordinates.
+     * An included root itself is not selected because the current remote index
+     * lists its contents, not the root entry. Exclusions always win.
      *
-     * @param bool $is_next_remote_index_entry Whether the path came from the
-     *                                         current next remote index.
-     * @param list<string>|null $included_path_prefixes Included roots, or the
-     *                                                   current pull includes.
-     * @param list<string>|null $excluded_path_prefixes Excluded roots, or the
-     *                                                   current pull exclusions.
+     * @param string $path Remote or local absolute path to check.
+     * @param bool $is_next_remote_index_entry Whether the server already applied
+     *                                         the include filter to this path.
+     * @param list<string>|null $included_path_prefixes Include prefixes in the
+     *                                                   path's coordinates, or
+     *                                                   null for the remote prefixes.
+     * @param list<string>|null $excluded_path_prefixes Exclude prefixes in the
+     *                                                   path's coordinates, or
+     *                                                   null for the remote prefixes.
      */
     private function is_selected_for_pulling(
         string $path,

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -982,29 +982,6 @@ class ImportClient
             $this->files_pull_mode =
                 $requested_files_pull_mode ?? $saved_files_pull_mode;
 
-            $effective_filter = $options["filter"]
-                ?? $this->get_state()->filter
-                ?? "none";
-            $effective_nonempty_behavior = $options["fs_root_nonempty_behavior"]
-                ?? $this->get_state()->fs_root_nonempty_behavior
-                ?? "error";
-            if (
-                !$abort
-                && $this->files_pull_mode === "mirror"
-                && (
-                    !empty($options["include"] ?? $options["only"] ?? [])
-                    || !empty($options["exclude"] ?? [])
-                    || $this->include_caches
-                    || $effective_filter !== "none"
-                    || $effective_nonempty_behavior === "preserve-local"
-                )
-            ) {
-                throw new InvalidArgumentException(
-                    "--mode=mirror requires a full pull without --include, --exclude, "
-                    . "--include-caches, a partial --filter, or "
-                    . "--on-fs-root-nonempty=preserve-local."
-                );
-            }
             $absolute_state_directory = realpath_with_missing_tail(
                 $this->state_dir[0] === "/"
                     ? $this->state_dir
@@ -3330,6 +3307,8 @@ class ImportClient
                 "mapped_remote_index_file" => $this->mapped_remote_index_file,
                 "filesystem_root" => $this->filesystem_root,
                 "path_mapper" => $this->path_mapper(),
+                "excluded_remote_absolute_path_prefixes" =>
+                    $this->pull_excluded_files_with_path_prefixes,
             ]);
             $this->build_files_pull_mirror_local_changes();
             $starting_diff_stage = true;
@@ -3500,7 +3479,7 @@ class ImportClient
             [$this->filesystem_root],
             $this->filesystem_root,
             false,
-            false,
+            $this->include_caches,
             $plan_directory
         );
         try {
@@ -3548,6 +3527,12 @@ class ImportClient
         try {
             while ($local_index_diff->next_path()) {
                 if ($local_index_diff->get_path_transition() === "unchanged") {
+                    continue;
+                }
+                if (
+                    $this->fs_root_nonempty_behavior === "preserve-local"
+                    && $local_index_diff->get_entry_in_old_index() === null
+                ) {
                     continue;
                 }
                 $entry = $local_index_diff->get_entry_in_new_index()
@@ -3598,15 +3583,32 @@ class ImportClient
             null,
             $decode_mapped_entry
         );
+        $included_local_absolute_path_prefixes =
+            $this->path_mapper()->remote_path_prefixes_to_local_path_prefixes(
+                $this->pull_only_files_with_path_prefixes
+            );
+        $excluded_local_absolute_path_prefixes =
+            $this->path_mapper()->remote_path_prefixes_to_local_path_prefixes(
+                $this->pull_excluded_files_with_path_prefixes
+            );
         try {
             while ($changed_path_diff->next_path()) {
                 $local_entry = $changed_path_diff->get_entry_in_old_index();
                 if ($local_entry === null) {
                     continue;
                 }
+                $local_relative_path = $local_entry["path"];
                 $remote_entry = $changed_path_diff->get_entry_in_new_index();
                 if ($remote_entry !== null) {
                     /** @var array{copy_source_path:string} $remote_entry */
+                    if (
+                        !$this->is_selected_for_pulling(
+                            $remote_entry["copy_source_path"],
+                            true
+                        )
+                    ) {
+                        continue;
+                    }
                     $this->append_to_fetch_list(
                         $remote_entry["copy_source_path"],
                         $fetch_list_replacement_file_handle
@@ -3614,11 +3616,28 @@ class ImportClient
                     continue;
                 }
 
-                $local_relative_path = $local_entry["path"];
                 $local_absolute_path = wp_join_unix_paths(
                     $this->filesystem_root,
                     $local_relative_path
                 );
+                if (
+                    (
+                        !$this->include_caches
+                        && $this->is_default_skipped_local_absolute_path(
+                            $local_absolute_path,
+                            $local_relative_path
+                        )
+                    )
+                    || !$this->is_selected_for_pulling(
+                        $local_absolute_path,
+                        false,
+                        $included_local_absolute_path_prefixes,
+                        $excluded_local_absolute_path_prefixes
+                    )
+                ) {
+                    continue;
+                }
+
                 if (
                     !$this->remove_local_absolute_path_without_following_symlinks(
                         $local_absolute_path
@@ -3651,6 +3670,32 @@ class ImportClient
         if (!rename($this->fetch_list_replacement_file, $this->fetch_list_file)) {
             throw new RuntimeException("Failed to replace the fetch list.");
         }
+    }
+
+    /** Whether the local path spells a default-skipped path before or after remapping. */
+    private function is_default_skipped_local_absolute_path(
+        string $local_absolute_path,
+        string $local_relative_path
+    ): bool {
+        $candidate_paths = [$local_relative_path];
+        foreach ($this->resolved_path_mappings as $remote_prefix => $local_prefix) {
+            $remainder = path_remainder_under(
+                $local_absolute_path,
+                $local_prefix
+            );
+            if ($remainder !== null) {
+                $candidate_paths[] = wp_join_unix_paths(
+                    $remote_prefix,
+                    $remainder
+                );
+            }
+        }
+        foreach ($candidate_paths as $candidate_path) {
+            if (FileIndexProcessor::path_is_default_skipped($candidate_path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Creates an empty local index when files-pull recorded no local paths. */
@@ -9740,17 +9785,30 @@ class ImportClient
      *
      * @param bool $is_next_remote_index_entry Whether the path came from the
      *                                         current next remote index.
+     * @param list<string>|null $included_path_prefixes Included roots, or the
+     *                                                   current pull includes.
+     * @param list<string>|null $excluded_path_prefixes Excluded roots, or the
+     *                                                   current pull exclusions.
      */
     private function is_selected_for_pulling(
         string $path,
-        bool $is_next_remote_index_entry
+        bool $is_next_remote_index_entry,
+        ?array $included_path_prefixes = null,
+        ?array $excluded_path_prefixes = null
     ): bool
     {
+        $included_path_prefixes ??=
+            $this->pull_only_files_with_path_prefixes;
+        $excluded_path_prefixes ??=
+            $this->pull_excluded_files_with_path_prefixes;
         if (!$is_next_remote_index_entry) {
-            $selected = empty($this->pull_only_files_with_path_prefixes);
+            $selected = empty($included_path_prefixes);
 
-            foreach ($this->pull_only_files_with_path_prefixes as $prefix) {
-                $remainder = path_remainder_under($path, $prefix);
+            foreach ($included_path_prefixes as $included_path_prefix) {
+                $remainder = path_remainder_under(
+                    $path,
+                    $included_path_prefix
+                );
                 if ($remainder === "") {
                     return false;
                 }
@@ -9765,8 +9823,11 @@ class ImportClient
             }
         }
 
-        foreach ($this->pull_excluded_files_with_path_prefixes as $prefix) {
-            if (path_remainder_under($path, $prefix) !== null) {
+        foreach ($excluded_path_prefixes as $excluded_path_prefix) {
+            if (
+                path_remainder_under($path, $excluded_path_prefix)
+                !== null
+            ) {
                 return false;
             }
         }

--- a/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
+++ b/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
@@ -2,6 +2,7 @@
 
 use function Reprint\Importer\sort_index_file;
 use function WordPress\Reprint\Exporter\path_is_descendant_of;
+use function WordPress\Reprint\Exporter\path_remainder_under;
 use function WordPress\Reprint\Exporter\relative_path_under;
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Filesystem paths are CLI values, never HTML output.
@@ -24,6 +25,7 @@ final class MappedRemoteIndexBuilder
      *     @type string                  $mapped_remote_index_file Output in mapped local order.
      *     @type string                  $filesystem_root          Local filesystem root.
      *     @type RemoteToLocalPathMapper $path_mapper              Remote-to-local path mapper.
+     *     @type list<string>            $excluded_remote_absolute_path_prefixes Remote prefixes omitted from the mapped index. Default empty.
      * }
      */
     public static function build(array $options): void
@@ -33,6 +35,7 @@ final class MappedRemoteIndexBuilder
             "mapped_remote_index_file",
             "filesystem_root",
             "path_mapper",
+            "excluded_remote_absolute_path_prefixes",
         ];
         $unknown_options = array_diff(array_keys($options), $allowed_options);
         if ($unknown_options !== []) {
@@ -75,6 +78,27 @@ final class MappedRemoteIndexBuilder
         $filesystem_root = $options["filesystem_root"];
         /** @var RemoteToLocalPathMapper $path_mapper */
         $path_mapper = $options["path_mapper"];
+        $excluded_remote_absolute_path_prefixes =
+            $options["excluded_remote_absolute_path_prefixes"] ?? [];
+        if (
+            !is_array($excluded_remote_absolute_path_prefixes)
+            || array_values($excluded_remote_absolute_path_prefixes)
+                !== $excluded_remote_absolute_path_prefixes
+        ) {
+            throw new InvalidArgumentException(
+                "Mapped remote-index option excluded_remote_absolute_path_prefixes "
+                . "must be a list of strings."
+            );
+        }
+        foreach ($excluded_remote_absolute_path_prefixes as $excluded_prefix) {
+            if (!is_string($excluded_prefix) || $excluded_prefix === "") {
+                $observed_type = gettype($excluded_prefix);
+                throw new InvalidArgumentException(
+                    "Mapped remote-index option excluded_remote_absolute_path_prefixes "
+                    . "must contain non-empty strings; received {$observed_type}."
+                );
+            }
+        }
 
         $remote_index_reader = new RemoteIndexReader($remote_index_file);
         $mapped_index_handle = fopen($mapped_remote_index_file, "wb");
@@ -87,12 +111,19 @@ final class MappedRemoteIndexBuilder
             $remote_index_reader->open();
             $remote_entry = $remote_index_reader->next_entry();
             while ($remote_entry !== null) {
-                self::write_mapped_entry(
-                    $mapped_index_handle,
-                    $remote_entry,
-                    $filesystem_root,
-                    $path_mapper
-                );
+                if (
+                    !self::path_is_excluded(
+                        $remote_entry["path"],
+                        $excluded_remote_absolute_path_prefixes
+                    )
+                ) {
+                    self::write_mapped_entry(
+                        $mapped_index_handle,
+                        $remote_entry,
+                        $filesystem_root,
+                        $path_mapper
+                    );
+                }
                 $remote_entry = $remote_index_reader->next_entry();
             }
             if (!fflush($mapped_index_handle)) {
@@ -111,6 +142,19 @@ final class MappedRemoteIndexBuilder
             );
         }
         self::assert_no_path_collisions($mapped_remote_index_file);
+    }
+
+    /** @param list<string> $excluded_remote_absolute_path_prefixes */
+    private static function path_is_excluded(
+        string $remote_absolute_path,
+        array $excluded_remote_absolute_path_prefixes
+    ): bool {
+        foreach ($excluded_remote_absolute_path_prefixes as $excluded_prefix) {
+            if (path_remainder_under($remote_absolute_path, $excluded_prefix) !== null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -110,10 +110,16 @@ final class RemoteToLocalPathMapper
     }
 
     /**
-     * Maps remote selection roots and nested remaps into local selection roots.
+     * Returns every local prefix reached by remote include or exclude prefixes.
      *
-     * @param list<string> $remote_absolute_path_prefixes Remote selection roots.
-     * @return list<string> Local selection roots.
+     * A nested remap can split one remote subtree across several local roots.
+     * For example, /remote/wp-content may map to /local/wp-content while its
+     * /remote/wp-content/uploads subtree maps separately to /local/media. The
+     * remote /remote/wp-content prefix therefore covers both local roots.
+     *
+     * @param list<string> $remote_absolute_path_prefixes Remote absolute include
+     *                                                    or exclude prefixes.
+     * @return list<string> Local absolute prefixes covered by the remote prefixes.
      */
     public function remote_path_prefixes_to_local_path_prefixes(
         array $remote_absolute_path_prefixes

--- a/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-to-local-path-mapper.php
@@ -108,4 +108,37 @@ final class RemoteToLocalPathMapper
 
         return wp_join_unix_paths($this->filesystem_root, $remote_absolute_path);
     }
+
+    /**
+     * Maps remote selection roots and nested remaps into local selection roots.
+     *
+     * @param list<string> $remote_absolute_path_prefixes Remote selection roots.
+     * @return list<string> Local selection roots.
+     */
+    public function remote_path_prefixes_to_local_path_prefixes(
+        array $remote_absolute_path_prefixes
+    ): array {
+        $local_absolute_path_prefixes = [];
+        foreach ($remote_absolute_path_prefixes as $remote_absolute_path_prefix) {
+            $local_absolute_path_prefixes[
+                $this->remote_path_to_local_path($remote_absolute_path_prefix)
+            ] = true;
+            foreach (
+                $this->resolved_path_mappings
+                as $mapped_remote_absolute_path_prefix => $mapped_local_absolute_path_prefix
+            ) {
+                if (
+                    path_remainder_under(
+                        $mapped_remote_absolute_path_prefix,
+                        $remote_absolute_path_prefix
+                    ) !== null
+                ) {
+                    $local_absolute_path_prefixes[
+                        $mapped_local_absolute_path_prefix
+                    ] = true;
+                }
+            }
+        }
+        return array_keys($local_absolute_path_prefixes);
+    }
 }

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -433,52 +433,286 @@ final class FilesPullLocalIndexTest extends TestCase
     }
 
     /**
-     * @dataProvider mirrorIncompatibleOptionProvider
-     * @param list<string> $arguments
+     * @dataProvider mirrorIncludeOptionProvider
      */
-    public function testMirrorRejectsPartialPathSelectionBeforeStarting(
-        array $arguments
-    ): void
-    {
-        $mirror = $this->runFilesPull(
-            array_merge(['--mode=mirror'], $arguments)
+    public function testMirrorChangesOnlyIncludedLocalPaths(
+        string $includeOption
+    ): void {
+        $arguments = [
+            '--mode=mirror',
+            $includeOption . '=/var/www/html/selected',
+        ];
+        $initial = $this->runFilesPull(['--mode=mirror']);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertFileExists(
+            $this->localTree . '/' . self::PULLED_PATH
+        );
+        $this->assertFileExists(
+            $this->localTree . '/unchanged.txt'
         );
 
-        $this->assertSame(1, $mirror['exit'], $mirror['output']);
-        $this->assertStringContainsString(
-            '--mode=mirror requires a full pull',
-            $mirror['output']
+        file_put_contents(
+            $this->localTree . '/' . self::PULLED_PATH,
+            'local selected edit'
         );
-        $savedState = json_decode(
-            file_get_contents($this->pullStateDirectory . '/state.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
+        file_put_contents(
+            $this->localTree . '/selected/local-only.txt',
+            'local selected addition'
         );
-        $this->assertSame('catch-up', $savedState['files_pull_mode']);
-        $this->assertNull(
-            $savedState['active_resumable_command']['command_name']
+        file_put_contents(
+            $this->localTree . '/unchanged.txt',
+            'local unselected edit'
+        );
+        unlink($this->localTree . '/deleted.txt');
+        mkdir($this->localTree . '/unselected', 0700, true);
+        file_put_contents(
+            $this->localTree . '/unselected/local-only.txt',
+            'local unselected addition'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            self::PULLED_CONTENTS,
+            file_get_contents($this->localTree . '/' . self::PULLED_PATH)
+        );
+        $this->assertFileDoesNotExist(
+            $this->localTree . '/selected/local-only.txt'
+        );
+        $this->assertSame(
+            'local unselected edit',
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+        $this->assertFileDoesNotExist($this->localTree . '/deleted.txt');
+        $this->assertSame(
+            'local unselected addition',
+            file_get_contents(
+                $this->localTree . '/unselected/local-only.txt'
+            )
         );
     }
 
-    /** @return iterable<string,array{list<string>}> */
-    public static function mirrorIncompatibleOptionProvider(): iterable
+    /** @return iterable<string,array{string}> */
+    public static function mirrorIncludeOptionProvider(): iterable
     {
-        yield 'included path' => [[
-            '--include=/var/www/html/selected',
-        ]];
-        yield 'excluded path' => [[
-            '--exclude=/var/www/html/ignored',
-        ]];
-        yield 'default skipped paths' => [[
-            '--include-caches',
-        ]];
-        yield 'partial filter' => [[
+        yield 'include' => ['--include'];
+        yield 'only alias' => ['--only'];
+    }
+
+    public function testMirrorKeepsExcludedLocalPaths(): void
+    {
+        $arguments = [
+            '--mode=mirror',
+            '--exclude=/var/www/html/folder',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertDirectoryDoesNotExist($this->localTree . '/folder');
+
+        mkdir($this->localTree . '/folder', 0700, true);
+        file_put_contents(
+            $this->localTree . '/folder/remote-deleted.txt',
+            'excluded local edit'
+        );
+        file_put_contents(
+            $this->localTree . '/folder/local-only.txt',
+            'excluded local addition'
+        );
+        file_put_contents(
+            $this->localTree . '/unchanged.txt',
+            'selected local edit'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            'excluded local edit',
+            file_get_contents(
+                $this->localTree . '/folder/remote-deleted.txt'
+            )
+        );
+        $this->assertSame(
+            'excluded local addition',
+            file_get_contents($this->localTree . '/folder/local-only.txt')
+        );
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+    }
+
+    public function testEssentialFilesMirrorKeepsLocalUploads(): void
+    {
+        $remoteUpload = 'wp-content/uploads/remote.txt';
+        $arguments = [
+            '--mode=mirror',
             '--filter=essential-files',
-        ]];
-        yield 'preserved local paths' => [[
+        ];
+        $this->writeRemoteOverrides([
+            'added_files' => [$remoteUpload => 'remote upload'],
+        ]);
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertFileDoesNotExist($this->localTree . '/' . $remoteUpload);
+
+        mkdir($this->localTree . '/wp-content/uploads', 0700, true);
+        file_put_contents(
+            $this->localTree . '/' . $remoteUpload,
+            'local upload'
+        );
+        file_put_contents(
+            $this->localTree . '/wp-content/uploads/local-only.txt',
+            'local only upload'
+        );
+        file_put_contents(
+            $this->localTree . '/unchanged.txt',
+            'selected local edit'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            'local upload',
+            file_get_contents($this->localTree . '/' . $remoteUpload)
+        );
+        $this->assertSame(
+            'local only upload',
+            file_get_contents(
+                $this->localTree . '/wp-content/uploads/local-only.txt'
+            )
+        );
+        $this->assertSame(
+            $this->remoteFiles['unchanged.txt'],
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+    }
+
+    public function testSkippedEarlierMirrorChangesOnlyUploads(): void
+    {
+        $remoteUpload = 'wp-content/uploads/remote.txt';
+        $arguments = [
+            '--mode=mirror',
+            '--filter=skipped-earlier',
+        ];
+        $this->writeRemoteOverrides([
+            'added_files' => [$remoteUpload => 'remote upload'],
+        ]);
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertSame(
+            'remote upload',
+            file_get_contents($this->localTree . '/' . $remoteUpload)
+        );
+        $this->assertFileDoesNotExist($this->localTree . '/unchanged.txt');
+
+        file_put_contents(
+            $this->localTree . '/' . $remoteUpload,
+            'local upload edit'
+        );
+        file_put_contents(
+            $this->localTree . '/unchanged.txt',
+            'local essential file'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            'remote upload',
+            file_get_contents($this->localTree . '/' . $remoteUpload)
+        );
+        $this->assertSame(
+            'local essential file',
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+    }
+
+    public function testMirrorIncludesDefaultSkippedPathsWhenRequested(): void
+    {
+        $remoteCache = 'wp-content/cache/remote.txt';
+        $this->writeRemoteOverrides([
+            'added_files' => [$remoteCache => 'remote cache'],
+        ]);
+        mkdir($this->localTree . '/wp-content/cache', 0700, true);
+        file_put_contents(
+            $this->localTree . '/' . $remoteCache,
+            'local cache edit'
+        );
+        file_put_contents(
+            $this->localTree . '/wp-content/cache/local-only.txt',
+            'local only cache'
+        );
+
+        $mirror = $this->runFilesPull([
+            '--mode=mirror',
+            '--include-caches',
+        ]);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            'remote cache',
+            file_get_contents($this->localTree . '/' . $remoteCache)
+        );
+        $this->assertFileDoesNotExist(
+            $this->localTree . '/wp-content/cache/local-only.txt'
+        );
+    }
+
+    public function testMirrorPreservesUnrecordedLocalPathsWhenRequested(): void
+    {
+        mkdir($this->localTree . '/local-only', 0700, true);
+        file_put_contents(
+            $this->localTree . '/unchanged.txt',
+            'pre-existing local file'
+        );
+        file_put_contents(
+            $this->localTree . '/local-only/file.txt',
+            'pre-existing local-only file'
+        );
+        $arguments = [
+            '--mode=mirror',
             '--on-fs-root-nonempty=preserve-local',
-        ]];
+        ];
+
+        $initial = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $this->assertSame(
+            'pre-existing local file',
+            file_get_contents($this->localTree . '/unchanged.txt')
+        );
+        $this->assertSame(
+            'pre-existing local-only file',
+            file_get_contents($this->localTree . '/local-only/file.txt')
+        );
+        $this->assertSame(
+            $this->remoteFiles['edited.txt'],
+            file_get_contents($this->localTree . '/edited.txt')
+        );
+
+        file_put_contents(
+            $this->localTree . '/edited.txt',
+            'local edit after the pull'
+        );
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            $this->remoteFiles['edited.txt'],
+            file_get_contents($this->localTree . '/edited.txt')
+        );
+        $this->assertSame(
+            'pre-existing local-only file',
+            file_get_contents($this->localTree . '/local-only/file.txt')
+        );
     }
 
     public function testMirrorRejectsAStateDirectoryInsideTheFilesystemRoot(): void
@@ -496,6 +730,84 @@ final class FilesPullLocalIndexTest extends TestCase
             '--mode=mirror requires --state-dir to be outside --fs-root.',
             $mirror['output']
         );
+    }
+
+    public function testMirrorAppliesIncludedPathsAfterLocalRemapping(): void
+    {
+        $arguments = [
+            '--mode=mirror',
+            '--include=/var/www/html/selected',
+            '--remap',
+            '/var/www/html',
+            ':fs-root:/var/www/html/remapped',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $remappedRoot = $this->localTree . '/remapped';
+        $selectedPath = $remappedRoot . '/' . self::PULLED_PATH;
+        $this->assertFileExists($selectedPath);
+
+        file_put_contents($selectedPath, 'local selected edit');
+        file_put_contents(
+            $remappedRoot . '/selected/local-only.txt',
+            'local selected addition'
+        );
+        file_put_contents(
+            $remappedRoot . '/outside-selection.txt',
+            'local unselected addition'
+        );
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            self::PULLED_CONTENTS,
+            file_get_contents($selectedPath)
+        );
+        $this->assertFileDoesNotExist(
+            $remappedRoot . '/selected/local-only.txt'
+        );
+        $this->assertSame(
+            'local unselected addition',
+            file_get_contents($remappedRoot . '/outside-selection.txt')
+        );
+    }
+
+    public function testMirrorAppliesIncludedPathsInsideANestedRemap(): void
+    {
+        $remotePath = 'selected/nested/remote.txt';
+        $this->writeRemoteOverrides([
+            'added_files' => [$remotePath => 'remote nested contents'],
+        ]);
+        $arguments = [
+            '--mode=mirror',
+            '--include=/var/www/html/selected',
+            '--remap',
+            '/var/www/html/selected/nested',
+            ':fs-root:/detached',
+        ];
+        $initial = $this->runFilesPull($arguments);
+        $this->assertSame(0, $initial['exit'], $initial['output']);
+        $mappedRemotePath = $this->rawFileRoot . '/detached/remote.txt';
+        $mappedLocalOnlyPath = $this->rawFileRoot . '/detached/local-only.txt';
+        $this->assertSame(
+            'remote nested contents',
+            file_get_contents($mappedRemotePath)
+        );
+
+        file_put_contents($mappedRemotePath, 'local nested edit');
+        file_put_contents($mappedLocalOnlyPath, 'local nested addition');
+
+        $this->abortFilesPull();
+        $mirror = $this->runFilesPull($arguments);
+
+        $this->assertSame(0, $mirror['exit'], $mirror['output']);
+        $this->assertSame(
+            'remote nested contents',
+            file_get_contents($mappedRemotePath)
+        );
+        $this->assertFileDoesNotExist($mappedLocalOnlyPath);
     }
 
     public function testMirrorUsesRemotePathsAfterLocalRemapping(): void

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -634,7 +634,7 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testMirrorIncludesDefaultSkippedPathsWhenRequested(): void
+    public function testMirrorIncludesGeneratedCachePathsWhenRequested(): void
     {
         $remoteCache = 'wp-content/cache/remote.txt';
         $this->writeRemoteOverrides([

--- a/tests/Import/FilesPullMirrorDiffTest.php
+++ b/tests/Import/FilesPullMirrorDiffTest.php
@@ -99,6 +99,47 @@ final class FilesPullMirrorDiffTest extends TestCase
         ], $this->readJsonLines($this->path($client, 'pull_index_wal_path')));
     }
 
+    public function testUsesCurrentRemoteIndexEntriesOutsideTheIncludeRoot(): void
+    {
+        $client = $this->client();
+        $localPath = $client->filesystem_root . '/followed/file.txt';
+        mkdir(dirname($localPath), 0755, true);
+        file_put_contents($localPath, 'local edit');
+        $localStat = lstat($localPath);
+        $this->assertIsArray($localStat);
+        $this->writeIndex($this->path($client, 'local_index_file'), [[
+            'path' => 'followed/file.txt',
+            'ctime' => $localStat['ctime'] - 1,
+            'size' => strlen('local edit'),
+            'type' => 'file',
+        ]]);
+        $this->writeMappedIndex($client, [[
+            'followed/file.txt',
+            '/outside/followed/file.txt',
+            'file',
+            strlen('remote'),
+        ]]);
+        $this->writeFetchList($client, []);
+        ( new \ReflectionProperty(
+            \ImportClient::class,
+            'pull_only_files_with_path_prefixes'
+        ) )->setValue($client, ['/remote/included']);
+
+        ( new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_local_changes'
+        ) )->invoke($client);
+        ( new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_fetch_list'
+        ) )->invoke($client);
+
+        $this->assertSame(
+            ['/outside/followed/file.txt'],
+            $this->readFetchList($client)
+        );
+    }
+
     private function client(): \ImportClient
     {
         return new \ImportClient(

--- a/tests/Import/MappedRemoteIndexBuilderTest.php
+++ b/tests/Import/MappedRemoteIndexBuilderTest.php
@@ -113,6 +113,49 @@ final class MappedRemoteIndexBuilderTest extends TestCase
         \MappedRemoteIndexBuilder::build(['remote_file' => 'index.jsonl']);
     }
 
+    public function testOmitsExcludedRemotePathsBeforeCollisionValidation(): void
+    {
+        $remoteIndex = $this->root . '/remote.jsonl';
+        $mappedIndex = $this->root . '/mapped.jsonl';
+        $this->writeRemoteIndex($remoteIndex, [
+            '/remote/included/file.txt',
+            '/remote/excluded/a.txt',
+            '/remote/excluded/b.txt',
+        ]);
+        $mapper = new \RemoteToLocalPathMapper(
+            $this->root . '/files',
+            ['/remote'],
+            [
+                '/remote/included' => $this->root . '/files/included',
+                '/remote/excluded/a.txt' => $this->root . '/files/collision',
+                '/remote/excluded/b.txt' => $this->root . '/files/collision',
+            ]
+        );
+
+        \MappedRemoteIndexBuilder::build([
+            'remote_index_file' => $remoteIndex,
+            'mapped_remote_index_file' => $mappedIndex,
+            'filesystem_root' => $this->root . '/files',
+            'path_mapper' => $mapper,
+            'excluded_remote_absolute_path_prefixes' => [
+                '/remote/excluded',
+            ],
+        ]);
+
+        $lines = file(
+            $mappedIndex,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        $this->assertCount(1, $lines);
+        $this->assertSame(
+            '/remote/included/file.txt',
+            \MappedRemoteIndexBuilder::decode_index_line(
+                $lines[0]
+            )['copy_source_path']
+        );
+    }
+
     /** @param list<string> $remotePaths */
     private function writeRemoteIndex(string $path, array $remotePaths): void
     {

--- a/tests/Import/RemapSeamTest.php
+++ b/tests/Import/RemapSeamTest.php
@@ -82,6 +82,25 @@ class RemapSeamTest extends TestCase
         $this->assertSame($this->root . '/wp-content/plugins/woo/woo.php', $local_absolute_path);
     }
 
+    public function testRemoteSelectionIncludesNestedRemapRoots(): void
+    {
+        $mapper = $this->mapperWithRules(array(
+            '/var/www/html/wp-content' => $this->root . '/wp-content',
+            '/var/www/html/wp-content/uploads' => $this->root . '/media',
+            '/var/www/html/wp-admin' => $this->root . '/admin',
+        ));
+
+        $this->assertSame(
+            array(
+                $this->root . '/wp-content',
+                $this->root . '/media',
+            ),
+            $mapper->remote_path_prefixes_to_local_path_prefixes(array(
+                '/var/www/html/wp-content',
+            ))
+        );
+    }
+
     public function testDeeperRemotePrefixWinsRegardlessOfLocalPrefixLength(): void
     {
         // Two nested remote prefixes; the deeper (more specific) one has the

--- a/tests/e2e/tests/import-59-files-pull-mirror.test.js
+++ b/tests/e2e/tests/import-59-files-pull-mirror.test.js
@@ -47,6 +47,10 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
     let nonemptyMirrorTempDir;
     let remappedMirrorTempDir;
     let typeChangeMirrorTempDir;
+    let selectedMirrorTempDir;
+    let filteredMirrorTempDir;
+    let cacheMirrorTempDir;
+    let preservedMirrorTempDir;
 
     const remoteConflictFile = join(
         getSiteDir(site),
@@ -100,6 +104,10 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         nonemptyMirrorTempDir = createTempDir('e2e-files-pull-mirror-nonempty');
         remappedMirrorTempDir = createTempDir('e2e-files-pull-mirror-remapped');
         typeChangeMirrorTempDir = createTempDir('e2e-files-pull-mirror-types');
+        selectedMirrorTempDir = createTempDir('e2e-files-pull-mirror-selected');
+        filteredMirrorTempDir = createTempDir('e2e-files-pull-mirror-filtered');
+        cacheMirrorTempDir = createTempDir('e2e-files-pull-mirror-caches');
+        preservedMirrorTempDir = createTempDir('e2e-files-pull-mirror-preserved');
         clearHookState(site);
         removeTestHooks(site);
     });
@@ -114,6 +122,10 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         cleanupTempDir(nonemptyMirrorTempDir);
         cleanupTempDir(remappedMirrorTempDir);
         cleanupTempDir(typeChangeMirrorTempDir);
+        cleanupTempDir(selectedMirrorTempDir);
+        cleanupTempDir(filteredMirrorTempDir);
+        cleanupTempDir(cacheMirrorTempDir);
+        cleanupTempDir(preservedMirrorTempDir);
         writeRemoteFile(remoteConflictFile, 'initial remote content\n');
         writeRemoteFile(remoteDeletedFile, 'present before remote deletion\n');
         removeRemotePath(remoteAddedFile);
@@ -441,6 +453,217 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
             `Repeated remapped mirror failed\nstderr: ${repeated.stderr}\nstdout: ${repeated.stdout}`,
         );
         assertTreesMatch(getSiteDir(site), remappedLocalRoot);
+    });
+
+    it('changes only the included paths outside excluded subtrees', () => {
+        const initial = runFilesPull(selectedMirrorTempDir, 'mirror');
+        assert.equal(
+            initial.exitCode,
+            0,
+            `Selected mirror setup failed\nstderr: ${initial.stderr}\nstdout: ${initial.stdout}`,
+        );
+        resetCompletedFilesPull(selectedMirrorTempDir);
+
+        const localRoot = localSiteRoot(selectedMirrorTempDir);
+        const selectedFile = join(localRoot, 'test-data', 'hello.txt');
+        const excludedFile = join(
+            localRoot,
+            'test-data',
+            'subdir',
+            'nested',
+            'deep.txt',
+        );
+        writeFileSync(selectedFile, 'selected local edit\n');
+        writeFileSync(excludedFile, 'excluded local edit\n');
+        writeFileSync(
+            join(localRoot, 'test-data', 'local-only.txt'),
+            'selected local-only file\n',
+        );
+        writeFileSync(
+            join(localRoot, 'test-data', 'subdir', 'local-only.txt'),
+            'excluded local-only file\n',
+        );
+
+        const result = runFilesPull(selectedMirrorTempDir, 'mirror', {
+            extraArgs: [
+                `--include=${join(getSiteDir(site), 'test-data')}`,
+                `--exclude=${join(getSiteDir(site), 'test-data', 'subdir')}`,
+            ],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `Selected mirror failed\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+        assert.deepEqual(
+            readFileSync(selectedFile),
+            readFileSync(join(getSiteDir(site), 'test-data', 'hello.txt')),
+        );
+        assert.ok(!existsSync(join(localRoot, 'test-data', 'local-only.txt')));
+        assert.equal(readFileSync(excludedFile, 'utf-8'), 'excluded local edit\n');
+        assert.equal(
+            readFileSync(
+                join(localRoot, 'test-data', 'subdir', 'local-only.txt'),
+                'utf-8',
+            ),
+            'excluded local-only file\n',
+        );
+    });
+
+    it('mirrors essential files and uploads in separate filter passes', () => {
+        const remoteUpload = join(
+            getSiteDir(site),
+            'wp-content',
+            'uploads',
+            'mirror-selection',
+            'remote.txt',
+        );
+        execFileSync('sudo', ['mkdir', '-p', join(remoteUpload, '..')]);
+        writeRemoteFile(remoteUpload, 'remote upload\n');
+        try {
+            const initial = runFilesPull(filteredMirrorTempDir, 'mirror');
+            assert.equal(
+                initial.exitCode,
+                0,
+                `Filtered mirror setup failed\nstderr: ${initial.stderr}\nstdout: ${initial.stdout}`,
+            );
+            resetCompletedFilesPull(filteredMirrorTempDir);
+
+            const localRoot = localSiteRoot(filteredMirrorTempDir);
+            const localUpload = join(
+                localRoot,
+                'wp-content',
+                'uploads',
+                'mirror-selection',
+                'remote.txt',
+            );
+            const localEssentialFile = join(localRoot, 'test-data', 'hello.txt');
+            writeFileSync(localUpload, 'local upload edit\n');
+            writeFileSync(localEssentialFile, 'local essential edit\n');
+
+            const essential = runFilesPull(filteredMirrorTempDir, 'mirror', {
+                extraArgs: ['--filter=essential-files'],
+            });
+            assert.equal(
+                essential.exitCode,
+                0,
+                `Essential-files mirror failed\nstderr: ${essential.stderr}\nstdout: ${essential.stdout}`,
+            );
+            assert.equal(readFileSync(localUpload, 'utf-8'), 'local upload edit\n');
+            assert.deepEqual(
+                readFileSync(localEssentialFile),
+                readFileSync(join(getSiteDir(site), 'test-data', 'hello.txt')),
+            );
+
+            resetCompletedFilesPull(filteredMirrorTempDir);
+            writeFileSync(localEssentialFile, 'second local essential edit\n');
+            const uploads = runFilesPull(filteredMirrorTempDir, 'mirror', {
+                extraArgs: ['--filter=skipped-earlier'],
+            });
+            assert.equal(
+                uploads.exitCode,
+                0,
+                `Skipped-earlier mirror failed\nstderr: ${uploads.stderr}\nstdout: ${uploads.stdout}`,
+            );
+            assert.equal(readFileSync(localUpload, 'utf-8'), 'remote upload\n');
+            assert.equal(
+                readFileSync(localEssentialFile, 'utf-8'),
+                'second local essential edit\n',
+            );
+        } finally {
+            removeRemotePath(join(getSiteDir(site), 'wp-content', 'uploads', 'mirror-selection'));
+        }
+    });
+
+    it('includes caches and preserves unrecorded local paths when requested', () => {
+        const remoteCache = join(
+            getSiteDir(site),
+            'wp-content',
+            'cache',
+            'mirror-selection',
+            'remote.txt',
+        );
+        execFileSync('sudo', ['mkdir', '-p', join(remoteCache, '..')]);
+        writeRemoteFile(remoteCache, 'remote cache\n');
+        try {
+            const cacheLocalRoot = localSiteRoot(cacheMirrorTempDir);
+            const localCacheDirectory = join(
+                cacheLocalRoot,
+                'wp-content',
+                'cache',
+                'mirror-selection',
+            );
+            mkdirSync(localCacheDirectory, { recursive: true });
+            writeFileSync(join(localCacheDirectory, 'remote.txt'), 'local cache edit\n');
+            writeFileSync(join(localCacheDirectory, 'local-only.txt'), 'local cache only\n');
+
+            const cacheResult = runFilesPull(cacheMirrorTempDir, 'mirror', {
+                extraArgs: ['--include-caches'],
+            });
+            assert.equal(
+                cacheResult.exitCode,
+                0,
+                `Cache mirror failed\nstderr: ${cacheResult.stderr}\nstdout: ${cacheResult.stdout}`,
+            );
+            assert.equal(
+                readFileSync(join(localCacheDirectory, 'remote.txt'), 'utf-8'),
+                'remote cache\n',
+            );
+            assert.ok(!existsSync(join(localCacheDirectory, 'local-only.txt')));
+
+            const preservedLocalRoot = localSiteRoot(preservedMirrorTempDir);
+            mkdirSync(join(preservedLocalRoot, 'test-data', 'local-only'), {
+                recursive: true,
+            });
+            writeFileSync(
+                join(preservedLocalRoot, 'test-data', 'hello.txt'),
+                'pre-existing local file\n',
+            );
+            writeFileSync(
+                join(preservedLocalRoot, 'test-data', 'local-only', 'file.txt'),
+                'pre-existing local-only file\n',
+            );
+            const preserveResult = runFilesPull(preservedMirrorTempDir, 'mirror', {
+                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
+            });
+            assert.equal(
+                preserveResult.exitCode,
+                0,
+                `Preserve-local mirror failed\nstderr: ${preserveResult.stderr}\nstdout: ${preserveResult.stdout}`,
+            );
+            assert.equal(
+                readFileSync(
+                    join(preservedLocalRoot, 'test-data', 'hello.txt'),
+                    'utf-8',
+                ),
+                'pre-existing local file\n',
+            );
+            assert.equal(
+                readFileSync(
+                    join(
+                        preservedLocalRoot,
+                        'test-data',
+                        'local-only',
+                        'file.txt',
+                    ),
+                    'utf-8',
+                ),
+                'pre-existing local-only file\n',
+            );
+            assert.ok(
+                existsSync(
+                    join(
+                        preservedLocalRoot,
+                        'test-data',
+                        'subdir',
+                        'nested',
+                        'deep.txt',
+                    ),
+                ),
+            );
+        } finally {
+            removeRemotePath(join(getSiteDir(site), 'wp-content', 'cache', 'mirror-selection'));
+        }
     });
 
     it('applies remote additions, deletions, and conflicts on both modes', () => {


### PR DESCRIPTION
`files-pull --mode=mirror` now applies the existing pull selection instead of requiring a full-tree pull.

For example, this command mirrors `wp-content` except `uploads`:

```bash
php reprint.phar files-pull "$URL" \
    --state-dir="$STATE_DIR" \
    --fs-root="$FS_ROOT" \
    --secret="$SECRET" \
    --mode=mirror \
    --include=:wp-content: \
    --exclude=:wp-uploads:
```

A local plugin edit is replaced by the current remote plugin file. A local-only plugin file is removed. Local uploads remain unchanged.

## Background

Before this PR, mirror rejected `--include`, `--only`, `--exclude`, `--filter`, `--include-caches`, and `--on-fs-root-nonempty=preserve-local`.

## This change

The existing remote index pass already applies the pull selection. This change applies that selection to the streaming comparison between the retained local index and the current local index.

When a changed local path has a current remote index entry, mirror passes that entry's remote absolute path through the existing `is_selected_for_pulling()` check. This also keeps current remote index entries discovered while following a selected symlink.

When no current remote entry exists, there is no remote path to check. Mirror compares that local-only path with the local forms of the include and exclude prefixes before removing it. A nested remap adds its local prefix to this check, so `--include=:wp-content:` also selects `:wp-content:/uploads` when that subtree is remapped to a separate local directory.

The local scan includes generated cache directories, version-control metadata, OS metadata, and editor scratch files only with `--include-caches`. `preserve-local` keeps an existing local path when no previous pull recorded it. If a previous pull did record the path, mirror still restores the current remote contents.

Excluded remote entries are omitted from the mapped current remote index before path-collision checks. An excluded subtree therefore cannot affect the selected mirror work.

Parent-symlink behavior is unchanged and remains outside this PR.

## Testing

The PHP tests cover `--include`, its `--only` alias, `--exclude`, both filter passes, caches, `preserve-local`, direct and nested remapping, current remote entries outside an include prefix, retained paths outside a later narrow selection, and excluded mapped collisions.

The Docker end-to-end suite runs the user-facing selection flows through the real CLI and WordPress export endpoint.
