### PR TITLE
[PHP] Verify two-error HTTP recovery across pull streaming endpoints

### DIFF
--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -2,8 +2,8 @@
  * Local reverse proxy which models an application firewall around WordPress.
  *
  * Reprint requests are accepted only when their Referer points to the same
- * origin's WordPress Media Library page. All accepted requests are streamed
- * to the real E2E WordPress site.
+ * origin's WordPress Media Library page. It injects the planned HTTP errors,
+ * then streams later requests to the real E2E WordPress site.
  */
 import http from 'node:http';
 import { appendFileSync } from 'node:fs';
@@ -14,6 +14,17 @@ if (!backendUrlString || !requestLogPath) {
 }
 
 const backendUrl = new URL(backendUrlString);
+
+// Return two different upstream errors before allowing each streaming endpoint
+// through. Together these cover every status in the importer's general
+// potentially transient list while staying below the three-failure limit.
+const injectedStatusesByEndpoint = new Map([
+    ['file_index', [408, 418]],
+    ['file_fetch', [425, 429]],
+    ['db_index', [500, 502]],
+    ['sql_chunk', [503, 504]],
+]);
+const injectedResponseCounts = new Map();
 
 function writeRequestLog(record) {
     appendFileSync(requestLogPath, `${JSON.stringify(record)}\n`);
@@ -28,16 +39,33 @@ const server = http.createServer((request, response) => {
     const expectedReferer = `http://${request.headers.host}/wp-admin/upload.php`;
     const referer = request.headers.referer || '';
     const allowed = !isReprintRequest || referer === expectedReferer;
+    const endpoint = requestUrl.searchParams.get('endpoint') || '';
+    const injectedStatuses = injectedStatusesByEndpoint.get(endpoint) || [];
+    const injectedResponseCount = injectedResponseCounts.get(endpoint) || 0;
+    const injectedStatus = allowed
+        ? injectedStatuses[injectedResponseCount] || null
+        : null;
+    const action = !allowed
+        ? 'blocked'
+        : injectedStatus === null
+            ? 'proxy'
+            : 'http-error';
+
+    if (injectedStatus !== null) {
+        injectedResponseCounts.set(endpoint, injectedResponseCount + 1);
+    }
 
     writeRequestLog({
         method: request.method,
         path: request.url,
         contentType,
-        endpoint: requestUrl.searchParams.get('endpoint') || '',
+        endpoint,
         referer,
         expectedReferer,
         isReprintRequest,
         allowed,
+        action,
+        injectedStatus,
         userAgent: request.headers['user-agent'] || '',
     });
 
@@ -48,6 +76,23 @@ const server = http.createServer((request, response) => {
             'X-App-Firewall': 'blocked',
         });
         response.end('<!doctype html><title>403 Forbidden</title><h1>Forbidden</h1>');
+        return;
+    }
+
+    if (injectedStatus !== null) {
+        // Drain uploads before responding so cURL observes the HTTP status
+        // instead of an upload-side socket error.
+        request.on('end', () => {
+            response.writeHead(injectedStatus, {
+                'Content-Type': 'text/html; charset=utf-8',
+                'X-App-Firewall': 'potentially-transient-error',
+            });
+            response.end(
+                `<!doctype html><title>HTTP ${injectedStatus}</title>` +
+                '<h1>Temporary upstream response</h1>',
+            );
+        });
+        request.resume();
         return;
     }
 

--- a/tests/e2e/tests/import-60-application-firewall.test.js
+++ b/tests/e2e/tests/import-60-application-firewall.test.js
@@ -3,7 +3,9 @@
  *
  * Runs a complete pull through a local HTTP reverse proxy which rejects
  * Reprint requests unless they have a same-origin WordPress admin Referer.
- * The proxy streams every accepted request to the real E2E site.
+ * Before forwarding each streaming endpoint, the proxy also returns two
+ * potentially transient HTTP errors. The third request reaches the real E2E
+ * site, so the pull must recover without hitting its three-failure limit.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -28,6 +30,7 @@ import {
     getSiteSecret,
     getSiteUrl,
     pullStateDirectory,
+    readAuditLog,
     runImporter,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
@@ -72,6 +75,7 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         pullResult = runImporter(importUrl, outputDirectory, 'pull', {
             secret: getSiteSecret(site),
             skipPreflight: true,
+            autoResume: false,
             timeout: 120000,
             wallTimeout: 240000,
             extraArgs: [
@@ -83,6 +87,14 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
             ],
         });
     }, 360000);
+
+    function readRequestRecords() {
+        return readFileSync(requestLogPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+    }
 
     afterAll(async () => {
         cleanupTempDir(outputDirectory);
@@ -102,11 +114,7 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
     });
 
     it('sends a same-origin WordPress admin Referer with every Reprint request', () => {
-        const requestRecords = readFileSync(requestLogPath, 'utf-8')
-            .trim()
-            .split('\n')
-            .filter(Boolean)
-            .map(line => JSON.parse(line))
+        const requestRecords = readRequestRecords()
             .filter(record => record.isReprintRequest);
         assert.ok(
             requestRecords.length > 0,
@@ -142,6 +150,63 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         }
     });
 
+    it('retries two potentially transient HTTP errors at every pull streaming endpoint', () => {
+        const expectedStatusesByEndpoint = new Map([
+            ['file_index', [408, 418]],
+            ['file_fetch', [425, 429]],
+            ['db_index', [500, 502]],
+            ['sql_chunk', [503, 504]],
+        ]);
+        const requestRecords = readRequestRecords();
+        const auditLog = readAuditLog(outputDirectory);
+
+        for (const [endpoint, expectedStatuses] of expectedStatusesByEndpoint) {
+            const endpointRecords = requestRecords.filter(
+                record => record.endpoint === endpoint,
+            );
+            assert.deepEqual(
+                endpointRecords.slice(0, 3).map(record => record.action),
+                ['http-error', 'http-error', 'proxy'],
+                `Expected two potentially transient HTTP errors and then a ` +
+                `proxied ${endpoint} request`,
+            );
+            assert.deepEqual(
+                endpointRecords
+                    .filter(record => record.action === 'http-error')
+                    .map(record => record.injectedStatus),
+                expectedStatuses,
+                `Expected the planned HTTP errors for ${endpoint}`,
+            );
+
+            const retryLines = auditLog
+                .split('\n')
+                .filter(line => line.includes(
+                    `TEMPORARY REQUEST FAILURE | ${endpoint} |`,
+                ));
+            for (let index = 0; index < expectedStatuses.length; index++) {
+                const expectedStatus = expectedStatuses[index];
+                const retryLine = retryLines.find(
+                    line => line.includes(`HTTP ${expectedStatus}`),
+                );
+                assert.ok(
+                    retryLine,
+                    `Expected ${endpoint} to record HTTP ${expectedStatus}`,
+                );
+                assert.ok(
+                    retryLine.includes(
+                        `consecutive_interrupted_responses=${index + 1}/3`,
+                    ),
+                    `Expected ${endpoint} HTTP ${expectedStatus} to record ` +
+                    `failure ${index + 1} of 3`,
+                );
+                assert.ok(
+                    retryLine.includes('cursor_moved=no'),
+                    `Expected ${endpoint} HTTP ${expectedStatus} to make no cursor progress`,
+                );
+            }
+        }
+    });
+
     it('completes pull through the application firewall', () => {
         assert.equal(
             pullResult.exitCode,
@@ -151,7 +216,13 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
 
         const stateFile = join(pullStateDirectory(outputDirectory, importUrl), 'state.json');
         assert.ok(existsSync(stateFile), 'Expected pull/state.json to exist');
-        assertPullPipelineComplete(JSON.parse(readFileSync(stateFile, 'utf-8')));
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assertPullPipelineComplete(state);
+        assert.equal(
+            state.consecutive_interrupted_responses,
+            0,
+            'Expected a successful response to clear the potentially transient failure count',
+        );
         assert.ok(
             existsSync(join(fsRootDir(outputDirectory), getSiteDir(site), 'test-data', 'hello.txt')),
             'Expected pull to write a source file through the application firewall',


### PR DESCRIPTION
Extends the full-pull application-firewall E2E test so each streaming endpoint must recover from two back-to-back potentially transient HTTP errors before its first successful response.

The reverse proxy returns 408 then 418 for `file_index`, 425 then 429 for `file_fetch`, 500 then 502 for `db_index`, and 503 then 504 for `sql_chunk`. It then forwards the next request to real WordPress. The test checks that the shared no-progress count reaches 1/3 then 2/3 for every endpoint, returns to zero after success, and the full pull completes in one PHP process.

This follows #679. It was prepared as a stacked PR, but #679 merged before this PR opened, so this now targets `trunk` directly.

## Testing

The focused Docker E2E passes all 4 tests. With the client restored to the commit before #679, it stops on the first HTTP 408 and the new recovery test fails.
