### PR TITLE
[PHP] PHP 5.6 compat changes in exporter pull endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,15 @@ jobs:
           php-version: '8.2'
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
           ini-values: phar.readonly=0
+          tools: composer:2.9.7
 
       - run: composer install --no-dev --no-interaction --prefer-dist
 
-      - name: Install plugin runtime dependencies
-        run: composer install --no-dev --no-interaction --prefer-dist --working-dir=reprint-server-wp
-
       - name: Build reprint.phar
         run: ./bin/build-reprint-phar.sh
+
+      - name: Install exporter plugin build dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist --working-dir=tools/php56-build
 
       - name: Stamp plugin version from git tag
         env:
@@ -78,11 +79,8 @@ jobs:
       # filename. Renaming it would install a second plugin beside the existing
       # reprint-exporter-wp/ instead of upgrading it. The source directory is
       # reprint-server-wp/; only the artifact keeps the legacy name.
-      # zip -r updates an existing archive in place, so remove any leftover
-      # first. The exclusion must be './secret.php': a '*/secret.php' pattern
-      # does not match the root-level entry this layout produces.
-      - name: Package reprint-exporter-wp.zip
-        run: rm -f reprint-exporter-wp.zip && cd reprint-server-wp && zip -r ../reprint-exporter-wp.zip . -x './secret.php'
+      - name: Build reprint-exporter-wp.zip
+        run: ./bin/build-exporter-plugin.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ and `wp-php-toolkit/reprint-importer`. Each renamed package replaces its
 predecessor at `self.version`, so the old and new names cannot be installed
 side by side; consumers migrate by changing the requirement name.
 
