### PR TITLE
[PHP] Explain HTTP 415 firewall greylist responses

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -36,6 +36,7 @@ use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
 use function Reprint\Importer\sort_index_file;
+use function Reprint\Importer\unsupported_media_type_error_detail;
 use function Reprint\Importer\wordpress_admin_referer;
 use function Reprint\Importer\write_file_index_processor_entry_to_local_index;
 use function Reprint\Importer\write_local_index_entry;
@@ -11294,6 +11295,16 @@ class ImportClient
             $msg .= "\n\nRun `php reprint.phar install-server` for setup " .
                      "instructions.";
             return ['code' => 'NOT_FOUND', 'message' => $msg];
+        }
+
+        // An endpoint media-type rejection and a firewall greylist can both
+        // return 415.
+        if ($http_code === 415) {
+            $msg = unsupported_media_type_error_detail();
+            if ($server_msg !== null) {
+                $msg .= "\n\nThe target reported: {$server_msg}";
+            }
+            return ['code' => 'UNSUPPORTED_MEDIA_TYPE', 'message' => $msg];
         }
 
         // ── Server errors ────────────────────────────────────────

--- a/packages/reprint-client/src/lib/import/functions.php
+++ b/packages/reprint-client/src/lib/import/functions.php
@@ -39,6 +39,24 @@ function wordpress_admin_referer(string $remote_reprint_api_url): ?string
 }
 
 /**
+ * Explain HTTP 415 without assuming it proves a firewall greylist.
+ *
+ * Imunify360 uses the same status for non-text requests from a greylisted
+ * source IP that an endpoint uses for a normal media-type rejection.
+ *
+ * @return string Actionable error detail for pull and push requests.
+ */
+function unsupported_media_type_error_detail(): string
+{
+	return 'The remote returned HTTP 415 Unsupported Media Type. This normally means the target rejected the ' .
+		'request\'s media type. Check the target\'s logs for a media-type rejection. Some web application ' .
+		'firewalls also return this status when the source IP address is greylisted and the request asks for a ' .
+		'non-text response. In that case, changing Reprint\'s Accept header to text/html would only replace this ' .
+		'response with a JavaScript challenge. Reprint cannot complete that challenge. If the firewall caused ' .
+		'it, ask the host to allowlist this machine\'s source IP address.';
+}
+
+/**
  * If the ALL_PROXY environment variable is set, apply it to the cURL
  * handle via CURLOPT_PROXY.
  *

--- a/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
@@ -2,6 +2,7 @@
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
+use function Reprint\Importer\unsupported_media_type_error_detail;
 use function Reprint\Importer\wordpress_admin_referer;
 
 require_once __DIR__ . '/../import/functions.php';
@@ -700,6 +701,16 @@ class MultipartPushStreamClient
                 'body_bytes_sent' => $this->body_bytes_sent,
             ];
         }
+        if ($http_code === 415) {
+            return [
+                'status' => 'failed',
+                'reason' => 'unsupported_media_type',
+                'detail' => unsupported_media_type_error_detail(),
+                'response' => null,
+                'parts_sent' => $this->parts_sent,
+                'body_bytes_sent' => $this->body_bytes_sent,
+            ];
+        }
         if (!is_array($decoded)) {
             if ($body !== '') {
                 return [
@@ -896,6 +907,16 @@ class MultipartPushStreamClient
         }
         $body = $response_body;
         $decoded = json_decode($body, true);
+        if ($http_code === 415) {
+            return [
+                'status' => 'failed',
+                'reason' => 'unsupported_media_type',
+                'detail' => unsupported_media_type_error_detail(),
+                'response' => null,
+                'parts_sent' => 0,
+                'body_bytes_sent' => 0,
+            ];
+        }
         if (!is_array($decoded)) {
             return [
                 'status' => 'failed',

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -247,6 +247,68 @@ class DiagnoseHttpErrorTest extends TestCase
         ));
     }
 
+    public function testPullJsonRequestReportsHttp415AsPossibleFirewallGreylist()
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('HTTP 415 wire coverage requires PHP curl and pcntl.');
+        }
+
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+        $this->assertNotFalse($listener, $error_message);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child === 0) {
+            $connection = stream_socket_accept($listener, 3);
+            if ($connection === false) {
+                exit(2);
+            }
+            stream_set_timeout($connection, 3);
+            $request = '';
+            while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    break;
+                }
+                $request .= $piece;
+            }
+            if (strpos($request, 'GET /?reprint-api=1') !== 0) {
+                exit(3);
+            }
+            $body = '<!doctype html><title>Unsupported Media Type</title>';
+            fwrite(
+                $connection,
+                "HTTP/1.1 415 Unsupported Media Type\r\nContent-Type: text/html\r\nContent-Length: "
+                    . strlen($body) . "\r\nConnection: close\r\n\r\n" . $body
+            );
+            fclose($connection);
+            fclose($listener);
+            exit(0);
+        }
+
+        $client = new \ImportClient(
+            'http://' . $address . '/?reprint-api=1',
+            sys_get_temp_dir(),
+            sys_get_temp_dir(),
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $method = $reflection->getMethod('fetch_json');
+        $result = $method->invoke($client, 'http://' . $address . '/?reprint-api=1&endpoint=preflight');
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame(415, $result['http_code']);
+        $this->assertSame('UNSUPPORTED_MEDIA_TYPE', $result['error_code']);
+        $this->assertStringContainsString('Unsupported Media Type', $result['error']);
+        $this->assertStringContainsString('normally means', $result['error']);
+        $this->assertStringContainsString('greylist', $result['error']);
+        $this->assertStringContainsString('allowlist', $result['error']);
+    }
+
     // ── HTML response on any status ──────────────────────────────
 
     public function testHtmlResponseOn200()

--- a/tests/Import/MultipartPushStreamClientTest.php
+++ b/tests/Import/MultipartPushStreamClientTest.php
@@ -557,6 +557,94 @@ final class MultipartPushStreamClientTest extends TestCase {
         }
     }
 
+    public function testPushControlRequestReportsHttp415AsPossibleFirewallGreylist(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('HTTP 415 wire coverage requires PHP curl and pcntl.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $response_body = (string) json_encode(['error' => 'Unsupported Media Type']);
+        $child = $this->fork_http_415_responder(
+            $listener,
+            'POST /?reprint-api=1&endpoint=push_create',
+            $response_body,
+            'application/json'
+        );
+
+        $client = new MultipartPushStreamClient([
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $result = $client->send_push_request('POST', 'push_create', [
+            'push_session_id' => str_repeat('5', 32),
+        ], ['created']);
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('unsupported_media_type', $result['reason']);
+        $this->assertSame(0, $result['parts_sent']);
+        $this->assertSame(0, $result['body_bytes_sent']);
+        $this->assertNull($result['response']);
+        $this->assertStringContainsString('Unsupported Media Type', $result['detail']);
+        $this->assertStringContainsString('greylist', $result['detail']);
+        $this->assertStringContainsString('allowlist', $result['detail']);
+    }
+
+    public function testPushUploadReportsHttp415AsPossibleFirewallGreylist(): void {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('HTTP 415 upload coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
+        }
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+        $this->assertNotFalse($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        $response_body = '<!doctype html><title>Unsupported Media Type</title>';
+        $child = $this->fork_http_415_responder(
+            $listener,
+            'POST /?reprint-api=1&endpoint=push_upload&push_session_id=',
+            $response_body,
+            'text/html',
+            true
+        );
+
+        $client = new MultipartPushStreamClient([
+            'remote_reprint_api_url' => 'http://' . $address . '/?reprint-api=1',
+            'allow_http' => true,
+            'hmac_client' => new Site_Export_HMAC_Client(self::SECRET),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        $this->assertTrue($client->start_upload_request(str_repeat('a', 32)));
+        $this->assertTrue($client->send_part([
+            'type' => 'file',
+            'path' => 'blocked.php',
+            'total_bytes' => 1,
+            'offset' => 0,
+            'payload' => 'x',
+        ]));
+        $result = $client->finish_request();
+        pcntl_waitpid($child, $status);
+        fclose($listener);
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame('unsupported_media_type', $result['reason']);
+        $this->assertSame(1, $result['parts_sent']);
+        $this->assertGreaterThan(0, $result['body_bytes_sent']);
+        $this->assertNull($result['response']);
+        $this->assertStringContainsString('Unsupported Media Type', $result['detail']);
+        $this->assertStringContainsString('greylist', $result['detail']);
+        $this->assertStringContainsString('allowlist', $result['detail']);
+    }
+
     public function testUploadRequestStopsReadingAnOversizedResponse(): void {
         if (!function_exists('curl_init') || !function_exists('pcntl_fork') || PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Raw upload-response coverage requires PHP curl, pcntl, and CURL_READFUNC_PAUSE support.');
@@ -967,6 +1055,66 @@ final class MultipartPushStreamClientTest extends TestCase {
         $this->assertGreaterThan(1.0, $elapsed);
         $this->assertTrue($sent, (string) json_encode($result));
         $this->assertSame('complete', $result['status'], (string) json_encode($result));
+    }
+
+    /**
+     * @param resource $listener Open loopback listener.
+     */
+    private function fork_http_415_responder(
+        $listener,
+        string $request_line_prefix,
+        string $response_body,
+        string $response_content_type,
+        bool $read_complete_multipart_body = false
+    ): int {
+        $child = pcntl_fork();
+        $this->assertNotSame(-1, $child);
+        if ($child !== 0) {
+            return $child;
+        }
+
+        $connection = stream_socket_accept($listener, 3);
+        if ($connection === false) {
+            exit(2);
+        }
+        stream_set_timeout($connection, 3);
+        $request = '';
+        while (strpos($request, "\r\n\r\n") === false && !feof($connection)) {
+            $piece = fread($connection, 64 * 1024);
+            if (!is_string($piece) || $piece === '') {
+                exit(3);
+            }
+            $request .= $piece;
+        }
+        if (strpos($request, $request_line_prefix) !== 0) {
+            exit(4);
+        }
+
+        if ($read_complete_multipart_body) {
+            if (preg_match('/boundary=(reprint-[a-f0-9]+)/', $request, $matches) !== 1) {
+                exit(5);
+            }
+            $closing_boundary = '--' . $matches[1] . "--\r\n";
+            while (strpos($request, $closing_boundary) === false && !feof($connection)) {
+                $piece = fread($connection, 64 * 1024);
+                if (!is_string($piece) || $piece === '') {
+                    exit(6);
+                }
+                $request .= $piece;
+            }
+            if (strpos($request, $closing_boundary) === false) {
+                exit(7);
+            }
+        }
+
+        fwrite(
+            $connection,
+            "HTTP/1.1 415 Unsupported Media Type\r\nContent-Type: {$response_content_type}\r\nContent-Length: "
+                . strlen($response_body) . "\r\nConnection: close\r\n\r\n" . $response_body
+        );
+        fclose($connection);
+        fclose($listener);
+        exit(0);
     }
 
     private function read_available($connection): string {


### PR DESCRIPTION
Reprint now reports HTTP 415 as an unsupported media type and explains that a host firewall greylist can return the same status.

## Background

HTTP 415 normally means the target rejected the request media type. [Imunify360 documents](https://docs.imunify360.com/features/#greylist-and-anti-bot-challenge) another cause: WebShield returns 415 when a greylisted source asks for a non-text response, including `Accept: application/json` and `Accept: */*`.

Changing `Accept` to `text/html` does not solve that firewall case. It returns a JavaScript challenge which Reprint cannot complete. The useful action is to check the target logs and, when the firewall caused the response, ask the host to allowlist the migration machine's source IP.

## This change

Pull reports `UNSUPPORTED_MEDIA_TYPE`. Push reports `unsupported_media_type`. Both use one shared explanation while keeping their existing result shapes.

## Testing

Three raw loopback tests return HTTP 415 to a pull JSON request, a push control request, and a multipart push upload. They cover HTML and JSON response bodies and check the reported code, detail, response, and request counters.
