### PR TITLE
[Tests] Retry performance setup and keep report comments non-blocking

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -7,6 +7,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Two PHAR builds can install GitHub-hosted archives at the same time. Keep each
+# Composer process serial so the workflow does not create a burst of requests.
+env:
+  COMPOSER_MAX_PARALLEL_HTTP: '1'
+
 jobs:
   build-pr-phar:
     name: Build reprint.phar (PR)
@@ -21,7 +26,19 @@ jobs:
           php-version: '8.5'
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
-      - run: composer install --no-dev --no-interaction --prefer-dist
+      - name: Install production dependencies
+        run: |
+          for attempt in 1 2 3; do
+            if composer install --no-dev --no-interaction --prefer-dist; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            wait_seconds=$((attempt * 20))
+            echo "Composer install attempt ${attempt}/3 failed; retrying in ${wait_seconds} seconds."
+            sleep "$wait_seconds"
+          done
       - run: ./bin/build-reprint-phar.sh
 
       - uses: actions/upload-artifact@v4
@@ -43,7 +60,19 @@ jobs:
           php-version: '8.5'
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
-      - run: composer install --no-dev --no-interaction --prefer-dist
+      - name: Install production dependencies
+        run: |
+          for attempt in 1 2 3; do
+            if composer install --no-dev --no-interaction --prefer-dist; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            wait_seconds=$((attempt * 20))
+            echo "Composer install attempt ${attempt}/3 failed; retrying in ${wait_seconds} seconds."
+            sleep "$wait_seconds"
+          done
       - run: ./bin/build-reprint-phar.sh
 
       - uses: actions/upload-artifact@v4
@@ -203,6 +232,9 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           steps.check_md.outputs.exists == 'true'
+        # The step summary and artifact already contain the benchmark result.
+        # A GitHub comment outage must not replace that result with a red check.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pull-pipeline-perf

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -260,10 +260,7 @@ function runPlaygroundSqliteDbPullBenchmark() {
     mkdirSync(stateDir, { recursive: true });
     mkdirSync(fsRootDir(stateDir), { recursive: true });
 
-    requireBenchStageOk(
-        runStage('preflight', stateDir),
-        'playground sqlite benchmark preflight',
-    );
+    runPreflightForSite(SITE, stateDir);
     const proof = runNativeMysqlParserProof({ requireParser: false });
     const baseDetails = {
         condition: 'db-pull in PHP.wasm',
@@ -295,10 +292,7 @@ function runPlaygroundSqliteDbApplyBenchmark() {
     mkdirSync(stateDir, { recursive: true });
     mkdirSync(fsRootDir(stateDir), { recursive: true });
 
-    requireBenchStageOk(
-        runStage('preflight', stateDir),
-        'playground sqlite benchmark preflight',
-    );
+    runPreflightForSite(SITE, stateDir);
     requireBenchStageOk(
         runStage('db-pull', stateDir),
         'playground sqlite benchmark db-pull',
@@ -536,7 +530,7 @@ register_shutdown_function(function () {
 function runPreflightForSite(site, stateDir) {
     const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     const args = [
-        IMPORTER_PATH,
+        PREFLIGHT_IMPORTER_PATH,
         'preflight',
         url,
         `--state-dir=${stateDir}`,


### PR DESCRIPTION
Performance Report now retries temporary setup failures and keeps a sticky-comment outage from failing a completed benchmark.

Composer archive downloads run one at a time, and the two PHAR builds retry installation up to three times. Playground database benchmarks reuse the existing readiness preflight retry before timed work. The timed preflight row and PR benchmark remain strict.

## Testing

Rely on this PR's Performance Report and required CI checks. The retry branches were checked locally with temporary-failure and persistent-failure simulations.
