### PR TITLE
[PHP] Cap each SQL part body at 16 MiB

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8607,6 +8607,7 @@ class ImportClient
                 $url = $this->build_url("sql_chunk", $cursor, $params);
 
                 $context = new StreamingContext();
+                $remote_sql_error = null;
                 $context->on_chunk = function ($chunk) use (
                     $mode,
                     &$cursor,
@@ -8619,7 +8620,8 @@ class ImportClient
                     $context,
                     $query_stream,
                     &$sql_statements_counted,
-                    &$chunks_since_save
+                    &$chunks_since_save,
+                    &$remote_sql_error
                 ) {
                     // Check if shutdown was requested
                     if ($this->shutdown_requested) {
@@ -8811,6 +8813,12 @@ class ImportClient
                         );
                     } elseif ($chunk_type === "error") {
                         $this->handle_error_chunk($chunk, "sql", $context);
+                        $error_data = json_decode($chunk["body"] ?? "", true);
+                        $remote_sql_error = is_array($error_data) &&
+                            is_string($error_data["message"] ?? null) &&
+                            $error_data["message"] !== ""
+                                ? $error_data["message"]
+                                : "The source returned a database export error without a message.";
                     }
                 };
 
@@ -8819,6 +8827,11 @@ class ImportClient
                 try {
                     $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
                 } catch (TransientInterruptionException $e) {
+                    if ($remote_sql_error !== null) {
+                        throw new RuntimeException(
+                            "The source could not export the database: {$remote_sql_error}",
+                        );
+                    }
                     // The source may time out or crash after complete SQL parts
                     // but before its completion part. SQL multipart bodies are
                     // delivered only at a complete part boundary, so resume from
@@ -8835,6 +8848,11 @@ class ImportClient
                     }
                     $this->audit_log($retry_log, true);
                     continue;
+                }
+                if ($remote_sql_error !== null) {
+                    throw new RuntimeException(
+                        "The source could not export the database: {$remote_sql_error}",
+                    );
                 }
                 $this->get_state()->consecutive_interrupted_responses = 0;
                 $wall_time = microtime(true) - $request_start;

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -42,7 +42,14 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  */
 class MySQLDumpProducer
 {
-    /** Maximum decoded SQL body bytes for one multipart part. */
+    /**
+     * Maximum decoded SQL body bytes for one multipart part.
+     *
+     * The producer uses this limit to split or reject one oversized row
+     * fragment. The exporter uses the same limit to stop grouping fragments
+     * before the complete multipart part becomes oversized, then checks its
+     * final byte length before writing it.
+     */
     public const MAX_SQL_PART_BODY_BYTES = 16 * 1024 * 1024;
 
     const STATE_INIT = "init";

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -27,9 +27,8 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  * directly to the column's declared charset. JSON columns are a special case — MySQL
  * rejects binary charset input for JSON, so those get an extra CONVERT(... USING utf8mb4).
  *
- * Rows that would exceed MySQL's max_allowed_packet are handled by inserting the row
- * with large columns set to empty strings, then appending the real data via a series
- * of UPDATE ... SET col = CONCAT(col, chunk) statements.
+ * For keyed rows, eligible large columns can be inserted as empty strings and then
+ * filled via UPDATE ... SET col = CONCAT(col, chunk) statements.
  *
  * Known limitations:
  *
@@ -43,6 +42,9 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  */
 class MySQLDumpProducer
 {
+    /** Maximum decoded SQL body bytes for one multipart part. */
+    public const MAX_SQL_PART_BODY_BYTES = 16 * 1024 * 1024;
+
     const STATE_INIT = "init";
     const STATE_EMIT_HEADER = "emit_header";
     const STATE_NEXT_TABLE = "next_table";
@@ -247,7 +249,10 @@ class MySQLDumpProducer
         $this->current_statement_size = strlen($header) + strlen($this->on_duplicate_key()) + 1;
 
         $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
-        $first_row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
+        $first_row_sql = $this->format_row_for_insert(
+            $this->row_reader->get_current_record(),
+            $this->current_statement_size
+        );
         $this->current_statement_size += strlen($first_row_sql) + 1;
 
         $this->row_reader->clear_current_record();
@@ -290,7 +295,10 @@ class MySQLDumpProducer
         }
 
         $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
-        $row_sql = $this->format_row_for_insert($this->row_reader->get_current_record());
+        $row_sql = $this->format_row_for_insert(
+            $this->row_reader->get_current_record(),
+            strlen($this->on_duplicate_key())
+        );
         $this->current_statement_size += strlen($row_sql) + 2;
         $this->row_reader->clear_current_record();
         $this->rows_in_batch++;
@@ -707,8 +715,10 @@ class MySQLDumpProducer
 
         /** Base64 output is always ceil(n/3)*4 bytes. */
         $estimated_base64_length = 4 * integer_divide($len + 2, 3);
-        // FROM_BASE64('<data>') => 15 bytes overhead + base64 length
-        return 15 + $estimated_base64_length;
+        // FROM_BASE64('<data>') adds 15 bytes. JSON adds the surrounding
+        // CONVERT(... USING utf8mb4), for 38 wrapper bytes in total.
+        $wrapper_bytes = strtoupper($data_type) === "JSON" ? 38 : 15;
+        return $wrapper_bytes + $estimated_base64_length;
     }
 
     /** Auto-detects max_allowed_packet and uses 80% of it. Falls back to 1MB. */
