### PR TITLE
[PHP] Retry potentially transient pull HTTP errors with a three-failure no-progress limit

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -11810,17 +11810,14 @@ class ImportClient
     private function is_transient_http_response(int $http_code, string $body): bool
     {
         $decoded_body = json_decode($body, true);
-        $server_error = is_array($decoded_body)
-            && is_string($decoded_body['error'] ?? null)
-                ? $decoded_body['error']
-                : null;
+        $is_reprint_error = is_array($decoded_body)
+            && isset($decoded_body['code'])
+            && $decoded_body['code'] === $http_code;
 
-        // A structured 503 is Reprint's permanent setup error.
-        if (
-            $http_code === 503
-            && $server_error !== null
-            && str_contains($server_error, 'Export not configured')
-        ) {
+        // Reprint includes the HTTP code in its deliberate JSON failures.
+        // HTML, empty, and unmarked JSON bodies can come from an upstream
+        // server or firewall instead.
+        if ($is_reprint_error) {
             return false;
         }
 
@@ -11828,18 +11825,10 @@ class ImportClient
             return true;
         }
 
-        $is_known_reprint_authentication_error = $server_error !== null && (
-            str_contains($server_error, 'HMAC signature verification failed')
-            || str_contains($server_error, 'timestamp expired')
-            || str_contains($server_error, 'Content hash mismatch')
-            || str_contains($server_error, 'Missing X-Auth-')
-        );
-
-        // An unrecognized 401 or 403 after a signed request can be a temporary
+        // An unmarked 401 or 403 after a signed request can be a temporary
         // firewall response produced before the request reaches Reprint.
         return ($http_code === 401 || $http_code === 403)
-            && $this->hmac_client !== null
-            && !$is_known_reprint_authentication_error;
+            && $this->hmac_client !== null;
     }
 
     /**

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -217,8 +217,8 @@ class ImportClient
         95, // CURLE_HTTP3        — HTTP/3 layer error
     ];
 
-    /** HTTP statuses for failures which can clear before the next request. */
-    private const TRANSIENT_HTTP_STATUS_CODES = [
+    /** HTTP statuses which may indicate a transient HTTP error. */
+    private const POTENTIALLY_TRANSIENT_HTTP_STATUS_CODES = [
         408, // Request Timeout
         418, // Observed when an upstream bot filter replaced a Reprint response
         425, // Too Early
@@ -11781,7 +11781,7 @@ class ImportClient
                 }
             }
 
-            if ($this->is_transient_http_response($http_code, $error_body)) {
+            if ($this->is_potentially_transient_http_error($http_code, $error_body)) {
                 // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This exception is rendered only as CLI text.
                 throw new TransientInterruptionException($error_msg);
             }
@@ -11804,10 +11804,8 @@ class ImportClient
         }
     }
 
-    /**
-     * Decide whether a streaming HTTP failure can clear before the next request.
-     */
-    private function is_transient_http_response(int $http_code, string $body): bool
+    /** Decide whether a streaming HTTP error is potentially transient. */
+    private function is_potentially_transient_http_error(int $http_code, string $body): bool
     {
         $decoded_body = json_decode($body, true);
         $is_reprint_error = is_array($decoded_body)
@@ -11821,7 +11819,13 @@ class ImportClient
             return false;
         }
 
-        if (in_array($http_code, self::TRANSIENT_HTTP_STATUS_CODES, true)) {
+        if (
+            in_array(
+                $http_code,
+                self::POTENTIALLY_TRANSIENT_HTTP_STATUS_CODES,
+                true,
+            )
+        ) {
             return true;
         }
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -194,7 +194,7 @@ class ImportClient
     private const SQL_GROUP_MARKER = "-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 ";
 
     /**
-     * Maximum number of consecutive interrupted responses with no cursor
+     * Maximum number of consecutive temporary request failures with no cursor
      * progress before the importer gives up. This prevents endless resumption
      * when the source cannot complete a response.
      */
@@ -215,6 +215,18 @@ class ImportClient
         92, // CURLE_HTTP2_STREAM — HTTP/2 stream reset by the server (RST_STREAM)
         // HTTP/3 framing layer. Inert until something opts into h3
         95, // CURLE_HTTP3        — HTTP/3 layer error
+    ];
+
+    /** HTTP statuses for failures which can clear before the next request. */
+    private const TRANSIENT_HTTP_STATUS_CODES = [
+        408, // Request Timeout
+        418, // Observed when an upstream bot filter replaced a Reprint response
+        425, // Too Early
+        429, // Too Many Requests
+        500, // Internal Server Error
+        502, // Bad Gateway
+        503, // Service Unavailable
+        504, // Gateway Timeout
     ];
 
     /** @var string Remote Reprint API URL. */
