### PR TITLE
[PHP] Add PHP 5.6 Rector downgrade rules

### DIFF
--- a/bin/downgrade-exporter-plugin.php
+++ b/bin/downgrade-exporter-plugin.php
@@ -1,0 +1,128 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use WordPress\Reprint\Build\Php56SyntaxValidator;
+
+const REPRINT_PHP56_TEMPORARY_VARIABLE_PREFIX = '$__reprint_php56_';
+
+$project_root = dirname(__DIR__);
+$tool_root = $project_root . '/tools/php56-build';
+$autoload = $tool_root . '/vendor/autoload.php';
+$rector = $tool_root . '/vendor/bin/rector';
+
+if ($argc !== 2) {
+    fail('Usage: php bin/downgrade-exporter-plugin.php <staging-root>');
+}
+if (!is_file($autoload) || !is_file($rector)) {
+    fail('Install the PHP 5.6 build tool with: composer install --no-dev --working-dir=tools/php56-build');
+}
+
+$staging_root = realpath($argv[1]);
+if ($staging_root === false || !is_dir($staging_root)) {
+    fail(sprintf('The staging root does not exist: %s', $argv[1]));
+}
+if ($staging_root === realpath($project_root)) {
+    fail('Refusing to downgrade the maintained source tree. Pass a separate staging root.');
+}
+
+$paths = [
+    $staging_root . '/packages/reprint-server/src',
+    $staging_root . '/reprint-server-wp/index.php',
+    $staging_root . '/reprint-server-wp/lib.php',
+    $staging_root . '/reprint-server-wp/wordpress',
+];
+foreach ($paths as $path) {
+    if (!file_exists($path)) {
+        fail(sprintf('The exporter staging tree is incomplete. Missing %s.', $path));
+    }
+    $source_path = $project_root . substr($path, strlen($staging_root));
+    if (realpath($path) === realpath($source_path)) {
+        fail(sprintf('Refusing to downgrade a path from the maintained source tree: %s.', $path));
+    }
+}
+
+assert_reserved_variables_are_unused($paths);
+
+$arguments = array_map('escapeshellarg', $paths);
+$command = escapeshellarg($rector)
+    . ' process '
+    . implode(' ', $arguments)
+    . ' --config '
+    . escapeshellarg($tool_root . '/rector.php')
+    . ' --no-progress-bar --no-diffs --clear-cache';
+passthru($command, $status);
+if ($status !== 0) {
+    fail(sprintf('The PHP 5.6 Rector downgrade failed with exit code %d.', $status));
+}
+
+require_once $autoload;
+
+try {
+    (new Php56SyntaxValidator())->assertPaths($paths);
+} catch (Throwable $throwable) {
+    fail($throwable->getMessage());
+}
+
+echo "Generated exporter PHP contains none of the unsupported syntax checked by the PHP 5.6 build.\n";
+
+/**
+ * @param string[] $paths Files and directories to inspect.
+ */
+function assert_reserved_variables_are_unused(array $paths): void
+{
+    foreach (php_files($paths) as $file) {
+        $code = file_get_contents($file);
+        if ($code === false) {
+            fail(sprintf('Could not read staged PHP file %s.', $file));
+        }
+        foreach (token_get_all($code) as $token) {
+            if (
+                is_array($token)
+                && $token[0] === T_VARIABLE
+                && strncmp($token[1], REPRINT_PHP56_TEMPORARY_VARIABLE_PREFIX, strlen(REPRINT_PHP56_TEMPORARY_VARIABLE_PREFIX)) === 0
+            ) {
+                fail(sprintf(
+                    'Staged PHP uses the reserved downgrade variable %s in %s on line %d.',
+                    $token[1],
+                    $file,
+                    $token[2]
+                ));
+            }
+        }
+    }
+}
+
+/**
+ * @param string[] $paths Files and directories to inspect.
+ * @return string[]
+ */
+function php_files(array $paths): array
+{
+    $files = [];
+    foreach ($paths as $path) {
+        if (is_file($path)) {
+            if (substr($path, -4) === '.php') {
+                $files[] = $path;
+            }
+            continue;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $file) {
+            if ($file->isFile() && substr($file->getFilename(), -4) === '.php') {
+                $files[] = $file->getPathname();
+            }
+        }
+    }
+
+    return $files;
+}
+
+function fail(string $message): never
+{
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+}