@@ -731,16 +741,15 @@ class MySQLDumpProducer
      *
      * The approach is estimate-first: compute the approximate encoded size of
      * each column before doing the actual (expensive) base64 encoding. If the
-     * row fits within max_statement_size, encode everything. If it doesn't,
-     * replace the largest non-PK columns with '' and queue their real values
-     * as UPDATE ... CONCAT() chunks in $this->oversized_queue.
+     * row fits the statement and part-body limits, encode everything. If it
+     * doesn't, replace eligible large non-PK columns with '' and queue their
+     * real values as UPDATE ... CONCAT() chunks in $this->oversized_queue.
      *
-     * Tables without a primary key can't use the UPDATE fallback (there's no
-     * stable row identifier for the WHERE clause), so oversized rows in
-     * PK-less tables are emitted as-is — the import may fail, but that's
-     * better than silently dropping data.
+     * Tables without a primary key can't use the UPDATE fallback because
+     * there is no stable row identifier for the WHERE clause. Reject those
+     * rows before building an over-limit SQL fragment.
      */
-    private function format_row_for_insert($row)
+    private function format_row_for_insert($row, $sql_fragment_fixed_bytes)
     {
         $estimated_sizes = [];
         $raw_values = [];
@@ -754,9 +763,13 @@ class MySQLDumpProducer
 
         // Estimate the size of "(val1,val2,val3)," — values + commas between them + parens + terminator
         $row_size_est = array_sum($estimated_sizes) + count($estimated_sizes) + 3;
-        $projected_size = $this->current_statement_size + $row_size_est;
+        $projected_statement_size = $this->current_statement_size + $row_size_est;
+        $projected_fragment_size = $sql_fragment_fixed_bytes + $row_size_est;
 
-        if ($projected_size <= $this->max_statement_size) {
+        if (
+            $projected_statement_size <= $this->max_statement_size &&
+            $projected_fragment_size <= self::MAX_SQL_PART_BODY_BYTES
+        ) {
             $formatted_values = [];
             foreach ($this->row_reader->get_current_column_names() as $col) {
                 $data_type = $this->row_reader->get_data_type($col);
@@ -769,12 +782,17 @@ class MySQLDumpProducer
         // the receiving end.
 
         if (!$this->row_reader->get_current_primary_key_columns() || count($this->row_reader->get_current_primary_key_columns()) === 0) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
             throw new \RuntimeException(
                 "Row in table " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) .
-                " exceeds max_statement_size ({$this->max_statement_size} bytes)" .
+                " has an estimated current INSERT size of {$projected_statement_size} bytes and SQL fragment size of" .
+                " {$projected_fragment_size} bytes. The limits are max_statement_size" .
+                " ({$this->max_statement_size} bytes) and the SQL part body limit" .
+                " (" . self::MAX_SQL_PART_BODY_BYTES . " bytes)," .
                 " but the table has no primary key, so the oversized row" .
                 " cannot be split into UPDATE ... CONCAT() chunks."
             );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
 
         $this->oversized_pk_values = [];
@@ -795,7 +813,12 @@ class MySQLDumpProducer
         $this->oversized_queue = [];
         $chunked_columns = [];
 
-        $excess = $projected_size - $this->max_statement_size;
+        $excess = max(
+            $projected_statement_size - $this->max_statement_size,
+            $projected_fragment_size - self::MAX_SQL_PART_BODY_BYTES
+        );
+        $saved_bytes = 0;
+        $skipped_non_byte_bounded_value = false;
 
         foreach ($sorted_sizes as $col => $size) {
             if (in_array($col, $this->row_reader->get_current_primary_key_columns())) {
@@ -816,12 +839,30 @@ class MySQLDumpProducer
             }
 
             $data_type = $this->row_reader->get_data_type($col);
+            // SUBSTRING counts characters for text columns. Only binary
+            // columns have byte-bounded chunks, which the part limit needs.
+            $normalized_data_type = strtoupper($data_type);
+            $binary_type = false;
+            foreach (["BINARY", "VARBINARY", "TINYBLOB", "BLOB", "MEDIUMBLOB", "LONGBLOB"] as $type) {
+                if (strpos($normalized_data_type, $type) === 0) {
+                    $binary_type = true;
+                    break;
+                }
+            }
+            if (
+                $projected_fragment_size - $saved_bytes > self::MAX_SQL_PART_BODY_BYTES &&
+                !$binary_type
+            ) {
+                $skipped_non_byte_bounded_value = true;
+                continue;
+            }
             $value_length = strlen($raw_value);
             $chunk_size = $this->compute_chunk_size($col);
 
             if ($value_length > $chunk_size) {
                 $chunked_columns[$col] = true;
-                $excess -= ($size - 2); // Saved bytes (size minus the '' replacement)
+                $saved_bytes += $size - 2; // Saved bytes (size minus the '' replacement)
+                $excess -= $size - 2;
 
                 $this->oversized_queue[] = [
                     'column' => $col,
@@ -830,6 +871,21 @@ class MySQLDumpProducer
                     'total_length' => $value_length,
                 ];
             }
+        }
+
+        if (
+            $projected_fragment_size - $saved_bytes >
+                self::MAX_SQL_PART_BODY_BYTES ||
+            ($skipped_non_byte_bounded_value && $excess > 0)
+        ) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
+            throw new \RuntimeException(
+                "Row in table " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) .
+                " cannot fit the SQL size limits with the available UPDATE chunking." .
+                " max_statement_size is {$this->max_statement_size}" .
+                " bytes and the SQL part body limit is " . self::MAX_SQL_PART_BODY_BYTES . " bytes."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
 
         if (empty($chunked_columns)) {
@@ -852,7 +908,7 @@ class MySQLDumpProducer
     /**
      * Computes the maximum raw byte size of each chunk for the given column,
      * such that an UPDATE ... SET col = CONCAT(col, FROM_BASE64('...'))
-     * statement stays within max_statement_size.
+     * statement stays within both SQL size limits.
      */
     private function compute_chunk_size($column)
     {
@@ -862,7 +918,11 @@ class MySQLDumpProducer
         $where_clause_size = $this->estimate_pk_where_size();
         $total_overhead = $update_overhead + $where_clause_size + 100; // Extra margin
 
-        $max_chunk_raw_size = ($this->max_statement_size - $total_overhead);
+        $maximum_update_statement_size = min(
+            $this->max_statement_size,
+            self::MAX_SQL_PART_BODY_BYTES
+        );
+        $max_chunk_raw_size = ($maximum_update_statement_size - $total_overhead);
 
         // Base64 inflates by ~1.33x, plus FROM_BASE64('') wrapper overhead
         $max_chunk_raw_size = (int)(($max_chunk_raw_size - 20) / 1.34);

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -766,7 +766,7 @@ function endpoint_sql_chunk(
         "create_table_query" => $config["create_table_query"] ?? true,
     ];
 
-    // -- Cap statement size to the smaller of client and server max_allowed_packet --
+    // -- Cap statement size to packet limits --
     // If the client sent its max_allowed_packet, cap the producer's
     // max_statement_size so the dump stays importable on the client.
     // We query the server's own max_allowed_packet too and use the
@@ -871,7 +871,7 @@ function endpoint_sql_chunk(
 
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch
-    // as a multipart chunk. Stop when the producer is exhausted or the
+    // as a multipart part. Stop when the producer is exhausted or the
     // resource budget (time/memory) runs out.
     $batches_processed = 0;
     $sql_bytes_processed = 0;
@@ -880,6 +880,8 @@ function endpoint_sql_chunk(
     $deferred_fragment = null;
     /** @var string|null $deferred_fragment_cursor */
     $deferred_fragment_cursor = null;
+    /** @var bool $deferred_fragment_must_be_its_own_part */
+    $deferred_fragment_must_be_its_own_part = false;
 
     $stream_failure = null;
     try {
@@ -887,19 +889,62 @@ function endpoint_sql_chunk(
             $budget->has_remaining()
         ) {
             $sql_fragments = [];
+            $sql_part_body_bytes = 0;
             $cursor = null;
+            /** @var string|null Cursor after the last fragment included in this part. */
+            $last_fragment_cursor = null;
             $sql_ends_with_complete_statement = false;
 
             $i = 0;
+            $part_must_end = false;
             if ($deferred_fragment !== null) {
                 $sql_fragments[] = $deferred_fragment;
+                $sql_part_body_bytes = strlen($deferred_fragment);
                 $cursor = $deferred_fragment_cursor;
-                $sql_ends_with_complete_statement = true;
+                $last_fragment_cursor = $deferred_fragment_cursor;
+                $trimmed_fragment = rtrim($deferred_fragment);
+                $sql_ends_with_complete_statement =
+                    $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
+                $part_must_end = $deferred_fragment_must_be_its_own_part;
+                $i = 1;
                 $deferred_fragment = null;
                 $deferred_fragment_cursor = null;
-            } else {
+                $deferred_fragment_must_be_its_own_part = false;
+            }
+
+            if (
+                !$part_must_end &&
+                $i < $fragments_per_batch
+            ) {
                 while ($reader->next_sql_fragment()) {
                     $fragment = (string) $reader->get_sql_fragment();
+                    $fragment_bytes = strlen($fragment);
+
+                    if (
+                        $fragment_bytes > MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
+                    ) {
+                        throw new RuntimeException(
+                            "The SQL producer returned a {$fragment_bytes}-byte fragment; " .
+                            "the decoded SQL part body limit is " .
+                            MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES .
+                            " bytes."
+                        );
+                    }
+                    $fragment_cursor = $reader->get_reentrancy_cursor();
+
+                    if (
+                        !empty($sql_fragments) &&
+                        $sql_part_body_bytes + $fragment_bytes >
+                            MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
+                    ) {
+                        // The producer has already advanced. Retain this fragment
+                        // and its cursor while this part keeps its earlier cursor.
+                        $deferred_fragment = $fragment;
+                        $deferred_fragment_cursor = $fragment_cursor;
+                        $deferred_fragment_must_be_its_own_part =
+                            $reader->current_fragment_must_be_its_own_part();
+                        break;
+                    }
 
                     // The importer stores a cursor only after executing a complete part.
                     // Keep the SET header alone before row data. Do not put DROP/CREATE
@@ -913,18 +958,21 @@ function endpoint_sql_chunk(
                         $sql_ends_with_complete_statement
                     ) {
                         $deferred_fragment = $fragment;
-                        $deferred_fragment_cursor = $reader->get_reentrancy_cursor();
+                        $deferred_fragment_cursor = $fragment_cursor;
+                        $deferred_fragment_must_be_its_own_part = true;
                         break;
                     }
 
                     $sql_fragments[] = $fragment;
+                    $sql_part_body_bytes += $fragment_bytes;
+                    $last_fragment_cursor = $fragment_cursor;
                     $i++;
 
                     $trimmed_fragment = rtrim($fragment);
                     $sql_ends_with_complete_statement =
                         $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
                     if ($sql_ends_with_complete_statement) {
-                        $cursor = $reader->get_reentrancy_cursor();
+                        $cursor = $fragment_cursor;
                     }
 
                     if ($reader->current_fragment_must_be_its_own_part()) {
@@ -947,15 +995,13 @@ function endpoint_sql_chunk(
             if ($sql === '') {
                 break;
             }
-            $sql_bytes_processed += strlen($sql);
-
             // Does this chunk end on a complete statement boundary?
             // A complete SQL statement ends with ";"; a fragment from an open
             // INSERT does not.
             $trimmed = rtrim($sql);
             $query_complete = $trimmed !== "" && substr($trimmed, -1) === ";";
             if (!$query_complete || $cursor === null) {
-                $cursor = $reader->get_reentrancy_cursor();
+                $cursor = $last_fragment_cursor;
             }
 
             // E2E test hook: before SQL batch is emitted
@@ -964,10 +1010,23 @@ function endpoint_sql_chunk(
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
+            $sql_part_body_bytes = strlen($sql);
+            if (
+                $sql_part_body_bytes > MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
+            ) {
+                throw new RuntimeException(
+                    "The decoded SQL part body is {$sql_part_body_bytes} bytes; " .
+                    "the limit is " .
+                    MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES .
+                    " bytes."
+                );
+            }
+            $sql_bytes_processed += $sql_part_body_bytes;
+
             $gz->write(
                 "--{$boundary}\r\n" .
                 "Content-Type: application/sql\r\n" .
-                "Content-Length: " . strlen($sql) . "\r\n" .
+                "Content-Length: " . $sql_part_body_bytes . "\r\n" .
                 "X-Chunk-Type: sql\r\n" .
                 "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
                 "X-Cursor: " . base64_encode($cursor) . "\r\n" .

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/MySQLDumpProducerTestBase.php';
 
+use WordPress\Reprint\Server\MySQLDumpProducer;
+
 /**
  * Tests MySQL dump with rows larger than max_allowed_packet.
  *
@@ -133,6 +135,113 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $this->assertEquals($blob1, $row['blob1']);
         $this->assertEquals($blob2, $row['blob2']);
         $this->assertEquals('small value', $row['small_col']);
+    }
+
+    /** Combined values must fail before an over-limit fragment is formatted. */
+    public function testCombinedValuesAbovePartBodyLimitThrowBeforeFormatting(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE combined_fragment_limit (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                blob1 LONGBLOB,
+                blob2 LONGBLOB
+            )
+        ");
+
+        $blob1 = str_repeat('a', 13 * 512 * 1024);
+        $blob2 = str_repeat('b', 13 * 512 * 1024);
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO combined_fragment_limit (blob1, blob2) VALUES (?, ?)"
+        );
+        $stmt->execute([$blob1, $blob2]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cannot fit the SQL size limits');
+        $this->expectExceptionMessage('SQL part body limit is 16777216 bytes');
+
+        $this->getDumpSQL(['max_statement_size' => 64 * 1024 * 1024]);
+    }
+
+    /** A text value skipped by the byte cap must not bypass the packet target. */
+    public function testMixedTextAndBlobDoNotExceedStatementLimit(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE mixed_fragment_limits (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                text_value LONGTEXT,
+                blob_value LONGBLOB
+            )
+        ");
+
+        $value = str_repeat('a', 13 * 512 * 1024);
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO mixed_fragment_limits (text_value, blob_value) VALUES (?, ?)"
+        );
+        $stmt->execute([$value, $value]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cannot fit the SQL size limits');
+        $this->expectExceptionMessage('max_statement_size is 8388608 bytes');
+
+        $this->getDumpSQL(['max_statement_size' => 8 * 1024 * 1024]);
+    }
+
+    /** A multipart boundary may split one larger INSERT between row fragments. */
+    public function testUnkeyedInsertMayExceedPartBodyLimit(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE unkeyed_large_insert (
+                payload MEDIUMBLOB NOT NULL
+            )
+        ");
+        $payload = str_repeat('x', 80 * 1024);
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO unkeyed_large_insert (payload) VALUES (?)"
+        );
+        for ($row = 0; $row < 160; ++$row) {
+            $stmt->execute([$payload]);
+        }
+
+        $producer = $this->createProducer([
+            'max_statement_size' => 64 * 1024 * 1024,
+        ]);
+        $fragments = $this->collectAllFragments($producer);
+        $sql = implode('', $fragments);
+
+        $this->assertGreaterThan(
+            MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
+            strlen($sql)
+        );
+        foreach ($fragments as $fragment) {
+            $this->assertLessThan(
+                MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
+                strlen($fragment)
+            );
+        }
+
+        $importPdo = $this->executeDumpInNewDatabase($sql);
+        $rowCount = $importPdo->query(
+            "SELECT COUNT(*) FROM unkeyed_large_insert"
+        )->fetchColumn();
+        $this->assertSame(160, (int) $rowCount);
+    }
+
+    /** JSON size calculation includes the CONVERT(... USING utf8mb4) wrapper. */
+    public function testJsonFormattedSizeIsExact(): void
+    {
+        $producer = $this->createProducer();
+        $estimate_formatted_size = new ReflectionMethod(
+            $producer,
+            'estimate_formatted_size'
+        );
+        $estimate_formatted_size->setAccessible(true);
+        $value = '{"key":"value"}';
+        $formatted = "CONVERT(FROM_BASE64('" . base64_encode($value) . "') USING utf8mb4)";
+
+        $this->assertSame(
+            strlen($formatted),
+            $estimate_formatted_size->invoke($producer, $value, 'JSON')
+        );
     }
 
     /**

--- a/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
+++ b/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
@@ -1,11 +1,14 @@
 /**
- * Direct MySQL output keeps the exporter's existing response budgets while
- * ending a SQL group before the next table replacement starts.
+ * Direct MySQL output keeps fragment and byte budgets while ending a SQL
+ * group before the next table replacement starts.
  */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
-    apiRequest, getSiteDir, createMysqlConnection, getDbName,
+    apiRequest, cleanupTempDir, createMysqlConnection, createTempDir,
+    clearHookState, getDbName, getSiteDir, getSiteSecret, getSiteUrl,
+    readAuditLog, readHookState, runImporter,
+    removeTestHooks, writeTestHooks,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -13,7 +16,14 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
     const site = 'budgeted-mysql-sql-groups';
     const firstTable = 'aa_budgeted_rows';
     const secondTable = 'bb_budgeted_rows';
+    const boundedPayloadTable = 'cc_bounded_payload_rows';
+    const splitPayloadTable = 'dd_split_payload_rows';
+    const unsplittablePayloadTable = 'ee_unsplittable_payload_rows';
+    const maximumSqlPartBodyBytes = 16 * 1024 * 1024;
+    const hookState = `/srv/e2e-sites/.e2e-hook-state-${site}`;
     let skippedTables;
+    let boundedPayloadSkippedTables;
+    let splitAndUnsplittableSkippedTables;
 
     beforeAll(async () => {
         await ensureSite(site, {
@@ -39,6 +49,40 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
                 );
                 await connection.query(`INSERT INTO \`${secondTable}\` VALUES (1)`);
 
+                await connection.query(
+                    `CREATE TABLE \`${boundedPayloadTable}\` (`
+                    + '`id` INT NOT NULL PRIMARY KEY, `payload` MEDIUMBLOB NOT NULL) ENGINE=InnoDB'
+                );
+                // The reader closes its first INSERT after 250 rows. The next
+                // INSERT makes the grouped SQL body cross 16 MiB, so the body
+                // limit must end a part while that second INSERT is still open.
+                for (let id = 1; id <= 400; id++) {
+                    await connection.query(
+                        `INSERT INTO \`${boundedPayloadTable}\` (id, payload) `
+                        + 'VALUES (?, REPEAT(CHAR(65 + MOD(?, 26)), 32 * 1024))',
+                        [id, id],
+                    );
+                }
+
+                await connection.query(
+                    `CREATE TABLE \`${splitPayloadTable}\` (`
+                    + '`id` INT NOT NULL PRIMARY KEY, '
+                    + '`payload` MEDIUMBLOB NOT NULL) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${splitPayloadTable}\` `
+                    + '(id, payload) VALUES ('
+                    + '1, REPEAT(CHAR(65), 13 * 1024 * 1024))'
+                );
+
+                await connection.query(
+                    `CREATE TABLE \`${unsplittablePayloadTable}\` (`
+                    + '`payload` MEDIUMBLOB NOT NULL) ENGINE=InnoDB'
+                );
+                await connection.query(
+                    `INSERT INTO \`${unsplittablePayloadTable}\` (payload) `
+                    + 'VALUES (REPEAT(CHAR(67), 13 * 1024 * 1024))'
+                );
             },
         });
 
@@ -52,10 +96,18 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             skippedTables = tables
                 .map(row => row.TABLE_NAME)
                 .filter(table => ![firstTable, secondTable].includes(table));
+            boundedPayloadSkippedTables = tables
+                .map(row => row.TABLE_NAME)
+                .filter(table => table !== boundedPayloadTable);
+            splitAndUnsplittableSkippedTables = tables
+                .map(row => row.TABLE_NAME)
+                .filter(
+                    table => ![splitPayloadTable, unsplittablePayloadTable].includes(table)
+                );
         } finally {
             await connection.end();
         }
-    });
+    }, 300000);
 
     async function sqlParts(fragmentsPerBatch) {
         const response = await apiRequest(site, 'sql_chunk', {}, {
@@ -72,6 +124,42 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             response.json?.error ?? response.text ?? 'The SQL endpoint rejected the request',
         );
         return response.chunks.filter(chunk => chunk.headers['x-chunk-type'] === 'sql');
+    }
+
+    function sqlPartBodyLengths(response) {
+        const contentType = response.headers['content-type'];
+        const boundary = contentType.match(/boundary="?([^";\s]+)"?/i)?.[1];
+        assert.ok(boundary, `Expected a multipart boundary in ${contentType}`);
+
+        const rawBody = response.raw.toString('binary');
+        const lengths = [];
+        for (const section of rawBody.split(`--${boundary}`).slice(1)) {
+            const headerEnd = section.indexOf('\r\n\r\n');
+            if (headerEnd === -1) {
+                continue;
+            }
+            const headers = section.substring(0, headerEnd).toLowerCase();
+            if (!headers.includes('\r\nx-chunk-type: sql\r\n')) {
+                continue;
+            }
+            const declared = Number(headers.match(/\r\ncontent-length: (\d+)\r\n/)?.[1]);
+            const bodyStart = headerEnd + 4;
+            const actual = section.length - bodyStart - 2;
+            lengths.push({ actual, declared });
+        }
+        return lengths;
+    }
+
+    function assertBoundedSqlPartBodies(response) {
+        const lengths = sqlPartBodyLengths(response);
+        assert.ok(lengths.length > 0, 'Expected SQL multipart parts');
+        for (const { actual, declared } of lengths) {
+            assert.equal(actual, declared, 'SQL part body must match its Content-Length');
+            assert.ok(
+                actual <= maximumSqlPartBodyBytes,
+                `SQL part body was ${actual} bytes`,
+            );
+        }
     }
 
     it('allows the existing fragment budget to group complete INSERT statements', async () => {
@@ -98,4 +186,203 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             'A one-fragment budget should split the large INSERT stream across parts',
         );
     });
+
+    it('bounds grouped SQL payloads and resumes before the deferred fragment', async () => {
+        const requestBody = {
+            directory: getSiteDir(site),
+            fragments_per_batch: 1000,
+            max_execution_time: 60,
+            skip_tables: boundedPayloadSkippedTables,
+        };
+        const response = await apiRequest(site, 'sql_chunk', {}, {
+            method: 'POST',
+            body: JSON.stringify(requestBody),
+        });
+        assert.equal(
+            response.status,
+            200,
+            response.json?.error ?? response.text ?? 'The SQL endpoint rejected the request',
+        );
+
+        assertBoundedSqlPartBodies(response);
+        const parts = response.chunks.filter(
+            chunk => chunk.headers['x-chunk-type'] === 'sql'
+        );
+        const completion = response.chunks.find(
+            chunk => chunk.headers['x-chunk-type'] === 'completion'
+        );
+        assert.equal(completion?.headers['x-status'], 'complete');
+
+        const firstInsertPartIndex = parts.findIndex(
+            part => part.body.includes(`INSERT INTO \`${boundedPayloadTable}\``)
+        );
+        assert.notEqual(firstInsertPartIndex, -1, 'Expected the bounded table INSERT');
+        const firstInsertPart = parts[firstInsertPartIndex];
+        assert.equal(
+            firstInsertPart.headers['x-query-complete'],
+            '0',
+            'The byte boundary should split the INSERT before its final row',
+        );
+        const expectedResumedSql = parts
+            .slice(firstInsertPartIndex + 1)
+            .map(part => part.body)
+            .join('');
+        assert.ok(
+            expectedResumedSql.includes('ON DUPLICATE KEY UPDATE'),
+            'Expected the rest of the INSERT in following SQL parts',
+        );
+
+        const encodedCursor = firstInsertPart.headers['x-cursor'];
+        assert.ok(encodedCursor, 'Expected a cursor on the bounded SQL part');
+        const cursor = Buffer.from(encodedCursor, 'base64').toString('utf8');
+        const resumedResponse = await apiRequest(site, 'sql_chunk', {}, {
+            method: 'POST',
+            body: JSON.stringify({ ...requestBody, cursor }),
+        });
+        assert.equal(
+            resumedResponse.status,
+            200,
+            resumedResponse.json?.error ?? resumedResponse.text ?? 'The resumed SQL request failed',
+        );
+        assertBoundedSqlPartBodies(resumedResponse);
+        const resumedCompletion = resumedResponse.chunks.find(
+            chunk => chunk.headers['x-chunk-type'] === 'completion'
+        );
+        assert.equal(resumedCompletion?.headers['x-status'], 'complete');
+
+        const resumedSql = resumedResponse.chunks
+            .filter(chunk => chunk.headers['x-chunk-type'] === 'sql')
+            .map(part => part.body)
+            .join('');
+        assert.equal(
+            resumedSql,
+            expectedResumedSql,
+            'Resume must begin with the fragment deferred by the byte boundary',
+        );
+    }, 300000);
+
+    it('splits a keyed value and stops when a row cannot fit the SQL part limit', async () => {
+        const response = await apiRequest(site, 'sql_chunk', {}, {
+            method: 'POST',
+            body: JSON.stringify({
+                directory: getSiteDir(site),
+                fragments_per_batch: 1000,
+                max_execution_time: 60,
+                skip_tables: splitAndUnsplittableSkippedTables,
+            }),
+        });
+        assert.equal(response.status, 200);
+
+        assertBoundedSqlPartBodies(response);
+        const sqlParts = response.chunks.filter(
+            chunk => chunk.headers['x-chunk-type'] === 'sql'
+        );
+        assert.ok(
+            sqlParts.some(part => part.body.includes(' = CONCAT(')),
+            'A large keyed value should use bounded UPDATE statements',
+        );
+        const errorPart = response.chunks.find(
+            chunk => chunk.headers['x-chunk-type'] === 'error'
+        );
+        assert.ok(errorPart, 'Expected an error multipart part');
+        const error = JSON.parse(errorPart.body);
+        const observedSize = error.message.match(/SQL fragment size of (\d+) bytes/);
+        assert.ok(
+            observedSize,
+            'The error should name the estimated SQL row size',
+        );
+        assert.ok(Number(observedSize[1]) > maximumSqlPartBodyBytes);
+        assert.match(error.message, /no primary key/);
+        const statementLimit = error.message.match(
+            /max_statement_size \((\d+) bytes\)/,
+        );
+        assert.ok(statementLimit, 'The error should report the SQL statement limit');
+        const partBodyLimit = error.message.match(
+            /SQL part body limit \((\d+) bytes\)/,
+        );
+        assert.ok(partBodyLimit, 'The error should report the SQL part body limit');
+        assert.equal(Number(partBodyLimit[1]), maximumSqlPartBodyBytes);
+
+        const completion = response.chunks.find(
+            chunk => chunk.headers['x-chunk-type'] === 'completion'
+        );
+        assert.equal(completion?.headers['x-status'], 'partial');
+
+        const outputDirectory = createTempDir('e2e-bounded-sql-error');
+        try {
+            const result = runImporter(
+                `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
+                outputDirectory,
+                'db-pull',
+                {
+                    secret: getSiteSecret(site),
+                    autoResume: false,
+                    timeout: 300000,
+                },
+            );
+            const output = `${result.stdout}\n${result.stderr}`;
+            assert.equal(result.exitCode, 1, output);
+            assert.match(
+                output,
+                /The source could not export the database: .*no primary key/,
+            );
+            const audit = readAuditLog(outputDirectory);
+            assert.equal(
+                audit.match(/REMOTE ERROR \| phase=sql/g)?.length,
+                1,
+                'The importer must stop after the first SQL export error',
+            );
+        } finally {
+            cleanupTempDir(outputDirectory);
+        }
+    }, 300000);
+
+    it('keeps the source error when the response ends before completion', () => {
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_completion($status, $gz, $boundary) {',
+            "    if ($status !== 'partial') { return; }",
+            `    file_put_contents('${hookState}', '{"completion_interrupted":true}');`,
+            '    exit(1);',
+            '}',
+        ].join('\n'));
+
+        const outputDirectory = createTempDir('e2e-bounded-sql-truncated-error');
+        try {
+            const result = runImporter(
+                `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
+                outputDirectory,
+                'db-pull',
+                {
+                    secret: getSiteSecret(site),
+                    autoResume: false,
+                    timeout: 300000,
+                    extraArgs: ['--max-exec=60'],
+                },
+            );
+            const output = `${result.stdout}\n${result.stderr}`;
+            assert.equal(result.exitCode, 1, output);
+            assert.match(
+                output,
+                /The source could not export the database: .*no primary key/,
+            );
+            assert.deepEqual(
+                readHookState(site),
+                { completion_interrupted: true },
+                'The response must end before its completion part',
+            );
+
+            const audit = readAuditLog(outputDirectory);
+            assert.equal(
+                audit.match(/REMOTE ERROR \| phase=sql/g)?.length,
+                1,
+                'The importer must keep the source error from the truncated response',
+            );
+            assert.doesNotMatch(audit, /SQL RETRY/);
+        } finally {
+            removeTestHooks(site);
+            clearHookState(site);
+            cleanupTempDir(outputDirectory);
+        }
+    }, 300000);
 });

--- a/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
+++ b/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
@@ -234,10 +234,9 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
 
         const encodedCursor = firstInsertPart.headers['x-cursor'];
         assert.ok(encodedCursor, 'Expected a cursor on the bounded SQL part');
-        const cursor = Buffer.from(encodedCursor, 'base64').toString('utf8');
         const resumedResponse = await apiRequest(site, 'sql_chunk', {}, {
             method: 'POST',
-            body: JSON.stringify({ ...requestBody, cursor }),
+            body: JSON.stringify({ ...requestBody, cursor: encodedCursor }),
         });
         assert.equal(
             resumedResponse.status,
@@ -343,6 +342,7 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             'function test_hook_before_completion($status, $gz, $boundary) {',
             "    if ($status !== 'partial') { return; }",
             `    file_put_contents('${hookState}', '{"completion_interrupted":true}');`,
+            '    $gz->finish();',
             '    exit(1);',
             '}',
         ].join('\n'));


### PR DESCRIPTION
Each SQL multipart part now carries at most 16 MiB of decoded SQL, so an interrupted response can resume from a nearby cursor instead of replaying one very large body.

## Background

The SQL endpoint grouped output by fragment count only. In the reported pull, one retry received 147,526,862 decoded bytes but ended before the current part finished. The importer accepts that part's cursor only after every declared body byte arrives, so none of those bytes established a new cursor.

## This change

The endpoint stops before the next complete producer fragment would take a SQL part above 16 MiB. It retains that fragment for the next part while the current part keeps the cursor after its last included fragment.

The producer and exporter apply that one limit at different boundaries. The producer understands rows and columns, so it can split a large keyed binary value or reject an unsafe row before formatting it. The exporter knows the final grouping, so it counts the actual bytes from all included fragments and checks the complete part immediately before writing it. Both checks are needed: several safe fragments can make an oversized part, while the exporter cannot cut one SQL fragment at an arbitrary byte.

Large keyed binary values continue through bounded `UPDATE ... CONCAT()` statements. A row which cannot fit the limit safely produces a clear export error before an over-limit row fragment is formatted. The importer treats a SQL error part as terminal even when the response ends before its completion part.

## Testing

The producer tests cover combined large values, mixed text and binary values, larger multi-row INSERTs, and exact formatted-size accounting. The real-endpoint test measures decoded multipart body lengths, resumes from a byte boundary inside an INSERT, checks bounded large-value updates, and covers clean and interrupted SQL error responses.
