### PR TITLE
[Tests] CWAF response inspection

### DIFF
--- a/packages/reprint-server/src/class-gzip-output-stream.php
+++ b/packages/reprint-server/src/class-gzip-output-stream.php
@@ -8,7 +8,9 @@ namespace WordPress\Reprint\Server;
 
 /**
  * Incremental gzip compressor that emits data as it arrives rather than
- * buffering the entire response.
+ * buffering the entire response. PHP-side gzip also gives outbound WAF rules
+ * that do not decode Content-Encoding the encoded byte stream; server-level
+ * compression can run after those rules inspect the body.
  */
 class GzipOutputStream
 {

--- a/tests/e2e/lib/outbound-application-firewall-fixture.js
+++ b/tests/e2e/lib/outbound-application-firewall-fixture.js
@@ -1,11 +1,27 @@
 /**
- * Local reverse proxy which models one reported CWAF response-body setup.
+ * Proxies Reprint requests to WordPress. For `file_fetch` and `sql_chunk`, it:
  *
- * Rule 214620 adds three points for PHP source-like text, rule 218140 adds two
- * points for MySQL error text, and rule 214940 replaces the response when the
- * total reaches four. This is not a complete CWAF engine. It applies that
- * reported score to the exact bytes emitted by WordPress, before the Reprint
- * client decodes Content-Encoding.
+ * - buffers at most 64 MiB of the upstream response;
+ * - scans those bytes without decoding Content-Encoding;
+ * - returns an HTML 403 when `fopen` or the test's MySQL error text is present;
+ * - otherwise forwards the original response and headers unchanged.
+ *
+ * Other proxied responses stream through without inspection. Two fixture-only
+ * routes send each clear-text marker through the same scanner.
+ *
+ * This models a reported CWAF failure. Public rules assign four points to the
+ * PHP match and five to the MySQL match, with an outgoing limit of four. Rule
+ * 214800 denies at that limit when point blocking is enabled; rule 214940 only
+ * logs it. The report does not identify which disruptive rule issued its 403,
+ * so this proxy models the threshold path to the same result.
+ *
+ * Reprint gzips export bodies inside PHP. Because this proxy does not decode
+ * gzip, it does not find the clear-text markers and the client receives the
+ * response. This is not a complete CWAF engine, and a firewall which decodes
+ * gzip can behave differently.
+ *
+ * Report: https://wordpress.org/support/topic/conflict-with-strict_mod_security/
+ * Rules: https://github.com/zcomtenten/cwaf/tree/f9a3f105768d72bb3ea1585fdc963176d1f41f73
  */
 import http from 'node:http';
 import { appendFileSync } from 'node:fs';
@@ -25,8 +41,8 @@ function inspectResponseBody(body) {
         'You have an error in your SQL syntax;',
     );
     const outboundPoints =
-        (phpSourceMatch ? 3 : 0) +
-        (mysqlLeakMatch ? 2 : 0);
+        (phpSourceMatch ? 4 : 0) +
+        (mysqlLeakMatch ? 5 : 0);
 
     return {
         phpSourceMatch,
@@ -67,15 +83,19 @@ function sendInspectedResponse(response, details) {
 }
 
 const server = http.createServer((request, response) => {
-    if (request.url === '/__outbound-firewall-clear-response') {
+    let clearResponseBody = null;
+    if (request.url === '/__outbound-firewall-clear-php-response') {
+        clearResponseBody = 'fopen';
+    } else if (request.url === '/__outbound-firewall-clear-mysql-response') {
+        clearResponseBody = 'You have an error in your SQL syntax;';
+    }
+    if (clearResponseBody !== null) {
         sendInspectedResponse(response, {
             endpoint: 'fixture_clear_response',
             statusCode: 200,
             statusMessage: 'OK',
             headers: { 'content-type': 'text/plain; charset=utf-8' },
-            body: Buffer.from(
-                'fopen: You have an error in your SQL syntax;',
-            ),
+            body: Buffer.from(clearResponseBody),
         });
         return;
     }

--- a/tests/e2e/lib/outbound-application-firewall-fixture.js
+++ b/tests/e2e/lib/outbound-application-firewall-fixture.js
@@ -1,0 +1,152 @@
+/**
+ * Local reverse proxy which models one reported CWAF response-body setup.
+ *
+ * Rule 214620 adds three points for PHP source-like text, rule 218140 adds two
+ * points for MySQL error text, and rule 214940 replaces the response when the
+ * total reaches four. This is not a complete CWAF engine. It applies that
+ * reported score to the exact bytes emitted by WordPress, before the Reprint
+ * client decodes Content-Encoding.
+ */
+import http from 'node:http';
+import { appendFileSync } from 'node:fs';
+
+const [backendUrlString, responseLogPath] = process.argv.slice(2);
+if (!backendUrlString || !responseLogPath) {
+    throw new Error('Expected backend URL and response log path arguments');
+}
+
+const backendUrl = new URL(backendUrlString);
+const maxInspectedResponseBytes = 64 * 1024 * 1024;
+
+function inspectResponseBody(body) {
+    const responseText = body.toString('latin1');
+    const phpSourceMatch = responseText.includes('fopen');
+    const mysqlLeakMatch = responseText.includes(
+        'You have an error in your SQL syntax;',
+    );
+    const outboundPoints =
+        (phpSourceMatch ? 3 : 0) +
+        (mysqlLeakMatch ? 2 : 0);
+
+    return {
+        phpSourceMatch,
+        mysqlLeakMatch,
+        outboundPoints,
+        blocked: outboundPoints >= 4,
+    };
+}
+
+function writeResponseLog(record) {
+    appendFileSync(responseLogPath, `${JSON.stringify(record)}\n`);
+}
+
+function sendInspectedResponse(response, details) {
+    const inspection = inspectResponseBody(details.body);
+    writeResponseLog({
+        endpoint: details.endpoint,
+        contentEncoding: details.headers['content-encoding'] || '',
+        bodyBytes: details.body.length,
+        ...inspection,
+    });
+
+    if (inspection.blocked) {
+        response.writeHead(403, {
+            'Content-Type': 'text/html; charset=utf-8',
+            'X-App-Firewall': 'outbound-response',
+        });
+        response.end('<!doctype html><title>403 Forbidden</title><h1>Forbidden</h1>');
+        return;
+    }
+
+    response.writeHead(
+        details.statusCode,
+        details.statusMessage,
+        details.headers,
+    );
+    response.end(details.body);
+}
+
+const server = http.createServer((request, response) => {
+    if (request.url === '/__outbound-firewall-clear-response') {
+        sendInspectedResponse(response, {
+            endpoint: 'fixture_clear_response',
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+            body: Buffer.from(
+                'fopen: You have an error in your SQL syntax;',
+            ),
+        });
+        return;
+    }
+
+    const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+    const endpoint = requestUrl.searchParams.get('endpoint') || '';
+    const inspectResponse = endpoint === 'file_fetch' || endpoint === 'sql_chunk';
+    const upstreamRequest = http.request({
+        protocol: backendUrl.protocol,
+        hostname: backendUrl.hostname,
+        port: backendUrl.port,
+        method: request.method,
+        path: request.url,
+        headers: {
+            ...request.headers,
+            host: backendUrl.host,
+        },
+    }, (upstreamResponse) => {
+        if (!inspectResponse) {
+            response.writeHead(
+                upstreamResponse.statusCode,
+                upstreamResponse.statusMessage,
+                upstreamResponse.headers,
+            );
+            upstreamResponse.pipe(response);
+            return;
+        }
+
+        const chunks = [];
+        let responseBytes = 0;
+        upstreamResponse.on('data', (chunk) => {
+            responseBytes += chunk.length;
+            if (responseBytes > maxInspectedResponseBytes) {
+                upstreamRequest.destroy(
+                    new Error(
+                        `Application firewall fixture response exceeded ` +
+                        `${maxInspectedResponseBytes} bytes`,
+                    ),
+                );
+                return;
+            }
+            chunks.push(chunk);
+        });
+        upstreamResponse.on('end', () => {
+            sendInspectedResponse(response, {
+                endpoint,
+                statusCode: upstreamResponse.statusCode,
+                statusMessage: upstreamResponse.statusMessage,
+                headers: upstreamResponse.headers,
+                body: Buffer.concat(chunks),
+            });
+        });
+    });
+
+    upstreamRequest.on('error', (error) => {
+        if (!response.headersSent) {
+            response.writeHead(502, { 'Content-Type': 'text/plain; charset=utf-8' });
+        }
+        response.end(
+            `Application firewall fixture could not reach WordPress: ${error.message}`,
+        );
+    });
+
+    request.pipe(upstreamRequest);
+});
+
+server.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    process.send?.({ port: address.port });
+});
+
+process.on('SIGTERM', () => {
+    server.close(() => process.exit(0));
+});

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -165,6 +165,9 @@
     "database-cursor-header-limit": {
       "port": 8133,
       "nginx": "cursor-header-limit"
+    },
+    "outbound-application-firewall": {
+      "port": 8134
     }
   }
 }

--- a/tests/e2e/tests/import-62-outbound-application-firewall.test.js
+++ b/tests/e2e/tests/import-62-outbound-application-firewall.test.js
@@ -1,10 +1,11 @@
 /**
  * Test 62: Outbound application firewall compatibility
  *
- * Runs a complete pull through a local reverse proxy which applies the
- * reported CWAF 214620, 218140, and 214940 score to raw response bytes.
- * Relevant export bodies are compressed inside PHP before the proxy sees
- * them. The fixture is not a complete CWAF engine.
+ * Runs a complete pull through a local reverse proxy which models two reported
+ * CWAF response matches and the four-point blocking threshold. Clear PHP and
+ * MySQL markers become HTTP 403 responses. The same values survive a full pull
+ * because the relevant export bodies are compressed inside PHP before the
+ * proxy sees them. The fixture is not a complete CWAF engine.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -36,9 +37,7 @@ import { ensureSite } from '../lib/site-setup.js';
 describe('Import: Outbound application firewall compatibility', { timeout: 240000 }, () => {
     const site = 'outbound-application-firewall';
     const importDb = 'e2e_outbound_application_firewall_62';
-    const phpAndSqlMarker =
-        '<?php $stream = fopen("php://memory", "r"); // ' +
-        'You have an error in your SQL syntax;';
+    const phpMarker = '<?php $stream = fopen("php://memory", "r");';
     const sqlMarker = 'You have an error in your SQL syntax;';
     let firewallProcess;
     let firewallOrigin;
@@ -61,7 +60,7 @@ describe('Import: Outbound application firewall compatibility', { timeout: 24000
             afterCreate: async (siteDirectory) => {
                 writeFileSync(
                     join(siteDirectory, 'test-data', 'outbound-firewall.php'),
-                    phpAndSqlMarker,
+                    phpMarker,
                 );
             },
         });
@@ -127,16 +126,19 @@ describe('Import: Outbound application firewall compatibility', { timeout: 24000
         await connection.end();
     });
 
-    it('blocks clear responses containing both published CWAF patterns', async () => {
-        const response = await fetch(
-            `${firewallOrigin}/__outbound-firewall-clear-response`,
-        );
+    it('blocks each clear response pattern at the published CWAF threshold', async () => {
+        for (const marker of ['php', 'mysql']) {
+            const response = await fetch(
+                `${firewallOrigin}/__outbound-firewall-clear-${marker}-response`,
+            );
 
-        assert.equal(response.status, 403);
-        assert.equal(
-            response.headers.get('x-app-firewall'),
-            'outbound-response',
-        );
+            assert.equal(response.status, 403, marker);
+            assert.equal(
+                response.headers.get('x-app-firewall'),
+                'outbound-response',
+                marker,
+            );
+        }
     });
 
     it('keeps PHP and SQL patterns out of emitted export response bytes', () => {
@@ -209,7 +211,7 @@ describe('Import: Outbound application firewall compatibility', { timeout: 24000
                 ),
                 'utf-8',
             ),
-            phpAndSqlMarker,
+            phpMarker,
         );
 
         const connection = await createMysqlConnection(importDb);

--- a/tests/e2e/tests/import-62-outbound-application-firewall.test.js
+++ b/tests/e2e/tests/import-62-outbound-application-firewall.test.js
@@ -1,0 +1,222 @@
+/**
+ * Test 62: Outbound application firewall compatibility
+ *
+ * Runs a complete pull through a local reverse proxy which applies the
+ * reported CWAF 214620, 218140, and 214940 score to raw response bytes.
+ * Relevant export bodies are compressed inside PHP before the proxy sees
+ * them. The fixture is not a complete CWAF engine.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { once } from 'node:events';
+import {
+    existsSync,
+    readFileSync,
+    unlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    assertPullPipelineComplete,
+    cleanupTempDir,
+    createMysqlConnection,
+    createTempDir,
+    fsRootDir,
+    getSiteDir,
+    getSiteSecret,
+    getSiteUrl,
+    pullStateDirectory,
+    runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Outbound application firewall compatibility', { timeout: 240000 }, () => {
+    const site = 'outbound-application-firewall';
+    const importDb = 'e2e_outbound_application_firewall_62';
+    const phpAndSqlMarker =
+        '<?php $stream = fopen("php://memory", "r"); // ' +
+        'You have an error in your SQL syntax;';
+    const sqlMarker = 'You have an error in your SQL syntax;';
+    let firewallProcess;
+    let firewallOrigin;
+    let importUrl;
+    let outputDirectory;
+    let pullResult;
+    let responseLogPath;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            customDb: async (_dbName, connection) => {
+                await connection.query(
+                    'CREATE TABLE wp_outbound_firewall_test (message TEXT NOT NULL)',
+                );
+                await connection.execute(
+                    'INSERT INTO wp_outbound_firewall_test (message) VALUES (?)',
+                    [sqlMarker],
+                );
+            },
+            afterCreate: async (siteDirectory) => {
+                writeFileSync(
+                    join(siteDirectory, 'test-data', 'outbound-firewall.php'),
+                    phpAndSqlMarker,
+                );
+            },
+        });
+
+        outputDirectory = createTempDir('e2e-outbound-app-firewall');
+        responseLogPath = join(
+            tmpdir(),
+            `reprint-outbound-app-firewall-${process.pid}-${Date.now()}.jsonl`,
+        );
+        writeFileSync(responseLogPath, '');
+
+        const firewallFixturePath = fileURLToPath(
+            new URL(
+                '../lib/outbound-application-firewall-fixture.js',
+                import.meta.url,
+            ),
+        );
+        firewallProcess = fork(
+            firewallFixturePath,
+            [getSiteUrl(site), responseLogPath],
+            { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] },
+        );
+        const [readyMessage] = await once(firewallProcess, 'message');
+        firewallOrigin = `http://127.0.0.1:${readyMessage.port}`;
+        importUrl =
+            `${firewallOrigin}/?reprint-api&directory=` +
+            encodeURIComponent(getSiteDir(site));
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await connection.query(`CREATE DATABASE \`${importDb}\``);
+        await connection.end();
+
+        pullResult = runImporter(importUrl, outputDirectory, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 240000,
+            extraArgs: [
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${importDb}`,
+                '--new-site-url=http://localhost:9999',
+                '--runtime=none',
+            ],
+        });
+    }, 360000);
+
+    afterAll(async () => {
+        cleanupTempDir(outputDirectory);
+
+        if (firewallProcess && firewallProcess.exitCode === null) {
+            firewallProcess.kill('SIGTERM');
+            await once(firewallProcess, 'exit');
+        }
+
+        if (responseLogPath && existsSync(responseLogPath)) {
+            unlinkSync(responseLogPath);
+        }
+
+        const connection = await createMysqlConnection();
+        await connection.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await connection.end();
+    });
+
+    it('blocks clear responses containing both published CWAF patterns', async () => {
+        const response = await fetch(
+            `${firewallOrigin}/__outbound-firewall-clear-response`,
+        );
+
+        assert.equal(response.status, 403);
+        assert.equal(
+            response.headers.get('x-app-firewall'),
+            'outbound-response',
+        );
+    });
+
+    it('keeps PHP and SQL patterns out of emitted export response bytes', () => {
+        const responseRecords = readFileSync(responseLogPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+        const exportRecords = responseRecords.filter(
+            record => record.endpoint === 'file_fetch' || record.endpoint === 'sql_chunk',
+        );
+        const fileFetchRecords = exportRecords.filter(
+            record => record.endpoint === 'file_fetch',
+        );
+        const sqlChunkRecords = exportRecords.filter(
+            record => record.endpoint === 'sql_chunk',
+        );
+
+        assert.ok(
+            fileFetchRecords.length > 0,
+            'Expected the firewall to inspect a file_fetch response',
+        );
+        assert.ok(
+            sqlChunkRecords.length > 0,
+            'Expected the firewall to inspect a sql_chunk response',
+        );
+        assert.ok(
+            fileFetchRecords.some(record => record.contentEncoding === 'gzip'),
+            `Expected at least one gzip file_fetch response, got ` +
+            JSON.stringify(fileFetchRecords),
+        );
+        assert.ok(
+            sqlChunkRecords.every(record => record.contentEncoding === 'gzip'),
+            `Expected gzip sql_chunk responses, got ` +
+            JSON.stringify(sqlChunkRecords),
+        );
+        assert.ok(
+            exportRecords.every(
+                record =>
+                    record.phpSourceMatch === false &&
+                    record.mysqlLeakMatch === false &&
+                    record.blocked === false,
+            ),
+            `Expected emitted bytes to clear outbound inspection: ` +
+            JSON.stringify(exportRecords),
+        );
+    });
+
+    it('completes the pull with the inspected source and database text intact', async () => {
+        assert.equal(
+            pullResult.exitCode,
+            0,
+            `Expected pull to succeed\nstderr: ${pullResult.stderr}\n` +
+            `stdout: ${pullResult.stdout}`,
+        );
+
+        const stateFile = join(
+            pullStateDirectory(outputDirectory, importUrl),
+            'state.json',
+        );
+        assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
+        assertPullPipelineComplete(JSON.parse(readFileSync(stateFile, 'utf-8')));
+        assert.equal(
+            readFileSync(
+                join(
+                    fsRootDir(outputDirectory),
+                    getSiteDir(site),
+                    'test-data',
+                    'outbound-firewall.php',
+                ),
+                'utf-8',
+            ),
+            phpAndSqlMarker,
+        );
+
+        const connection = await createMysqlConnection(importDb);
+        const [[row]] = await connection.query(
+            'SELECT message FROM wp_outbound_firewall_test',
+        );
+        await connection.end();
+        assert.equal(row.message, sqlMarker);
+    });
+});


### PR DESCRIPTION
Adds a full-pull regression test for Cloud Web Application Firewall (CWAF) setups that can replace a valid Reprint export response with HTTP 403.

## Failure mode

A pull returns file bytes through `file_fetch` and database bytes through `sql_chunk`. Those bytes can contain normal PHP names and SQL text. To a response scanner, they can look like source-code or database-error leakage.

One [reported ModSecurity log](https://wordpress.org/support/topic/conflict-with-strict_mod_security/) contains these two matches:

```text
214620  PHP source-like text such as fopen                  +4 points
218140  MySQL error text                                    +5 points
                                                             ---------
Reported total                                                9 points
Configured outbound limit                                     4 points
```

The point values come from a [public copy of the matching CWAF initialization](https://github.com/zcomtenten/cwaf/blob/f9a3f105768d72bb3ea1585fdc963176d1f41f73/00_Init_Initialization.conf#L31-L36). [Rule 214620](https://github.com/zcomtenten/cwaf/blob/f9a3f105768d72bb3ea1585fdc963176d1f41f73/16_Outgoing_FilterPHP.conf#L14-L15) adds `points_limit3`, which is four. [Rule 218140](https://github.com/zcomtenten/cwaf/blob/f9a3f105768d72bb3ea1585fdc963176d1f41f73/17_Outgoing_FilterSQL.conf#L76-L80) adds `points_limit4`, which is five. Both matching rules also carry a `block` action.

The same ruleset has two later checks with different jobs. When response point blocking is enabled, phase-4 [rule 214800](https://github.com/zcomtenten/cwaf/blob/f9a3f105768d72bb3ea1585fdc963176d1f41f73/20_Outgoing_FiltersEnd.conf#L13-L18) denies a response whose outbound total has reached four. Phase-5 [rule 214940](https://github.com/zcomtenten/cwaf/blob/f9a3f105768d72bb3ea1585fdc963176d1f41f73/20_Outgoing_FiltersEnd.conf#L31-L32) only records that the limit was exceeded. It does not perform that threshold denial.

Response scanning and point blocking depend on the host configuration. The reported log confirms both matches, a total of nine, and a final 403. It does not show whether one matching rule's `block` action or rule 214800 issued that 403. The fixture models one public path to the same result: point blocking is enabled and a total of four or more becomes 403.

```text
WordPress emits clear PHP or SQL bytes
    -> the response scanner finds one marker
    -> that marker alone reaches the four-point limit
    -> the proxy sends HTML HTTP 403 instead of the export response
    -> Reprint cannot parse the expected multipart response, so the pull stops
```

Compression helps only when it happens before the scan. [The ModSecurity 2.x manual](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v2.x%29) says embedded `mod_deflate` may compress between response phases 4 and 5. That can be too late for a phase-4 response-body rule. Reprint instead uses `GzipOutputStream` inside PHP:

```text
WordPress emits gzip bytes
    -> the proxy scans those encoded bytes without decompressing them
    -> the clear PHP and SQL markers are absent
    -> the proxy forwards the response unchanged
    -> the Reprint client decompresses it and restores the original data
```

## What the test does

The source site contains a PHP file with `fopen` and a database row with `You have an error in your SQL syntax;`. A bounded local reverse proxy sits between the Reprint client and WordPress.

Two clear control responses check the fixture itself. `fopen` scores four and becomes 403. The MySQL phrase scores five and becomes 403. Testing them separately proves that either match is enough; the test does not need to combine them to cross the limit.

A complete pull also runs through the same proxy. The proxy inspects only `file_fetch` and `sql_chunk`. It scans the exact entity bytes received from WordPress and deliberately does not decode `Content-Encoding`. It records the encoding, marker matches, score, and block decision for each inspected response.

The checks confirm that:

1. both clear control responses become 403;
2. gzip is used for the export stream which contains the markers;
3. neither clear marker appears in the encoded bytes seen by the proxy;
4. the proxy does not replace an export response with 403;
5. the pull completes; and
6. the restored PHP file and database value exactly match the source values after client-side decompression.

The proxy is not a complete CWAF or ModSecurity engine. It models these two literal matches, their public point values, the four-point threshold, the byte ordering, and the final 403. It does not model the rest of the CWAF rules, regular-expression transforms, response MIME selection, or a firewall which decompresses gzip before scanning. The PHP 5.6 identity-response path is also outside this protection.

This PR changes no wire behavior. It records why gzip is produced inside PHP and keeps that ordering under E2E coverage.

## Testing

The focused Docker E2E completes the pull and passes all three outbound-firewall checks.
