### PR TITLE
[PHP] Send same-origin WordPress admin Referer with file-fetch uploads

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -219,6 +219,9 @@ class ImportClient
     /** @var string Remote Reprint API URL. */
     public $remote_reprint_api_url;
 
+    /** @var string|null Same-origin WordPress Media Library URL for file-fetch uploads. */
+    private $file_fetch_referer = null;
+
     /** @var string Caller-selected state directory for this filesystem root. */
     public $state_dir;
 
@@ -508,6 +511,23 @@ class ImportClient
         }
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
+        $remote_url = parse_url( $this->remote_reprint_api_url );
+        if (
+            is_array( $remote_url ) &&
+            isset( $remote_url["scheme"], $remote_url["host"] )
+        ) {
+            $site_path = rtrim((string) ( $remote_url["path"] ?? "" ), "/");
+            if (substr( $site_path, -10 ) === "/index.php") {
+                $site_path = substr( $site_path, 0, -10 );
+            }
+
+            $this->file_fetch_referer =
+                $remote_url["scheme"] . "://" . $remote_url["host"];
+            if (isset( $remote_url["port"] )) {
+                $this->file_fetch_referer .= ":" . $remote_url["port"];
+            }
+            $this->file_fetch_referer .= "{$site_path}/wp-admin/upload.php";
+        }
         $this->state_dir = trim_right_slash($state_dir);
         $this->filesystem_root = trim_right_slash($filesystem_root);
         $remote_state_directory = $selected_remote_state_directory === null
@@ -11472,6 +11492,16 @@ class ImportClient
                 }
             }
             if ($has_file) {
+                if (
+                    $endpoint === "file_fetch" &&
+                    $this->file_fetch_referer !== null
+                ) {
+                    // Some application firewalls admit WordPress uploads
+                    // only after a same-site wp-admin Referer. The HMAC
+                    // remains the authentication check for file_fetch.
+                    $headers[] = "Referer: {$this->file_fetch_referer}";
+                }
+
                 // For CURLFile uploads, sign the raw file content — this
                 // is the logical payload the server will receive, even
                 // though curl wraps it in multipart framing.

--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -1,0 +1,90 @@
+/**
+ * Local reverse proxy which models an application firewall around WordPress.
+ *
+ * Multipart file_fetch requests are accepted only when their Referer points to
+ * the same origin's WordPress Media Library page. All accepted requests are
+ * streamed to the real E2E WordPress site.
+ */
+import http from 'node:http';
+import { appendFileSync } from 'node:fs';
+
+const [backendUrlString, requestLogPath] = process.argv.slice(2);
+if (!backendUrlString || !requestLogPath) {
+    throw new Error('Expected backend URL and request log path arguments');
+}
+
+const backendUrl = new URL(backendUrlString);
+
+function writeRequestLog(record) {
+    appendFileSync(requestLogPath, `${JSON.stringify(record)}\n`);
+}
+
+const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+    const contentType = request.headers['content-type'] || '';
+    const isMultipartFileFetch =
+        request.method === 'POST' &&
+        requestUrl.searchParams.get('endpoint') === 'file_fetch' &&
+        contentType.startsWith('multipart/form-data;');
+    const expectedReferer = `http://${request.headers.host}/wp-admin/upload.php`;
+    const referer = request.headers.referer || '';
+    const allowed = !isMultipartFileFetch || referer === expectedReferer;
+
+    writeRequestLog({
+        method: request.method,
+        path: request.url,
+        contentType,
+        referer,
+        expectedReferer,
+        isMultipartFileFetch,
+        allowed,
+        userAgent: request.headers['user-agent'] || '',
+    });
+
+    if (!allowed) {
+        request.resume();
+        response.writeHead(403, {
+            'Content-Type': 'text/html; charset=utf-8',
+            'X-App-Firewall': 'blocked',
+        });
+        response.end('<!doctype html><title>403 Forbidden</title><h1>Forbidden</h1>');
+        return;
+    }
+
+    const upstreamRequest = http.request({
+        protocol: backendUrl.protocol,
+        hostname: backendUrl.hostname,
+        port: backendUrl.port,
+        method: request.method,
+        path: request.url,
+        headers: {
+            ...request.headers,
+            host: backendUrl.host,
+        },
+    }, (upstreamResponse) => {
+        response.writeHead(
+            upstreamResponse.statusCode,
+            upstreamResponse.statusMessage,
+            upstreamResponse.headers,
+        );
+        upstreamResponse.pipe(response);
+    });
+
+    upstreamRequest.on('error', (error) => {
+        if (!response.headersSent) {
+            response.writeHead(502, { 'Content-Type': 'text/plain; charset=utf-8' });
+        }
+        response.end(`Application firewall fixture could not reach WordPress: ${error.message}`);
+    });
+
+    request.pipe(upstreamRequest);
+});
+
+server.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    process.send?.({ port: address.port });
+});
+
+process.on('SIGTERM', () => {
+    server.close(() => process.exit(0));
+});

