### PR TITLE
[PHP] Pass pull request context to push requests

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -246,8 +246,8 @@ class ImportClient
     /** @var string Remote Reprint API URL. */
     public $remote_reprint_api_url;
 
-    /** @var string|null Same-origin WordPress Media Library URL for remote Reprint requests. */
-    private $remote_reprint_api_referer = null;
+    /** @var array<string,string> Request-context headers shared by pull and push. */
+    private $request_context_headers = [];
 
     /** @var string Caller-selected state directory for this filesystem root. */
     public $state_dir;
@@ -520,9 +520,18 @@ class ImportClient
         }
 
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, "?&");
-        $this->remote_reprint_api_referer = wordpress_admin_referer(
-            $this->remote_reprint_api_url
-        );
+        // Some WAFs reject automated requests without User-Agent or Referer.
+        // Accept-Language supplies the browser-language context managed hosts
+        // ask users to configure when diagnosing request-header blocks. These
+        // headers do not authenticate the request.
+        $this->request_context_headers = [
+            'User-Agent' => self::DEFAULT_USER_AGENT,
+            'Accept-Language' => 'en-US,en;q=0.9',
+        ];
+        $referer = wordpress_admin_referer($this->remote_reprint_api_url);
+        if ($referer !== null) {
+            $this->request_context_headers['Referer'] = $referer;
+        }
         $this->state_dir = trim_right_slash($state_dir);
         $this->filesystem_root = trim_right_slash($filesystem_root);
         $remote_state_directory = $selected_remote_state_directory === null
@@ -957,7 +966,7 @@ class ImportClient
             }
             // files-push reads preflight to locate the remote document root,
             // but its lifecycle never writes pull state.
-            $this->state = $this->load_state();
+            $this->state = $this->load_state_with_request_context();
             $this->require_preflight();
             $this->run_files_push($options, $process_lock);
             return;
@@ -977,7 +986,7 @@ class ImportClient
             $this->pull->assert_options_valid_before_state_write($command, $options);
         }
 