--- a/tools/php56-build/composer.json
+++ b/tools/php56-build/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "wp-php-toolkit/reprint-php56-build",
+    "description": "Build-only PHP 5.6 downgrade tool for the exporter plugin",
+    "type": "project",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.1",
+        "nikic/php-parser": "^5.8",
+        "rector/rector": "^2.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "WordPress\\Reprint\\Build\\": "src/"
+        }
+    },
+    "scripts": {
+        "test": "php tests/run.php"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/tools/php56-build/composer.lock
+++ b/tools/php56-build/composer.lock
@@ -1,0 +1,202 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a532ac638f1d1c7d0abfb804f54a12fe",
+    "packages": [
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.8",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-04T22:21:45+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.6"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-12T06:23:05+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.1"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/tools/php56-build/rector.php
+++ b/tools/php56-build/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\ValueObject\PhpVersion;
+use WordPress\Reprint\Build\Rector\DowngradeArrayDestructuringRector;
+use WordPress\Reprint\Build\Rector\DowngradeClassConstantVisibilityRector;
+use WordPress\Reprint\Build\Rector\DowngradeFunctionTypeDeclarationsRector;
+use WordPress\Reprint\Build\Rector\DowngradeNullCoalescingRector;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+return RectorConfig::configure()
+    ->withoutParallel()
+    ->withPhpVersion(PhpVersion::PHP_56)
+    ->withRules([
+        DowngradeFunctionTypeDeclarationsRector::class,
+        DowngradeClassConstantVisibilityRector::class,
+        DowngradeNullCoalescingRector::class,
+        DowngradeArrayDestructuringRector::class,
+    ]);

--- a/tools/php56-build/src/Php56SyntaxValidator.php
+++ b/tools/php56-build/src/Php56SyntaxValidator.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\Reprint\Build;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\AssignOp\Coalesce as AssignCoalesce;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\BinaryOp\Spaceship;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\YieldFrom;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use RuntimeException;
+
+final class Php56SyntaxValidator
+{
+    private Parser $parser;
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+    }
+
+    /**
+     * @param string[] $paths Files and directories containing generated PHP.
+     */
+    public function assertPaths(array $paths): void
+    {
+        foreach ($this->phpFiles($paths) as $file) {
+            $this->assertFile($file);
+        }
+    }
+
+    public function assertFile(string $file): void
+    {
+        $code = file_get_contents($file);
+        if ($code === false) {
+            throw new RuntimeException(sprintf('Could not read generated PHP file %s.', $file));
+        }
+
+        try {
+            $statements = $this->parser->parse($code);
+        } catch (\Throwable $throwable) {
+            throw new RuntimeException(sprintf(
+                'Generated PHP could not be parsed in %s: %s',
+                $file,
+                $throwable->getMessage()
+            ), 0, $throwable);
+        }
+
+        if ($statements === null) {
+            return;
+        }
+
+        $name_resolver = new NodeTraverser();
+        $name_resolver->addVisitor(new NameResolver());
+        $statements = $name_resolver->traverse($statements);
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new class($file) extends NodeVisitorAbstract {
+            private string $file;
+
+            public function __construct(string $file)
+            {
+                $this->file = $file;
+            }
+
+            public function enterNode(Node $node): ?Node
+            {
+                $reason = $this->unsupportedReason($node);
+                if ($reason !== null) {
+                    throw new RuntimeException(sprintf(
+                        'Generated PHP still contains %s in %s on line %d.',
+                        $reason,
+                        $this->file,
+                        $node->getStartLine()
+                    ));
+                }
+
+                return null;
+            }
+
+            private function unsupportedReason(Node $node): ?string
+            {
+                if ($node instanceof FunctionLike && $node->getReturnType() !== null) {
+                    return 'a return type declaration';
+                }
+                if ($node instanceof Param && $node->flags !== 0) {
+                    return 'a promoted parameter';
+                }
+                if (
+                    $node instanceof Param
+                    && $node->type !== null
+                    && !$this->isPhp56ParameterType($node->type)
+                ) {
+                    return 'a parameter type which PHP 5.6 cannot parse';
+                }
+                if ($node instanceof Property && $node->type !== null) {
+                    return 'a typed property';
+                }
+                if ($node instanceof ClassConst && $node->flags !== 0) {
+                    return 'a class-constant modifier';
+                }
+                if ($node instanceof Coalesce || $node instanceof AssignCoalesce) {
+                    return 'a null-coalescing operator';
+                }
+                if ($node instanceof Spaceship) {
+                    return 'a spaceship operator';
+                }
+                if ($node instanceof YieldFrom) {
+                    return 'a yield-from expression';
+                }
+                if ($node instanceof ArrowFunction) {
+                    return 'an arrow function';
+                }
+                if ($node instanceof GroupUse) {
+                    return 'a grouped use declaration';
+                }
+                if ($node instanceof Catch_ && count($node->types) !== 1) {
+                    return 'a multi-catch declaration';
+                }
+                if ($node instanceof New_ && $node->class instanceof Class_) {
+                    return 'an anonymous class';
+                }
+                if ($node instanceof List_) {
+                    if ($node->getAttribute('kind') === List_::KIND_ARRAY) {
+                        return 'short array destructuring';
+                    }
+                    foreach ($node->items as $item) {
+                        if ($item !== null && $item->key !== null) {
+                            return 'keyed array destructuring';
+                        }
+                    }
+                }
+                if ($node instanceof Arg && $node->name !== null) {
+                    return 'a named argument';
+                }
+                if (property_exists($node, 'attrGroups') && $node->attrGroups !== []) {
+                    return 'an attribute';
+                }
+
+                return null;
+            }
+
+            private function isPhp56ParameterType(Node $type): bool
+            {
+                if ($type instanceof Name) {
+                    $resolved_name = $type->getAttribute('resolvedName');
+                    $type_name = $resolved_name instanceof Name
+                        ? $resolved_name->toString()
+                        : $type->toString();
+
+                    return strtolower($type_name) !== 'throwable';
+                }
+
+                return $type instanceof Identifier
+                    && in_array(strtolower($type->name), ['array', 'callable'], true);
+            }
+        });
+        $traverser->traverse($statements);
+    }
+
+    /**
+     * @param string[] $paths Files and directories to inspect.
+     * @return string[]
+     */
+    private function phpFiles(array $paths): array
+    {
+        $files = [];
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                if (substr($path, -4) === '.php') {
+                    $files[] = $path;
+                }
+                continue;
+            }
+            if (!is_dir($path)) {
+                throw new RuntimeException(sprintf('Generated PHP path does not exist: %s.', $path));
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $file) {
+                if ($file->isLink()) {
+                    throw new RuntimeException(sprintf('Generated PHP path contains a symbolic link: %s.', $file->getPathname()));
+                }
+                if ($file->isFile() && substr($file->getFilename(), -4) === '.php') {
+                    $files[] = $file->getPathname();
+                }
+            }
+        }
+        sort($files);
+
+        return array_values(array_unique($files));
+    }
+}