-Both packages depend on [`wp-php-toolkit/data-liberation`](https://packagist.org/packages/wp-php-toolkit/data-liberation) and [`wp-php-toolkit/html`](https://packagist.org/packages/wp-php-toolkit/html), which Composer pulls in automatically.
+The client package depends on
+[`wp-php-toolkit/data-liberation`](https://packagist.org/packages/wp-php-toolkit/data-liberation)
+and [`wp-php-toolkit/html`](https://packagist.org/packages/wp-php-toolkit/html),
+which Composer pulls in automatically. The server package has no package
+dependencies.
 
 ## Repository layout
 
@@ -117,11 +121,12 @@ Both packages depend on [`wp-php-toolkit/data-liberation`](https://packagist.org
 
 On the **migration source** side:
 
- - PHP 7.4+
+ - The release WordPress exporter plugin supports pull endpoints on PHP 5.6.20+; push endpoints require PHP 7.2+
+ - The typed `wp-php-toolkit/reprint-server` Composer package requires PHP 7.2+
  - ext-json — JSON encoding/decoding
  - ext-hash — hash_hmac, hash_equals
- - ext-zlib — deflate_init/deflate_add for gzip streaming
- - ext-pdo + ext-pdo_mysql — database access (already in composer.json)
+ - ext-zlib (optional) — PHP 7.0+ uses it for gzip streaming; otherwise the exporter streams the multipart response without compression
+ - ext-pdo + ext-pdo_mysql — recommended for MySQL exports; the plugin falls back to WordPress's wpdb layer when they are unavailable
 
 Hosts exposing the push endpoints must set `display_errors=Off` at PHP
 startup, through `php.ini`, `.user.ini`, or the PHP-FPM pool configuration.

--- a/bin/build-exporter-plugin.sh
+++ b/bin/build-exporter-plugin.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Builds the PHP 5.6-compatible WordPress exporter plugin ZIP from the typed
+# source tree. The source checkout is never rewritten; all downgrade work is
+# confined to a temporary staging directory.
+#
+# Usage:
+#   ./bin/build-exporter-plugin.sh
+#   ./bin/build-exporter-plugin.sh /path/to/reprint-exporter-wp.zip
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_PATH="${1:-$PROJECT_ROOT/reprint-exporter-wp.zip}"
+
+case "$OUTPUT_PATH" in
+    /*) ;;
+    *) OUTPUT_PATH="$(pwd)/$OUTPUT_PATH" ;;
+esac
+
+for command_name in php composer zip; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        echo "Error: $command_name not found in PATH." >&2
+        exit 1
+    fi
+done
+
+if [ ! -x "$PROJECT_ROOT/tools/php56-build/vendor/bin/rector" ]; then
+    echo "Error: exporter build dependencies are missing." >&2
+    echo "Run: composer install --no-dev --working-dir=tools/php56-build" >&2
+    exit 1
+fi
+
+BUILD_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/reprint-exporter-build.XXXXXX")"
+trap 'rm -rf "$BUILD_ROOT"' EXIT
+
+mkdir -p \
+    "$BUILD_ROOT/reprint-server-wp" \
+    "$BUILD_ROOT/packages/reprint-server"
+
+cp -R "$PROJECT_ROOT/reprint-server-wp/." "$BUILD_ROOT/reprint-server-wp/"
+cp -R "$PROJECT_ROOT/packages/reprint-server/." "$BUILD_ROOT/packages/reprint-server/"
+
+# Runtime dependencies are generated from the downgraded package below. Never
+# carry a development vendor tree or a local secret into the release artifact.
+rm -rf "$BUILD_ROOT/reprint-server-wp/vendor"
+rm -f \
+    "$BUILD_ROOT/reprint-server-wp/composer.lock" \
+    "$BUILD_ROOT/reprint-server-wp/secret.php"
+
+php "$PROJECT_ROOT/bin/downgrade-exporter-plugin.php" "$BUILD_ROOT"
+
+# The Composer packages describe the typed source requirement. Only the
+# generated plugin distribution advertises and resolves for PHP 5.6.
+php -r '
+$paths = array($argv[1], $argv[2]);
+foreach ($paths as $path) {
+    $contents = file_get_contents($path);
+    $manifest = json_decode($contents, true);
+    if (!is_array($manifest) || !isset($manifest["require"])) {
+        fwrite(STDERR, "Error: could not read Composer manifest " . $path . ".\n");
+        exit(1);
+    }
+    $manifest["require"]["php"] = ">=5.6.20";
+    if ($path === $argv[1]) {
+        if (!isset($manifest["config"]) || !is_array($manifest["config"])) {
+            $manifest["config"] = array();
+        }
+        if (!isset($manifest["config"]["platform"]) || !is_array($manifest["config"]["platform"])) {
+            $manifest["config"]["platform"] = array();
+        }
+        $manifest["config"]["platform"]["php"] = "5.6.20";
+    }
+    file_put_contents(
+        $path,
+        json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+    );
+}
+' \
+    "$BUILD_ROOT/reprint-server-wp/composer.json" \
+    "$BUILD_ROOT/packages/reprint-server/composer.json"
+
+sed -i.bak \
+    's/^ \* Requires PHP: .*/ * Requires PHP: 5.6.20/' \
+    "$BUILD_ROOT/reprint-server-wp/index.php"
+rm -f "$BUILD_ROOT/reprint-server-wp/index.php.bak"
+
+if ! grep -Fq ' * Requires PHP: 5.6.20' "$BUILD_ROOT/reprint-server-wp/index.php"; then
+    echo "Error: failed to set the generated plugin PHP requirement." >&2
+    exit 1
+fi
+
+COMPOSER_DISABLE_NETWORK=1 COMPOSER_MIRROR_PATH_REPOS=1 composer update \
+    --no-dev \
+    --no-audit \
+    --no-interaction \
+    --no-progress \
+    --prefer-dist \
+    --working-dir="$BUILD_ROOT/reprint-server-wp"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+# zip updates an existing archive in place, so remove any leftover first. The
+# exclusion must be './secret.php': a '*/secret.php' pattern does not match the
+# root-level entry produced by this layout.
+rm -f "$OUTPUT_PATH"
+(
+    cd "$BUILD_ROOT/reprint-server-wp"
+    zip -qr "$OUTPUT_PATH" . -x './secret.php'
+)
+
+echo "Built $OUTPUT_PATH"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "test": "cd tests && phpunit --testdox --colors",
         "test:coverage": "cd tests && phpunit --coverage-html coverage/ --coverage-text",
         "build:phar": "./bin/build-reprint-phar.sh",
-        "build:server-plugin": "rm -f reprint-exporter-wp.zip && composer install --no-dev --working-dir=reprint-server-wp && cd reprint-server-wp && zip -r ../reprint-exporter-wp.zip . -x './secret.php'",
+        "build:server-plugin": "./bin/build-exporter-plugin.sh",
         "build:exporter-plugin": "@build:server-plugin",
         "analyze": "phpstan analyze --memory-limit=1G",
         "lint:php": "phpcs --standard=phpcs.xml.dist",

--- a/packages/reprint-server/src/class-file-tree-producer.php
+++ b/packages/reprint-server/src/class-file-tree-producer.php
@@ -630,7 +630,7 @@ class FileTreeProducer
         $low = 0;
         $high = count($entries);
         while ($low < $high) {
-            $mid = intdiv($low + $high, 2);
+            $mid = integer_divide($low + $high, 2);
             if (strcmp($entries[$mid], $last) <= 0) {
                 $low = $mid + 1;
             } else {

--- a/packages/reprint-server/src/class-gzip-output-stream.php
+++ b/packages/reprint-server/src/class-gzip-output-stream.php
@@ -7,8 +7,11 @@
 namespace WordPress\Reprint\Server;
 
 /**
- * Incremental gzip compressor that emits data as it arrives rather than
- * buffering the entire response.
+ * Incremental response writer.
+ *
+ * PHP 7.0 and newer can gzip each bounded write without buffering the whole
+ * response. PHP 5.6 lacks the incremental zlib API, so it sends the same
+ * multipart stream without a Content-Encoding header.
  */
 class GzipOutputStream
 {
@@ -18,7 +21,9 @@ class GzipOutputStream
 
     public function __construct(bool $enabled = true)
     {
-        $this->enabled = $enabled;
+        $this->enabled = $enabled
+            && function_exists('deflate_init')
+            && function_exists('deflate_add');
         if ($this->enabled) {
             $this->deflate_ctx = deflate_init(ZLIB_ENCODING_GZIP, ["level" => 6]);
             if ($this->deflate_ctx === false) {

--- a/packages/reprint-server/src/class-hmac-client.php
+++ b/packages/reprint-server/src/class-hmac-client.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPress\Reprint\Server\generate_random_bytes;
+
 /**
  * HMAC Client for the Site Export API.
  *
@@ -31,7 +33,7 @@ class Site_Export_HMAC_Client {
 
     /** @return string Hex-encoded 16-byte nonce. */
     public function generate_nonce(): string {
-        return bin2hex(random_bytes(16));
+        return bin2hex(generate_random_bytes(16));
     }
 
     /** @return string Microsecond-precision Unix timestamp. */

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -319,7 +319,24 @@ final class Site_Export_HTTP_Server {
         }
 
         $handler = $this->handlers[$endpoint];
-        if ($endpoint === 'preflight' || self::is_push_endpoint($endpoint)) {
+        if (self::is_push_endpoint($endpoint)) {
+            if (PHP_VERSION_ID < 70200) {
+                http_response_code(503);
+                header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+                header('Pragma: no-cache');
+                header('Expires: 0');
+                header('Content-Type: application/json');
+                echo json_encode([
+                    'status' => 'rejected',
+                    'reason' => 'push_disabled',
+                    'detail' => 'Push endpoints require PHP 7.2 or newer; observed PHP ' . PHP_VERSION . '.',
+                ]);
+                return;
+            }
+            call_user_func($handler, $config);
+            return;
+        }
+        if ($endpoint === 'preflight') {
             call_user_func($handler, $config);
             return;
         }
@@ -332,7 +349,8 @@ final class Site_Export_HTTP_Server {
     }
 
     public static function is_push_endpoint(string $endpoint): bool {
-        return isset(self::PUSH_ENDPOINT_METHODS[$endpoint]);
+        $push_endpoint_methods = self::PUSH_ENDPOINT_METHODS;
+        return isset($push_endpoint_methods[$endpoint]);
     }
 
     /**

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -678,7 +678,7 @@ class MySQLDumpProducer
         }
 
         /** Base64 output is always ceil(n/3)*4 bytes. */
-        $estimated_base64_length = 4 * intdiv($len + 2, 3);
+        $estimated_base64_length = 4 * integer_divide($len + 2, 3);
         // FROM_BASE64('<data>') => 15 bytes overhead + base64 length
         return 15 + $estimated_base64_length;
     }

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -13,6 +13,7 @@ use WordPress\Reprint\Server\WpdbDriverPDO;
 
 use function WordPress\Reprint\Server\assert_valid_path;
 use function WordPress\Reprint\Server\build_pdo_dsn;
+use function WordPress\Reprint\Server\generate_random_bytes;
 use function WordPress\Reprint\Server\json_encode_or_throw;
 use function WordPress\Reprint\Server\parse_size;
 use function WordPress\Reprint\Server\path_is_same_as_or_descendant_of;
@@ -55,8 +56,8 @@ define('STAT_TYPE_FIFO',   0010000);
 
 /**
  * Global streaming context. When set, the error handlers emit error chunks
- * into the active gzip multipart stream instead of sending plain JSON
- * (which would corrupt the compressed response).
+ * into the active multipart stream instead of sending plain JSON, which would
+ * corrupt either a compressed or uncompressed multipart response.
  *
  * Set by each streaming endpoint right after creating $gz and $boundary.
  * Keys: 'gz' => GzipOutputStream, 'boundary' => string
@@ -108,7 +109,7 @@ function begin_multipart_stream(bool $require_headers = false, bool $gzip = true
      * Also, every chunk declares its Content-Length, so the client never needs
      * to search arbitrary body bytes for the boundary.
      */
-    $boundary = "boundary-" . bin2hex(random_bytes(16));
+    $boundary = "boundary-" . bin2hex(generate_random_bytes(16));
     $can_send_headers = !headers_sent();
 
     if ($require_headers && !$can_send_headers) {
@@ -390,7 +391,7 @@ if (!class_exists('Site_Export_HTTP_Server', false)) {
 }
 
 /**
- * Emits an error chunk into a gzip multipart stream.
+ * Emits an error chunk into a multipart stream.
  */
 function emit_error_chunk($gz, string $boundary, string $message): void
 {
@@ -409,13 +410,20 @@ function emit_error_chunk($gz, string $boundary, string $message): void
         "X-Chunk-Type: error\r\n" .
         "\r\n" .
         $json . "\r\n";
+    $write_failed = false;
     try {
         $gz->write($chunk);
         $gz->sync();
+    } catch (\Exception $e) {
+        $write_failed = true;
     } catch (\Throwable $e) {
-        // Gzip stream is broken — fall back to raw output.
-        // The response is already partially gzipped so the client likely
-        // can't parse this, but it's better than silent failure.
+        $write_failed = true;
+    }
+
+    if ($write_failed) {
+        // The output stream is broken, so make one last raw write. If gzip was
+        // active, the client likely cannot parse it, but this is better than
+        // silent failure.
         echo $chunk;
         flush();
     }
@@ -513,8 +521,12 @@ register_shutdown_function(function () {
                 $streaming_context['boundary'],
                 $message
             );
+        } catch (Exception $ignored) {
+            // Stream is too broken to write to — nothing more we can do.
+            return;
         } catch (Throwable $ignored) {
             // Stream is too broken to write to — nothing more we can do.
+            return;
         }
         return;
     }
@@ -869,6 +881,7 @@ function endpoint_sql_chunk(
     /** @var string|null $deferred_fragment_cursor */
     $deferred_fragment_cursor = null;
 
+    $stream_failure = null;
     try {
         while (
             $budget->has_remaining()
@@ -909,7 +922,7 @@ function endpoint_sql_chunk(
 
                     $trimmed_fragment = rtrim($fragment);
                     $sql_ends_with_complete_statement =
-                        $trimmed_fragment !== '' && $trimmed_fragment[-1] === ';';
+                        $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
                     if ($sql_ends_with_complete_statement) {
                         $cursor = $reader->get_reentrancy_cursor();
                     }
@@ -941,7 +954,7 @@ function endpoint_sql_chunk(
             // intermediate INSERT rows with ",", so checking the last
             // character is sufficient.
             $trimmed = rtrim($sql);
-            $query_complete = $trimmed !== "" && $trimmed[-1] === ";";
+            $query_complete = $trimmed !== "" && substr($trimmed, -1) === ";";
             if (!$query_complete || $cursor === null) {
                 $cursor = $reader->get_reentrancy_cursor();
             }
@@ -971,10 +984,16 @@ function endpoint_sql_chunk(
                 break;
             }
         }
+    } catch (Exception $e) {
+        $stream_failure = $e;
     } catch (Throwable $e) {
+        $stream_failure = $e;
+    }
+
+    if ($stream_failure !== null) {
         $aborted = true;
-        error_log("SQL streaming error: " . $e->getMessage());
-        emit_error_chunk($gz, $boundary, $e->getMessage());
+        error_log("SQL streaming error: " . $stream_failure->getMessage());
+        emit_error_chunk($gz, $boundary, $stream_failure->getMessage());
     }
 
     // Best-effort completion chunk — the client already has the data chunks.
@@ -988,6 +1007,7 @@ function endpoint_sql_chunk(
         _e2e_call_hook('test_hook_before_completion', $hook_args);
     }
 
+    $completion_failure = null;
     try {
         $gz->write(
             "--{$boundary}\r\n" .
@@ -1005,8 +1025,13 @@ function endpoint_sql_chunk(
             "--{$boundary}--\r\n"
         );
         $gz->finish();
+    } catch (\Exception $e) {
+        $completion_failure = $e;
     } catch (\Throwable $e) {
-        error_log("Export: failed to write completion chunk: " . $e->getMessage());
+        $completion_failure = $e;
+    }
+    if ($completion_failure !== null) {
+        error_log("Export: failed to write completion chunk: " . $completion_failure->getMessage());
     }
 
     return [
@@ -1063,6 +1088,7 @@ function endpoint_db_index(
     $status = "partial";
     $aborted = false;
 
+    $stream_failure = null;
     try {
         while (
             $budget->has_remaining()
@@ -1135,11 +1161,22 @@ function endpoint_db_index(
                 break;
             }
         }
+    } catch (\Exception $e) {
+        $stream_failure = $e;
     } catch (\Throwable $e) {
-        $aborted = true;
-        emit_error_chunk($gz, $boundary, get_class($e) . ": " . $e->getMessage());
+        $stream_failure = $e;
     }
 
+    if ($stream_failure !== null) {
+        $aborted = true;
+        emit_error_chunk(
+            $gz,
+            $boundary,
+            get_class($stream_failure) . ": " . $stream_failure->getMessage()
+        );
+    }
+
+    $completion_failure = null;
     try {
         if (getenv('SITE_EXPORT_TEST_MODE')) {
             $hook_status = $aborted ? "partial" : $status;
@@ -1163,8 +1200,13 @@ function endpoint_db_index(
             "--{$boundary}--\r\n"
         );
         $gz->finish();
+    } catch (\Exception $e) {
+        $completion_failure = $e;
     } catch (\Throwable $e) {
-        error_log("Export: failed to write completion chunk: " . $e->getMessage());
+        $completion_failure = $e;
+    }
+    if ($completion_failure !== null) {
+        error_log("Export: failed to write completion chunk: " . $completion_failure->getMessage());
     }
 
     return [
@@ -1889,6 +1931,10 @@ function endpoint_preflight(array $config): array
                         $db["wp"]["wp_version"] = isset($wp_version) && is_string($wp_version)
                             ? $wp_version
                             : null;
+                    } catch (Exception $e) {
+                        if ($db["wp"]["error"] === null) {
+                            $db["wp"]["error"] = $e->getMessage();
+                        }
                     } catch (Throwable $e) {
                         if ($db["wp"]["error"] === null) {
                             $db["wp"]["error"] = $e->getMessage();
@@ -2087,6 +2133,18 @@ function endpoint_preflight(array $config): array
         $wp_content["roots"][] = $root_entry;
     }
 
+    $environment_variables = [];
+    if (PHP_VERSION_ID >= 70100) {
+        $all_environment_variables = getenv();
+        if (is_array($all_environment_variables)) {
+            $environment_variables = $all_environment_variables;
+        }
+    }
+    $environment_variable_names = array_values(array_unique(array_merge(
+        array_keys($_ENV),
+        array_keys($environment_variables)
+    )));
+
     // -- Assemble and return the preflight response --
     $ok =
         $preflight_error === null &&
@@ -2160,12 +2218,11 @@ function endpoint_preflight(array $config): array
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,
             "cwd" => getcwd() ?: null,
-            // Names of all defined environment variables (no values) so the
-            // importer can use their presence as a webhost detection signal.
-            "env_names" => array_values(array_unique(array_merge(
-                array_keys($_ENV),
-                array_keys(getenv())
-            ))),
+            // Names of environment variables exposed without their values so
+            // the importer can use their presence as a webhost detection
+            // signal. PHP 5.6 cannot list getenv(), so it contributes only
+            // names present in $_ENV.
+            "env_names" => $environment_variable_names,
             '$_SERVER_names' => array_keys($_SERVER),
         ],
         "filesystem" => [
@@ -2230,6 +2287,7 @@ function stream_file_producer(
     // and progress updates. Each chunk type is wrapped in a multipart part
     // with metadata headers (path, cursor, size, ctime). The loop runs
     // until the producer is exhausted or the resource budget runs out.
+    $stream_failure = null;
     try {
         $initial_progress = $producer->get_progress();
         $initial_progress_json = json_encode_or_throw($initial_progress);
@@ -2427,17 +2485,24 @@ function stream_file_producer(
                 $gz->sync();
             }
         }
+    } catch (Exception $e) {
+        $stream_failure = $e;
     } catch (Throwable $e) {
+        $stream_failure = $e;
+    }
+
+    if ($stream_failure !== null) {
         $aborted = true;
         $abort_payload = [
             "error_type" => "exception",
             "path" => "",
-            "message" => $e->getMessage(),
+            "message" => $stream_failure->getMessage(),
         ];
     }
 
     // Best-effort error and completion chunks — the client already has the
     // data chunks. If the stream is broken at this point, log and move on.
+    $completion_failure = null;
     try {
         // @TODO: If an exception is thrown right after the previous chunk header,
         //        it read the fixed Content-Length value and will consume this next
@@ -2489,8 +2554,13 @@ function stream_file_producer(
             "--{$boundary}--\r\n"
         );
         $gz->finish();
+    } catch (\Exception $e) {
+        $completion_failure = $e;
     } catch (\Throwable $e) {
-        error_log("Export: failed to write completion chunk: " . $e->getMessage());
+        $completion_failure = $e;
+    }
+    if ($completion_failure !== null) {
+        error_log("Export: failed to write completion chunk: " . $completion_failure->getMessage());
     }
 
     $status = $aborted ? "partial" : ($status ?? "partial");
@@ -2603,6 +2673,7 @@ function endpoint_file_index(
     $aborted = false;
     $abort_payload = null;
 
+    $stream_failure = null;
     try {
         $metadata = [
             "filesystem_root" => base64_encode($filesystem_root),
@@ -2672,13 +2743,19 @@ function endpoint_file_index(
                     break;
             }
         }
+    } catch (Exception $e) {
+        $stream_failure = $e;
     } catch (Throwable $e) {
+        $stream_failure = $e;
+    }
+
+    if ($stream_failure !== null) {
         $aborted = true;
         $current_directory = $file_index->get_current_directory();
         $abort_payload = [
             "error_type" => "exception",
             "path" => base64_encode($current_directory ?? $list_directory),
-            "message" => $e->getMessage(),
+            "message" => $stream_failure->getMessage(),
         ];
     }
 
@@ -2688,6 +2765,7 @@ function endpoint_file_index(
         $total_entries += count($batch_items);
     }
 
+    $completion_failure = null;
     try {
         if ($abort_payload !== null) {
             emit_file_index_error(
@@ -2723,10 +2801,15 @@ function endpoint_file_index(
             "--{$boundary}--\r\n"
         );
         $gz->finish();
+    } catch (Exception $e) {
+        $completion_failure = $e;
     } catch (Throwable $e) {
-        error_log("Export: failed to write completion chunk: " . $e->getMessage());
+        $completion_failure = $e;
     } finally {
         $file_index->close();
+    }
+    if ($completion_failure !== null) {
+        error_log("Export: failed to write completion chunk: " . $completion_failure->getMessage());
     }
 
     return [

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -13,11 +13,11 @@
  * the package gets these symbols on every request.
  *
  * The two str_* polyfills at the top stay global on purpose: they
- * backfill PHP 7.4 built-ins, so callers expect to reach them via
+ * backfill functions unavailable before PHP 8.0, so callers reach them via
  * the global namespace without a use-statement.
  */
 
-// Polyfill for PHP 7.4 which lacks str_starts_with().
+// Polyfill for PHP versions before 8.0, which lack str_starts_with().
 namespace {
     if (!function_exists('str_starts_with')) {
         function str_starts_with(string $haystack, string $needle): bool {
@@ -25,7 +25,7 @@ namespace {
         }
     }
 
-    // Polyfill for PHP 7.4 which lacks str_contains().
+    // Polyfill for PHP versions before 8.0, which lack str_contains().
     if (!function_exists('str_contains')) {
         function str_contains(string $haystack, string $needle): bool {
             return $needle === '' || strpos($haystack, $needle) !== false;
@@ -62,6 +62,50 @@ use RuntimeException;
 //
 // Function bodies stay unindented inside their guards, matching how the
 // bracketed namespace blocks in this file are written.
+
+if (!function_exists(__NAMESPACE__ . '\\generate_random_bytes')) {
+/**
+ * Returns cryptographically secure random bytes on every supported PHP version.
+ *
+ * @param int $length Number of bytes to return.
+ * @return string Random bytes.
+ * @throws RuntimeException When the runtime has no secure random-byte source.
+ */
+function generate_random_bytes(int $length): string
+{
+    if (function_exists('random_bytes')) {
+        return random_bytes($length);
+    }
+
+    if (function_exists('openssl_random_pseudo_bytes')) {
+        $strong = false;
+        $bytes = openssl_random_pseudo_bytes($length, $strong);
+        if ($bytes !== false && $strong && strlen($bytes) === $length) {
+            return $bytes;
+        }
+    }
+
+    throw new RuntimeException('The PHP runtime has no cryptographically secure random-byte source.');
+}
+}
+
+if (!function_exists(__NAMESPACE__ . '\\integer_divide')) {
+/**
+ * Divides two integers and rounds the result toward zero.
+ *
+ * @param int $dividend Number to divide.
+ * @param int $divisor Number to divide by.
+ * @return int Integer quotient.
+ */
+function integer_divide(int $dividend, int $divisor): int
+{
+    if (function_exists('intdiv')) {
+        return intdiv($dividend, $divisor);
+    }
+
+    return intval($dividend / $divisor);
+}
+}
 
 if (!function_exists(__NAMESPACE__ . '\\build_pdo_dsn')) {
 /**

--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -4,6 +4,11 @@ When working from this monorepo checkout, run `composer install` in
 `reprint-server-wp/` to populate the bundled `vendor/` directory used by the
 plugin runtime. GitHub release ZIPs already include that vendor tree.
 
+The maintained source keeps its PHP 7.2 type declarations. The release build
+copies that source to a temporary directory and removes unsupported syntax from
+the copy. The resulting plugin ZIP supports pull endpoints on PHP 5.6.20 or
+newer. Push endpoints require PHP 7.2 or newer.
+
 ## API Routing
 
 Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside `wp-content/plugins/` at the web server level, returning a 403 before the request ever reaches PHP. To work around this, export API requests are routed through WordPress's front controller (`index.php` at the site root), which hosts never block.

--- a/reprint-server-wp/composer.json
+++ b/reprint-server-wp/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.2",
         "wp-php-toolkit/reprint-server": "*@dev"
     }
 }

--- a/reprint-server-wp/composer.lock
+++ b/reprint-server-wp/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "648476139f09aef406475c1adbe2b8ae",
+    "content-hash": "8686a9b348ce7bca80631b264318c871",
     "packages": [
         {
             "name": "wp-php-toolkit/reprint-server",
-            "version": "dev-phase-a",
+            "version": "dev-codex/php56-exporter-plugin",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-server",
@@ -56,7 +56,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=7.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/reprint-server-wp/index.php
+++ b/reprint-server-wp/index.php
@@ -4,6 +4,8 @@
  * Plugin URI: https://github.com/WordPress/playground-tools
  * Description: Reprint Server – exposes a site export API with HMAC-authenticated endpoints for database and file synchronization.
  * Version: 0.9.5-dev
+ * Requires PHP: 7.2
+ * PHP 5.6 support: release builds downgrade a copy of this PHP 7.2 source and set its requirement to 5.6.20.
  * Author: WordPress Contributors
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -80,6 +80,11 @@ function _site_export_is_push_endpoint(string $endpoint): bool {
     return strpos($endpoint, 'push_') === 0;
 }
 
+/** Returns whether this PHP runtime can serve push endpoints. */
+function _site_export_push_is_supported(): bool {
+    return PHP_VERSION_ID >= 70200;
+}
+
 /**
  * Resolve and load the server package runtime.
  *
@@ -450,6 +455,14 @@ function _site_export_handle_api_request(array $options = []): void {
         }
     } else {
         _site_export_default_authenticate();
+    }
+
+    if (!_site_export_push_is_supported() && _site_export_is_push_endpoint($endpoint)) {
+        _site_export_push_error(
+            503,
+            'push_disabled',
+            'Push endpoints require PHP 7.2 or newer; observed PHP ' . PHP_VERSION . '.'
+        );
     }
 
     // Authentication completes first. Every push operation requires current

--- a/reprint-server-wp/wordpress/site-export.php
+++ b/reprint-server-wp/wordpress/site-export.php
@@ -167,6 +167,16 @@ class Site_Export_Plugin {
             return;
         }
 
+        if (!_site_export_push_is_supported()) {
+            add_settings_error(
+                'site_export',
+                'push_access_unsupported',
+                'Push access requires PHP 7.2 or newer. Downloads remain available.',
+                'error'
+            );
+            return;
+        }
+
         if (_site_export_get_managed_push_enabled() !== null) {
             add_settings_error(
                 'site_export',
@@ -199,8 +209,9 @@ class Site_Export_Plugin {
         $api_url = home_url('?reprint-api');
         $is_configured = $effective_secret !== '';
         $has_file_override = _site_export_has_secret_file();
+        $push_supported = _site_export_push_is_supported();
         $managed_push_enabled = _site_export_get_managed_push_enabled();
-        $push_enabled = _site_export_is_push_authorized();
+        $push_enabled = $push_supported && _site_export_is_push_authorized();
 
         ?>
         <style>
@@ -406,7 +417,9 @@ class Site_Export_Plugin {
                 <h2>Push access</h2>
                 <p class="card-desc">You do not need push access when moving this site to another host.</p>
 
-                <?php if ($managed_push_enabled !== null): ?>
+                <?php if (!$push_supported): ?>
+                <p class="card-desc">Push access requires PHP 7.2 or newer. This site runs PHP <?php echo esc_html(PHP_VERSION); ?>. Downloads remain available.</p>
+                <?php elseif ($managed_push_enabled !== null): ?>
                 <label>
                     <input type="checkbox" name="site_export_push_enabled" value="1"<?php echo $push_enabled ? ' checked' : ''; ?> disabled />
                     <span>Allow push to change files on this site</span>


### PR DESCRIPTION
Runs the release WordPress exporter plugin's pull endpoints on PHP 5.6.20 without removing type declarations from the maintained PHP 7.2 source.

## Stack

1. #665 — Rector downgrade rules
2. #671 — exporter PHP 5.6 compatibility (this PR)
3. #672 — CI and tests

## Background

The release ZIP copied the source files as written. PHP 5.6 stopped while parsing the first typed function in `lib.php`, before the plugin could check the PHP version or return a useful error. Removing that one return type would not be enough: the pull runtime also uses scalar and nullable types, null coalescing, keyed destructuring, class-constant visibility, and PHP 7 runtime functions.

## This change

The release builder copies the plugin and server package to a temporary directory, invokes the Rector tool from the preceding PR, changes only the copied manifests and plugin header to PHP 5.6.20, installs the copied package, and creates the ZIP. The maintained source stays typed and requires PHP 7.2.

Small runtime branches cover what syntax rewriting cannot: PHP 5.6 sends multipart pull responses without gzip, uses compatible random-byte and integer-division helpers, lists environment variables without the newer `getenv()` form, and catches PHP 5 exceptions.

Pull endpoints support PHP 5.6.20. Push endpoints still require PHP 7.2. An authenticated push request on PHP 5.6 returns HTTP 503 with `push_disabled`, and the settings screen shows downloads-only access. The release workflow now uses this builder instead of zipping the source tree directly.

## Testing

The exact middle commit built a release ZIP whose 33 PHP files parsed on PHP 5.6. Its runtime smoke completed on PHP 5.6. The next PR adds those checks to CI and WordPress E2E.
