### PR TITLE
Test the exporter plugin on PHP 5.6

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,15 +28,42 @@ jobs:
           name: importer-phar
           path: reprint.phar
 
+  build-exporter-plugin:
+    name: Build PHP 5.6 exporter plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+          coverage: none
+          tools: composer:2.9.7
+
+      - run: composer install --no-dev --no-interaction --prefer-dist --working-dir=tools/php56-build
+
+      - run: ./bin/build-exporter-plugin.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: exporter-plugin
+          path: reprint-exporter-wp.zip
+
   e2e:
     name: E2E (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
-    needs: build-phar
+    needs: [build-phar, build-exporter-plugin]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
+          - exporter_php: '5.6'
+            importer_php: '8.2'
+            wordpress_version: '6.2.9'
           - exporter_php: '7.2'
             importer_php: '8.2'
           - exporter_php: '7.4'
@@ -63,6 +90,20 @@ jobs:
         with:
           name: importer-phar
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: exporter-plugin
+          path: ${{ runner.temp }}/exporter-plugin-download
+
+      - name: Extract generated exporter plugin
+        run: |
+          artifact_root="$RUNNER_TEMP/generated-exporter-plugin"
+          mkdir -p "$artifact_root/reprint-server-wp"
+          unzip -q \
+            "$RUNNER_TEMP/exporter-plugin-download/reprint-exporter-wp.zip" \
+            -d "$artifact_root/reprint-server-wp"
+          echo "E2E_EXPORTER_PROJECT_ROOT=$artifact_root" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -87,6 +128,14 @@ jobs:
       - name: Setup infrastructure
         run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.exporter_php }}"
 
+      - name: Restore importer PHP and Composer for CLI tools
+        if: matrix.importer_php != matrix.exporter_php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.importer_php }}
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
+          coverage: none
+
       - name: Setup test sites
         run: tests/e2e/setup.sh
 
@@ -96,6 +145,8 @@ jobs:
 
       - name: Provision basic site and smoke-test API
         env:
+          E2E_WORDPRESS_VERSION: ${{ matrix.wordpress_version }}
+          E2E_WP_CLI_PHP_BINARY: php${{ matrix.importer_php }}
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
           IMPORTER_PHP: php${{ matrix.importer_php }}
         working-directory: tests/e2e
@@ -141,6 +192,14 @@ jobs:
           if [ "$warmup_ok" -ne 1 ]; then
             echo "Export endpoint did not respond within the warmup window"
             exit 1
+          fi
+
+          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
+            # API dispatch exits before index.php loads the plugin's WordPress
+            # admin-registration file. A regular page request covers that path
+            # with the PHP 5.6 FPM worker too.
+            echo "=== Loading WordPress with the exporter on PHP 5.6 ==="
+            curl -fsS -o /dev/null -m 30 "http://127.0.0.1:8081/"
           fi
 
           if [ "$IMPORTER_PHP" = "php7.4" ] || [ "$IMPORTER_PHP" = "php8.0" ]; then
@@ -199,6 +258,25 @@ jobs:
             exit "$preflight_status"
           fi
 
+          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
+            echo "=== Exporter push endpoint PHP version gate ==="
+            PUSH_STATE_DIR="/tmp/e2e-exporter-push-version-state"
+            PUSH_FS_ROOT="/tmp/e2e-exporter-push-version-files"
+            mkdir -p "$PUSH_FS_ROOT"
+            printf 'push must stay disabled on PHP 5.6\n' > "$PUSH_FS_ROOT/probe.txt"
+            "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" >/dev/null
+            set +e
+            exporter_push_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" --force-http 2>&1)"
+            exporter_push_status=$?
+            set -e
+            if [ "$exporter_push_status" -ne 1 ]; then
+              echo "$exporter_push_output"
+              echo "Expected the PHP 5.6 exporter to reject files-push; got ${exporter_push_status}"
+              exit 1
+            fi
+            echo "$exporter_push_output" | grep -F 'Push endpoints require PHP 7.2 or newer'
+          fi
+
           echo "=== Importer files-pull ==="
           # One files-pull invocation has no wall-clock self-limit on the CLI
           # (max_execution_time is 0), so on a slow runner it can still be