--- a/tools/php56-build/src/Rector/DowngradeArrayDestructuringRector.php
+++ b/tools/php56-build/src/Rector/DowngradeArrayDestructuringRector.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\Reprint\Build\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DowngradeArrayDestructuringRector extends AbstractRector
+{
+    private const TEMPORARY_VARIABLE_PREFIX = '__reprint_php56_destructure_';
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [List_::class, Expression::class];
+    }
+
+    /**
+     * @param List_|Expression $node
+     * @return Node|Node[]|null
+     */
+    public function refactor(Node $node)
+    {
+        if ($node instanceof List_) {
+            return $this->downgradeUnkeyedShortDestructuring($node);
+        }
+
+        if (!$node->expr instanceof Assign || !$node->expr->var instanceof List_) {
+            return null;
+        }
+
+        $list = $node->expr->var;
+        if (!$this->hasKeys($list)) {
+            return null;
+        }
+
+        $temporary_variable_name = self::TEMPORARY_VARIABLE_PREFIX
+            . $node->getStartLine()
+            . '_'
+            . max(0, $node->getStartFilePos());
+        $temporary_assignment = new Expression(
+            new Assign(new Variable($temporary_variable_name), $node->expr->expr)
+        );
+        $this->mirrorComments($temporary_assignment, $node);
+        $statements = [$temporary_assignment];
+
+        foreach ($list->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+            if ($item->key === null || $item->byRef || $item->unpack) {
+                throw new ShouldNotHappenException(sprintf(
+                    'Cannot safely downgrade the array destructuring on line %d in %s.',
+                    $node->getStartLine(),
+                    $this->getFile()->getFilePath()
+                ));
+            }
+
+            $assignment = new Expression(new Assign(
+                $item->value,
+                new ArrayDimFetch(
+                    new Variable($temporary_variable_name),
+                    $this->cloneExpression($item->key)
+                )
+            ));
+            if ($item->getComments() !== []) {
+                $assignment->setAttribute('comments', $item->getComments());
+            }
+            $statements[] = $assignment;
+        }
+
+        return $statements;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace PHP 7 array destructuring with PHP 5.6 list or assignment statements.',
+            [new CodeSample('[$host, $port] = $address;', 'list($host, $port) = $address;')]
+        );
+    }
+
+    private function downgradeUnkeyedShortDestructuring(List_ $list): ?List_
+    {
+        if ($list->getAttribute('kind') !== List_::KIND_ARRAY || $this->hasKeys($list)) {
+            return null;
+        }
+
+        $replacement = new List_($list->items, ['kind' => List_::KIND_LIST]);
+        $this->mirrorComments($replacement, $list);
+
+        return $replacement;
+    }
+
+    private function hasKeys(List_ $list): bool
+    {
+        foreach ($list->items as $item) {
+            if ($item !== null && $item->key !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function cloneExpression(Expr $expression): Expr
+    {
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new CloningVisitor());
+        /** @var Expr $clone */
+        $clone = $traverser->traverse([$expression])[0];
+
+        return $clone;
+    }
+}

--- a/tools/php56-build/src/Rector/DowngradeClassConstantVisibilityRector.php
+++ b/tools/php56-build/src/Rector/DowngradeClassConstantVisibilityRector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\Reprint\Build\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DowngradeClassConstantVisibilityRector extends AbstractRector
+{
+    private const VISIBILITY_FLAGS = Class_::MODIFIER_PUBLIC
+        | Class_::MODIFIER_PROTECTED
+        | Class_::MODIFIER_PRIVATE;
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassConst::class];
+    }
+
+    /**
+     * @param ClassConst $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (($node->flags & self::VISIBILITY_FLAGS) === 0) {
+            return null;
+        }
+
+        $node->flags &= ~self::VISIBILITY_FLAGS;
+
+        return $node;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove class-constant visibility which PHP 5.6 cannot parse.',
+            [new CodeSample('private const TOKEN = 1;', 'const TOKEN = 1;')]
+        );
+    }
+}

--- a/tools/php56-build/src/Rector/DowngradeFunctionTypeDeclarationsRector.php
+++ b/tools/php56-build/src/Rector/DowngradeFunctionTypeDeclarationsRector.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\Reprint\Build\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DowngradeFunctionTypeDeclarationsRector extends AbstractRector
+{
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class, Closure::class];
+    }
+
+    /**
+     * @param Function_|ClassMethod|Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $changed = false;
+
+        if ($node->returnType !== null) {
+            $node->returnType = null;
+            $changed = true;
+        }
+
+        foreach ($node->params as $param) {
+            if ($param->type === null || $this->isPhp56ParameterType($param->type)) {
+                continue;
+            }
+
+            $param->type = null;
+            $changed = true;
+        }
+
+        return $changed ? $node : null;
+    }
+
+    private function isPhp56ParameterType(Node $type): bool
+    {
+        if ($type instanceof Name) {
+            $resolved_name = $type->getAttribute('resolvedName');
+            $type_name = $resolved_name instanceof Name
+                ? $resolved_name->toString()
+                : $type->toString();
+
+            return strtolower($type_name) !== 'throwable';
+        }
+
+        return $type instanceof Identifier
+            && in_array(strtolower($type->name), ['array', 'callable'], true);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove parameter and return type declarations which PHP 5.6 cannot parse.',
+            [
+                new CodeSample(
+                    'function render(string $value): string { return $value; }',
+                    'function render($value) { return $value; }'
+                ),
+            ]
+        );
+    }
+}

--- a/tools/php56-build/src/Rector/DowngradeNullCoalescingRector.php
+++ b/tools/php56-build/src/Rector/DowngradeNullCoalescingRector.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\Reprint\Build\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DowngradeNullCoalescingRector extends AbstractRector
+{
+    private const TEMPORARY_VARIABLE_PREFIX = '__reprint_php56_coalesce_';
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Coalesce::class];
+    }
+
+    /**
+     * @param Coalesce $node
+     */
+    public function refactor(Node $node): Node
+    {
+        if ($this->canRepeatInsideIsset($node->left)) {
+            $replacement = new Ternary(
+                new Isset_([$this->cloneExpression($node->left)]),
+                $this->cloneExpression($node->left),
+                $node->right
+            );
+            $this->mirrorComments($replacement, $node);
+
+            return $replacement;
+        }
+
+        $temporary_variable_name = $this->temporaryVariableName($node);
+
+        if ($node->left instanceof FuncCall || $node->left instanceof Coalesce) {
+            $replacement = new Ternary(
+                new NotIdentical(
+                    new Assign(new Variable($temporary_variable_name), $node->left),
+                    new ConstFetch(new Name('null'))
+                ),
+                new Variable($temporary_variable_name),
+                $node->right
+            );
+            $this->mirrorComments($replacement, $node);
+
+            return $replacement;
+        }
+
+        if (
+            $node->left instanceof ArrayDimFetch
+            && !$this->canRepeatInsideIsset($node->left->var)
+            && $this->isRepeatableDimension($node->left->dim)
+        ) {
+            // PHP 5.6 cannot parse isset(($temporary = make_array())['key']),
+            // so assign before fetching the key through the plain variable.
+            $condition_fetch = new ArrayDimFetch(
+                new Variable($temporary_variable_name),
+                $this->cloneNullableExpression($node->left->dim)
+            );
+            $value_fetch = new ArrayDimFetch(
+                new Variable($temporary_variable_name),
+                $this->cloneNullableExpression($node->left->dim)
+            );
+            $replacement = new Ternary(
+                new BooleanAnd(
+                    new NotIdentical(
+                        new Assign(new Variable($temporary_variable_name), $node->left->var),
+                        new ConstFetch(new Name('null'))
+                    ),
+                    new Isset_([$condition_fetch])
+                ),
+                $value_fetch,
+                $node->right
+            );
+            $this->mirrorComments($replacement, $node);
+
+            return $replacement;
+        }
+
+        throw new ShouldNotHappenException(sprintf(
+            'Cannot safely downgrade the null-coalescing expression on line %d in %s.',
+            $node->getStartLine(),
+            $this->getFile()->getFilePath()
+        ));
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace null coalescing with a PHP 5.6 conditional without evaluating an effectful expression twice.',
+            [new CodeSample('$value = $items["key"] ?? "default";', '$value = isset($items["key"]) ? $items["key"] : "default";')]
+        );
+    }
+
+    private function canRepeatInsideIsset(Expr $expression): bool
+    {
+        if ($expression instanceof Variable) {
+            return is_string($expression->name);
+        }
+
+        if ($expression instanceof ArrayDimFetch) {
+            return $this->canRepeatInsideIsset($expression->var)
+                && $this->isRepeatableDimension($expression->dim);
+        }
+
+        if ($expression instanceof PropertyFetch) {
+            return $this->canRepeatInsideIsset($expression->var)
+                && $expression->name instanceof Node\Identifier;
+        }
+
+        return false;
+    }
+
+    private function isRepeatableDimension(?Expr $expression): bool
+    {
+        return $expression instanceof Scalar
+            || $expression instanceof ConstFetch
+            || $expression instanceof ClassConstFetch
+            || ($expression instanceof Variable && is_string($expression->name));
+    }
+
+    private function temporaryVariableName(Coalesce $node): string
+    {
+        return self::TEMPORARY_VARIABLE_PREFIX
+            . $node->getStartLine()
+            . '_'
+            . max(0, $node->getStartFilePos());
+    }
+
+    private function cloneExpression(Expr $expression): Expr
+    {
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new CloningVisitor());
+        /** @var Expr $clone */
+        $clone = $traverser->traverse([$expression])[0];
+
+        return $clone;
+    }
+
+    private function cloneNullableExpression(?Expr $expression): ?Expr
+    {
+        return $expression === null ? null : $this->cloneExpression($expression);
+    }
+}