--- a/tests/e2e/tests/import-60-application-firewall.test.js
+++ b/tests/e2e/tests/import-60-application-firewall.test.js
@@ -1,0 +1,162 @@
+/**
+ * Test 60: Application firewall compatibility
+ *
+ * Runs a complete pull through a local HTTP reverse proxy which rejects
+ * multipart file uploads unless they have a same-origin WordPress admin
+ * Referer. The proxy streams every accepted request to the real E2E site.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { once } from 'node:events';
+import {
+    existsSync,
+    readFileSync,
+    unlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    assertPullPipelineComplete,
+    cleanupTempDir,
+    createMysqlConnection,
+    createTempDir,
+    fsRootDir,
+    getSiteDir,
+    getSiteSecret,
+    getSiteUrl,
+    pullStateDirectory,
+    runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Application firewall compatibility', { timeout: 240000 }, () => {
+    const site = 'basic';
+    const importDb = 'e2e_app_firewall_60';
+    let firewallProcess;
+    let firewallOrigin;
+    let importUrl;
+    let outputDirectory;
+    let pullResult;
+    let requestLogPath;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+
+        outputDirectory = createTempDir('e2e-app-firewall');
+        requestLogPath = join(
+            tmpdir(),
+            `reprint-app-firewall-${process.pid}-${Date.now()}.jsonl`,
+        );
+        writeFileSync(requestLogPath, '');
+
+        const firewallFixturePath = fileURLToPath(
+            new URL('../lib/app-firewall-fixture.js', import.meta.url),
+        );
+        firewallProcess = fork(
+            firewallFixturePath,
+            [getSiteUrl(site), requestLogPath],
+            { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] },
+        );
+        const [readyMessage] = await once(firewallProcess, 'message');
+        firewallOrigin = `http://127.0.0.1:${readyMessage.port}`;
+        importUrl = `${firewallOrigin}/?reprint-api&directory=${encodeURIComponent(getSiteDir(site))}`;
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await connection.query(`CREATE DATABASE \`${importDb}\``);
+        await connection.end();
+
+        pullResult = runImporter(importUrl, outputDirectory, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 240000,
+            extraArgs: [
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${importDb}`,
+                '--new-site-url=http://localhost:9999',
+                '--runtime=none',
+            ],
+        });
+    }, 360000);
+
+    afterAll(async () => {
+        cleanupTempDir(outputDirectory);
+
+        if (firewallProcess && firewallProcess.exitCode === null) {
+            firewallProcess.kill('SIGTERM');
+            await once(firewallProcess, 'exit');
+        }
+
+        if (requestLogPath && existsSync(requestLogPath)) {
+            unlinkSync(requestLogPath);
+        }
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await connection.end();
+    });
+
+    it('sends a same-origin WordPress admin Referer with multipart file_fetch requests', () => {
+        const requestRecords = readFileSync(requestLogPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+        const multipartFileFetchRequests = requestRecords.filter(
+            record => record.isMultipartFileFetch,
+        );
+        assert.ok(
+            multipartFileFetchRequests.length > 0,
+            `Expected pull to make a multipart file_fetch request\n` +
+            `stderr: ${pullResult.stderr}\nstdout: ${pullResult.stdout}`,
+        );
+        assert.ok(
+            multipartFileFetchRequests.every(
+                record => record.referer === `${firewallOrigin}/wp-admin/upload.php`,
+            ),
+            `Expected Referer ${firewallOrigin}/wp-admin/upload.php, got ` +
+            multipartFileFetchRequests.map(record => JSON.stringify(record.referer)).join(', '),
+        );
+    });
+
+    it('completes pull through the application firewall', () => {
+        assert.equal(
+            pullResult.exitCode,
+            0,
+            `Expected pull to succeed\nstderr: ${pullResult.stderr}\nstdout: ${pullResult.stdout}`,
+        );
+
+        const stateFile = join(pullStateDirectory(outputDirectory, importUrl), 'state.json');
+        assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+        assertPullPipelineComplete(JSON.parse(readFileSync(stateFile, 'utf-8')));
+        assert.ok(
+            existsSync(join(fsRootDir(outputDirectory), getSiteDir(site), 'test-data', 'hello.txt')),
+            'Expected pull to write a source file through the application firewall',
+        );
+    });
+
+    it('rejects a multipart file upload without the Referer', async () => {
+        const form = new FormData();
+        form.append(
+            'file_list',
+            new Blob(['[]'], { type: 'application/json' }),
+            'file-list.json',
+        );
+
+        const response = await fetch(
+            `${firewallOrigin}/?reprint-api&endpoint=file_fetch`,
+            {
+                method: 'POST',
+                body: form,
+            },
+        );
+
+        assert.equal(response.status, 403);
+        assert.equal(response.headers.get('x-app-firewall'), 'blocked');
+    });
+});


### PR DESCRIPTION
Multipart `file_fetch` requests now send the same-origin WordPress Media Library URL as their `Referer`.

## Background

Some application-firewall rules classify a request as a file upload only after parsing a multipart file part. One related rule behaved like this:

```text
multipart file + no WordPress admin Referer    -> 403 before PHP
multipart file + /wp-admin/upload.php Referer -> PHP and Reprint's HMAC check
```

That policy admits normal WordPress Media Library traffic but rejects Reprint's custom multipart upload before Reprint can authenticate it.

## This change

For multipart `file_fetch` requests, Reprint derives a same-origin `/wp-admin/upload.php` Referer from the remote URL. It retains the remote port and WordPress subdirectory. Other endpoints and non-file requests are unchanged.

The Referer is only a firewall compatibility signal. The existing HMAC remains the authentication check.

## Testing

A new local application-firewall E2E group models this file-upload policy. Its first test checks the Referer, its second confirms a complete pull, and its third confirms the same multipart upload receives 403 without the header. The existing basic pull and delta re-pull tests also pass.

## Follow-up

- Research host application-firewall Referer rules more broadly, then decide whether Reprint should send the same-origin WordPress admin Referer with more request types.