@@ -10889,12 +10901,13 @@ class ImportClient
     }
 
     /**
-     * Reset curl-related state at the start of each HTTP request.
+     * Reset request error state at the start of each HTTP request.
      */
-    private function reset_curl_state(): void
+    private function reset_request_error_state(): void
     {
         $this->last_curl_errno = null;
         $this->last_curl_timeout = false;
+        $this->last_error_code = null;
     }
 
     /**
@@ -11096,7 +11109,7 @@ class ImportClient
     }
 
     /**
-     * Track consecutive interrupted responses and decide whether to resume.
+     * Track consecutive temporary request failures and decide whether to resume.
      *
      * Compares the cursor before and after the request. A cursor advance means
      * the request produced another durable part, so the counter resets. If the
@@ -11106,7 +11119,7 @@ class ImportClient
      * @param string                           $phase         Human-readable phase name.
      * @param ?string                          $cursor_before Cursor at request start.
      * @param ?string                          $cursor_after  Last durable cursor.
-     * @param TransientInterruptionException   $exception     Response failure.
+     * @param TransientInterruptionException   $exception     Temporary request failure.
      */
     protected function assert_can_resume_after_interrupted_response(
         string $phase,
@@ -11123,7 +11136,7 @@ class ImportClient
         $count = $this->get_state()->consecutive_interrupted_responses;
 
         $this->audit_log(
-            "INTERRUPTED RESPONSE | {$phase} | " .
+            "TEMPORARY REQUEST FAILURE | {$phase} | " .
                 "consecutive_interrupted_responses={$count}/" .
                 self::MAX_CONSECUTIVE_INTERRUPTED_RESPONSES .
                 " | cursor_moved=" .
@@ -11133,11 +11146,13 @@ class ImportClient
         );
 
         if ($count >= self::MAX_CONSECUTIVE_INTERRUPTED_RESPONSES) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The remote failure is rendered only as CLI text.
             throw new RuntimeException(
-                "The remote response ended before completion {$count} " .
-                "consecutive times without cursor progress during {$phase}. " .
-                "Giving up.",
+                "The remote request failed {$count} consecutive times " .
+                "without cursor progress during {$phase}. Last failure: " .
+                $exception->getMessage(),
             );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
     }
 
@@ -11330,7 +11345,7 @@ class ImportClient
      */
     private function fetch_json(string $url): array
     {
-        $this->reset_curl_state();
+        $this->reset_request_error_state();
 
         $this->audit_log("HTTP_REQUEST | GET | {$url}", false);
 
@@ -11440,7 +11455,7 @@ class ImportClient
         ?array $post_data = null,
         ?string $endpoint = null
     ): void {
-        $this->reset_curl_state();
+        $this->reset_request_error_state();
 
         // Log HTTP request details
         $log_parts = ["HTTP_REQUEST", $post_data ? "POST" : "GET", $url];
@@ -11766,6 +11781,11 @@ class ImportClient
                 }
             }
 
+            if ($this->is_transient_http_response($http_code, $error_body)) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This exception is rendered only as CLI text.
+                throw new TransientInterruptionException($error_msg);
+            }
+
             throw new RuntimeException($error_msg);
         }
 
@@ -11782,6 +11802,44 @@ class ImportClient
                 "Invalid response: missing completion chunk from server.",
             );
         }
