### PR TITLE
[PHP] Stop WordPress root discovery at blocked parent paths

### DIFF
--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -659,9 +659,24 @@ function detect_wp_roots(array $start_paths): array
             $seen[$current] = true;
             $wp_load_path = wp_join_unix_paths($current, "wp-load.php");
             $wp_config_path = wp_join_unix_paths($current, "wp-config.php");
-            $has_wp_load = file_exists($wp_load_path);
-            $has_wp_config = file_exists($wp_config_path);
-            $has_wp_content = is_dir(wp_join_unix_paths($current, "wp-content"));
+            $filesystem_probe_warning = false;
+            set_error_handler(function () use (&$filesystem_probe_warning) {
+                $filesystem_probe_warning = true;
+                return true;
+            });
+            try {
+                $has_wp_load = file_exists($wp_load_path);
+                $has_wp_config = file_exists($wp_config_path);
+                $has_wp_content = is_dir(wp_join_unix_paths($current, "wp-content"));
+            } finally {
+                restore_error_handler();
+            }
+            if ($filesystem_probe_warning) {
+                // WordPress root discovery is speculative. If this path cannot be
+                // inspected reliably, keep roots found by this walk and let
+                // preflight continue with the other start paths.
+                break;
+            }
             if ($has_wp_load || $has_wp_config) {
                 $roots[$current] = [
                     "path" => $current,

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -662,6 +662,10 @@ function detect_wp_roots(array $start_paths): array
             $wp_content_path = wp_join_unix_paths($current, "wp-content");
             $filesystem_probe_warning = false;
             $reprint_error_handler = null;
+            // During preflight, Reprint's error handler turns a warning into HTTP 500.
+            // These checks move up to parent directories that open_basedir may block.
+            // Catch probe warnings here so we can stop only this walk. Send other error
+            // types to the previous handler, then restore that handler in finally below.
             $reprint_error_handler = set_error_handler(
                 function ($errno, $errstr, $errfile, $errline) use (
                     &$filesystem_probe_warning,

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -659,15 +659,34 @@ function detect_wp_roots(array $start_paths): array
             $seen[$current] = true;
             $wp_load_path = wp_join_unix_paths($current, "wp-load.php");
             $wp_config_path = wp_join_unix_paths($current, "wp-config.php");
+            $wp_content_path = wp_join_unix_paths($current, "wp-content");
             $filesystem_probe_warning = false;
-            set_error_handler(function () use (&$filesystem_probe_warning) {
-                $filesystem_probe_warning = true;
-                return true;
-            });
+            $reprint_error_handler = null;
+            $reprint_error_handler = set_error_handler(
+                function ($errno, $errstr, $errfile, $errline) use (
+                    &$filesystem_probe_warning,
+                    &$reprint_error_handler
+                ) {
+                    if ($errno === E_WARNING) {
+                        $filesystem_probe_warning = true;
+                        return true;
+                    }
+                    if (!is_callable($reprint_error_handler)) {
+                        return false;
+                    }
+                    return call_user_func(
+                        $reprint_error_handler,
+                        $errno,
+                        $errstr,
+                        $errfile,
+                        $errline
+                    );
+                }
+            );
             try {
                 $has_wp_load = file_exists($wp_load_path);
                 $has_wp_config = file_exists($wp_config_path);
-                $has_wp_content = is_dir(wp_join_unix_paths($current, "wp-content"));
+                $has_wp_content = is_dir($wp_content_path);
             } finally {
                 restore_error_handler();
             }

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -131,7 +131,11 @@ sudo rm -f /etc/nginx/conf.d/default.conf
 
 # Read site definitions from registry (single source of truth)
 # Standard sites — each gets the same fastcgi template on its own port.
-jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | "\(.key) \(.value.port)"' "$REGISTRY" | while read site port; do
+jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
+    php_admin_value=""
+    if [ "$open_basedir" = "true" ]; then
+        php_admin_value="        fastcgi_param PHP_ADMIN_VALUE \"open_basedir=${SITE_ROOT}/${site}:/tmp\";"
+    fi
     cat <<VHOST | sudo tee "/etc/nginx/conf.d/e2e-${site}.conf" >/dev/null
 server {
     listen 127.0.0.1:${port};
@@ -148,6 +152,7 @@ server {
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_param SITE_EXPORT_TEST_MODE "1";
+${php_admin_value}
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REGISTRY="${SCRIPT_DIR}/../site-registry.json"
 SITE_ROOT=$(jq -r '.siteRoot' "$REGISTRY")
 FPM_SOCKET="/run/php/e2e.sock"
+OPEN_BASEDIR_FPM_SOCKET="/run/php/e2e-open-basedir.sock"
 
 echo "=== Setting up infrastructure with PHP ${PHP_VERSION} ==="
 
@@ -97,6 +98,33 @@ php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 
 env[SITE_EXPORT_TEST_MODE] = 1
+
+; Keep open_basedir in its own worker pool. A request-level value can remain
+; active when the same worker handles a request for another test site.
+[e2e-open-basedir]
+user = nginx
+group = nginx
+listen = ${OPEN_BASEDIR_FPM_SOCKET}
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+
+pm = ondemand
+pm.max_children = 4
+
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 120
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M
+php_admin_value[error_reporting] = E_ALL
+php_admin_value[display_errors] = Off
+php_admin_value[log_errors] = On
+php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
+php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
+
+env[SITE_EXPORT_TEST_MODE] = 1
 EOF
 
 # ---------- Nginx config ----------
@@ -132,9 +160,9 @@ sudo rm -f /etc/nginx/conf.d/default.conf
 # Read site definitions from registry (single source of truth)
 # Standard sites — each gets the same fastcgi template on its own port.
 jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
-    php_admin_value=""
+    site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
-        php_admin_value="        fastcgi_param PHP_ADMIN_VALUE \"open_basedir=${SITE_ROOT}/${site}:/tmp\";"
+        site_fpm_socket="$OPEN_BASEDIR_FPM_SOCKET"
     fi
     cat <<VHOST | sudo tee "/etc/nginx/conf.d/e2e-${site}.conf" >/dev/null
 server {
@@ -147,12 +175,11 @@ server {
     }
 
     location ~ \\.php\$ {
-        fastcgi_pass unix:${FPM_SOCKET};
+        fastcgi_pass unix:${site_fpm_socket};
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_param SITE_EXPORT_TEST_MODE "1";
-${php_admin_value}
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -89,7 +89,11 @@ rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 
 # Standard sites — serve from WordPress root so that index.php
 # bootstraps WordPress and the site-export plugin handles the request.
-jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | "\(.key) \(.value.port)"' "$REGISTRY" | while read site port; do
+jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
+    php_admin_value=""
+    if [ "$open_basedir" = "true" ]; then
+        php_admin_value="        fastcgi_param PHP_ADMIN_VALUE \"open_basedir=${SITE_ROOT}/${site}:/tmp\";"
+    fi
     cat > "/etc/nginx/conf.d/e2e-${site}.conf" <<VHOST
 server {
     listen 127.0.0.1:${port};
@@ -102,6 +106,7 @@ server {
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_param SITE_EXPORT_TEST_MODE "1";
+${php_admin_value}
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 PHP_VERSION="${PHP_VERSION:-8.2}"
 FPM_SOCKET="/run/php/e2e.sock"
+OPEN_BASEDIR_FPM_SOCKET="/run/php/e2e-open-basedir.sock"
+REGISTRY="/app/tests/e2e/site-registry.json"
+SITE_ROOT=$(jq -r '.siteRoot' "$REGISTRY")
 
 echo "=== Starting services ==="
 
@@ -51,19 +54,41 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 env[SITE_EXPORT_TEST_MODE] = 1
+
+; Keep open_basedir in its own worker pool. A request-level value can remain
+; active when the same worker handles a request for another test site.
+[e2e-open-basedir]
+user = nginx
+group = nginx
+listen = ${OPEN_BASEDIR_FPM_SOCKET}
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+pm = ondemand
+pm.max_children = 4
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 120
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M
+php_admin_value[error_reporting] = E_ALL
+php_admin_value[display_errors] = Off
+php_admin_value[log_errors] = On
+php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
+php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
+env[SITE_EXPORT_TEST_MODE] = 1
 EOF
 rm -f "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 "php-fpm${PHP_VERSION}" --nodaemonize &
 
 # Wait for FPM socket
 for i in $(seq 1 30); do
-    if [ -S "$FPM_SOCKET" ]; then break; fi
+    if [ -S "$FPM_SOCKET" ] && [ -S "$OPEN_BASEDIR_FPM_SOCKET" ]; then break; fi
     sleep 0.5
 done
 
 # Nginx — generate configs from site-registry.json
-REGISTRY="/app/tests/e2e/site-registry.json"
-SITE_ROOT=$(jq -r '.siteRoot' "$REGISTRY")
 mkdir -p "$SITE_ROOT"
 chown nginx:nginx "$SITE_ROOT"
 
@@ -90,9 +115,9 @@ rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 # Standard sites — serve from WordPress root so that index.php
 # bootstraps WordPress and the site-export plugin handles the request.
 jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
-    php_admin_value=""
+    site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
-        php_admin_value="        fastcgi_param PHP_ADMIN_VALUE \"open_basedir=${SITE_ROOT}/${site}:/tmp\";"
+        site_fpm_socket="$OPEN_BASEDIR_FPM_SOCKET"
     fi
     cat > "/etc/nginx/conf.d/e2e-${site}.conf" <<VHOST
 server {
@@ -101,12 +126,11 @@ server {
     index index.php;
     location / { try_files \$uri \$uri/ /index.php?\$query_string; }
     location ~ \\.php\$ {
-        fastcgi_pass unix:${FPM_SOCKET};
+        fastcgi_pass unix:${site_fpm_socket};
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_param SITE_EXPORT_TEST_MODE "1";
-${php_admin_value}
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -45,6 +45,9 @@ let
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
             fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            ${lib.optionalString (cfg.openBasedir or false) ''
+              fastcgi_param PHP_ADMIN_VALUE "open_basedir=${siteRoot}/${name}:/tmp";
+            ''}
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -29,7 +29,11 @@ let
   redirectSites = lib.filterAttrs (n: v: (v.nginx or null) == "redirect") registry.sites;
 
   # Generate Nginx virtualHost config for standard sites
-  makeVhost = name: cfg: {
+  makeVhost = name: cfg: let
+    fpmSocket = if (cfg.openBasedir or false)
+      then config.services.phpfpm.pools."e2e-open-basedir".socket
+      else config.services.phpfpm.pools.e2e.socket;
+  in {
     name = "e2e-${name}";
     value = {
       listen = [{ addr = "127.0.0.1"; port = cfg.port; }];
@@ -40,14 +44,11 @@ let
         };
         "~ \\.php$" = {
           extraConfig = ''
-            fastcgi_pass unix:${config.services.phpfpm.pools.e2e.socket};
+            fastcgi_pass unix:${fpmSocket};
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
             fastcgi_param SITE_EXPORT_TEST_MODE "1";
-            ${lib.optionalString (cfg.openBasedir or false) ''
-              fastcgi_param PHP_ADMIN_VALUE "open_basedir=${siteRoot}/${name}:/tmp";
-            ''}
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';
@@ -155,6 +156,34 @@ in {
       "php_admin_value[error_log]" = "/tmp/php-e2e-errors.log";
       "php_admin_value[user_ini.cache_ttl]" = "0";
       "php_admin_value[realpath_cache_ttl]" = "0";
+    };
+    phpEnv = {
+      SITE_EXPORT_TEST_MODE = "1";
+    };
+  };
+
+  # Keep open_basedir in its own worker pool. A request-level value can remain
+  # active when the same worker handles a request for another test site.
+  services.phpfpm.pools."e2e-open-basedir" = {
+    user = "nginx";
+    group = "nginx";
+    phpPackage = phpPackage;
+    settings = {
+      "listen.owner" = "nginx";
+      "listen.group" = "nginx";
+      "pm" = "ondemand";
+      "pm.max_children" = 4;
+      "php_admin_value[memory_limit]" = "512M";
+      "php_admin_value[max_execution_time]" = "120";
+      "php_admin_value[upload_max_filesize]" = "50M";
+      "php_admin_value[post_max_size]" = "50M";
+      "php_admin_value[error_reporting]" = "E_ALL";
+      "php_admin_value[display_errors]" = "Off";
+      "php_admin_value[log_errors]" = "On";
+      "php_admin_value[error_log]" = "/tmp/php-e2e-errors.log";
+      "php_admin_value[user_ini.cache_ttl]" = "0";
+      "php_admin_value[realpath_cache_ttl]" = "0";
+      "php_admin_value[open_basedir]" = "${siteRoot}/open-basedir:/tmp";
     };
     phpEnv = {
       SITE_EXPORT_TEST_MODE = "1";

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -157,6 +157,9 @@
     },
     "open-basedir": {
       "port": 8131
+    },
+    "parent-wp-config": {
+      "port": 8132
     }
   }
 }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -154,6 +154,9 @@
     },
     "files-pull-mirror": {
       "port": 8130
+    },
+    "open-basedir": {
+      "port": 8131
     }
   }
 }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -156,7 +156,8 @@
       "port": 8130
     },
     "open-basedir": {
-      "port": 8131
+      "port": 8131,
+      "openBasedir": true
     },
     "parent-wp-config": {
       "port": 8132

--- a/tests/e2e/tests/import-60-preflight-open-basedir.test.js
+++ b/tests/e2e/tests/import-60-preflight-open-basedir.test.js
@@ -7,8 +7,9 @@
  */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
     apiRequest,
     getSiteDir,
@@ -31,14 +32,28 @@ describe('Import: Preflight with an open_basedir boundary', () => {
 
     it('keeps the detected WordPress root when its parent cannot be inspected', async () => {
         const siteDir = getSiteDir(site);
-        const response = await apiRequest(site, 'preflight');
+        const expectedOpenBasedir = `${siteDir}:/tmp`;
+        let response;
+
+        // PHP-FPM can briefly miss a newly written .user.ini while the test
+        // sites are being provisioned in parallel. Retry until it is active.
+        for (let attempt = 1; attempt <= 5; attempt++) {
+            response = await apiRequest(site, 'preflight');
+            if (response.json?.limits?.open_basedir === expectedOpenBasedir) {
+                break;
+            }
+            if (attempt < 5) {
+                execSync(`sudo touch ${JSON.stringify(join(siteDir, '.user.ini'))}`);
+                await new Promise((resolve) => setTimeout(resolve, 500));
+            }
+        }
 
         assert.equal(
             response.status,
             200,
             `Expected HTTP 200, got ${response.status}: ${JSON.stringify(response.json || response.text)}`,
         );
-        assert.equal(response.json.limits.open_basedir, `${siteDir}:/tmp`);
+        assert.equal(response.json.limits.open_basedir, expectedOpenBasedir);
         assert.equal(response.json.ok, true, `Preflight failed: ${response.json.error}`);
         assert.ok(response.json.wp_detect.found, 'Expected WordPress to be found');
         assert.ok(
@@ -47,5 +62,6 @@ describe('Import: Preflight with an open_basedir boundary', () => {
             ),
             `Expected a detected WordPress root at ${siteDir}`,
         );
+        assert.deepEqual(response.json.wp_detect.searched, [siteDir, dirname(siteDir)]);
     });
 });

--- a/tests/e2e/tests/import-60-preflight-open-basedir.test.js
+++ b/tests/e2e/tests/import-60-preflight-open-basedir.test.js
@@ -1,0 +1,51 @@
+/**
+ * Test 60: Preflight with an open_basedir boundary above WordPress
+ *
+ * The site itself is allowed, but its parent is not. WordPress root
+ * discovery must keep the root it finds instead of failing when its
+ * speculative parent scan reaches the open_basedir boundary.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    apiRequest,
+    getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Preflight with an open_basedir boundary', () => {
+    const site = 'open-basedir';
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                writeFileSync(
+                    join(siteDir, '.user.ini'),
+                    `open_basedir=${siteDir}:/tmp\n`,
+                );
+            },
+        });
+    });
+
+    it('keeps the detected WordPress root when its parent cannot be inspected', async () => {
+        const siteDir = getSiteDir(site);
+        const response = await apiRequest(site, 'preflight');
+
+        assert.equal(
+            response.status,
+            200,
+            `Expected HTTP 200, got ${response.status}: ${JSON.stringify(response.json || response.text)}`,
+        );
+        assert.equal(response.json.limits.open_basedir, `${siteDir}:/tmp`);
+        assert.equal(response.json.ok, true, `Preflight failed: ${response.json.error}`);
+        assert.ok(response.json.wp_detect.found, 'Expected WordPress to be found');
+        assert.ok(
+            response.json.wp_detect.roots.some(
+                (root) => root.path === siteDir && root.wp_load && root.wp_config,
+            ),
+            `Expected a detected WordPress root at ${siteDir}`,
+        );
+    });
+});

--- a/tests/e2e/tests/import-60-preflight-open-basedir.test.js
+++ b/tests/e2e/tests/import-60-preflight-open-basedir.test.js
@@ -1,67 +1,161 @@
 /**
- * Test 60: Preflight with an open_basedir boundary above WordPress
+ * Test 60: Pull with an open_basedir boundary above WordPress
  *
  * The site itself is allowed, but its parent is not. WordPress root
- * discovery must keep the root it finds instead of failing when its
- * speculative parent scan reaches the open_basedir boundary.
+ * discovery must keep the root it finds when its parent scan reaches the
+ * open_basedir boundary. A selected file pull and the database pull must
+ * then finish through the normal high-level pipelines.
  */
-import { describe, it, beforeAll } from 'vitest';
+import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
     apiRequest,
+    assertPullPipelineComplete,
+    cleanupTempDir,
+    compareDatabases,
+    createMysqlConnection,
+    createTempDir,
+    fsRootDir,
+    getDbName,
     getSiteDir,
+    getSiteSecret,
+    getSiteUrl,
+    pullStateDirectory,
+    runImporter,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: Preflight with an open_basedir boundary', () => {
+describe('Import: Pull with an open_basedir boundary', { timeout: 180000 }, () => {
     const site = 'open-basedir';
+    const importDb = 'e2e_open_basedir_import_60';
+    let tempDir;
+    let preflightResponse;
 
     beforeAll(async () => {
-        await ensureSite(site, {
-            afterCreate: async (siteDir) => {
-                writeFileSync(
-                    join(siteDir, '.user.ini'),
-                    `open_basedir=${siteDir}:/tmp\n`,
-                );
-            },
-        });
+        await ensureSite(site);
+        preflightResponse = await apiRequest(site, 'preflight');
+
+        tempDir = createTempDir('e2e-open-basedir');
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
     });
 
-    it('keeps the detected WordPress root when its parent cannot be inspected', async () => {
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    it('keeps the detected WordPress root when its parent cannot be inspected', () => {
         const siteDir = getSiteDir(site);
         const expectedOpenBasedir = `${siteDir}:/tmp`;
-        let response;
-
-        // PHP-FPM can briefly miss a newly written .user.ini while the test
-        // sites are being provisioned in parallel. Retry until it is active.
-        for (let attempt = 1; attempt <= 5; attempt++) {
-            response = await apiRequest(site, 'preflight');
-            if (response.json?.limits?.open_basedir === expectedOpenBasedir) {
-                break;
-            }
-            if (attempt < 5) {
-                execSync(`sudo touch ${JSON.stringify(join(siteDir, '.user.ini'))}`);
-                await new Promise((resolve) => setTimeout(resolve, 500));
-            }
-        }
 
         assert.equal(
-            response.status,
+            preflightResponse.status,
             200,
-            `Expected HTTP 200, got ${response.status}: ${JSON.stringify(response.json || response.text)}`,
+            `Expected HTTP 200, got ${preflightResponse.status}: ` +
+            JSON.stringify(preflightResponse.json || preflightResponse.text),
         );
-        assert.equal(response.json.limits.open_basedir, expectedOpenBasedir);
-        assert.equal(response.json.ok, true, `Preflight failed: ${response.json.error}`);
-        assert.ok(response.json.wp_detect.found, 'Expected WordPress to be found');
+        assert.equal(preflightResponse.json.limits.open_basedir, expectedOpenBasedir);
+        assert.equal(
+            preflightResponse.json.ok,
+            true,
+            `Preflight failed: ${preflightResponse.json.error}`,
+        );
+        assert.ok(preflightResponse.json.wp_detect.found, 'Expected WordPress to be found');
         assert.ok(
-            response.json.wp_detect.roots.some(
+            preflightResponse.json.wp_detect.roots.some(
                 (root) => root.path === siteDir && root.wp_load && root.wp_config,
             ),
             `Expected a detected WordPress root at ${siteDir}`,
         );
-        assert.deepEqual(response.json.wp_detect.searched, [siteDir, dirname(siteDir)]);
+        assert.deepEqual(preflightResponse.json.wp_detect.searched, [siteDir, dirname(siteDir)]);
+    });
+
+    it('migrates wp-content and the database while open_basedir is active', async () => {
+        const siteDir = getSiteDir(site);
+        const remoteUrl = getSiteUrl(site);
+        const expectedOpenBasedir = `${siteDir}:/tmp`;
+
+        // `pull` does not expose --include. Run the supported high-level file
+        // and database pipelines separately.
+        const filesResult = runImporter(remoteUrl, tempDir, 'pull-files', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: ['--include=:wp-content:'],
+        });
+        assert.equal(
+            filesResult.exitCode,
+            0,
+            `pull-files failed:\nstdout:\n${filesResult.stdout}\nstderr:\n${filesResult.stderr}`,
+        );
+
+        let state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, remoteUrl), 'state.json'),
+            'utf-8',
+        ));
+        assertPullPipelineComplete(state, 'pull-files');
+        assert.deepEqual(state.pull_pipeline.stage_sequence, ['preflight', 'files-pull']);
+        assert.equal(state.preflight.data.limits.open_basedir, expectedOpenBasedir);
+
+        const importedSiteDir = join(fsRootDir(tempDir), siteDir);
+        const importedWpContent = join(importedSiteDir, 'wp-content');
+        assert.ok(existsSync(importedWpContent), `Expected ${importedWpContent} to exist`);
+        assert.equal(
+            readFileSync(join(importedWpContent, 'plugins', 'site-export', 'secret.php'), 'utf-8'),
+            `<?php return '${getSiteSecret(site)}';\n`,
+        );
+        assert.ok(!existsSync(join(importedSiteDir, 'wp-load.php')),
+            'wp-load.php is outside the selected wp-content directory');
+
+        const databaseResult = runImporter(remoteUrl, tempDir, 'pull-db', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: [
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${importDb}`,
+            ],
+        });
+        assert.equal(
+            databaseResult.exitCode,
+            0,
+            `pull-db failed:\nstdout:\n${databaseResult.stdout}\nstderr:\n${databaseResult.stderr}`,
+        );
+
+        state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, remoteUrl), 'state.json'),
+            'utf-8',
+        ));
+        assertPullPipelineComplete(state, 'pull-db');
+        assert.deepEqual(
+            state.pull_pipeline.stage_sequence,
+            ['preflight', 'db-pull', 'db-apply'],
+        );
+        assert.equal(state.preflight.data.limits.open_basedir, expectedOpenBasedir);
+
+        const databaseComparison = await compareDatabases(getDbName(site), importDb);
+        assert.deepEqual(databaseComparison.extraTables, []);
+        assert.ok(
+            databaseComparison.match,
+            `Database mismatch: missing=${JSON.stringify(databaseComparison.missingTables)}, ` +
+            `counts=${JSON.stringify(databaseComparison.rowCounts)}`,
+        );
+
+        const importedDatabase = await createMysqlConnection(importDb);
+        const [[blogName]] = await importedDatabase.query(
+            "SELECT option_value FROM wp_options WHERE option_name = 'blogname'",
+        );
+        await importedDatabase.end();
+        assert.equal(blogName.option_value, `E2E: ${site}`);
     });
 });

--- a/tests/e2e/tests/import-61-preflight-parent-wp-config.test.js
+++ b/tests/e2e/tests/import-61-preflight-parent-wp-config.test.js
@@ -1,0 +1,96 @@
+/**
+ * Test 61: Preflight with wp-config.php above ABSPATH
+ *
+ * WordPress supports wp-config.php one directory above its core files.
+ * Root discovery must keep walking after finding wp-load.php so the parent
+ * configuration directory is also reported to the client.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    mkdirSync,
+    readdirSync,
+    renameSync,
+    writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+    apiRequest,
+    getSiteDir,
+    getSiteUrl,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Preflight with wp-config.php above ABSPATH', () => {
+    const site = 'parent-wp-config';
+
+    beforeAll(async () => {
+        const siteUrl = new URL(getSiteUrl(site)).origin;
+        await ensureSite(site, {
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    "UPDATE wp_options SET option_value = ? WHERE option_name = 'home'",
+                    [siteUrl],
+                );
+                await connection.query(
+                    "UPDATE wp_options SET option_value = ? WHERE option_name = 'siteurl'",
+                    [`${siteUrl}/wordpress`],
+                );
+            },
+            afterCreate: async (siteDir) => {
+                const wordpressDir = join(siteDir, 'wordpress');
+                mkdirSync(wordpressDir);
+
+                for (const entry of readdirSync(siteDir)) {
+                    if (entry === 'wordpress' || entry === 'wp-config.php') {
+                        continue;
+                    }
+                    renameSync(join(siteDir, entry), join(wordpressDir, entry));
+                }
+
+                writeFileSync(
+                    join(siteDir, 'index.php'),
+                    `<?php
+define( 'WP_USE_THEMES', true );
+require __DIR__ . '/wordpress/wp-blog-header.php';
+`,
+                );
+                // Make the post-provision file move visible to PHP-FPM immediately.
+                writeFileSync(
+                    join(siteDir, '.user.ini'),
+                    'opcache.revalidate_freq=0\n',
+                );
+            },
+        });
+    });
+
+    it('reports both the WordPress core and its parent configuration root', async () => {
+        const siteDir = getSiteDir(site);
+        const wordpressDir = join(siteDir, 'wordpress');
+        const response = await apiRequest(site, 'preflight');
+
+        assert.equal(
+            response.status,
+            200,
+            `Expected HTTP 200, got ${response.status}: ${JSON.stringify(response.json || response.text)}`,
+        );
+        assert.equal(response.json.ok, true, `Preflight failed: ${response.json.error}`);
+        assert.equal(response.json.database.connected, true, 'Expected WordPress database connection');
+        assert.equal(response.json.database.wp.paths_urls.abspath, wordpressDir);
+
+        const wordpressRoot = response.json.wp_detect.roots.find(
+            (root) => root.path === wordpressDir,
+        );
+        assert.ok(wordpressRoot, `Expected a WordPress core root at ${wordpressDir}`);
+        assert.equal(wordpressRoot.wp_load, true);
+        assert.equal(wordpressRoot.wp_config, false);
+
+        const configRoot = response.json.wp_detect.roots.find(
+            (root) => root.path === siteDir,
+        );
+        assert.ok(configRoot, `Expected a parent configuration root at ${siteDir}`);
+        assert.equal(configRoot.wp_load, false);
+        assert.equal(configRoot.wp_config, true);
+        assert.equal(configRoot.wp_config_path, join(siteDir, 'wp-config.php'));
+    });
+});


### PR DESCRIPTION
Preflight now keeps WordPress roots found below a blocked parent instead of ending with HTTP 500 when PHP rejects a speculative marker probe.

## Background

When a request does not provide `directory`, the WordPress plugin uses `ABSPATH` as preflight's default start path. Root discovery checks each directory for three WordPress markers:

```text
wp-load.php
wp-config.php
wp-content/
```

A directory is recorded when it contains either `wp-load.php` or `wp-config.php`. Discovery then moves to the parent directory and repeats the checks.

Continuing above a directory that contains `wp-load.php` supports WordPress's one-directory-up configuration layout:

```text
/srv/site/wordpress/wp-load.php  -> records /srv/site/wordpress
/srv/site/wp-config.php          -> records /srv/site
```

There does not need to be another `wp-load.php` in `/srv/site`. The parent walk finds the `wp-config.php` there. The client uses every recorded root as a default file-export directory, so stopping at the first `wp-load.php` could leave the parent configuration file out of the migration when no other reported runtime path adds `/srv/site`.

A simplified version of the reported layout is:

```text
/home/example/public_html/wp-load.php  -> readable and found
/home/example/wp-load.php              -> speculative parent candidate
```

PHP allowed `/home/example/public_html` but not `/home/example`. Discovery recorded the real root, moved to the parent, and called `file_exists('/home/example/wp-load.php')`. The call emitted `E_WARNING`; Reprint's global error handler ended the request before root discovery could receive its `false` result.

Stopping immediately after the first `wp-load.php` would avoid that exact parent probe, and it makes test 60 pass. It also changes successful discovery on hosts that keep `wp-config.php` above `ABSPATH`. Test 61 recreates that supported layout and fails under the stop-after-`wp-load.php` variant because the parent configuration root is missing from `wp_detect.roots`. That shortcut also would not handle a warning reached before any `wp-load.php` was found, or a warning from the `wp-config.php` or `wp-content` probes.

## This change

The three marker probes now run under a small, temporary error handler:

- `E_WARNING` marks the current directory as unsafe to inspect and is consumed.
- In the endpoint, every other error is passed to Reprint's existing error handler. If no prior handler is installed, control returns to PHP instead.
- Reprint's handler is restored in `finally` after the probes.

After a probe warning, discovery stops only that upward walk. Roots already found below the blocked directory remain in the preflight response, and any other configured start paths can still be inspected. When every probe succeeds or returns `false` normally, discovery behaves exactly as before and continues walking upward.

This does not disable or parse `open_basedir`. PHP still blocks the parent path. The change only prevents an expected failure in speculative root discovery from ending the whole preflight request. It does not declare blocked migration paths usable or add partial-pull support; those cases remain outside this PR.

## Testing

The two E2E tests cover the warning boundary and the reason discovery must continue above `wp-load.php` separately.

### Test 60: blocked parent probe and migration

Test 60 provisions a normal WordPress site behind PHP-FPM:

```text
/srv/e2e-sites/open-basedir/wp-load.php
/srv/e2e-sites/open-basedir/wp-config.php
/srv/e2e-sites/open-basedir/wp-content/
```

The site uses a dedicated PHP-FPM pool. That pool limits PHP to the site directory and `/tmp`. Other E2E sites stay on the normal pool, so they cannot reuse a worker carrying this restriction. The real `wp-load.php` remains inside the allowed site. The rejected path is the next speculative candidate, `/srv/e2e-sites/wp-load.php`.

Against the pre-change source, the request returned HTTP 500 with the same `open_basedir restriction in effect` warning. With this change, it returns HTTP 200, reports the active restriction, keeps the real site in `wp_detect.roots`, and records no paths above the blocked parent in `wp_detect.searched`.

The test then runs the two supported high-level migration commands:

```text
pull-files --include=:wp-content:
pull-db --target-user=... --target-pass=... --target-db=...
```

The `pull` command does not expose `--include`, so the test uses its supported file and database pipelines separately. Each command runs its own preflight without a `directory` parameter. Each pipeline state records the same active `open_basedir` value.

The file pipeline completes `preflight → files-pull`. It copies the Reprint secret from `wp-content` with the exact source bytes, while `wp-load.php` remains absent because it is outside the selected path. The database pipeline completes `preflight → db-pull → db-apply`. The new database has the same tables and row counts as the source, plus the expected site-specific `blogname` value.

### Test 61: parent wp-config.php

Test 61 boots a real WordPress site with the supported one-directory-up configuration layout:

```text
/srv/e2e-sites/parent-wp-config/
├── index.php
├── wp-config.php
└── wordpress/
    ├── wp-load.php
    ├── wp-settings.php
    └── wp-content/plugins/site-export/
```

The root front controller loads `wordpress/wp-blog-header.php`. WordPress sets `ABSPATH` to the `wordpress` directory, loads `wp-config.php` from its parent, connects to the database, and loads the active Reprint plugin from the child `wp-content` directory.

The test confirms the reported `ABSPATH`, the database connection, the child root containing `wp-load.php`, and the parent root containing `wp-config.php`. The rejected stop-after-`wp-load.php` variant returns HTTP 200 but fails at the parent-root assertion because `/srv/e2e-sites/parent-wp-config` is absent from `wp_detect.roots`.

Tests 60 and 61 pass locally, and the full CI suite passes.