@@ -236,8 +314,26 @@ jobs:
             exit "$files_pull_status"
           fi
 
+          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
+            echo "=== Importer db-pull ==="
+            db_pull_status=2
+            db_pull_attempt=0
+            while { [ "$db_pull_status" -eq 2 ] || [ "$db_pull_status" -eq 124 ]; } \
+                  && [ "$db_pull_attempt" -lt 6 ]; do
+              db_pull_attempt=$((db_pull_attempt + 1))
+              db_pull_output="$(timeout 90 "$IMPORTER_PHP" "$IMPORTER_PATH" db-pull "${BASE}&directory=${DIR}" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" 2>&1)" && db_pull_status=0 || db_pull_status=$?
+              echo "$db_pull_output" | head -50
+            done
+            if [ "$db_pull_status" -ne 0 ]; then
+              echo "EXIT: $db_pull_status (db-pull did not complete after ${db_pull_attempt} attempts)"
+              exit "$db_pull_status"
+            fi
+            test -s "$STATE_DIR/db.sql"
+            grep -F 'CREATE TABLE' "$STATE_DIR/db.sql" >/dev/null
+          fi
+
       - name: Run E2E tests
-        if: matrix.exporter_php != '7.2'
+        if: matrix.exporter_php != '5.6' && matrix.exporter_php != '7.2'
         env:
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
         working-directory: tests/e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,6 +53,9 @@ jobs:
           path: reprint-exporter-wp.zip
 
   e2e:
+    # Keep the existing source E2E rows running if only the new exporter
+    # artifact build fails. The PHP 5.6 row will fail when its artifact is absent.
+    if: ${{ always() && !cancelled() && needs['build-phar'].result == 'success' }}
     name: E2E (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
     needs: [build-phar, build-exporter-plugin]
     runs-on: ubuntu-22.04
@@ -91,11 +94,13 @@ jobs:
           name: importer-phar
 
       - uses: actions/download-artifact@v4
+        if: matrix.exporter_php == '5.6'
         with:
           name: exporter-plugin
           path: ${{ runner.temp }}/exporter-plugin-download
 
       - name: Extract generated exporter plugin
+        if: matrix.exporter_php == '5.6'
         run: |
           artifact_root="$RUNNER_TEMP/generated-exporter-plugin"
           mkdir -p "$artifact_root/reprint-server-wp"
@@ -129,7 +134,7 @@ jobs:
         run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.exporter_php }}"
 
       - name: Restore importer PHP and Composer for CLI tools
-        if: matrix.importer_php != matrix.exporter_php
+        if: matrix.exporter_php == '5.6'
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.importer_php }}
@@ -146,7 +151,6 @@ jobs:
       - name: Provision basic site and smoke-test API
         env:
           E2E_WORDPRESS_VERSION: ${{ matrix.wordpress_version }}
-          E2E_WP_CLI_PHP_BINARY: php${{ matrix.importer_php }}
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
           IMPORTER_PHP: php${{ matrix.importer_php }}
         working-directory: tests/e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -314,23 +314,16 @@ jobs:
             exit "$files_pull_status"
           fi
 
-          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
-            echo "=== Importer db-pull ==="
-            db_pull_status=2
-            db_pull_attempt=0
-            while { [ "$db_pull_status" -eq 2 ] || [ "$db_pull_status" -eq 124 ]; } \
-                  && [ "$db_pull_attempt" -lt 6 ]; do
-              db_pull_attempt=$((db_pull_attempt + 1))
-              db_pull_output="$(timeout 90 "$IMPORTER_PHP" "$IMPORTER_PATH" db-pull "${BASE}&directory=${DIR}" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" 2>&1)" && db_pull_status=0 || db_pull_status=$?
-              echo "$db_pull_output" | head -50
-            done
-            if [ "$db_pull_status" -ne 0 ]; then
-              echo "EXIT: $db_pull_status (db-pull did not complete after ${db_pull_attempt} attempts)"
-              exit "$db_pull_status"
-            fi
-            test -s "$STATE_DIR/db.sql"
-            grep -F 'CREATE TABLE' "$STATE_DIR/db.sql" >/dev/null
-          fi
+      - name: Run full pull from PHP 5.6 site
+        if: matrix.exporter_php == '5.6'
+        env:
+          E2E_EXPECTED_EXPORTER_PHP_VERSION: ${{ matrix.exporter_php }}
+          E2E_WORDPRESS_VERSION: ${{ matrix.wordpress_version }}
+          E2E_WP_CLI_PHP_BINARY: php${{ matrix.importer_php }}
+          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          PHP_BINARY: php${{ matrix.importer_php }}
+        working-directory: tests/e2e
+        run: npx vitest run tests/import-46-pull-basic.test.js --test-timeout=180000
 
       - name: Run E2E tests
         if: matrix.exporter_php != '5.6' && matrix.exporter_php != '7.2'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,6 +42,28 @@ jobs:
       # The generated plugin gets its real PHP 5.6 check in exporter-56 below.
       - run: composer lint:php:compat
 