+    }
+
+    /**
+     * Decide whether a streaming HTTP failure can clear before the next request.
+     */
+    private function is_transient_http_response(int $http_code, string $body): bool
+    {
+        $decoded_body = json_decode($body, true);
+        $server_error = is_array($decoded_body)
+            && is_string($decoded_body['error'] ?? null)
+                ? $decoded_body['error']
+                : null;
+
+        // A structured 503 is Reprint's permanent setup error.
+        if (
+            $http_code === 503
+            && $server_error !== null
+            && str_contains($server_error, 'Export not configured')
+        ) {
+            return false;
+        }
+
+        if (in_array($http_code, self::TRANSIENT_HTTP_STATUS_CODES, true)) {
+            return true;
+        }
+
+        $is_known_reprint_authentication_error = $server_error !== null && (
+            str_contains($server_error, 'HMAC signature verification failed')
+            || str_contains($server_error, 'timestamp expired')
+            || str_contains($server_error, 'Content hash mismatch')
+            || str_contains($server_error, 'Missing X-Auth-')
+        );
+
+        // An unrecognized 401 or 403 after a signed request can be a temporary
+        // firewall response produced before the request reaches Reprint.
+        return ($http_code === 401 || $http_code === 403)
+            && $this->hmac_client !== null
+            && !$is_known_reprint_authentication_error;
     }
 
     /**

--- a/packages/reprint-client/src/lib/import/class-transient-interruption-exception.php
+++ b/packages/reprint-client/src/lib/import/class-transient-interruption-exception.php
@@ -3,7 +3,7 @@
 namespace Reprint\Importer;
 
 /**
- * Thrown when an interrupted response can be requested again from its last
- * durable cursor.
+ * Thrown when a temporary transfer or HTTP response failure can be requested
+ * again from its last durable cursor.
  */
 class TransientInterruptionException extends InterruptedResponseException {}

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -844,10 +844,10 @@ class Pull
     }
 
     /**
-     * Lower-level commands return with completion_state="partial" when a
-     * server timeout drops the connection. This loop retries automatically,
-     * resetting the completion state to "in_progress" so the handler enters
-     * its resume path on the next call.
+     * Lower-level commands return with completion_state="partial" after a
+     * temporary streaming failure. This loop retries automatically, resetting
+     * the completion state to "in_progress" so the handler enters its resume
+     * path on the next call.
      */
     private function run_until_complete(string $stage, callable $handler): void
     {

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -180,6 +180,109 @@ class CurlTimeoutRecoveryTest extends TestCase
         );
     }
 
