### PR TITLE
[PHP] Checkpoint SQL prefixes and send MySQL statements separately

### DIFF
--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -103,6 +103,9 @@ jobs:
         run: node benchmark/bench-pull.mjs
 
       - name: Capture commit metadata
+        # A branch dispatch may validate the full benchmark, but only merged
+        # trunk commits belong in the published history.
+        if: github.ref == 'refs/heads/trunk'
         id: commit
         run: |
           echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
@@ -115,6 +118,7 @@ jobs:
           echo "date=$(git log -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout gh-pages branch
+        if: github.ref == 'refs/heads/trunk'
         run: |
           set -euo pipefail
           git config user.name 'github-actions[bot]'
@@ -129,6 +133,7 @@ jobs:
           fi
 
       - name: Update site files and append history entry
+        if: github.ref == 'refs/heads/trunk'
         env:
           BENCH_JSON: tests/e2e/bench-trunk.json
           HISTORY_JSON: pages/data/history.json
@@ -146,6 +151,7 @@ jobs:
           node tests/e2e/benchmark/append-history.mjs
 
       - name: Commit and push
+        if: github.ref == 'refs/heads/trunk'
         working-directory: pages
         run: |
           set -euo pipefail

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -6856,36 +6856,6 @@ class ImportClient
     }
 
     /**
-     * Parses one exporter group and applies URL replacements to its statements.
-     *
-     * @return array { Rewritten SQL followed by the number of statements. }
-     */
-    private function prepare_mysql_sql_group(
-        string $sql,
-        ?SqlStatementRewriter $stmt_rewriter
-    ): array {
-        $query_stream = new \WP_MySQL_FastQueryStream();
-        $query_stream->append_sql($sql);
-        $query_stream->mark_input_complete();
-        $mysql_sql = "";
-        $statement_count = 0;
-        while ($query_stream->next_query()) {
-            $query = $query_stream->get_query();
-            if ($stmt_rewriter !== null) {
-                $query = $stmt_rewriter->rewrite($query);
-            }
-            $mysql_sql .= $query . "\n";
-            ++$statement_count;
-        }
-        if ($statement_count === 0) {
-            throw new RuntimeException(
-                "db.sql contains an SQL group with no complete statement. Run db-pull again.",
-            );
-        }
-        return [$mysql_sql, $statement_count];
-    }
-
-    /**
      * Executes one complete exporter group and saves its next position in the target.
      *
      * @param DatabaseConnection $connection Open target connection.
@@ -6902,11 +6872,26 @@ class ImportClient
         ?SqlStatementRewriter $stmt_rewriter = null
     ): int {
         if ($target_engine === 'mysql') {
-            [$mysql_sql, $statement_count] = $this->prepare_mysql_sql_group(
-                $sql,
-                $stmt_rewriter,
-            );
-            $connection->exec($mysql_sql);
+            $query_stream = new \WP_MySQL_FastQueryStream();
+            $query_stream->append_sql($sql);
+            $query_stream->mark_input_complete();
+            $statement_count = 0;
+            while ($query_stream->next_query()) {
+                $query = $query_stream->get_query();
+                if ($stmt_rewriter !== null) {
+                    $query = $stmt_rewriter->rewrite($query);
+                }
+                // The exporter applies its packet-size cap to each statement.
+                // Keep each MySQL command within that cap even when one
+                // resumable group contains several complete statements.
+                $connection->exec($query);
+                ++$statement_count;
+            }
+            if ($statement_count === 0) {
+                throw new RuntimeException(
+                    "db.sql contains an SQL group with no complete statement. Run db-pull again.",
+                );
+            }
             $this->save_database_import_position(
                 $connection,
                 $source_hash,

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -957,9 +957,28 @@ function endpoint_sql_chunk(
         $gz->sync();
     }
 
+    $emit_sql_multipart_part = function (
+        string $sql,
+        bool $query_complete,
+        string $cursor
+    ) use ($gz, $boundary): void {
+        $gz->write(
+            "--{$boundary}\r\n" .
+            "Content-Type: application/sql\r\n" .
+            "Content-Length: " . strlen($sql) . "\r\n" .
+            "X-Chunk-Type: sql\r\n" .
+            "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "\r\n"
+        );
+        $gz->write($sql);
+        $gz->write("\r\n");
+        $gz->sync();
+    };
+
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch
-    // as a multipart chunk. Stop when the producer is exhausted or the
+    // as multipart SQL parts. Stop when the producer is exhausted or the
     // resource budget (time/memory) runs out.
     $batches_processed = 0;
     $sql_bytes_processed = 0;
@@ -976,12 +995,20 @@ function endpoint_sql_chunk(
             $sql_fragments = [];
             $cursor = null;
             $sql_ends_with_complete_statement = false;
+            $complete_prefix_fragment_count = 0;
+            $complete_prefix_byte_length = 0;
+            $complete_prefix_cursor = null;
+            $sql_batch_bytes = 0;
 
             $i = 0;
             if ($deferred_fragment !== null) {
                 $sql_fragments[] = $deferred_fragment;
                 $cursor = $deferred_fragment_cursor;
                 $sql_ends_with_complete_statement = true;
+                $complete_prefix_fragment_count = 1;
+                $complete_prefix_byte_length = strlen($deferred_fragment);
+                $complete_prefix_cursor = $cursor;
+                $sql_batch_bytes = $complete_prefix_byte_length;
                 $deferred_fragment = null;
                 $deferred_fragment_cursor = null;
             } else {
@@ -1005,6 +1032,7 @@ function endpoint_sql_chunk(
                     }
 
                     $sql_fragments[] = $fragment;
+                    $sql_batch_bytes += strlen($fragment);
                     $i++;
 
                     $trimmed_fragment = rtrim($fragment);
@@ -1012,6 +1040,9 @@ function endpoint_sql_chunk(
                         $trimmed_fragment !== '' && $trimmed_fragment[-1] === ';';
                     if ($sql_ends_with_complete_statement) {
                         $cursor = $reader->get_reentrancy_cursor();
+                        $complete_prefix_fragment_count = count($sql_fragments);
+                        $complete_prefix_byte_length = $sql_batch_bytes;
+                        $complete_prefix_cursor = $cursor;
                     }
 
                     if ($reader->current_fragment_must_be_its_own_part()) {
@@ -1030,40 +1061,64 @@ function endpoint_sql_chunk(
                 }
             }
 
-            $sql = implode("", $sql_fragments);
-            if ($sql === '') {
+            if (empty($sql_fragments) || $sql_batch_bytes === 0) {
                 break;
             }
-            $sql_bytes_processed += strlen($sql);
 
             // Does this chunk end on a complete statement boundary?
             // The producer terminates complete statements with ";" and
             // intermediate INSERT rows with ",", so checking the last
             // character is sufficient.
-            $trimmed = rtrim($sql);
-            $query_complete = $trimmed !== "" && $trimmed[-1] === ";";
+            $query_complete = $sql_ends_with_complete_statement;
             if (!$query_complete || $cursor === null) {
                 $cursor = $reader->get_reentrancy_cursor();
             }
 
+            $sql_bytes_processed += $sql_batch_bytes;
+            $test_sql = null;
             // E2E test hook: before SQL batch is emitted
             if (getenv('SITE_EXPORT_TEST_MODE')) {
-                $hook_args = [&$sql, $cursor];
+                $test_sql = implode("", $sql_fragments);
+                $hook_args = [&$test_sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/sql\r\n" .
-                "Content-Length: " . strlen($sql) . "\r\n" .
-                "X-Chunk-Type: sql\r\n" .
-                "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
-                "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                "\r\n"
+            if (
+                !$query_complete
+                && $complete_prefix_fragment_count > 0
+                && $complete_prefix_cursor !== null
+            ) {
+                // Expose the last complete statement boundary before the
+                // incomplete suffix. The importer can then save that cursor
+                // instead of retaining earlier statements with the suffix.
+                $sql = $test_sql !== null
+                    ? substr($test_sql, 0, $complete_prefix_byte_length)
+                    : implode(
+                        "",
+                        array_slice($sql_fragments, 0, $complete_prefix_fragment_count)
+                    );
+                $emit_sql_multipart_part(
+                    $sql,
+                    true,
+                    $complete_prefix_cursor
+                );
+                unset($sql);
+
+                $sql = $test_sql !== null
+                    ? substr($test_sql, $complete_prefix_byte_length)
+                    : implode(
+                        "",
+                        array_slice($sql_fragments, $complete_prefix_fragment_count)
+                    );
+            } else {
+                $sql = $test_sql ?? implode("", $sql_fragments);
+            }
+
+            $emit_sql_multipart_part(
+                $sql,
+                $query_complete,
+                $cursor
             );
-            $gz->write($sql);
-            $gz->write("\r\n");
-            $gz->sync();
 
             $batches_processed++;
 

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -154,6 +154,9 @@
     },
     "files-pull-mirror": {
       "port": 8130
+    },
+    "mysql-packet-sql-groups": {
+      "port": 8131
     }
   }
 }

--- a/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
+++ b/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
@@ -23,7 +23,7 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
                     `CREATE TABLE \`${firstTable}\` (`
                     + '`id` INT NOT NULL PRIMARY KEY, `value` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
                 );
-                const rows = Array.from({ length: 600 }, (_, index) => [
+                const rows = Array.from({ length: 1001 }, (_, index) => [
                     index + 1,
                     `row-${index + 1}`,
                 ]);
@@ -57,14 +57,18 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         }
     });
 
-    async function sqlParts(fragmentsPerBatch) {
+    async function sqlParts(fragmentsPerBatch, cursor = null) {
+        const request = {
+            directory: getSiteDir(site),
+            fragments_per_batch: fragmentsPerBatch,
+            skip_tables: skippedTables,
+        };
+        if (cursor !== null) {
+            request.cursor = cursor;
+        }
         const response = await apiRequest(site, 'sql_chunk', {}, {
             method: 'POST',
-            body: JSON.stringify({
-                directory: getSiteDir(site),
-                fragments_per_batch: fragmentsPerBatch,
-                skip_tables: skippedTables,
-            }),
+            body: JSON.stringify(request),
         });
         assert.equal(
             response.status,
@@ -74,7 +78,7 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         return response.chunks.filter(chunk => chunk.headers['x-chunk-type'] === 'sql');
     }
 
-    it('allows the existing fragment budget to group complete INSERT statements', async () => {
+    it('emits a complete SQL part before an unfinished batch suffix', async () => {
         const parts = await sqlParts(1000);
         const firstTableInsertPart = parts.find(
             part => part.body.includes(`INSERT INTO \`${firstTable}\``)
@@ -84,6 +88,35 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             firstTableInsertPart.body.match(new RegExp('INSERT INTO `' + firstTable + '`', 'g'))?.length,
             3,
             'Expected the three producer INSERT statements in one budgeted SQL part',
+        );
+        assert.equal(
+            firstTableInsertPart.headers['x-query-complete'],
+            '1',
+            'The complete prefix should be exposed as its own SQL part',
+        );
+        const firstTableInsertPartIndex = parts.indexOf(firstTableInsertPart);
+        const incompleteSuffixPart = parts[firstTableInsertPartIndex + 1];
+        assert.equal(
+            incompleteSuffixPart?.headers['x-query-complete'],
+            '0',
+            'The unfinished INSERT suffix should follow the complete prefix',
+        );
+        assert.ok(
+            incompleteSuffixPart.body.includes(`INSERT INTO \`${firstTable}\``),
+            'The unfinished suffix should contain the next INSERT statement',
+        );
+        assert.ok(
+            !incompleteSuffixPart.body.includes(';'),
+            'The unfinished suffix must not retain a complete statement',
+        );
+        const resumedParts = await sqlParts(
+            1000,
+            firstTableInsertPart.headers['x-cursor'],
+        );
+        assert.equal(
+            resumedParts.map(part => part.body).join(''),
+            parts.slice(firstTableInsertPartIndex + 1).map(part => part.body).join(''),
+            'The complete prefix cursor should resume at the unfinished suffix',
         );
         assert.ok(
             !firstTableInsertPart.body.includes(`DROP TABLE IF EXISTS \`${secondTable}\``),

--- a/tests/e2e/tests/import-60-mysql-packet-sql-groups.test.js
+++ b/tests/e2e/tests/import-60-mysql-packet-sql-groups.test.js
@@ -1,0 +1,216 @@
+/**
+ * db-apply sends each statement separately when one saved exporter SQL group
+ * is larger than the MySQL target's packet limit.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { createReadStream } from 'node:fs';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, getDbName,
+    createMysqlConnection,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const describeWithHostPhpProcess = process.env.PHP_BINARY?.endsWith('/playground-php.sh')
+    ? describe.skip
+    : describe;
+
+describeWithHostPhpProcess('Import: MySQL packet-sized SQL commands', { timeout: 600000 }, () => {
+    const site = 'mysql-packet-sql-groups';
+    const sourceTable = 'aa_packet_group_rows';
+    const rowCount = 1024;
+    const targetDb = `${getDbName(site)}_import`;
+    const sqlGroupMarker = '-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 ';
+    let maxAllowedPacket;
+    let rowByteLength;
+    let tempDir;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    beforeAll(async () => {
+        const connection = await createMysqlConnection();
+        try {
+            const [[packet]] = await connection.query(
+                'SELECT @@SESSION.max_allowed_packet AS max_allowed_packet'
+            );
+            maxAllowedPacket = Number(packet.max_allowed_packet);
+            assert.ok(maxAllowedPacket >= 1024 * 1024, 'Expected a usable MySQL packet limit');
+
+            // The first complete prefix contains 750 rows because the table
+            // comment takes one of the 1,000 exporter fragment slots. Its
+            // base64 SQL is about 10% larger than the target packet limit.
+            rowByteLength = Math.ceil(maxAllowedPacket * 1.1 / 1000);
+        } finally {
+            await connection.end();
+        }
+
+        await ensureSite(site, {
+            files: 'none',
+            customDb: async (_database, sourceConnection) => {
+                await sourceConnection.query(
+                    `CREATE TABLE \`${sourceTable}\` (`
+                    + '`id` INT NOT NULL PRIMARY KEY, `payload` MEDIUMBLOB NOT NULL) ENGINE=InnoDB'
+                );
+                await sourceConnection.query(
+                    `INSERT INTO \`${sourceTable}\` (id, payload) VALUES (1, '')`
+                );
+                for (let rows = 1; rows < rowCount; rows *= 2) {
+                    await sourceConnection.query(
+                        `INSERT INTO \`${sourceTable}\` (id, payload) `
+                        + `SELECT id + ?, payload FROM \`${sourceTable}\``,
+                        [rows],
+                    );
+                }
+                await sourceConnection.query(
+                    `UPDATE \`${sourceTable}\` `
+                    + 'SET payload = REPEAT(CHAR(65 + MOD(id, 26)), ?)',
+                    [rowByteLength],
+                );
+            },
+        });
+
+        tempDir = createTempDir('e2e-mysql-packet-sql-groups');
+        const targetConnection = await createMysqlConnection();
+        try {
+            await targetConnection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+            await targetConnection.query(`CREATE DATABASE \`${targetDb}\``);
+        } finally {
+            await targetConnection.end();
+        }
+    }, 300000);
+
+    afterAll(async () => {
+        if (tempDir) {
+            cleanupTempDir(tempDir);
+        }
+        const connection = await createMysqlConnection();
+        try {
+            await connection.query(`DROP DATABASE IF EXISTS \`${targetDb}\``);
+        } finally {
+            await connection.end();
+        }
+    });
+
+    it('writes a marker-delimited group larger than one target packet', async () => {
+        const result = runImporter(importUrl(), tempDir, 'db-pull', {
+            secret: getSiteSecret(site),
+            timeout: 300000,
+            wallTimeout: 600000,
+            extraArgs: [
+                `--max-allowed-packet=${maxAllowedPacket}`,
+                '--sql-fragments-start=1000',
+                '--sql-fragments-min=1000',
+                '--sql-fragments-max=1000',
+            ],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `db-pull failed:\n${result.stderr}\n${result.stdout}`,
+        );
+
+        const targetInsert = `INSERT INTO \`${sourceTable}\``;
+        const targetGroups = [];
+        let groupByteLength = 0;
+        let statementByteLength = null;
+        let statementByteLengths = [];
+        const lines = createInterface({
+            input: createReadStream(join(tempDir, 'db.sql')),
+            crlfDelay: Infinity,
+        });
+
+        for await (const line of lines) {
+            if (line.startsWith(sqlGroupMarker)) {
+                assert.equal(statementByteLength, null, 'The marker split an INSERT statement');
+                if (statementByteLengths.length > 0) {
+                    targetGroups.push({ groupByteLength, statementByteLengths });
+                }
+                groupByteLength = 0;
+                statementByteLengths = [];
+                continue;
+            }
+
+            const text = `${line}\n`;
+            groupByteLength += Buffer.byteLength(text);
+            let offset = 0;
+            while (offset < text.length) {
+                if (statementByteLength === null) {
+                    const insertOffset = text.indexOf(targetInsert, offset);
+                    if (insertOffset === -1) {
+                        break;
+                    }
+                    statementByteLength = 0;
+                    offset = insertOffset;
+                }
+
+                const statementEnd = text.indexOf(';', offset);
+                if (statementEnd === -1) {
+                    statementByteLength += Buffer.byteLength(text.slice(offset));
+                    break;
+                }
+                statementByteLength += Buffer.byteLength(text.slice(offset, statementEnd + 1));
+                statementByteLengths.push(statementByteLength);
+                statementByteLength = null;
+                offset = statementEnd + 1;
+            }
+        }
+
+        const oversizedGroup = targetGroups.find(
+            group => group.groupByteLength > maxAllowedPacket
+        );
+        assert.ok(
+            oversizedGroup,
+            `Expected a saved SQL group larger than ${maxAllowedPacket} bytes`,
+        );
+        assert.ok(
+            oversizedGroup.statementByteLengths.length > 1,
+            'Expected the large SQL group to contain several INSERT statements',
+        );
+        assert.ok(
+            oversizedGroup.statementByteLengths.every(bytes => bytes < maxAllowedPacket),
+            'Expected every INSERT statement to fit within the target packet limit',
+        );
+    });
+
+    it('applies the large group through statement-sized MySQL commands', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-apply', {
+            secret: getSiteSecret(site),
+            timeout: 300000,
+            wallTimeout: 600000,
+            extraArgs: [
+                '--target-engine=mysql',
+                '--target-host=127.0.0.1',
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${targetDb}`,
+            ],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `db-apply failed:\n${result.stderr}\n${result.stdout}`,
+        );
+    });
+
+    it('keeps every source row byte-for-byte', async () => {
+        const sourceConnection = await createMysqlConnection(getDbName(site));
+        const targetConnection = await createMysqlConnection(targetDb);
+        try {
+            const sql = `SELECT id, OCTET_LENGTH(payload) AS byte_length, `
+                + `SHA2(payload, 256) AS sha256 FROM \`${sourceTable}\` ORDER BY id`;
+            const [sourceRows] = await sourceConnection.query(sql);
+            const [targetRows] = await targetConnection.query(sql);
+
+            assert.equal(sourceRows.length, rowCount);
+            assert.deepEqual(targetRows, sourceRows);
+        } finally {
+            await sourceConnection.end();
+            await targetConnection.end();
+        }
+    });
+});


### PR DESCRIPTION
Database imports now checkpoint the last complete SQL prefix before carrying an unfinished statement into the next response part. MySQL sends each parsed statement as a separate command, then stores the group cursor and commits after every statement in that group succeeds.

## Background

A 1,000-fragment response can contain three complete `INSERT` statements plus 249 rows of the next `INSERT`. The old response marked the whole part incomplete. Repeated parts made `db.sql` hold 57.7 MiB behind one cursor. Performance History then failed in two places:

- PHP.wasm ran out of its 256 MiB limit while growing that group.
- MariaDB closed a 57.7 MiB `multi_query()` command at its 16 MiB packet limit.

## This change

The exporter sends the complete prefix and incomplete suffix as two existing multipart SQL parts. The prefix carries its exact cursor, so file and direct-MySQL imports can save it immediately. No protocol field changes.

MySQL parses the saved group and sends one statement per command. It still stores the group cursor and commits only after the full group succeeds, so the current resume boundary stays the same.

A branch-dispatched Performance History run skips the publishing steps. This allows the full data set to run before merge without adding unmerged numbers to `gh-pages`.

## Testing

CI covers the mixed complete/incomplete response, exact cursor resume, and a real MariaDB import where one saved group is larger than `max_allowed_packet` while each statement fits.
