### PR TITLE
[PHP] Send same-origin WordPress admin Referer with all API requests

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -36,6 +36,7 @@ use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
 use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\wordpress_admin_referer;
 use function Reprint\Importer\write_file_index_processor_entry_to_local_index;
 use function Reprint\Importer\write_local_index_entry;
 use function WordPress\Filesystem\wp_join_unix_paths;
@@ -219,8 +220,8 @@ class ImportClient
     /** @var string Remote Reprint API URL. */
     public $remote_reprint_api_url;
 
-    /** @var string|null Same-origin WordPress Media Library URL for file-fetch uploads. */
-    private $file_fetch_referer = null;
+    /** @var string|null Same-origin WordPress Media Library URL for remote Reprint requests. */
+    private $remote_reprint_api_referer = null;
 
     /** @var string Caller-selected state directory for this filesystem root. */
     public $state_dir;
@@ -511,23 +512,9 @@ class ImportClient
         }
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
-        $remote_url = parse_url( $this->remote_reprint_api_url );
-        if (
-            is_array( $remote_url ) &&
-            isset( $remote_url["scheme"], $remote_url["host"] )
-        ) {
-            $site_path = rtrim((string) ( $remote_url["path"] ?? "" ), "/");
-            if (substr( $site_path, -10 ) === "/index.php") {
-                $site_path = substr( $site_path, 0, -10 );
-            }
-
-            $this->file_fetch_referer =
-                $remote_url["scheme"] . "://" . $remote_url["host"];
-            if (isset( $remote_url["port"] )) {
-                $this->file_fetch_referer .= ":" . $remote_url["port"];
-            }
-            $this->file_fetch_referer .= "{$site_path}/wp-admin/upload.php";
-        }
+        $this->remote_reprint_api_referer = wordpress_admin_referer(
+            $this->remote_reprint_api_url
+        );
         $this->state_dir = trim_right_slash($state_dir);
         $this->filesystem_root = trim_right_slash($filesystem_root);
         $remote_state_directory = $selected_remote_state_directory === null
