### PR TITLE
[PHP] Return rows from prepared database queries

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8866,7 +8866,8 @@ class ImportClient
             40,
         );
         $lock_result = $database->query(
-            'SELECT GET_LOCK(' . $database->quote($lock_name) . ', 60)'
+            'SELECT GET_LOCK(?, 60)',
+            [$lock_name]
         );
         $lock_acquired = $lock_result->fetchColumn();
         $lock_result->closeCursor();
@@ -9019,7 +9020,6 @@ class ImportClient
 
         // The saved cursor comes before any SQL that was still running when
         // the process stopped. Check the target table before repeating that SQL.
-        $quoted_current_table = $database->quote($current_table);
         $table_result = $database->query(
             "SELECT `TABLES`.`TABLE_TYPE` AS `table_type`, " .
             "`TABLES`.`ENGINE` AS `engine`, `ENGINES`.`TRANSACTIONS` AS `supports_transactions` " .
@@ -9027,7 +9027,8 @@ class ImportClient
             "LEFT JOIN `INFORMATION_SCHEMA`.`ENGINES` AS `ENGINES` " .
             "ON `ENGINES`.`ENGINE` = `TABLES`.`ENGINE` " .
             "WHERE `TABLES`.`TABLE_SCHEMA` = DATABASE() " .
-            "AND BINARY `TABLES`.`TABLE_NAME` = BINARY {$quoted_current_table}"
+            "AND BINARY `TABLES`.`TABLE_NAME` = BINARY ?",
+            [$current_table]
         );
         $table = $table_result->fetch(PDO::FETCH_ASSOC);
         $table_result->closeCursor();
@@ -9066,10 +9067,11 @@ class ImportClient
             "AND `COLUMNS`.`TABLE_NAME` = `STATISTICS`.`TABLE_NAME` " .
             "AND `COLUMNS`.`COLUMN_NAME` = `STATISTICS`.`COLUMN_NAME` " .
             "WHERE `STATISTICS`.`TABLE_SCHEMA` = DATABASE() " .
-            "AND BINARY `STATISTICS`.`TABLE_NAME` = BINARY {$quoted_current_table} " .
+            "AND BINARY `STATISTICS`.`TABLE_NAME` = BINARY ? " .
             "AND `STATISTICS`.`NON_UNIQUE` = 0 " .
             "GROUP BY `STATISTICS`.`INDEX_NAME` " .
-            "HAVING SUM(`COLUMNS`.`IS_NULLABLE` = 'YES') = 0 LIMIT 1"
+            "HAVING SUM(`COLUMNS`.`IS_NULLABLE` = 'YES') = 0 LIMIT 1",
+            [$current_table]
         );
         $has_replay_key = $key_result->fetchColumn() !== false;
         $key_result->closeCursor();

--- a/packages/reprint-client/src/lib/database/class-mysqli-database-connection.php
+++ b/packages/reprint-client/src/lib/database/class-mysqli-database-connection.php
@@ -7,6 +7,7 @@ namespace Reprint\Importer\Database;
 use mysqli;
 use mysqli_result;
 use mysqli_sql_exception;
+use mysqli_stmt;
 use PDOException;
 use RuntimeException;
 
@@ -21,8 +22,16 @@ class MysqliDatabaseConnection implements DatabaseConnection {
         $this->database = $database;
     }
 