-        $this->state = $this->load_state();
+        $this->state = $this->load_state_with_request_context();
 
         if ($command === "pull-metadata") {
             $this->run_pull_metadata();
@@ -1744,6 +1753,7 @@ class ImportClient
             'document_root' => $document_root,
             'push_state_directory' => $context['push_state_directory'],
             'remote_reprint_api_url' => $context['remote_reprint_api_url'],
+            'request_context_headers' => $this->request_context_headers,
             'hmac_client' => new \Site_Export_HMAC_Client($options['secret']),
             'allow_http' => $options['force_http'] ?? false,
             'chunk_bytes' => $chunk_bytes,
@@ -2610,8 +2620,16 @@ class ImportClient
         // headers), so we cycle through candidates and remember the winner.
         $result = null;
         $payload = null;
-        foreach (self::USER_AGENTS as $ua) {
+        $user_agents = array_values(array_unique(array_merge(
+            [
+                $this->request_context_headers['User-Agent'],
+                self::DEFAULT_USER_AGENT,
+            ],
+            self::ALTERNATE_USER_AGENTS
+        )));
+        foreach ($user_agents as $ua) {
             $this->get_state()->user_agent = $ua;
+            $this->request_context_headers['User-Agent'] = $ua;
             $result = $this->fetch_json($url);
             $payload = $result["json"] ?? null;
             if ($payload !== null) {
@@ -11632,35 +11650,34 @@ class ImportClient
         $this->last_error_code = null;
     }
 
+    /** Honest non-browser User-Agent used when no saved choice exists. */
+    private const DEFAULT_USER_AGENT = "Reprint/1.0";
+
     /**
-     * User-Agent strings to try during preflight, in order of preference.
-     * Some WAFs block browser UAs that carry custom auth headers, so we
-     * start with an honest non-browser identity and fall back to common
-     * browser strings.
+     * Browser User-Agent candidates retained for preflight fallback.
+     * Some WAFs block browser UAs that carry custom auth headers, so the
+     * honest non-browser identity remains the default when none is saved.
      */
-    private const USER_AGENTS = [
-        "Reprint/1.0",
+    private const ALTERNATE_USER_AGENTS = [
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0",
     ];
 
     private function get_base_headers(string $accept): array
     {
-        $ua = $this->get_state()->user_agent ?? self::USER_AGENTS[0];
-        $headers = [
-            "User-Agent: {$ua}",
-            "Accept: {$accept}",
-            "Accept-Language: en-US,en;q=0.9",
-            "Accept-Encoding: gzip, deflate",
-            "Cache-Control: no-cache",
-            "Pragma: no-cache",
-            "Connection: keep-alive",
-        ];
-        if ($this->remote_reprint_api_referer !== null) {
-            $headers[] = "Referer: {$this->remote_reprint_api_referer}";
+        $headers = $this->request_context_headers;
+        $headers['Accept'] = $accept;
+        $headers['Accept-Encoding'] = 'gzip, deflate';
+        $headers['Cache-Control'] = 'no-cache';
+        $headers['Pragma'] = 'no-cache';
+        $headers['Connection'] = 'keep-alive';
+
+        $header_lines = [];
+        foreach ($headers as $name => $value) {
+            $header_lines[] = "{$name}: {$value}";
         }
 
-        return $headers;
+        return $header_lines;
     }
 
     /**
@@ -12659,6 +12676,7 @@ class ImportClient
         $this->state->set_preflight_record($previous_state->preflight_record());
         $this->state->version = $previous_state->version;
         $this->state->webhost = $previous_state->webhost;
+        $this->state->user_agent = $previous_state->user_agent;
         $this->state->follow_symlinks = $previous_state->follow_symlinks;
         $this->state->include_host_plugins = $previous_state->include_host_plugins;
         $this->state->apply->remote_paths_removed_from_local_site = $previous_state->apply->remote_paths_removed_from_local_site;
@@ -12900,9 +12918,16 @@ class ImportClient
         return $decoded;
     }
 
-    /**
-     * Load pull state from disk.
-     */
+    /** Load pull state and apply its saved User-Agent to the shared request context. */
+    private function load_state_with_request_context(): PullState
+    {
+        $state = $this->load_state();
+        $this->request_context_headers['User-Agent'] =
+            $state->user_agent ?? self::DEFAULT_USER_AGENT;
+        return $state;
+    }
+
+    /** Load pull state from disk. */
     private function load_state(): PullState
     {
         if (!file_exists($this->pull_state_file)) {

--- a/packages/reprint-client/src/lib/push/class-push-files-sender.php
+++ b/packages/reprint-client/src/lib/push/class-push-files-sender.php
@@ -257,6 +257,7 @@ final class PushFilesSender
      *     @type string                  $document_root           Required remote absolute document root.
      *     @type string                  $push_state_directory    Required local push state directory.
      *     @type string                  $remote_reprint_api_url  Required remote Reprint API URL.
+     *     @type array<string,string>    $request_context_headers Required header-name-to-value map selected by ImportClient.
      *     @type Site_Export_HMAC_Client $hmac_client             Required envelope signer.
      *     @type string[]                $excluded_paths          Additional document-root-relative paths this push must not change. Default empty.
      *     @type bool                    $allow_http              Explicit plain-HTTP opt-in. Default false.
@@ -384,6 +385,7 @@ final class PushFilesSender
 
         $push_stream_client_options = [
             'remote_reprint_api_url' => $options['remote_reprint_api_url'] ?? null,
+            'request_context_headers' => $options['request_context_headers'] ?? null,
             'hmac_client' => $options['hmac_client'] ?? null,
             'allow_http' => $options['allow_http'] ?? false,
         ];

--- a/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
@@ -4,7 +4,6 @@ use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
 use function Reprint\Importer\apply_zipwp_access_cookie;
 use function Reprint\Importer\unsupported_media_type_error_detail;
-use function Reprint\Importer\wordpress_admin_referer;
 
 require_once __DIR__ . '/../import/functions.php';
 
@@ -72,8 +71,8 @@ class MultipartPushStreamClient
     /** @var string Remote Reprint API URL used for every signed request target. */
     private string $remote_reprint_api_url;
 
-    /** @var string|null Same-origin WordPress Media Library URL for remote Reprint requests. */
-    private ?string $remote_reprint_api_referer;
+    /** @var array<string,string> Request-context headers shared by pull and push. */
+    private array $request_context_headers;
 
     /** @var Site_Export_HMAC_Client Signs the exact method and URL before transfer. */
     private Site_Export_HMAC_Client $hmac_client;
@@ -177,6 +176,8 @@ class MultipartPushStreamClient
      *
      *     @type string $remote_reprint_api_url Required remote Reprint API URL. Must use HTTPS
      *         unless `allow_http` is true.
+     *     @type array<string,string> $request_context_headers Required non-empty
+     *         header-name-to-value map selected by ImportClient.
      *     @type Site_Export_HMAC_Client $hmac_client Required signer for the
      *         exact method and request URL.
      *     @type bool $allow_http Whether to permit an explicit HTTP remote Reprint API URL.
@@ -222,10 +223,14 @@ class MultipartPushStreamClient
         if (!$hmac_client instanceof Site_Export_HMAC_Client) {
             throw new InvalidArgumentException('MultipartPushStreamClient requires a Site_Export_HMAC_Client.');
         }
+        $request_context_headers = $options['request_context_headers'] ?? null;
+        if (!is_array($request_context_headers) || $request_context_headers === []) {
+            throw new InvalidArgumentException(
+                'MultipartPushStreamClient requires a non-empty request_context_headers map.'
+            );
+        }
         $this->remote_reprint_api_url = rtrim($remote_reprint_api_url, '?&');
-        $this->remote_reprint_api_referer = wordpress_admin_referer(
-            $this->remote_reprint_api_url
-        );
+        $this->request_context_headers = $request_context_headers;
         $this->hmac_client = $hmac_client;
         $this->request_sizer = $options['request_sizer'] ?? new PushRequestSizer();
         if (!$this->request_sizer instanceof PushRequestSizer) {
@@ -285,11 +290,11 @@ class MultipartPushStreamClient
         $this->response_too_large = false;
 
         $request_url = $this->endpoint_url('push_upload', ['push_session_id' => $push_session_id]);
-        $headers = $this->hmac_client->get_envelope_auth_headers('POST', $request_url);
-        $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
-        if ($this->remote_reprint_api_referer !== null) {
-            $headers['Referer'] = $this->remote_reprint_api_referer;
+        $headers = $this->request_context_headers;
+        foreach ($this->hmac_client->get_envelope_auth_headers('POST', $request_url) as $name => $value) {
+            $headers[$name] = $value;
         }
+        $headers['Content-Type'] = 'multipart/mixed; boundary=' . $this->boundary;
         $header_lines = [];
         foreach ($headers as $name => $value) {
             $header_lines[] = $name . ': ' . $value;
@@ -826,11 +831,12 @@ class MultipartPushStreamClient
             throw new InvalidArgumentException('Push requests require one or more string success statuses.');
         }
         $url = $this->endpoint_url($endpoint, $parameters);
-        $headers = $this->hmac_client->get_envelope_auth_headers($method, $url);
-        $lines = ['Accept: application/json', 'Expect:'];
-        if ($this->remote_reprint_api_referer !== null) {
-            $lines[] = 'Referer: ' . $this->remote_reprint_api_referer;
+        $headers = $this->request_context_headers;
+        $headers['Accept'] = 'application/json';
+        foreach ($this->hmac_client->get_envelope_auth_headers($method, $url) as $name => $value) {
+            $headers[$name] = $value;
         }
+        $lines = ['Expect:'];
         foreach ($headers as $name => $value) {
             $lines[] = $name . ': ' . $value;
         }

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -258,6 +258,11 @@ final class FilesPullLocalIndexTest extends TestCase
                 'push_state_directory' => $pushStateDirectory,
                 'remote_reprint_api_url' =>
                     $remoteReprintApiUrl,
+                'request_context_headers' => [
+                    'User-Agent' => 'Reprint/1.0',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                    'Referer' => 'http://127.0.0.1/wp-admin/upload.php',
+                ],
                 'hmac_client' => new \Site_Export_HMAC_Client('secret'),
                 'allow_http' => true,
             ], $processLock);

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -339,6 +339,7 @@ class FilesPullStateTest extends TestCase
         file_put_contents($remoteIndexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
+            "user_agent" => "Saved-Browser/1.0",
             "active_resumable_command" => [
                 "command_name" => "files-pull",
                 "completion_state" => "complete",
@@ -351,6 +352,7 @@ class FilesPullStateTest extends TestCase
         $abortMethod->invoke($client, 'files-pull');
 
         $state = $this->readState();
+        $this->assertSame("Saved-Browser/1.0", $state["user_agent"]);
         $this->assertNotEquals(
             "complete",
             $state["active_resumable_command"]["completion_state"] ?? null,

--- a/tests/Import/FilesPushCommandTest.php
+++ b/tests/Import/FilesPushCommandTest.php
@@ -310,6 +310,76 @@ final class FilesPushCommandTest extends TestCase
         $this->assertNoSenderState($remoteReprintApiUrl);
     }
 
+    public function testFilesPushUsesTheUserAgentSavedByPreflight(): void
+    {
+        if (PHP_VERSION_ID < 80100 || !function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Raw files-push request coverage requires PHP 8.1+ with curl and pcntl.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertIsResource($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+        $remoteReprintApiUrl = 'http://' . $address . '/?reprint-api=1';
+        $savedUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0';
+        $this->writePreflightState($remoteReprintApiUrl, '/', $savedUserAgent);
+        $requestPath = $this->root . '/push-create-request.txt';
+
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 5);
+            if ($connection === false) {
+                fclose($listener);
+                exit(2);
+            }
+            stream_set_timeout($connection, 5);
+            $request = '';
+            while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    break;
+                }
+                $request .= $piece;
+            }
+            file_put_contents($requestPath, $request);
+            fwrite(
+                $connection,
+                "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $result = $this->runFilesPush(
+            $remoteReprintApiUrl,
+            ['--secret=token', '--force-http', '--progress=jsonl']
+        );
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame(1, $result['exit'], $result['output']);
+        $request = (string) file_get_contents($requestPath);
+        $this->assertStringStartsWith(
+            'POST /?reprint-api=1&endpoint=push_create&push_session_id=',
+            $request
+        );
+        $this->assertStringContainsString("User-Agent: {$savedUserAgent}\r\n", $request);
+        $this->assertStringContainsString("Accept-Language: en-US,en;q=0.9\r\n", $request);
+        $this->assertStringContainsString(
+            "Referer: http://{$address}/wp-admin/upload.php\r\n",
+            $request
+        );
+        $this->assertStringContainsString("Accept: application/json\r\n", $request);
+        $this->assertStringContainsString("X-Auth-Signature: ", $request);
+        $this->assertStringContainsString("X-Auth-Nonce: ", $request);
+        $this->assertStringContainsString("X-Auth-Timestamp: ", $request);
+        $this->assertStringNotContainsString("Content-Type: multipart/mixed", $request);
+        $this->assertStringNotContainsString("Expect: 100-continue", $request);
+    }
+
     public function testFilesPushMasksTheSharedSecretInOutputAndStateFiles(): void
     {
         $secret = 'shared-secret-' . bin2hex(random_bytes(6));
@@ -531,7 +601,8 @@ final class FilesPushCommandTest extends TestCase
 
     private function writePreflightState(
         string $remoteReprintApiUrl,
-        string $documentRoot = '/'
+        string $documentRoot = '/',
+        ?string $userAgent = null
     ): void {
         $pullStateFile = $this->pullStateFileForRemoteReprintApiUrl($remoteReprintApiUrl);
         $pullStateDirectory = dirname($pullStateFile);
@@ -539,6 +610,7 @@ final class FilesPushCommandTest extends TestCase
             mkdir($pullStateDirectory, 0700, true);
         }
         $pullState = new \PullState();
+        $pullState->user_agent = $userAgent;
         $pullState->set_preflight_record([
             'http_code' => 200,
             'data' => [

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -14,6 +14,13 @@ final class MultipartPushStreamClientTest extends TestCase {
 
     private const SECRET = 'multipart-stream-client-test-secret';
 
+    private const REQUEST_CONTEXT_HEADERS = [
+        'User-Agent' => 'Multipart-Test/1.0',
+        'Accept-Language' => 'pl-PL,pl;q=0.9',
+        'Referer' => 'https://request-context.example/wp-admin/upload.php',
+        'X-Reprint-Test-Context' => 'forwarded',
+    ];
+
     public function testSendPartPutsMultipartBytesOnTheWireBeforeFinishRequest(): void {
         if (!function_exists('curl_init') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Caller-driven multipart upload requires PHP curl with CURL_READFUNC_PAUSE support.');
@@ -21,7 +28,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -50,6 +57,9 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertTrue($client->has_sent_parts());
         $received .= $this->read_available($connection);
         $this->assertStringContainsString('Content-Type: multipart/mixed; boundary=reprint-', $received);
+        $this->assertStringContainsString('X-Auth-Signature: ', $received);
+        $this->assertStringContainsString('X-Auth-Nonce: ', $received);
+        $this->assertStringContainsString('X-Auth-Timestamp: ', $received);
         $this->assertStringContainsString('X-Chunk-Type: file', $received);
         $this->assertStringContainsString("a\0b", $received, 'The raw part payload is on the network before finish_request().');
         $this->assertTrue($client->send_part([
@@ -68,7 +78,9 @@ final class MultipartPushStreamClientTest extends TestCase {
         fclose($listener);
 
         $result = $client->finish_request();
-        $this->assertStringContainsString("Referer: http://{$address}/wp-admin/upload.php\r\n", $received);
+        foreach (self::REQUEST_CONTEXT_HEADERS as $name => $value) {
+            $this->assertStringContainsString("{$name}: {$value}\r\n", $received);
+        }
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
         $this->assertSame(2, $result['parts_sent']);
         $this->assertFalse($client->has_sent_parts());
@@ -156,7 +168,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -190,7 +202,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -222,7 +234,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'start_bytes' => 512,
             'max_bytes' => 512,
         ]);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -257,8 +269,20 @@ final class MultipartPushStreamClientTest extends TestCase {
     public function testPlainHttpRequiresAnExplicitOptIn(): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('allow_http is true');
-        new MultipartPushStreamClient([
+        $this->newClient([
             'remote_reprint_api_url' => 'http://example.test/?reprint-api=1',
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+        ]);
+    }
+
+    public function testRequestContextHeadersAreRequired(): void {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Push request context validation requires PHP 8.1+.');
+        }
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('request_context_headers');
+        new MultipartPushStreamClient([
+            'remote_reprint_api_url' => 'https://example.test/?reprint-api=1',
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
         ]);
     }
@@ -270,7 +294,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -319,7 +343,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'start_bytes' => 512,
             'max_bytes' => 2048,
         ]);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -353,7 +377,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -398,7 +422,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -470,7 +494,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -490,7 +514,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertSame('The target response exceeded 1048576 bytes.', $result['detail']);
     }
 
-    public function testPushControlRequestsSendSameOriginWordPressAdminReferer(): void {
+    public function testPushControlRequestsSendRequestContextHeaders(): void {
         if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
             $this->markTestSkipped('Raw push-request coverage requires PHP curl and pcntl.');
         }
@@ -517,15 +541,28 @@ final class MultipartPushStreamClientTest extends TestCase {
                     }
                     $request .= $piece;
                 }
-                if (strpos($request, "Referer: http://{$address}/wp-admin/upload.php\r\n") === false) {
-                    fclose($connection);
-                    fclose($listener);
-                    exit(3);
+                foreach (self::REQUEST_CONTEXT_HEADERS as $name => $value) {
+                    if (strpos($request, "{$name}: {$value}\r\n") === false) {
+                        fclose($connection);
+                        fclose($listener);
+                        exit(3);
+                    }
                 }
                 if (strpos($request, "{$method} /?reprint-api=1&endpoint={$endpoint}&") !== 0) {
                     fclose($connection);
                     fclose($listener);
                     exit(4);
+                }
+                if (
+                    strpos($request, "Accept: application/json\r\n") === false
+                    || strpos($request, "X-Auth-Signature: ") === false
+                    || strpos($request, "X-Auth-Nonce: ") === false
+                    || strpos($request, "X-Auth-Timestamp: ") === false
+                    || strpos($request, "Content-Type: multipart/mixed") !== false
+                ) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(5);
                 }
                 $response = (string) json_encode(['status' => $response_status]);
                 fwrite(
@@ -538,7 +575,7 @@ final class MultipartPushStreamClientTest extends TestCase {
                 exit(0);
             }
 
-            $client = new MultipartPushStreamClient([
+            $client = $this->newClient([
                 'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
                 'allow_http' => true,
                 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -572,7 +609,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             'application/json'
         );
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -613,7 +650,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             true
         );
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -696,7 +733,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -781,7 +818,7 @@ final class MultipartPushStreamClientTest extends TestCase {
                 exit(0);
             }
 
-            $client = new MultipartPushStreamClient([
+            $client = $this->newClient([
                 'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
                 'allow_http' => true,
                 'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -820,7 +857,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -863,7 +900,7 @@ final class MultipartPushStreamClientTest extends TestCase {
         $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
         $this->assertNotFalse($listener, (string) $error);
         $address = stream_socket_get_name($listener, false);
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -946,7 +983,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -1027,7 +1064,7 @@ final class MultipartPushStreamClientTest extends TestCase {
             exit(0);
         }
 
-        $client = new MultipartPushStreamClient([
+        $client = $this->newClient([
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
@@ -1131,5 +1168,12 @@ final class MultipartPushStreamClientTest extends TestCase {
             }
         } while (microtime(true) < $deadline);
         return $received;
+    }
+
+    /** @param array<string,mixed> $options */
+    private function newClient(array $options): MultipartPushStreamClient {
+        $options['request_context_headers'] =
+            $options['request_context_headers'] ?? self::REQUEST_CONTEXT_HEADERS;
+        return new MultipartPushStreamClient($options);
     }
 }

--- a/tests/Import/ZipwpAccessCookieTest.php
+++ b/tests/Import/ZipwpAccessCookieTest.php
@@ -142,6 +142,11 @@ final class ZipwpAccessCookieTest extends TestCase {
     {
         $client = new \MultipartPushStreamClient([
             'remote_reprint_api_url' => 'http://demo.zipwp.to/',
+            'request_context_headers' => [
+                'User-Agent' => 'Reprint/1.0',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Referer' => 'http://demo.zipwp.to/wp-admin/upload.php',
+            ],
             'allow_http' => true,
             'hmac_client' => new \Site_Export_HMAC_Client('zipwp-test-secret'),
             'connect_timeout' => 2,

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -2815,6 +2815,11 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'request_context_headers' => [
+                'User-Agent' => 'Reprint/1.0',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Referer' => 'http://127.0.0.1/wp-admin/upload.php',
+            ],
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'connect_timeout' => 2,
@@ -3747,6 +3752,11 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
+            'request_context_headers' => [
+                'User-Agent' => 'Reprint/1.0',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Referer' => 'http://127.0.0.1/wp-admin/upload.php',
+            ],
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 4 * 1024 * 1024,
@@ -4001,6 +4011,11 @@ final class PushEndpointsTest extends TestCase {
             'document_root' => '/',
             'push_state_directory' => $push_state_directory,
             'remote_reprint_api_url' => $this->remote_reprint_api_url,
+            'request_context_headers' => [
+                'User-Agent' => 'Reprint/1.0',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Referer' => 'http://127.0.0.1/wp-admin/upload.php',
+            ],
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
             'chunk_bytes' => 64,
@@ -4286,6 +4301,11 @@ final class PushEndpointsTest extends TestCase {
     {
         return new MultipartPushStreamClient([
             'remote_reprint_api_url' => $remote_reprint_api_url ?? $this->remote_reprint_api_url,
+            'request_context_headers' => [
+                'User-Agent' => 'Reprint/1.0',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Referer' => 'http://127.0.0.1/wp-admin/upload.php',
+            ],
             'allow_http' => true,
             'hmac_client' => new Site_Export_HMAC_Client($secret),
             'chunk_bytes' => 4,

--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -1,10 +1,11 @@
 /**
  * Local reverse proxy which models an application firewall around WordPress.
  *
- * Reprint requests are accepted only when their Referer points to the same
+ * Reprint requests are accepted only when they send the expected Referer,
+ * User-Agent, and Accept-Language headers. The Referer must point to the same
  * origin's WordPress Media Library page. After preflight, path query values
- * must not expose absolute filesystem paths. It injects the planned HTTP
- * errors, then streams later requests to the real E2E WordPress site.
+ * must not expose absolute filesystem paths. It injects the planned potentially
+ * transient HTTP errors, then streams later requests to the real E2E WordPress site.
  */
 import http from 'node:http';
 import { appendFileSync } from 'node:fs';
@@ -39,12 +40,19 @@ const server = http.createServer((request, response) => {
         requestUrl.searchParams.has('site-export-api');
     const expectedReferer = `http://${request.headers.host}/wp-admin/upload.php`;
     const referer = request.headers.referer || '';
+    const expectedUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+    const userAgent = request.headers['user-agent'] || '';
+    const expectedAcceptLanguage = 'en-US,en;q=0.9';
+    const acceptLanguage = request.headers['accept-language'] || '';
     const endpoint = requestUrl.searchParams.get('endpoint') || '';
     const rawPathParameter = ['directory', 'list_dir', 'pulled_before']
         .flatMap(parameter => requestUrl.searchParams.getAll(parameter))
         .find(value => value.startsWith('/')) || null;
     const allowed = !isReprintRequest || (
-        referer === expectedReferer && (
+        referer === expectedReferer &&
+        userAgent === expectedUserAgent &&
+        acceptLanguage === expectedAcceptLanguage && (
             endpoint === 'preflight' || rawPathParameter === null
         )
     );
@@ -71,11 +79,14 @@ const server = http.createServer((request, response) => {
         referer,
         expectedReferer,
         rawPathParameter,
+        userAgent,
+        expectedUserAgent,
+        acceptLanguage,
+        expectedAcceptLanguage,
         isReprintRequest,
         allowed,
         action,
         injectedStatus,
-        userAgent: request.headers['user-agent'] || '',
     });
 
     if (!allowed) {

--- a/tests/e2e/tests/import-60-application-firewall.test.js
+++ b/tests/e2e/tests/import-60-application-firewall.test.js
@@ -1,8 +1,8 @@
 /**
  * Test 60: Application firewall compatibility
  *
- * Runs a complete pull through a local HTTP reverse proxy which rejects
- * Reprint requests unless they have a same-origin WordPress admin Referer.
+ * Runs a complete pull through a local HTTP reverse proxy which checks the
+ * expected same-origin WordPress admin Referer, User-Agent, and Accept-Language.
  * After preflight reports base64 path support, the proxy also rejects clear
  * path query values. Before forwarding each streaming endpoint, it returns two
  * potentially transient HTTP errors. The third request reaches the real E2E
@@ -39,6 +39,8 @@ import { ensureSite } from '../lib/site-setup.js';
 describe('Import: Application firewall compatibility', { timeout: 240000 }, () => {
     const site = 'basic';
     const importDb = 'e2e_app_firewall_60';
+    const acceptedUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
     let firewallProcess;
     let firewallOrigin;
     let importUrl;
@@ -114,7 +116,7 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         await connection.end();
     });
 
-    it('sends a same-origin WordPress admin Referer with every Reprint request', () => {
+    it('reuses the first User-Agent accepted by the firewall', () => {
         const requestRecords = readRequestRecords()
             .filter(record => record.isReprintRequest);
         assert.ok(
@@ -128,6 +130,32 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
             ),
             `Expected Referer ${firewallOrigin}/wp-admin/upload.php, got ` +
             requestRecords.map(record => JSON.stringify(record.referer)).join(', '),
+        );
+        const preflightRecords = requestRecords.filter(
+            record => record.endpoint === 'preflight',
+        );
+        assert.deepEqual(
+            preflightRecords.slice(0, 2).map(record => [
+                record.userAgent,
+                record.allowed,
+            ]),
+            [
+                ['Reprint/1.0', false],
+                [acceptedUserAgent, true],
+            ],
+            'Expected the firewall to reject the default and accept the browser User-Agent',
+        );
+        const acceptedRecords = requestRecords.filter(record => record.allowed);
+        assert.ok(acceptedRecords.length > 0, 'Expected accepted Reprint requests');
+        assert.ok(
+            acceptedRecords.every(record => record.userAgent === acceptedUserAgent),
+            `Expected accepted User-Agent ${acceptedUserAgent}, got ` +
+            acceptedRecords.map(record => JSON.stringify(record.userAgent)).join(', '),
+        );
+        assert.ok(
+            requestRecords.every(record => record.acceptLanguage === 'en-US,en;q=0.9'),
+            `Expected Accept-Language en-US,en;q=0.9, got ` +
+            requestRecords.map(record => JSON.stringify(record.acceptLanguage)).join(', '),
         );
         assert.ok(requestRecords.some(record => record.method === 'GET'));
         assert.ok(requestRecords.some(record => record.method === 'POST'));
@@ -247,9 +275,111 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         );
     });
 
+    it('loads the accepted User-Agent in a later importer process', () => {
+        const laterOutputDirectory = createTempDir(
+            'e2e-app-firewall-request-context',
+        );
+        const firstLaterRecord = readRequestRecords().length;
+
+        try {
+            const result = runImporter(
+                importUrl,
+                laterOutputDirectory,
+                'files-index',
+                {
+                    secret: getSiteSecret(site),
+                    autoResume: false,
+                    timeout: 120000,
+                    wallTimeout: 240000,
+                },
+            );
+            const state = JSON.parse(readFileSync(
+                join(
+                    pullStateDirectory(laterOutputDirectory, importUrl),
+                    'state.json',
+                ),
+                'utf-8',
+            ));
+            const requestRecords = readRequestRecords()
+                .slice(firstLaterRecord)
+                .filter(record => record.isReprintRequest);
+            const preflightRecords = requestRecords.filter(
+                record => record.endpoint === 'preflight',
+            );
+            const fileIndexRecord = requestRecords.find(
+                record => record.endpoint === 'file_index',
+            );
+
+            assert.equal(
+                result.exitCode,
+                0,
+                `Expected files-index to succeed\n` +
+                `stderr: ${result.stderr}\nstdout: ${result.stdout}`,
+            );
+            assert.equal(state.user_agent, acceptedUserAgent);
+            assert.deepEqual(
+                preflightRecords.map(record => [
+                    record.userAgent,
+                    record.allowed,
+                ]),
+                [
+                    ['Reprint/1.0', false],
+                    [acceptedUserAgent, true],
+                ],
+            );
+            assert.ok(
+                fileIndexRecord,
+                'Expected the later process to request file_index',
+            );
+            assert.equal(fileIndexRecord.userAgent, state.user_agent);
+            assert.equal(fileIndexRecord.allowed, true);
+            assert.equal(fileIndexRecord.action, 'proxy');
+        } finally {
+            cleanupTempDir(laterOutputDirectory);
+        }
+    });
+
     it('rejects a Reprint GET without the Referer', async () => {
         const response = await fetch(
             `${firewallOrigin}/?reprint-api&endpoint=preflight`,
+            {
+                headers: {
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    'User-Agent': acceptedUserAgent,
+                },
+            },
+        );
+
+        assert.equal(response.status, 403);
+        assert.equal(response.headers.get('x-app-firewall'), 'blocked');
+    });
+
+    it('rejects a Reprint GET without the User-Agent', async () => {
+        const response = await fetch(
+            `${firewallOrigin}/?reprint-api&endpoint=preflight`,
+            {
+                headers: {
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    Referer: `${firewallOrigin}/wp-admin/upload.php`,
+                    'User-Agent': '',
+                },
+            },
+        );
+
+        assert.equal(response.status, 403);
+        assert.equal(response.headers.get('x-app-firewall'), 'blocked');
+    });
+
+    it('rejects a Reprint GET without Accept-Language', async () => {
+        const response = await fetch(
+            `${firewallOrigin}/?reprint-api&endpoint=preflight`,
+            {
+                headers: {
+                    'Accept-Language': '',
+                    Referer: `${firewallOrigin}/wp-admin/upload.php`,
+                    'User-Agent': acceptedUserAgent,
+                },
+            },
         );
 
         assert.equal(response.status, 403);
@@ -259,7 +389,13 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
     it('rejects a clear absolute path after preflight', async () => {
         const response = await fetch(
             `${firewallOrigin}/?reprint-api&endpoint=file_index&directory=/srv/site`,
-            { headers: { Referer: `${firewallOrigin}/wp-admin/upload.php` } },
+            {
+                headers: {
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    Referer: `${firewallOrigin}/wp-admin/upload.php`,
+                    'User-Agent': acceptedUserAgent,
+                },
+            },
         );
 
         assert.equal(response.status, 403);


### PR DESCRIPTION
Push requests now send the same `User-Agent`, `Accept-Language`, and `Referer` headers as pull requests.

For example, a firewall can reject `Reprint/1.0` but accept a browser User-Agent. Preflight saves the accepted value for later requests. Before this PR, push sent the Referer but omitted User-Agent and Accept-Language. A firewall that requires these headers could accept pull and reject push.

`ImportClient` now supplies one set of headers to pull and push. Later commands load the saved User-Agent. Each push request still gets its own authentication headers.

## Pull behavior

Pull keeps the same header names and default values. Two behaviors change when a User-Agent was saved: resetting command state now keeps that value, and preflight tries it before `Reprint/1.0`. Without a saved value, preflight still starts with `Reprint/1.0`.

## Testing

Use a test site whose firewall rejects `Reprint/1.0` but accepts a browser User-Agent. Run preflight, then start `files-index` in a new process with the same state directory. Check the server's request log: both commands must use the accepted User-Agent after preflight selects it.

After `files-pull --abort`, repeat preflight and check that its first request uses the saved User-Agent.

Pull the test site, change one local file, and run `files-push` with the same state directory. Check that push upload and control requests send the same three headers as pull requests.