--- a/tools/php56-build/tests/Fixture/php72-syntax.expected.php
+++ b/tools/php56-build/tests/Fixture/php72-syntax.expected.php
@@ -1,0 +1,67 @@
+<?php
+
+use Throwable as FixtureThrowable;
+
+$fixture_calls = 0;
+$fixture_map_calls = 0;
+
+function fixture_nullable_value()
+{
+    ++$GLOBALS['fixture_calls'];
+    return null;
+}
+
+function fixture_map()
+{
+    ++$GLOBALS['fixture_map_calls'];
+    return ['user' => 'mapped'];
+}
+
+class Php56ParentFixture
+{
+}
+
+final class Php72SyntaxFixture extends Php56ParentFixture
+{
+    /** Kept on the generated constant. */
+    const DEFAULT_HOST = 'localhost';
+
+    private $optional;
+
+    /** Kept on the generated method. */
+    public function render($value, array $options = [])
+    {
+        $host = isset($options['host']) ? $options['host'] : self::DEFAULT_HOST;
+        $optional = isset($this->optional) ? $this->optional : 'property-default';
+        list($address, $port) = $options['address'];
+        $__reprint_php56_destructure_37_786 = $options['metadata'];
+        // Kept with the generated assignment.
+        $name = $__reprint_php56_destructure_37_786['name'];
+        $enabled = $__reprint_php56_destructure_37_786['enabled'];
+        $secret = ($__reprint_php56_coalesce_42_955 = fixture_nullable_value()) !== null ? $__reprint_php56_coalesce_42_955 : 'secret-default';
+        $user = ($__reprint_php56_coalesce_43_1017 = fixture_map()) !== null && isset($__reprint_php56_coalesce_43_1017['user']) ? $__reprint_php56_coalesce_43_1017['user'] : 'map-default';
+        $nested = ($__reprint_php56_coalesce_44_1075 = isset($options['nested']) ? $options['nested'] : null) !== null ? $__reprint_php56_coalesce_44_1075 : 'nested-default';
+
+        return implode('|', [$value, $host, $optional, $address, $port, $name, $enabled, $secret, $user, $nested]);
+    }
+
+    public function preservedHints(
+        array $items,
+        callable $formatter,
+        Php72SyntaxFixture $other,
+        self $same,
+        parent $parent,
+        $throwable
+    ) {
+        return $formatter($items[0]);
+    }
+}
+
+echo json_encode([
+    (new Php72SyntaxFixture())->render(null, [
+        'address' => ['127.0.0.1', 8080],
+        'metadata' => ['name' => 'fixture', 'enabled' => true],
+    ]),
+    $fixture_calls,
+    $fixture_map_calls,
+]);