@@ -10907,7 +10894,7 @@ class ImportClient
     private function get_base_headers(string $accept): array
     {
         $ua = $this->get_state()->user_agent ?? self::USER_AGENTS[0];
-        return [
+        $headers = [
             "User-Agent: {$ua}",
             "Accept: {$accept}",
             "Accept-Language: en-US,en;q=0.9",
@@ -10916,6 +10903,11 @@ class ImportClient
             "Pragma: no-cache",
             "Connection: keep-alive",
         ];
+        if ($this->remote_reprint_api_referer !== null) {
+            $headers[] = "Referer: {$this->remote_reprint_api_referer}";
+        }
+
+        return $headers;
     }
 
     /**
@@ -11492,16 +11484,6 @@ class ImportClient
                 }
             }
             if ($has_file) {
-                if (
-                    $endpoint === "file_fetch" &&
-                    $this->file_fetch_referer !== null
-                ) {
-                    // Some application firewalls admit WordPress uploads
-                    // only after a same-site wp-admin Referer. The HMAC
-                    // remains the authentication check for file_fetch.
-                    $headers[] = "Referer: {$this->file_fetch_referer}";
-                }
-
                 // For CURLFile uploads, sign the raw file content — this
                 // is the logical payload the server will receive, even
                 // though curl wraps it in multipart framing.

--- a/packages/reprint-client/src/lib/import/functions.php
+++ b/packages/reprint-client/src/lib/import/functions.php
@@ -6,6 +6,39 @@ use PDO;
 use RuntimeException;
 
 /**
+ * Build the fixed WordPress admin Referer for a remote Reprint API URL.
+ *
+ * @param string $remote_reprint_api_url Remote Reprint API URL.
+ * @return string|null Same-origin WordPress Media Library URL, or null when
+ *                     the remote URL has no scheme or host.
+ */
+function wordpress_admin_referer(string $remote_reprint_api_url): ?string
+{
+	// Some WAFs reject automated requests when Referer is absent. A fixed,
+	// query-free WordPress admin URL supplies request context only; this header
+	// does not authenticate the request.
+	$remote_url = parse_url($remote_reprint_api_url);
+	if (
+		! is_array($remote_url) ||
+		! isset($remote_url['scheme'], $remote_url['host'])
+	) {
+		return null;
+	}
+
+	$site_path = rtrim( (string) ( $remote_url['path'] ?? '' ), '/' );
+	if (substr($site_path, -10) === '/index.php') {
+		$site_path = substr($site_path, 0, -10);
+	}
+
+	$referer = $remote_url['scheme'] . '://' . $remote_url['host'];
+	if (isset($remote_url['port'])) {
+		$referer .= ':' . $remote_url['port'];
+	}
+
+	return $referer . $site_path . '/wp-admin/upload.php';
+}
+
+/**
  * If the ALL_PROXY environment variable is set, apply it to the cURL
  * handle via CURLOPT_PROXY.
  *

--- a/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
@@ -2,6 +2,9 @@
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
+use function Reprint\Importer\wordpress_admin_referer;
+
+require_once __DIR__ . '/../import/functions.php';
 
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Transport errors are CLI/API values, never HTML output.
 
@@ -66,6 +69,9 @@ class MultipartPushStreamClient
 
     /** @var string Remote Reprint API URL used for every signed request target. */
     private string $remote_reprint_api_url;
+
+    /** @var string|null Same-origin WordPress Media Library URL for remote Reprint requests. */
+    private ?string $remote_reprint_api_referer;
 
     /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
     private Site_Export_HMAC_Client $hmac_client;
@@ -215,6 +221,9 @@ class MultipartPushStreamClient
             throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
         }
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
+        $this->remote_reprint_api_referer = wordpress_admin_referer(
+            $this->remote_reprint_api_url
+        );
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
         if (!$this->request_sizer instanceof PushRequestSizer) {
@@ -276,6 +285,9 @@ class MultipartPushStreamClient
         $request_url = $this->endpoint_url('push_upload', ['push_session_id' => $push_session_id]);
         $headers = $this->hmac_client->get_envelope_auth_headers('POST', $request_url);
         $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
+        if ($this->remote_reprint_api_referer !== null) {
+            $headers['Referer'] = $this->remote_reprint_api_referer;
+        }
         $header_lines = [];
         foreach ($headers as $name => $value) {
             $header_lines[] = $name . ': ' . $value;
@@ -803,6 +815,9 @@ class MultipartPushStreamClient
         $url = $this->endpoint_url($endpoint, $parameters);
         $headers = $this->hmac_client->get_envelope_auth_headers($method, $url);
         $lines = ['Accept: application/json', 'Expect:'];
+        if ($this->remote_reprint_api_referer !== null) {
+            $lines[] = 'Referer: ' . $this->remote_reprint_api_referer;
+        }
         foreach ($headers as $name => $value) {
             $lines[] = $name . ': ' . $value;
         }

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -68,6 +68,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         fclose($listener);
 
         $result = $client->finish_request();
+        $this->assertStringContainsString("Referer: http://{$address}/wp-admin/upload.php\r\n", $received);
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(2, $result['parts_sent']);
         $this->assertFalse($client->has_sent_parts());
@@ -487,6 +488,73 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame('failed', $result['status']);
         $this->assertSame('response_too_large', $result['reason']);
         $this->assertSame('The target response exceeded 1048576 bytes.', $result['detail']);
+    }
+
+    public function testPushControlRequestsSendSameOriginWordPressAdminReferer(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Raw push-request coverage requires PHP curl and pcntl.');
+        }
+        foreach ([
+            ['GET', 'push_status', 'status'],
+            ['POST', 'push_create', 'created'],
+        ] as [$method, $endpoint, $response_status]) {
+            $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+            $this->assertNotFalse($listener, (string) $error);
+            $address = stream_socket_get_name($listener, false);
+            $child = pcntl_fork();
+            $this->assertNotSame(-1, $child);
+            if ($child === 0) {
+                $connection = stream_socket_accept($listener, 3);
+                if ($connection === false) {
+                    exit(2);
+                }
+                stream_set_timeout($connection, 3);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                    $piece = fread($connection, 64 * 1024);
+                    if (!is_string($piece) || $piece === '') {
+                        break;
+                    }
+                    $request .= $piece;
+                }
+                if (strpos($request, "Referer: http://{$address}/wp-admin/upload.php\r\n") === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(3);
+                }
+                if (strpos($request, "{$method} /?reprint-api=1&endpoint={$endpoint}&") !== 0) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(4);
+                }
+                $response = (string) json_encode(['status' => $response_status]);
+                fwrite(
+                    $connection,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " . strlen($response)
+                        . "\r\nConnection: close\r\n\r\n" . $response
+                );
+                fclose($connection);
+                fclose($listener);
+                exit(0);
+            }
+
+            $client = new MultipartPushStreamClient([
+                'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+                'allow_http' => true,
+                'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+                'connect_timeout' => 2,
+                'response_timeout' => 2,
+            ]);
+            $result = $client->send_push_request($method, $endpoint, [
+                'push_session_id' => str_repeat('0', 32),
+            ], [$response_status]);
+            pcntl_waitpid($child, $status);
+            fclose($listener);
+
+            $this->assertTrue(pcntl_wifexited($status));
+            $this->assertSame(0, pcntl_wexitstatus($status));
+            $this->assertSame('complete', $result['status'], (string) json_encode($result));
+        }
     }
 
     public function testUploadRequestStopsReadingAnOversizedResponse(): void {

--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -1,9 +1,9 @@
 /**
  * Local reverse proxy which models an application firewall around WordPress.
  *
- * Multipart file_fetch requests are accepted only when their Referer points to
- * the same origin's WordPress Media Library page. All accepted requests are
- * streamed to the real E2E WordPress site.
+ * Reprint requests are accepted only when their Referer points to the same
+ * origin's WordPress Media Library page. All accepted requests are streamed
+ * to the real E2E WordPress site.
  */
 import http from 'node:http';
 import { appendFileSync } from 'node:fs';
@@ -22,21 +22,21 @@ function writeRequestLog(record) {
 const server = http.createServer((request, response) => {
     const requestUrl = new URL(request.url, `http://${request.headers.host}`);
     const contentType = request.headers['content-type'] || '';
-    const isMultipartFileFetch =
-        request.method === 'POST' &&
-        requestUrl.searchParams.get('endpoint') === 'file_fetch' &&
-        contentType.startsWith('multipart/form-data;');
+    const isReprintRequest =
+        requestUrl.searchParams.has('reprint-api') ||
+        requestUrl.searchParams.has('site-export-api');
     const expectedReferer = `http://${request.headers.host}/wp-admin/upload.php`;
     const referer = request.headers.referer || '';
-    const allowed = !isMultipartFileFetch || referer === expectedReferer;
+    const allowed = !isReprintRequest || referer === expectedReferer;
 
     writeRequestLog({
         method: request.method,
         path: request.url,
         contentType,
+        endpoint: requestUrl.searchParams.get('endpoint') || '',
         referer,
         expectedReferer,
-        isMultipartFileFetch,
+        isReprintRequest,
         allowed,
         userAgent: request.headers['user-agent'] || '',
     });

--- a/tests/e2e/tests/import-60-application-firewall.test.js
+++ b/tests/e2e/tests/import-60-application-firewall.test.js
@@ -2,8 +2,8 @@
  * Test 60: Application firewall compatibility
  *
  * Runs a complete pull through a local HTTP reverse proxy which rejects
- * multipart file uploads unless they have a same-origin WordPress admin
- * Referer. The proxy streams every accepted request to the real E2E site.
+ * Reprint requests unless they have a same-origin WordPress admin Referer.
+ * The proxy streams every accepted request to the real E2E site.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -101,27 +101,45 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         await connection.end();
     });
 
-    it('sends a same-origin WordPress admin Referer with multipart file_fetch requests', () => {
+    it('sends a same-origin WordPress admin Referer with every Reprint request', () => {
         const requestRecords = readFileSync(requestLogPath, 'utf-8')
             .trim()
             .split('\n')
             .filter(Boolean)
-            .map(line => JSON.parse(line));
-        const multipartFileFetchRequests = requestRecords.filter(
-            record => record.isMultipartFileFetch,
-        );
+            .map(line => JSON.parse(line))
+            .filter(record => record.isReprintRequest);
         assert.ok(
-            multipartFileFetchRequests.length > 0,
-            `Expected pull to make a multipart file_fetch request\n` +
+            requestRecords.length > 0,
+            `Expected pull to make Reprint requests\n` +
             `stderr: ${pullResult.stderr}\nstdout: ${pullResult.stdout}`,
         );
         assert.ok(
-            multipartFileFetchRequests.every(
+            requestRecords.every(
                 record => record.referer === `${firewallOrigin}/wp-admin/upload.php`,
             ),
             `Expected Referer ${firewallOrigin}/wp-admin/upload.php, got ` +
-            multipartFileFetchRequests.map(record => JSON.stringify(record.referer)).join(', '),
+            requestRecords.map(record => JSON.stringify(record.referer)).join(', '),
         );
+        assert.ok(requestRecords.some(record => record.method === 'GET'));
+        assert.ok(requestRecords.some(record => record.method === 'POST'));
+        assert.ok(
+            requestRecords.some(
+                record =>
+                    record.method === 'POST' &&
+                    record.endpoint === 'file_fetch' &&
+                    record.contentType.startsWith('multipart/form-data;'),
+            ),
+        );
+        const endpoints = new Set(requestRecords.map(record => record.endpoint));
+        for (const endpoint of [
+            'preflight',
+            'file_index',
+            'file_fetch',
+            'db_index',
+            'sql_chunk',
+        ]) {
+            assert.ok(endpoints.has(endpoint), `Expected pull to request ${endpoint}`);
+        }
     });
 
     it('completes pull through the application firewall', () => {
@@ -140,20 +158,9 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         );
     });
 
-    it('rejects a multipart file upload without the Referer', async () => {
-        const form = new FormData();
-        form.append(
-            'file_list',
-            new Blob(['[]'], { type: 'application/json' }),
-            'file-list.json',
-        );
-
+    it('rejects a Reprint GET without the Referer', async () => {
         const response = await fetch(
-            `${firewallOrigin}/?reprint-api&endpoint=file_fetch`,
-            {
-                method: 'POST',
-                body: form,
-            },
+            `${firewallOrigin}/?reprint-api&endpoint=preflight`,
         );
 
         assert.equal(response.status, 403);


### PR DESCRIPTION
Every Reprint API request now sends the same-origin WordPress Media Library URL as its `Referer`.

## Background

Published WAF rule lists include `POST without Referrer`, which classifies an automated POST with no `Referer` as fake-bot traffic. Other WordPress-specific WAF rules use `/wp-admin/` in `Referer` outside file uploads.

PR #669 added that context only to multipart `file_fetch` requests. Preflight, index, SQL, and push requests still sent no `Referer`.

## This change

The client derives one fixed, query-free `/wp-admin/upload.php` URL from the configured remote URL and reuses it for every pull and push API request. It keeps an explicit port and WordPress subdirectory.

The inline comment records the WAF reason. The header supplies request context only. Request authentication stays separate.

## Testing

The application-firewall E2E fixture now requires the header on every Reprint request. A full pull with the built PHAR passes through that fixture. Raw TCP tests cover streaming push uploads plus GET and POST push control requests.

Tested with:

```
cd tests && ../vendor/bin/phpunit Import/MultipartPushStreamClientTest.php
cd tests && ../vendor/bin/phpunit PushEndpointsTest.php
vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src
```