+    public function testSqlDownloadRetriesHttp418ThenCompletes()
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('HTTP retry coverage requires PHP curl and pcntl.');
+        }
+
+        $cursor = base64_encode('{"table":"wp_posts","pk":42}');
+        $http418 = $this->httpResponse(
+            "418 I'm a teapot",
+            'text/html',
+            '<!doctype html><title>Temporary bot response</title>',
+        );
+        $boundary = 'http-retry-test';
+        $completion_body = "--{$boundary}\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: 0\r\n"
+            . "X-Chunk-Type: completion\r\n"
+            . "X-Status: complete\r\n"
+            . "\r\n"
+            . "\r\n"
+            . "--{$boundary}--\r\n";
+        $server = $this->startSqlResponseServer([
+            $http418,
+            $this->httpResponse(
+                '200 OK',
+                "multipart/mixed; boundary={$boundary}",
+                $completion_body,
+            ),
+        ], $cursor);
+        $wire_client = $this->prepareWireSqlClient(
+            $server['url'],
+            $cursor,
+        );
+        $client = $wire_client['client'];
+        $reflection = $wire_client['reflection'];
+
+        try {
+            $reflection->getMethod('fetch_sql')->invoke($client);
+        } finally {
+            pcntl_waitpid($server['child_pid'], $status);
+        }
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame(
+            0,
+            $client->get_state()->consecutive_interrupted_responses,
+        );
+        $this->assertNull(
+            $client->last_error_code,
+            'A successful repeated request must clear the earlier HTTP error code.',
+        );
+    }
+
+    public function testSqlDownloadPreservesHttp418AfterRetryLimit()
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('HTTP retry coverage requires PHP curl and pcntl.');
+        }
+
+        $cursor = base64_encode('{"table":"wp_posts","pk":42}');
+        $http418 = $this->httpResponse(
+            "418 I'm a teapot",
+            'text/html',
+            '<!doctype html><title>Temporary bot response</title>',
+        );
+        $server = $this->startSqlResponseServer([
+            $http418,
+            $http418,
+            $http418,
+        ], $cursor);
+        $wire_client = $this->prepareWireSqlClient(
+            $server['url'],
+            $cursor,
+        );
+        $client = $wire_client['client'];
+        $reflection = $wire_client['reflection'];
+
+        $failure = null;
+        try {
+            $reflection->getMethod('fetch_sql')->invoke($client);
+            $this->fail('The third HTTP 418 response should stop the pull.');
+        } catch (\RuntimeException $error) {
+            $failure = $error;
+        } finally {
+            pcntl_waitpid($server['child_pid'], $status);
+        }
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertNotNull($failure);
+        $this->assertStringContainsString(
+            '3 consecutive times without cursor progress',
+            $failure->getMessage(),
+        );
+        $this->assertStringContainsString('HTTP 418', $failure->getMessage());
+        $this->assertSame('HTML_RESPONSE', $client->last_error_code);
+        $this->assertSame(
+            3,
+            $client->get_state()->consecutive_interrupted_responses,
+        );
+    }
+
     // ---------------------------------------------------------------
     // fetch_file_batch: timeout saves state and returns false
     // ---------------------------------------------------------------
@@ -684,6 +787,127 @@ PHP);
             $state["consecutive_interrupted_responses"],
             "Successful request should reset consecutive_interrupted_responses to 0"
         );
+    }
+
+    private function httpResponse(
+        string $status_line,
+        string $content_type,
+        string $body
+    ): string {
+        return "HTTP/1.1 {$status_line}\r\n"
+            . "Content-Type: {$content_type}\r\n"
+            . 'Content-Length: ' . strlen($body) . "\r\n"
+            . "Connection: close\r\n\r\n"
+            . $body;
+    }
+
+    /**
+     * Start a child server which returns one supplied response per SQL request.
+     *
+     * @param string[] $responses Complete HTTP responses in request order.
+     * @param string   $cursor    Expected SQL cursor on every request.
+     * @return array {
+     *     @type int    $child_pid Child process ID.
+     *     @type string $url       Remote Reprint API URL.
+     * }
+     */
+    private function startSqlResponseServer(array $responses, string $cursor): array
+    {
+        $listener = stream_socket_server(
+            'tcp://127.0.0.1:0',
+            $error_number,
+            $error_message,
+        );
+        $this->assertNotFalse($listener, $error_message);
+        $address = stream_socket_get_name($listener, false);
+        $this->assertIsString($address);
+
+        $child_pid = pcntl_fork();
+        $this->assertNotSame(-1, $child_pid);
+        if ($child_pid === 0) {
+            foreach ($responses as $response) {
+                $connection = stream_socket_accept($listener, 5);
+                if ($connection === false) {
+                    exit(2);
+                }
+                stream_set_timeout($connection, 5);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false) {
+                    $piece = fread($connection, 8192);
+                    if ($piece === false || $piece === '') {
+                        fclose($connection);
+                        fclose($listener);
+                        exit(3);
+                    }
+                    $request .= $piece;
+                }
+                if (strpos($request, 'endpoint=sql_chunk') === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(4);
+                }
+                if (stripos($request, "X-Export-Cursor: {$cursor}\r\n") === false) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(5);
+                }
+                if (fwrite($connection, $response) !== strlen($response)) {
+                    fclose($connection);
+                    fclose($listener);
+                    exit(6);
+                }
+                fclose($connection);
+            }
+            fclose($listener);
+            exit(0);
+        }
+
+        fclose($listener);
+
+        return [
+            'child_pid' => $child_pid,
+            'url' => 'http://' . $address . '/?reprint-api=1',
+        ];
+    }
+
+    /**
+     * Prepare a real ImportClient for an SQL wire retry test.
+     *
+     * @return array {
+     *     @type \ImportClient     $client     Client with resumable SQL state.
+     *     @type \ReflectionClass $reflection Reflection for invoking fetch_sql().
+     * }
+     */
+    private function prepareWireSqlClient(
+        string $url,
+        string $cursor
+    ): array {
+        $client = new \ImportClient(
+            $url,
+            $this->stateDir,
+            $this->filesystem_root,
+        );
+        \write_current_pull_state($client, [
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "follow_symlinks" => false,
+            "fs_root_nonempty_behavior" => "preserve-local",
+            "active_resumable_command" => [
+                "command_name" => "db-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "sql",
+                "remote_cursor" => $cursor,
+            ],
+            "sql_bytes" => 0,
+        ]);
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('is_tty')->setValue($client, false);
+        $reflection->getProperty('sql_output_mode')->setValue($client, 'file');
+
+        return [
+            'client' => $client,
+            'reflection' => $reflection,
+        ];
     }
 
 }

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -32,7 +32,7 @@ class DiagnoseHttpErrorTest extends TestCase
         return $method->invoke($client, $http_code, $body, $redirect_url);
     }
 