--- a/tools/php56-build/tests/Fixture/php72-syntax.input.php
+++ b/tools/php56-build/tests/Fixture/php72-syntax.input.php
@@ -1,0 +1,68 @@
+<?php
+
+use Throwable as FixtureThrowable;
+
+$fixture_calls = 0;
+$fixture_map_calls = 0;
+
+function fixture_nullable_value(): ?string
+{
+    ++$GLOBALS['fixture_calls'];
+    return null;
+}
+
+function fixture_map(): array
+{
+    ++$GLOBALS['fixture_map_calls'];
+    return ['user' => 'mapped'];
+}
+
+class Php56ParentFixture
+{
+}
+
+final class Php72SyntaxFixture extends Php56ParentFixture
+{
+    /** Kept on the generated constant. */
+    private const DEFAULT_HOST = 'localhost';
+
+    private $optional;
+
+    /** Kept on the generated method. */
+    public function render(?string $value, array $options = []): string
+    {
+        $host = $options['host'] ?? self::DEFAULT_HOST;
+        $optional = $this->optional ?? 'property-default';
+        [$address, $port] = $options['address'];
+        [
+            // Kept with the generated assignment.
+            'name' => $name,
+            'enabled' => $enabled,
+        ] = $options['metadata'];
+        $secret = fixture_nullable_value() ?? 'secret-default';
+        $user = fixture_map()['user'] ?? 'map-default';
+        $nested = ($options['nested'] ?? null) ?? 'nested-default';
+
+        return implode('|', [$value, $host, $optional, $address, $port, $name, $enabled, $secret, $user, $nested]);
+    }
+
+    public function preservedHints(
+        array $items,
+        callable $formatter,
+        Php72SyntaxFixture $other,
+        self $same,
+        parent $parent,
+        FixtureThrowable $throwable
+    ): string {
+        return $formatter($items[0]);
+    }
+}
+
+echo json_encode([
+    (new Php72SyntaxFixture())->render(null, [
+        'address' => ['127.0.0.1', 8080],
+        'metadata' => ['name' => 'fixture', 'enabled' => true],
+    ]),
+    $fixture_calls,
+    $fixture_map_calls,
+]);

