### PR TITLE
[PHP] Bump client and server wire protocol to 3

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -134,7 +134,7 @@ require_once __DIR__ . '/lib/pull/class-pull-index-journal.php';
  * multipart structure, header names, endpoint parameters, response format)
  * would break an older export plugin.
  */
-define('PULL_PROTOCOL_VERSION', 2);
+define('PULL_PROTOCOL_VERSION', 3);
 
 register_shutdown_function(function () {
     $error = error_get_last();

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -42,7 +42,7 @@ if (!ob_get_level()) {
  * protocol (cursor encoding, multipart structure, header names, endpoint
  * parameters, response format) would break an older importer.
  */
-define('EXPORT_PROTOCOL_VERSION', 2);
+define('EXPORT_PROTOCOL_VERSION', 3);
 
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);


### PR DESCRIPTION
Marks the current path and SQL transfer formats as wire protocol 3.

`preflight-assert` now requires both the Reprint client and export plugin to report protocol 3.

## Testing

- `php -l packages/reprint-client/src/import.php`
- `php -l packages/reprint-server/src/export.php`
- `git diff --check`