-    private function isTransientHttpResponse(
+    private function isPotentiallyTransientHttpError(
         int $http_code,
         string $body,
         bool $has_secret = true
@@ -50,7 +50,7 @@ class DiagnoseHttpErrorTest extends TestCase
             );
         }
 
-        return $reflection->getMethod('is_transient_http_response')->invoke(
+        return $reflection->getMethod('is_potentially_transient_http_error')->invoke(
             $client,
             $http_code,
             $body,
@@ -211,37 +211,37 @@ class DiagnoseHttpErrorTest extends TestCase
         $this->assertSame('SERVER_ERROR', $result['code']);
     }
 
-    public function testTransientHttpResponseClassification()
+    public function testPotentiallyTransientHttpErrorClassification()
     {
-        $this->assertTrue($this->isTransientHttpResponse(
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
             418,
             '<!doctype html><title>Temporary bot response</title>',
         ));
-        $this->assertTrue($this->isTransientHttpResponse(
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
             403,
             '<!doctype html><title>Temporary firewall response</title>',
         ));
-        $this->assertTrue($this->isTransientHttpResponse(
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
             403,
             '{"error":"Bot protection is temporarily unavailable"}',
         ));
-        $this->assertTrue($this->isTransientHttpResponse(
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
             503,
             '{"error":"Upstream service is temporarily unavailable"}',
         ));
-        $this->assertFalse($this->isTransientHttpResponse(
+        $this->assertFalse($this->isPotentiallyTransientHttpError(
             403,
             '{"error":"Invalid timestamp format","code":403}',
         ));
-        $this->assertFalse($this->isTransientHttpResponse(
+        $this->assertFalse($this->isPotentiallyTransientHttpError(
             503,
             '{"error":"Invalid secret.php configuration","code":503}',
         ));
-        $this->assertFalse($this->isTransientHttpResponse(
+        $this->assertFalse($this->isPotentiallyTransientHttpError(
             500,
             '{"error":"Reprint Server runtime is incomplete","code":500}',
         ));
-        $this->assertFalse($this->isTransientHttpResponse(
+        $this->assertFalse($this->isPotentiallyTransientHttpError(
             415,
             '<!doctype html><title>Unsupported Media Type</title>',
         ));

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -32,6 +32,31 @@ class DiagnoseHttpErrorTest extends TestCase
         return $method->invoke($client, $http_code, $body, $redirect_url);
     }
 
+    private function isTransientHttpResponse(
+        int $http_code,
+        string $body,
+        bool $has_secret = true
+    ): bool {
+        $client = new \ImportClient(
+            'http://example.com',
+            sys_get_temp_dir(),
+            sys_get_temp_dir(),
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        if ($has_secret) {
+            $reflection->getProperty('hmac_client')->setValue(
+                $client,
+                new \stdClass(),
+            );
+        }
+
+        return $reflection->getMethod('is_transient_http_response')->invoke(
+            $client,
+            $http_code,
+            $body,
+        );
+    }
+
     // ── Redirects ────────────────────────────────────────────────
 
     public function testRedirectWithTargetUrl()
@@ -184,6 +209,38 @@ class DiagnoseHttpErrorTest extends TestCase
     {
         $result = $this->diagnose(502, '<html>Bad Gateway</html>');
         $this->assertSame('SERVER_ERROR', $result['code']);
+    }
+
+    public function testTransientHttpResponseClassification()
+    {
+        $this->assertTrue($this->isTransientHttpResponse(
+            418,
+            '<!doctype html><title>Temporary bot response</title>',
+        ));
+        $this->assertTrue($this->isTransientHttpResponse(
+            403,
+            '<!doctype html><title>Temporary firewall response</title>',
+        ));
+        $this->assertTrue($this->isTransientHttpResponse(
+            403,
+            '{"error":"Bot protection is temporarily unavailable"}',
+        ));
+        $this->assertTrue($this->isTransientHttpResponse(
+            503,
+            '{"error":"Upstream service is temporarily unavailable"}',
+        ));
+        $this->assertFalse($this->isTransientHttpResponse(
+            403,
+            '{"error":"HMAC signature verification failed"}',
+        ));
+        $this->assertFalse($this->isTransientHttpResponse(
+            503,
+            '{"error":"Export not configured"}',
+        ));
+        $this->assertFalse($this->isTransientHttpResponse(
+            415,
+            '<!doctype html><title>Unsupported Media Type</title>',
+        ));
     }
 
     // ── HTML response on any status ──────────────────────────────

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -231,11 +231,15 @@ class DiagnoseHttpErrorTest extends TestCase
         ));
         $this->assertFalse($this->isTransientHttpResponse(
             403,
-            '{"error":"HMAC signature verification failed"}',
+            '{"error":"Invalid timestamp format","code":403}',
         ));
         $this->assertFalse($this->isTransientHttpResponse(
             503,
-            '{"error":"Export not configured"}',
+            '{"error":"Invalid secret.php configuration","code":503}',
+        ));
+        $this->assertFalse($this->isTransientHttpResponse(
+            500,
+            '{"error":"Reprint Server runtime is incomplete","code":500}',
         ));
         $this->assertFalse($this->isTransientHttpResponse(
             415,


### PR DESCRIPTION
An SQL pull that receives an HTML HTTP 418 response from an upstream filter now repeats the request from its last durable cursor instead of ending immediately.

## Retry limit

The limit counts **consecutive potentially transient failures whose durable cursor does not move**. It does not require the failures to have the same HTTP status, error code, or message.

For a stalled transfer:

1. The initial request fails: count 1.
2. The first repeated request fails at the same cursor: count 2.
3. The second repeated request fails at the same cursor: count 3, then the pull stops.

There is no fourth request. This means two repeat attempts after the initial failure. The final error includes the last failure message.

A successful request resets the count. A failed streaming request that advances the durable cursor also resets the count because the transfer made progress. A stalled sequence therefore cannot repeat indefinitely. An interrupted transfer may keep resuming while each request delivers new durable parts.

This uses the existing limit for temporary cURL failures. It classifies HTTP statuses 408, 418, 425, 429, 500, 502, 503, and 504 as potentially transient. An unmarked 401 or 403 from a signed request is also potentially transient because a firewall may return it before the request reaches Reprint. Reprint's deliberate JSON failures carry a numeric code matching the HTTP status and still stop immediately. Redirects, 404 responses, and other permanent failures also remain fatal.

## Testing

The wire tests return HTTP 418 before a valid multipart completion, then return HTTP 418 three times to check the request limit and final message. The classifier tests cover potentially transient firewall responses and permanent Reprint setup and authentication errors.

```
cd tests && ../vendor/bin/phpunit --testsuite 'Import Tests' --stop-on-failure
./vendor/bin/phpstan analyze --memory-limit=1G --no-progress
./vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src
git diff --check
```