--- a/tools/php56-build/tests/Fixture/unsupported-coalesce.input.php
+++ b/tools/php56-build/tests/Fixture/unsupported-coalesce.input.php
@@ -1,0 +1,6 @@
+<?php
+
+function unsupported_coalesce()
+{
+    return (new stdClass())->missing ?? 'fallback';
+}

--- a/tools/php56-build/tests/run.php
+++ b/tools/php56-build/tests/run.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use WordPress\Reprint\Build\Php56SyntaxValidator;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+$tool_root = dirname(__DIR__);
+$fixture_root = __DIR__ . '/Fixture';
+$temporary_root = sys_get_temp_dir() . '/reprint-php56-rector-' . getmypid();
+if (!mkdir($temporary_root, 0700) && !is_dir($temporary_root)) {
+    fail_test('Could not create the temporary fixture directory.');
+}
+
+try {
+    $input = $fixture_root . '/php72-syntax.input.php';
+    $generated = $temporary_root . '/php72-syntax.php';
+    copy($input, $generated);
+
+    $validator = new Php56SyntaxValidator();
+    try {
+        $validator->assertFile($generated);
+        fail_test('The PHP 7.2 fixture unexpectedly passed the pre-downgrade syntax check.');
+    } catch (RuntimeException $runtime_exception) {
+        if (strpos($runtime_exception->getMessage(), 'return type declaration') === false) {
+            throw $runtime_exception;
+        }
+    }
+
+    run_rector($tool_root, $generated, true);
+    $validator->assertFile($generated);
+
+    $expected = $fixture_root . '/php72-syntax.expected.php';
+    if (!is_file($expected)) {
+        fail_test(sprintf('Missing expected Rector fixture %s.', $expected));
+    }
+    assert_same_file($expected, $generated);
+
+    $input_output = run_php($input);
+    $generated_output = run_php($generated);
+    if ($input_output !== $generated_output) {
+        fail_test(sprintf(
+            "The generated fixture changed behavior.\nInput: %s\nGenerated: %s",
+            $input_output,
+            $generated_output
+        ));
+    }
+
+    $unsupported = $temporary_root . '/unsupported-coalesce.php';
+    copy($fixture_root . '/unsupported-coalesce.input.php', $unsupported);
+    $unsupported_output = run_rector($tool_root, $unsupported, false);
+    if (strpos($unsupported_output, 'Cannot safely downgrade the null-coalescing expression') === false) {
+        fail_test("The unsupported null-coalescing fixture did not fail with the expected message.\n" . $unsupported_output);
+    }
+
+    echo "PHP 5.6 Rector fixtures passed.\n";
+} finally {
+    remove_tree($temporary_root);
+}
+
+function run_rector(string $tool_root, string $path, bool $must_succeed): string
+{
+    $command = escapeshellarg($tool_root . '/vendor/bin/rector')
+        . ' process '
+        . escapeshellarg($path)
+        . ' --config '
+        . escapeshellarg($tool_root . '/rector.php')
+        . ' --no-progress-bar --clear-cache 2>&1';
+    exec($command, $lines, $status);
+    $output = implode("\n", $lines);
+    if ($must_succeed && $status !== 0) {
+        fail_test(sprintf("Rector failed with exit code %d.\n%s", $status, $output));
+    }
+    if (!$must_succeed && $status === 0) {
+        fail_test('Rector unexpectedly accepted an unsafe null-coalescing expression.');
+    }
+
+    return $output;
+}
+
+function run_php(string $path): string
+{
+    $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($path) . ' 2>&1';
+    exec($command, $lines, $status);
+    $output = implode("\n", $lines);
+    if ($status !== 0) {
+        fail_test(sprintf("Fixture execution failed with exit code %d.\n%s", $status, $output));
+    }
+
+    return $output;
+}
+
+function assert_same_file(string $expected, string $actual): void
+{
+    $expected_contents = str_replace("\r\n", "\n", (string) file_get_contents($expected));
+    $actual_contents = str_replace("\r\n", "\n", (string) file_get_contents($actual));
+    if ($expected_contents === $actual_contents) {
+        return;
+    }
+
+    fail_test(sprintf('Generated fixture does not match %s.', $expected));
+}
+
+function remove_tree(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $file) {
+        $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+    }
+    rmdir($path);
+}
+
+function fail_test(string $message): void
+{
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+}


### PR DESCRIPTION
Adds build-only Rector rules that lower a copied exporter tree from PHP 7.2 syntax to PHP 5.6 syntax. The maintained exporter source and release artifact are unchanged by this PR.

## Stack

1. #665 — Rector downgrade rules (this PR)
2. #671 — exporter PHP 5.6 compatibility
3. #672 — CI and tests

## This change

`tools/php56-build` is an isolated Composer project with pinned Rector and PHP-Parser versions. Its four rules remove unsupported function type declarations and class-constant visibility, and lower null coalescing and array destructuring. Effectful expressions are evaluated once.

`bin/downgrade-exporter-plugin.php` runs those rules only on a separate staging tree. It refuses the maintained checkout, reserves its generated variable prefix, and rejects syntax that the narrow rules do not handle.

The fixture suite compares the generated PHP byte for byte, checks that calls are not repeated, executes the generated result, and requires unsafe null-coalescing shapes to fail closed.

## Testing

Run `composer validate --strict --working-dir=tools/php56-build` and `composer test --working-dir=tools/php56-build`.