-    public function query(string $sql): DatabaseResult
+    public function query(string $sql, array $params = []): DatabaseResult
     {
+        if ($params !== []) {
+            return $this->run_mysqli_operation('prepared query', function () use ($sql, $params): DatabaseResult {
+                return new MysqliPreparedDatabaseResult(
+                    $this->prepare_and_execute($sql, $params, 'prepared query')
+                );
+            });
+        }
+
         return $this->run_mysqli_operation('query', function () use ($sql): DatabaseResult {
             $result = $this->get_database()->query($sql);
             if (!$result instanceof mysqli_result) {
@@ -70,42 +79,7 @@ class MysqliDatabaseConnection implements DatabaseConnection {
     public function execute(string $sql, array $params = []): int
     {
         return $this->run_mysqli_operation('prepared statement', function () use ($sql, $params): int {
-            $statement = $this->get_database()->prepare($sql);
-            if ($statement === false) {
-                throw $this->new_query_exception('prepared statement');
-            }
-
-            if ($params !== []) {
-                $values = array_values($params);
-                $types = '';
-                foreach ($values as $value) {
-                    if (is_int($value) || is_bool($value)) {
-                        $types .= 'i';
-                    } elseif (is_float($value)) {
-                        $types .= 'd';
-                    } else {
-                        $types .= 's';
-                    }
-                }
-                $arguments = [$types];
-                foreach ($values as $index => &$value) {
-                    $arguments[] = &$values[$index];
-                }
-                unset($value);
-                if (!call_user_func_array([$statement, 'bind_param'], $arguments)) {
-                    $error = $statement->error;
-                    $statement->close();
-                    // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
-                    throw new PDOException('The target database could not bind a prepared statement: ' . $error);
-                }
-            }
-
-            if (!$statement->execute()) {
-                $error = $statement->error;
-                $statement->close();
-                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
-                throw new PDOException('The target database prepared statement failed: ' . $error);
-            }
+            $statement = $this->prepare_and_execute($sql, $params, 'prepared statement');
             $affected_rows = max(0, $statement->affected_rows);
             $statement->close();
             return $affected_rows;
@@ -178,6 +152,51 @@ class MysqliDatabaseConnection implements DatabaseConnection {
     }
 
     /**
+     * @param array<int,mixed> $params Values for the statement's question marks.
+     */
+    private function prepare_and_execute(string $sql, array $params, string $operation): mysqli_stmt
+    {
+        $statement = $this->get_database()->prepare($sql);
+        if ($statement === false) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The operation is a fixed adapter label.
+            throw $this->new_query_exception($operation);
+        }
+
+        if ($params !== []) {
+            $values = array_values($params);
+            $types = '';
+            foreach ($values as $value) {
+                if (is_int($value) || is_bool($value)) {
+                    $types .= 'i';
+                } elseif (is_float($value)) {
+                    $types .= 'd';
+                } else {
+                    $types .= 's';
+                }
+            }
+            $arguments = [$types];
+            foreach ($values as $index => &$value) {
+                $arguments[] = &$values[$index];
+            }
+            unset($value);
+            if (!call_user_func_array([$statement, 'bind_param'], $arguments)) {
+                $error = $statement->error;
+                $statement->close();
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+                throw new PDOException("The target database could not bind a {$operation}: {$error}");
+            }
+        }
+
+        if (!$statement->execute()) {
+            $error = $statement->error;
+            $statement->close();
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException("The target database {$operation} failed: {$error}");
+        }
+        return $statement;
+    }
+
+    /**
      * @template T
      * @param callable():T $callback Native mysqli call.
      * @return T
@@ -191,6 +210,14 @@ class MysqliDatabaseConnection implements DatabaseConnection {
             throw new PDOException(
                 "The target database {$operation} failed: {$error->getMessage()}",
                 $error->getCode(),
+                $error,
+            );
+        } catch (\ArgumentCountError $error) {
+            // mysqli throws this when the number of values does not match the
+            // prepared statement. Expose it through the same error type as PDO.
+            throw new PDOException(
+                "The target database {$operation} failed: {$error->getMessage()}",
+                0,
                 $error,
             );
             // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/packages/reprint-client/src/lib/database/class-mysqli-prepared-database-result.php
+++ b/packages/reprint-client/src/lib/database/class-mysqli-prepared-database-result.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Reprint\Importer\Database;
 
 use mysqli_result;
+use mysqli_sql_exception;
 use mysqli_stmt;
 use PDO;
 use PDOException;
@@ -59,7 +60,17 @@ class MysqliPreparedDatabaseResult implements DatabaseResult {
         }
 
         $statement = $this->get_statement();
-        $fetched = $statement->fetch();
+        try {
+            $fetched = $statement->fetch();
+        } catch (mysqli_sql_exception $error) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException(
+                'The target database could not fetch a prepared query row: ' . $error->getMessage(),
+                $error->getCode(),
+                $error,
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
         if ($fetched === null) {
             return false;
         }

--- a/packages/reprint-client/src/lib/database/class-mysqli-prepared-database-result.php
+++ b/packages/reprint-client/src/lib/database/class-mysqli-prepared-database-result.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reprint\Importer\Database;
+
+use mysqli_result;
+use mysqli_stmt;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+/** Reads rows from a mysqli prepared statement without requiring mysqlnd. */
+class MysqliPreparedDatabaseResult implements DatabaseResult {
+
+    private ?mysqli_stmt $statement;
+
+    /** @var string[] */
+    private array $column_names = [];
+
+    /** @var array<int,mixed> Values populated by mysqli_stmt::fetch(). */
+    private array $column_values = [];
+
+    public function __construct(mysqli_stmt $statement)
+    {
+        $metadata = $statement->result_metadata();
+        if (!$metadata instanceof mysqli_result) {
+            $error = $statement->error;
+            $statement->close();
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException('The target database prepared query returned no columns: ' . $error);
+        }
+
+        foreach ($metadata->fetch_fields() as $field) {
+            $this->column_names[] = $field->name;
+            $this->column_values[] = null;
+        }
+        $metadata->free();
+
+        $bound_values = [];
+        foreach ($this->column_values as $index => &$value) {
+            $bound_values[$index] = &$value;
+        }
+        unset($value);
+        if (!call_user_func_array([$statement, 'bind_result'], $bound_values)) {
+            $error = $statement->error;
+            $statement->close();
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException('The target database could not read a prepared query: ' . $error);
+        }
+
+        $this->statement = $statement;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_BOTH)
+    {
+        if ($mode !== PDO::FETCH_ASSOC && $mode !== PDO::FETCH_NUM && $mode !== PDO::FETCH_BOTH) {
+            throw new RuntimeException('The target database result supports FETCH_ASSOC, FETCH_NUM, and FETCH_BOTH.');
+        }
+
+        $statement = $this->get_statement();
+        $fetched = $statement->fetch();
+        if ($fetched === null) {
+            return false;
+        }
+        if ($fetched === false) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database errors are CLI text.
+            throw new PDOException('The target database could not fetch a prepared query row: ' . $statement->error);
+        }
+
+        $row = [];
+        foreach ($this->column_values as $index => $value) {
+            if ($mode !== PDO::FETCH_ASSOC) {
+                $row[$index] = $value;
+            }
+            if ($mode !== PDO::FETCH_NUM) {
+                $row[$this->column_names[$index]] = $value;
+            }
+        }
+        return $row;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_BOTH): array
+    {
+        $rows = [];
+        // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Read one row per iteration.
+        while (( $row = $this->fetch($mode) ) !== false) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+
+    public function fetchColumn(int $column = 0)
+    {
+        $row = $this->fetch(PDO::FETCH_NUM);
+        return $row === false || !array_key_exists($column, $row)
+            ? false
+            : $row[$column];
+    }
+
+    public function closeCursor(): bool
+    {
+        if ($this->statement === null) {
+            return true;
+        }
+        $this->statement->free_result();
+        $this->statement->close();
+        $this->statement = null;
+        return true;
+    }
+
+    private function get_statement(): mysqli_stmt
+    {
+        if ($this->statement === null) {
+            throw new RuntimeException('The database result is already closed.');
+        }
+        return $this->statement;
+    }
+}

--- a/packages/reprint-client/src/lib/database/class-pdo-database-connection.php
+++ b/packages/reprint-client/src/lib/database/class-pdo-database-connection.php
@@ -32,8 +32,19 @@ class PdoDatabaseConnection implements DatabaseConnection {
         $this->prepared_database = $prepared_database ?? $query_database;
     }
 
-    public function query(string $sql): DatabaseResult
+    public function query(string $sql, array $params = []): DatabaseResult
     {
+        if ($params !== []) {
+            $statement = $this->get_prepared_database()->prepare($sql);
+            if ($statement === false) {
+                throw new PDOException('The target database could not prepare a query.');
+            }
+            if (!$statement->execute($params)) {
+                throw new PDOException('The target database prepared query failed.');
+            }
+            return new PdoDatabaseResult($statement);
+        }
+
         $statement = $this->get_query_database()->query($sql);
         if ($statement === false) {
             throw new PDOException('The target database query failed.');

--- a/packages/reprint-client/src/lib/database/interface-database-connection.php
+++ b/packages/reprint-client/src/lib/database/interface-database-connection.php
@@ -7,8 +7,12 @@ namespace Reprint\Importer\Database;
 /** The database operations used by Reprint's target-side commands. */
 interface DatabaseConnection {
 
-    /** Executes a query which returns rows. */
-    public function query(string $sql): DatabaseResult;
+    /**
+     * Executes a query which returns rows.
+     *
+     * @param array<int,mixed> $params Values for the query's question marks.
+     */
+    public function query(string $sql, array $params = []): DatabaseResult;
 
     /** Quotes one string for use as an SQL literal. */
     public function quote(string $value): string;

--- a/packages/reprint-client/src/lib/database/load.php
+++ b/packages/reprint-client/src/lib/database/load.php
@@ -5,4 +5,5 @@ require_once __DIR__ . '/interface-database-connection.php';
 require_once __DIR__ . '/class-pdo-database-result.php';
 require_once __DIR__ . '/class-pdo-database-connection.php';
 require_once __DIR__ . '/class-mysqli-database-result.php';
+require_once __DIR__ . '/class-mysqli-prepared-database-result.php';
 require_once __DIR__ . '/class-mysqli-database-connection.php';

--- a/tests/Import/DatabaseConnectionTest.php
+++ b/tests/Import/DatabaseConnectionTest.php
@@ -4,9 +4,13 @@
 namespace ImportTests;
 
 use PDO;
+use PDOException;
 use PHPUnit\Framework\TestCase;
+use Reprint\Importer\Database\MysqliDatabaseConnection;
 use Reprint\Importer\Database\MysqliDatabaseResult;
+use Reprint\Importer\Database\MysqliPreparedDatabaseResult;
 use Reprint\Importer\Database\PdoDatabaseConnection;
+use RuntimeException;
 
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/database/load.php';
 
@@ -28,7 +32,10 @@ class DatabaseConnectionTest extends TestCase {
             $database->execute('INSERT INTO records (id, value) VALUES (?, ?)', [1, 'first'])
         );
 
-        $result = $database->query('SELECT id, value FROM records');
+        $result = $database->query(
+            'SELECT id, value FROM records WHERE value = ?',
+            ['first']
+        );
         $this->assertSame(['id' => 1, 'value' => 'first'], $result->fetch(PDO::FETCH_ASSOC));
         $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
         $this->assertTrue($result->closeCursor());
@@ -105,5 +112,140 @@ class DatabaseConnectionTest extends TestCase {
         $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
         $this->assertTrue($result->closeCursor());
         $this->assertTrue($result->closeCursor());
+    }
+
+    public function testMysqliPreparedResultUsesTheSameFetchModes(): void
+    {
+        if (!extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli extension required');
+        }
+
+        $metadata = new class() extends \mysqli_result {
+            public function __construct()
+            {
+            }
+
+            public function fetch_fields(): array
+            {
+                return [
+                    (object) ['name' => 'duplicate_value'],
+                    (object) ['name' => 'duplicate_value'],
+                ];
+            }
+
+            public function free(): void
+            {
+            }
+        };
+        $statement = new class($metadata) extends \mysqli_stmt {
+            private \mysqli_result $metadata;
+            private array $rows = [[1, 2], [3, 4], [5, 6]];
+            private array $bound_values = [];
+
+            public function __construct(\mysqli_result $metadata)
+            {
+                $this->metadata = $metadata;
+            }
+
+            public function result_metadata(): \mysqli_result|false
+            {
+                return $this->metadata;
+            }
+
+            public function bind_result(mixed &...$vars): bool
+            {
+                foreach ($vars as $index => &$value) {
+                    $this->bound_values[$index] = &$value;
+                }
+                unset($value);
+                return true;
+            }
+
+            public function fetch(): ?bool
+            {
+                $row = array_shift($this->rows);
+                if ($row === null) {
+                    return null;
+                }
+                foreach ($row as $index => $value) {
+                    $this->bound_values[$index] = $value;
+                }
+                return true;
+            }
+
+            public function free_result(): void
+            {
+            }
+
+            #[\ReturnTypeWillChange]
+            public function close()
+            {
+                return true;
+            }
+        };
+        $result = new MysqliPreparedDatabaseResult($statement);
+
+        try {
+            $result->fetch(PDO::FETCH_OBJ);
+            $this->fail('The mysqli prepared result accepted an unsupported fetch mode.');
+        } catch (RuntimeException $error) {
+            $this->assertStringContainsString('FETCH_ASSOC, FETCH_NUM, and FETCH_BOTH', $error->getMessage());
+        }
+
+        $this->assertSame([1, 2], $result->fetch(PDO::FETCH_NUM));
+        $this->assertSame(['duplicate_value' => 4], $result->fetch(PDO::FETCH_ASSOC));
+        $this->assertSame(
+            [[0 => 5, 'duplicate_value' => 6, 1 => 6]],
+            $result->fetchAll(PDO::FETCH_BOTH)
+        );
+        $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
+        $this->assertTrue($result->closeCursor());
+        $this->assertTrue($result->closeCursor());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The database result is already closed.');
+        $result->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function testMysqliPreparedQueryReportsExtraParametersAsADatabaseError(): void
+    {
+        if (!extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli extension required');
+        }
+
+        $statement = new class() extends \mysqli_stmt {
+            public function __construct()
+            {
+            }
+
+            public function bind_param(string $types, mixed &...$vars): bool
+            {
+                throw new \ArgumentCountError('The number of variables must match the number of parameters.');
+            }
+
+            #[\ReturnTypeWillChange]
+            public function close()
+            {
+                return true;
+            }
+        };
+        $mysqli = new class($statement) extends \mysqli {
+            private \mysqli_stmt $statement;
+
+            public function __construct(\mysqli_stmt $statement)
+            {
+                $this->statement = $statement;
+            }
+
+            public function prepare(string $query): \mysqli_stmt|false
+            {
+                return $this->statement;
+            }
+        };
+        $database = new MysqliDatabaseConnection($mysqli);
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('The target database prepared query failed');
+        $database->query('SELECT ? AS value', [1, 2]);
     }
 }

--- a/tests/Import/DatabaseConnectionTest.php
+++ b/tests/Import/DatabaseConnectionTest.php
@@ -248,4 +248,68 @@ class DatabaseConnectionTest extends TestCase {
         $this->expectExceptionMessage('The target database prepared query failed');
         $database->query('SELECT ? AS value', [1, 2]);
     }
+
+    public function testMysqliPreparedResultReportsFetchFailuresAsDatabaseErrors(): void
+    {
+        if (!extension_loaded('mysqli')) {
+            $this->markTestSkipped('mysqli extension required');
+        }
+
+        $metadata = new class() extends \mysqli_result {
+            public function __construct()
+            {
+            }
+
+            public function fetch_fields(): array
+            {
+                return [ (object) ['name' => 'value'] ];
+            }
+
+            public function free(): void
+            {
+            }
+        };
+        $statement = new class($metadata) extends \mysqli_stmt {
+            private \mysqli_result $metadata;
+
+            public function __construct(\mysqli_result $metadata)
+            {
+                $this->metadata = $metadata;
+            }
+
+            public function result_metadata(): \mysqli_result|false
+            {
+                return $this->metadata;
+            }
+
+            public function bind_result(mixed &...$vars): bool
+            {
+                return true;
+            }
+
+            public function fetch(): ?bool
+            {
+                throw new \mysqli_sql_exception('The connection was lost while reading a row.', 2013);
+            }
+
+            #[\ReturnTypeWillChange]
+            public function close()
+            {
+                return true;
+            }
+        };
+        $result = new MysqliPreparedDatabaseResult($statement);
+
+        try {
+            $result->fetch(PDO::FETCH_ASSOC);
+            $this->fail('The mysqli prepared result did not report its fetch failure.');
+        } catch (PDOException $error) {
+            $this->assertStringContainsString(
+                'The target database could not fetch a prepared query row',
+                $error->getMessage()
+            );
+            $this->assertSame(2013, $error->getCode());
+            $this->assertInstanceOf(\mysqli_sql_exception::class, $error->getPrevious());
+        }
+    }
 }

--- a/tests/Import/DatabaseUrlRewriteCommandTest.php
+++ b/tests/Import/DatabaseUrlRewriteCommandTest.php
@@ -408,10 +408,10 @@ class DatabaseUrlRewriteCommandTest extends TestCase {
         ) extends \Reprint\Importer\Database\PdoDatabaseConnection {
             public array $queries = [];
 
-            public function query(string $sql): \Reprint\Importer\Database\DatabaseResult
+            public function query(string $sql, array $params = []): \Reprint\Importer\Database\DatabaseResult
             {
                 $this->queries[] = $sql;
-                return parent::query($sql);
+                return parent::query($sql, $params);
             }
         };
         $processor = new \Reprint\Importer\DatabaseUrlRewriteProcessor(

--- a/tests/Import/PreparedDatabaseQueryTest.php
+++ b/tests/Import/PreparedDatabaseQueryTest.php
@@ -1,0 +1,292 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace ImportTests;
+
+use PDO;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\Database\DatabaseConnection;
+use Reprint\Importer\Database\MysqliDatabaseConnection;
+use Reprint\Importer\Database\PdoDatabaseConnection;
+use RuntimeException;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/database/load.php';
+require_once __DIR__ . '/../../lib/sqlite-database-integration/packages/mysql-on-sqlite/src/load.php';
+
+class PreparedDatabaseQueryTest extends TestCase {
+
+    private ?DatabaseConnection $database = null;
+    private ?\mysqli $mysql_root = null;
+    private ?string $mysql_database_name = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->database !== null) {
+            $this->database->close();
+            $this->database = null;
+        }
+        if ($this->mysql_root !== null && $this->mysql_database_name !== null) {
+            $database_name = str_replace('`', '``', $this->mysql_database_name);
+            $this->mysql_root->query("DROP DATABASE IF EXISTS `{$database_name}`");
+            $this->mysql_root->close();
+        }
+        $this->mysql_root = null;
+        $this->mysql_database_name = null;
+        parent::tearDown();
+    }
+
+    public static function targetProvider(): array
+    {
+        return [
+            'MySQL through mysqli' => ['mysql'],
+            'SQLite through the MySQL-on-SQLite PDO driver' => ['sqlite'],
+        ];
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testBindsEverySupportedParameterType(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $result = $database->query(
+            'SELECT ? AS integer_value, ? AS true_value, ? AS false_value, ? AS decimal_value, ' .
+            '? AS empty_value, ? AS string_value, ? AS binary_value, ? AS null_value',
+            [42, true, false, 1.25, '', "quote ' question ? emoji 🚀", "nul\0byte", null]
+        );
+        $row = $result->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame(42, (int) $row['integer_value']);
+        $this->assertSame(1, (int) $row['true_value']);
+        $this->assertSame(0, (int) $row['false_value']);
+        $this->assertEqualsWithDelta(1.25, (float) $row['decimal_value'], 0.000001);
+        $this->assertSame('', $row['empty_value']);
+        $this->assertSame("quote ' question ? emoji 🚀", $row['string_value']);
+        $this->assertSame("nul\0byte", $row['binary_value']);
+        $this->assertNull($row['null_value']);
+        $this->assertFalse($result->fetch(PDO::FETCH_ASSOC));
+        $this->assertTrue($result->closeCursor());
+        $this->assertTrue($result->closeCursor());
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testTreatsParameterTextOnlyAsData(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $this->createRecordsTable($database);
+        $database->execute(
+            'INSERT INTO prepared_query_records (id, value) VALUES (?, ?)',
+            [1, 'first']
+        );
+        $database->execute(
+            'INSERT INTO prepared_query_records (id, value) VALUES (?, ?)',
+            [2, "x' OR 1 = 1 --"]
+        );
+
+        $result = $database->query(
+            'SELECT id, value FROM prepared_query_records WHERE value = ?',
+            ["x' OR 1 = 1 --"]
+        );
+        $this->assertSame(2, (int) $result->fetchColumn());
+        $this->assertFalse($result->fetchColumn());
+        $result->closeCursor();
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testCanReuseSqlWithDifferentParameters(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $this->createRecordsTable($database);
+        $database->execute(
+            'INSERT INTO prepared_query_records (id, value) VALUES (?, ?)',
+            [1, 'first']
+        );
+        $database->execute(
+            'INSERT INTO prepared_query_records (id, value) VALUES (?, ?)',
+            [2, 'second']
+        );
+
+        $sql = 'SELECT value FROM prepared_query_records WHERE id = ?';
+        $first = $database->query($sql, [1]);
+        $this->assertSame('first', $first->fetchColumn());
+        $first->closeCursor();
+
+        $second = $database->query($sql, [2]);
+        $this->assertSame('second', $second->fetchColumn());
+        $second->closeCursor();
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testSupportsFetchModesAndDuplicateColumnNames(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $result = $database->query(
+            'SELECT ? AS duplicate_value, ? AS duplicate_value, ? AS named_value',
+            [1, 2, 'third']
+        );
+        $row = $result->fetch(PDO::FETCH_BOTH);
+
+        $this->assertSame(1, (int) $row[0]);
+        $this->assertSame(2, (int) $row[1]);
+        $this->assertSame('third', $row[2]);
+        $this->assertSame(2, (int) $row['duplicate_value']);
+        $this->assertSame('third', $row['named_value']);
+        $result->closeCursor();
+
+        $numeric_result = $database->query(
+            'SELECT ? AS duplicate_value, ? AS duplicate_value',
+            [3, 4]
+        );
+        $rows = $numeric_result->fetchAll(PDO::FETCH_NUM);
+        $this->assertCount(1, $rows);
+        $this->assertSame([3, 4], array_map('intval', $rows[0]));
+        $numeric_result->closeCursor();
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testDistinguishesNullMissingColumnsAndNoRows(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $this->createRecordsTable($database);
+        $database->execute(
+            'INSERT INTO prepared_query_records (id, value) VALUES (?, ?)',
+            [1, null]
+        );
+
+        $null_result = $database->query(
+            'SELECT value FROM prepared_query_records WHERE id = ?',
+            [1]
+        );
+        $this->assertNull($null_result->fetchColumn());
+        $null_result->closeCursor();
+
+        $missing_column = $database->query(
+            'SELECT value FROM prepared_query_records WHERE id = ?',
+            [1]
+        );
+        $this->assertFalse($missing_column->fetchColumn(1));
+        $missing_column->closeCursor();
+
+        $no_rows = $database->query(
+            'SELECT value FROM prepared_query_records WHERE id = ?',
+            [999]
+        );
+        $this->assertFalse($no_rows->fetch(PDO::FETCH_ASSOC));
+        $this->assertSame([], $no_rows->fetchAll(PDO::FETCH_ASSOC));
+        $no_rows->closeCursor();
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testClosesPreparedResultsAndRecoversAfterInvalidSql(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        $result = $database->query('SELECT ? AS value', [1]);
+        $this->assertTrue($result->closeCursor());
+
+        try {
+            $result->fetch(PDO::FETCH_ASSOC);
+            $this->fail('A closed prepared result accepted another fetch.');
+        } catch (RuntimeException $error) {
+            $this->assertSame('The database result is already closed.', $error->getMessage());
+        }
+
+        try {
+            $database->query('SELECT ? FROM reprint_missing_prepared_query_table', [1]);
+            $this->fail('An invalid prepared query did not fail.');
+        } catch (PDOException $error) {
+            $this->assertNotSame('', $error->getMessage());
+        }
+
+        $next_result = $database->query('SELECT ? AS value', [2]);
+        $this->assertSame(2, (int) $next_result->fetchColumn());
+        $next_result->closeCursor();
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testRejectsExtraParameters(string $target): void
+    {
+        $database = $this->createDatabase($target);
+        try {
+            $database->query('SELECT ? AS first_value', [1, 2]);
+            $this->fail('A prepared query accepted an extra parameter.');
+        } catch (PDOException $error) {
+            $this->assertNotSame('', $error->getMessage());
+        }
+
+        $result = $database->query('SELECT ? AS value', [3]);
+        $this->assertSame(3, (int) $result->fetchColumn());
+        $result->closeCursor();
+    }
+
+    private function createDatabase(string $target): DatabaseConnection
+    {
+        if ($target === 'mysql') {
+            if (!extension_loaded('mysqli')) {
+                $this->markTestSkipped('mysqli extension required');
+            }
+            $host = getenv('DB_HOST') ?: '127.0.0.1';
+            $user = getenv('DB_USER') ?: 'root';
+            $password = getenv('DB_PASS') ?: '';
+            try {
+                $root = new \mysqli($host, $user, $password);
+            } catch (\Throwable $error) {
+                $this->markTestSkipped('MySQL not reachable: ' . $error->getMessage());
+            }
+            if ($root->connect_errno !== 0) {
+                $this->markTestSkipped('MySQL not reachable: ' . $root->connect_error);
+            }
+
+            $this->mysql_database_name = 'test_prepared_queries_' . bin2hex(random_bytes(4));
+            $database_name = str_replace('`', '``', $this->mysql_database_name);
+            $root->query(
+                "CREATE DATABASE `{$database_name}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+            );
+            $this->mysql_root = $root;
+
+            $mysqli = new \mysqli($host, $user, $password, $this->mysql_database_name);
+            $mysqli->set_charset('utf8mb4');
+            $this->database = new MysqliDatabaseConnection($mysqli);
+            return $this->database;
+        }
+
+        if ($target === 'sqlite') {
+            if (!extension_loaded('pdo_sqlite')) {
+                $this->markTestSkipped('pdo_sqlite extension required');
+            }
+            $driver = new \WP_PDO_MySQL_On_SQLite(
+                'mysql-on-sqlite:path=:memory:;dbname=prepared_queries',
+                null,
+                null,
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+            $this->database = new PdoDatabaseConnection(
+                $driver,
+                $driver->get_connection()->get_pdo()
+            );
+            return $this->database;
+        }
+
+        $this->fail("Unknown target database: {$target}");
+    }
+
+    private function createRecordsTable(DatabaseConnection $database): void
+    {
+        $database->exec(
+            'CREATE TABLE prepared_query_records (' .
+            'id BIGINT NOT NULL PRIMARY KEY, value TEXT NULL)'
+        );
+    }
+}

--- a/tests/e2e/tests/import-59-target-database-connections.test.js
+++ b/tests/e2e/tests/import-59-target-database-connections.test.js
@@ -43,7 +43,8 @@ describeWithHostPhpProcess('Target database connection classes', () => {
                 $null_result->closeCursor();
 
                 $duplicate_columns = $database->query(
-                    'SELECT 1 AS duplicate_value, 2 AS duplicate_value'
+                    'SELECT ? AS duplicate_value, ? AS duplicate_value',
+                    array(1, 2)
                 );
                 $duplicate_values = $duplicate_columns->fetch(PDO::FETCH_NUM);
                 if (array_map('intval', $duplicate_values) !== array(1, 2)) {
@@ -55,7 +56,8 @@ describeWithHostPhpProcess('Target database connection classes', () => {
                     array(1, 'first')
                 );
                 $row = $database->query(
-                    'SELECT id, value FROM reprint_connection_contract WHERE id = 1'
+                    'SELECT id, value FROM reprint_connection_contract WHERE id = ?',
+                    array(1)
                 )->fetch(PDO::FETCH_ASSOC);
                 if ((int) $row['id'] !== 1 || $row['value'] !== 'first') {
                     throw new RuntimeException('The target query returned the wrong row.');


### PR DESCRIPTION
Adds row-returning prepared queries to the shared target database API:

```php
// MySQL through mysqli.
$mysqli = new mysqli($host, $user, $password, $database_name, $port);
$mysqli->set_charset('utf8mb4');
$database = new MysqliDatabaseConnection($mysqli);

$result = $database->query(
    'SELECT id, value FROM records WHERE id = ?',
    [1]
);
$row = $result->fetch(PDO::FETCH_ASSOC);
$result->closeCursor();
```

Before this PR, `query()` returned rows but accepted no parameters, while `execute()` accepted parameters but returned only an affected-row count. Code which needed rows had to quote values and insert them into the SQL string.

Both adapters now support `query($sql, $params)`. PDO uses its prepared connection. mysqli binds the input values and returned columns, then reads one row at a time. It does not call `mysqli_stmt::get_result()`, so this does not add a `mysqlnd` requirement. Both adapters report query and row-reading failures as `PDOException`.

The importer now uses prepared queries for its MySQL lock name and `INFORMATION_SCHEMA` table-name checks.

## Testing

The same prepared-query contract runs against MySQL through mysqli and SQLite through `WP_PDO_MySQL_On_SQLite`. It covers integers, booleans, decimals, `NULL`, empty strings, quotes, question marks, Unicode, NUL bytes, SQL-looking text, reused SQL, all supported fetch modes, duplicate column names, missing rows, closed results, invalid SQL, extra parameters, and connection reuse after an error. A focused mysqli test also covers a connection failure while reading a row.