+  syntax-72:
+    # PHPCompatibility 9.3.5 misses arrow functions and numeric separators, so
+    # a real PHP 7.2 parser is the authoritative check that the exporter (which
+    # runs on old shared hosting) contains no 7.3/7.4-only syntax.
+    name: PHP 7.2 syntax (exporter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.2"
+          coverage: none
+
+      - name: Lint exporter sources for PHP 7.2 parse errors
+        run: |
+          find packages/reprint-server/src reprint-server-wp \
+            -name '*.php' -not -path 'reprint-server-wp/wordpress/*' \
+            -print0 | xargs -0 -n1 php -l
+
   exporter-56:
     # PHPCompatibility 9.3.5 misses arrow functions and numeric separators, so
     # a real PHP 5.6 parser remains the authoritative syntax check. Parse the

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,28 +38,59 @@ jobs:
 
       - run: composer install --no-interaction --prefer-dist
 
-      # Checks exporter compat at PHP 7.2 (shared hosting) and importer at 7.4,
-      # via two PHPCompatibility runs (see lint:php:compat in composer.json).
+      # Checks the typed exporter source at PHP 7.2 and importer at PHP 7.4.
+      # The generated plugin gets its real PHP 5.6 check in exporter-56 below.
       - run: composer lint:php:compat
 
-  syntax-72:
+  exporter-56:
     # PHPCompatibility 9.3.5 misses arrow functions and numeric separators, so
-    # a real PHP 7.2 parser is the authoritative check that the exporter (which
-    # runs on old shared hosting) contains no 7.3/7.4-only syntax.
-    name: PHP 7.2 syntax (exporter)
-    runs-on: ubuntu-latest
+    # a real PHP 5.6 parser remains the authoritative syntax check. Parse the
+    # same plugin tree shipped in the release ZIP so the check covers the
+    # WordPress wrapper and the physical Composer vendor copy too.
+    name: PHP 5.6 exporter artifact
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: true
 
-      - uses: shivammathur/setup-php@v2
+      # Match the release job's artifact build before switching to the old
+      # runtime which must parse and run the result.
+      - name: Set up release build PHP
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.2"
+          php-version: "8.2"
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
           coverage: none
+          tools: composer:2.9.7
 
-      - name: Lint exporter sources for PHP 7.2 parse errors
+      - name: Install exporter artifact build dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist --working-dir=tools/php56-build
+
+      - name: Test PHP 5.6 downgrade rules
+        run: composer test --working-dir=tools/php56-build
+
+      - name: Build reprint-exporter-wp.zip
+        run: ./bin/build-exporter-plugin.sh
+
+      - name: Confirm the typed source was not rewritten
+        run: git diff --exit-code -- packages/reprint-server reprint-server-wp
+
+      - name: Set up PHP 5.6 parser
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "5.6"
+          coverage: none
+          tools: none
+
+      - name: Lint packaged PHP files with PHP 5.6
         run: |
-          find packages/reprint-server/src reprint-server-wp \
-            -name '*.php' -not -path 'reprint-server-wp/wordpress/*' \
-            -print0 | xargs -0 -n1 php -l
+          artifact_dir="$RUNNER_TEMP/reprint-exporter-wp"
+          rm -rf "$artifact_dir"
+          mkdir -p "$artifact_dir"
+          unzip -q reprint-exporter-wp.zip -d "$artifact_dir"
+          grep -F ' * Requires PHP: 5.6.20' "$artifact_dir/index.php"
+          while IFS= read -r -d '' php_file; do
+            php -l "$php_file"
+          done < <(find "$artifact_dir" -type f -name '*.php' -print0)
+          php tests/php56-exporter-smoke.php "$artifact_dir"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ composer lint:php
 # Apply PHPCS auto-fixes from the ruleset
 composer lint:php:fix
 
-# Run PHP 7.4+ compatibility
+# Check typed exporter source on PHP 7.2 and importer source on PHP 7.4
 composer lint:php:compat
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ The ruleset has temporary exclusions for existing standards debt so cleanup can
 happen in focused passes instead of one giant formatting change. New or touched
 code should follow WPCS unless the ruleset explicitly excludes that sniff.
 
-Run `composer lint:php:compat` for the separate PHP 7.4+ compatibility check.
+Run `composer lint:php:compat` to check the typed exporter source on PHP 7.2+
+and the importer on PHP 7.4+. CI builds the exporter plugin ZIP and checks every
+PHP file in that generated artifact with PHP 5.6.
 
 ### Cutting a release
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "lint:php": "phpcs --standard=phpcs.xml.dist",
         "lint:php:fix": "phpcbf --standard=phpcs.xml.dist",
         "lint:php:compat": [
-            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-server/src reprint-server-wp/index.php reprint-server-wp/lib.php reprint-server-wp/wordpress",
+            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-server/src reprint-server-wp",
             "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src"
         ],
         "compat": "@lint:php:compat"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "lint:php": "phpcs --standard=phpcs.xml.dist",
         "lint:php:fix": "phpcbf --standard=phpcs.xml.dist",
         "lint:php:compat": [
-            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-server/src reprint-server-wp --ignore=reprint-server-wp/wordpress",
+            "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps packages/reprint-server/src reprint-server-wp/index.php reprint-server-wp/lib.php reprint-server-wp/wordpress",
             "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src"
         ],
         "compat": "@lint:php:compat"

--- a/tests/ExporterCompatibilityUtilitiesTest.php
+++ b/tests/ExporterCompatibilityUtilitiesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Server\generate_random_bytes;
+use function WordPress\Reprint\Server\integer_divide;
+
+final class ExporterCompatibilityUtilitiesTest extends TestCase
+{
+    public function testRandomByteFallbackContract(): void
+    {
+        $bytes = generate_random_bytes(32);
+
+        $this->assertSame(32, strlen($bytes));
+    }
+
+    public function testIntegerDivisionRoundsTowardZero(): void
+    {
+        $this->assertSame(2, integer_divide(7, 3));
+        $this->assertSame(-2, integer_divide(-7, 3));
+    }
+}

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -22,7 +22,8 @@ const SITE_ROOT = REGISTRY.siteRoot;
 const DB_HOST = REGISTRY.dbHost;
 const DB_USER = REGISTRY.dbUser;
 const DB_PASS = REGISTRY.dbPass;
-const WP_VERSION = REGISTRY.wpVersion;
+const WP_VERSION = process.env.E2E_WORDPRESS_VERSION || REGISTRY.wpVersion;
+const WP_CLI_PHP_BINARY = process.env.E2E_WP_CLI_PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const EXPORTER_PROJECT_ROOT = process.env.E2E_EXPORTER_PROJECT_ROOT || PROJECT_ROOT;
 // E2E_EXPORTER_PROJECT_ROOT may point at a historical checkout that predates
@@ -117,7 +118,7 @@ require_once ABSPATH . 'wp-settings.php';
 function wpCoreInstall(siteDir, siteUrl, siteName) {
     const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
     execSync(
-        `php ${WP_CLI_PATH} core install` +
+        `${WP_CLI_PHP_BINARY} ${WP_CLI_PATH} core install` +
         ` --path=${JSON.stringify(siteDir)}` +
         ` --url=${JSON.stringify(siteUrl)}` +
         ` --title=${JSON.stringify('E2E: ' + siteName)}` +
@@ -136,7 +137,7 @@ function wpCoreInstall(siteDir, siteUrl, siteName) {
 function wpPluginActivate(siteDir, pluginSlug) {
     const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
     execSync(
-        `php ${WP_CLI_PATH} plugin activate ${pluginSlug}` +
+        `${WP_CLI_PHP_BINARY} ${WP_CLI_PATH} plugin activate ${pluginSlug}` +
         ` --path=${JSON.stringify(siteDir)}` +
         allowRoot,
         { timeout: 30000, stdio: 'pipe' }

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -69,6 +69,15 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
+
+        const expectedExporterPhpVersion = process.env.E2E_EXPECTED_EXPORTER_PHP_VERSION;
+        if (expectedExporterPhpVersion) {
+            const exporterPhpVersion = state.preflight?.data?.php?.version;
+            assert.ok(
+                exporterPhpVersion?.startsWith(`${expectedExporterPhpVersion}.`),
+                `Expected exporter PHP ${expectedExporterPhpVersion}.x, got ${exporterPhpVersion ?? 'missing'}`,
+            );
+        }
     });
 
     it('files match source', () => {

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -301,7 +301,13 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                             const decoded = JSON.parse(
                                 Buffer.from(savedSourceCursor, 'base64').toString('utf8')
                             );
-                            if (decoded.current_table === table) {
+                            // MyISAM rows can become visible before the importer saves
+                            // the cursor after their INSERT. A complete row count
+                            // alone does not confirm the finished-table position.
+                            if (
+                                decoded.current_table === table
+                                && (completedRowCount === null || decoded.state === 'next_table')
+                            ) {
                                 return { importedRowCount, savedSourceCursor, decoded };
                             }
                         }
@@ -316,7 +322,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                     ) {
                         const result = await databasePull.exit;
                         assert.fail(
-                            `db-pull exited before MySQL saved partial work (${result.code}/${result.signal}):\n`
+                            `db-pull exited before MySQL saved the requested table position (${result.code}/${result.signal}):\n`
                             + databasePull.output.stderr + databasePull.output.stdout,
                         );
                     }
@@ -325,7 +331,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             } finally {
                 await interruptedTarget.end();
             }
-            assert.fail(`db-pull did not save a partial position for ${table}`);
+            assert.fail(`db-pull did not save the requested position for ${table}`);
         }
 
         const firstPosition = await waitForSavedTablePosition(sourceTable, first);

--- a/tests/php56-exporter-smoke.php
+++ b/tests/php56-exporter-smoke.php
@@ -1,0 +1,104 @@
+<?php
+
+if ($argc !== 2 || !is_dir($argv[1])) {
+    fail_php56_exporter_smoke('Usage: php php56-exporter-smoke.php <plugin-directory>');
+}
+
+$plugin_directory = realpath($argv[1]);
+define('ABSPATH', sys_get_temp_dir() . '/reprint-php56-wordpress/');
+date_default_timezone_set('UTC');
+
+require $plugin_directory . '/lib.php';
+
+if (_site_export_push_is_supported()) {
+    fail_php56_exporter_smoke('Push must remain disabled below PHP 7.2.');
+}
+
+$export_runtime = _site_export_load_exporter_runtime();
+if ($export_runtime === null) {
+    fail_php56_exporter_smoke('The packaged exporter runtime could not be loaded.');
+}
+require_once $export_runtime;
+
+if (!class_exists('Site_Export_HTTP_Server')) {
+    fail_php56_exporter_smoke('The packaged HTTP server class could not be loaded.');
+}
+if (Site_Export_HTTP_Server::is_push_endpoint('preflight')) {
+    fail_php56_exporter_smoke('The preflight endpoint was classified as push.');
+}
+
+$temporary_directory = sys_get_temp_dir() . '/reprint-php56-exporter-' . getmypid();
+if (!mkdir($temporary_directory, 0700) && !is_dir($temporary_directory)) {
+    fail_php56_exporter_smoke('The temporary exporter directory could not be created.');
+}
+
+try {
+    $docroot = $temporary_directory . '/docroot';
+    if (!mkdir($docroot, 0700) && !is_dir($docroot)) {
+        fail_php56_exporter_smoke('The push smoke-test document root could not be created.');
+    }
+    $reprint_directory = $temporary_directory . '/push-state';
+    $server = new Site_Export_HTTP_Server([
+        'push' => [
+            'reprint_directory' => $reprint_directory,
+            'docroot' => $docroot,
+            'excluded_paths' => [],
+        ],
+    ]);
+    ob_start();
+    $server->dispatch([
+        'endpoint' => 'push_create',
+        'push_session_id' => str_repeat('a', 32),
+    ]);
+    $push_response = json_decode(ob_get_clean(), true);
+    if (
+        http_response_code() !== 503
+        || !is_array($push_response)
+        || !isset($push_response['status'])
+        || $push_response['status'] !== 'rejected'
+        || !isset($push_response['reason'])
+        || $push_response['reason'] !== 'push_disabled'
+        || !isset($push_response['detail'])
+        || strpos($push_response['detail'], 'Push endpoints require PHP 7.2 or newer') === false
+    ) {
+        fail_php56_exporter_smoke('The packaged HTTP server returned the wrong push version response.');
+    }
+    if (file_exists($reprint_directory)) {
+        fail_php56_exporter_smoke('The packaged HTTP server started push work below PHP 7.2.');
+    }
+    rmdir($docroot);
+    http_response_code(200);
+
+    ob_start();
+    $preflight = endpoint_preflight(['directory' => [$temporary_directory]]);
+    ob_end_clean();
+    if (!isset($preflight['stats']['php']['version'])) {
+        fail_php56_exporter_smoke('Preflight did not report the PHP version.');
+    }
+
+    ob_start();
+    $output_stream = new WordPress\Reprint\Server\GzipOutputStream(true);
+    $output_stream->write('php56-stream');
+    $output_stream->finish();
+    $stream_output = ob_get_clean();
+    if ($stream_output !== 'php56-stream') {
+        fail_php56_exporter_smoke('PHP 5.6 did not use the identity streaming fallback.');
+    }
+
+    if (strlen(WordPress\Reprint\Server\generate_random_bytes(16)) !== 16) {
+        fail_php56_exporter_smoke('The PHP 5.6 random-byte fallback returned the wrong length.');
+    }
+} finally {
+    rmdir($temporary_directory);
+}
+
+echo "PHP 5.6 exporter runtime smoke passed.\n";
+
+function plugin_dir_path($path) {
+    return dirname($path) . '/';
+}
+
+function fail_php56_exporter_smoke($message) {
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -21,6 +21,7 @@
         </testsuite>
         <testsuite name="Export Utility Tests">
             <file>BuildPdoDsnTest.php</file>
+            <file>ExporterCompatibilityUtilitiesTest.php</file>
             <file>CreateDbConnectionTest.php</file>
             <file>PushCommitTest.php</file>
             <file>ExportHttpServerTest.php</file>


### PR DESCRIPTION
Builds the exact release exporter ZIP in CI, parses every packaged PHP file with PHP 5.6, and exercises the pull path against WordPress 6.2.9.

## Stack

1. #665 — Rector downgrade rules
2. #671 — exporter PHP 5.6 compatibility
3. #672 — CI and tests (this PR)

## This change

The existing real PHP 7.2 parser continues to lint the typed exporter source. A separate static job runs the Rector fixtures, builds the release ZIP on PHP 8.2, confirms the maintained source was not rewritten, then switches to PHP 5.6 to lint every PHP file in the extracted artifact and run the runtime smoke test.

The new PHP 5.6 E2E row installs that generated ZIP, loads WordPress, confirms preflight ran on PHP 5.6, runs the full `pull` pipeline, compares pulled file hashes and the applied MySQL table names and row counts, and confirms that push returns the PHP 7.2 requirement without starting push work. Existing PHP 7.2–8.5 rows continue testing the typed source checkout.

The focused unit test covers the random-byte and integer-division helpers. The compatibility scan now includes the WordPress wrapper and admin code without narrowing its former recursive scope.

## Testing

Rely on the PHP 7.2 source parser, the PHP 5.6 artifact job, and the full E2E matrix.
