### PR TITLE
[PHP] Retry unmarked HTTP 400 responses during pull

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -220,6 +220,7 @@ class ImportClient
 
     /** HTTP statuses which may indicate a transient HTTP error. */
     private const POTENTIALLY_TRANSIENT_HTTP_STATUS_CODES = [
+        400, // Bad Request
         408, // Request Timeout
         418, // Observed when an upstream bot filter replaced a Reprint response
         425, // Too Early

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use WordPress\Reprint\Server\SqliteDriverPDO;
+use WordPress\Reprint\Server\WpdbDriverPDO;
 
 final class CreateDbConnectionTest extends TestCase {
     public function testMysqlSessionUsesStableCharsetAndCollation(): void
@@ -188,7 +189,7 @@ final class CreateDbConnectionTest extends TestCase {
         );
         $this->assertSame(
             [
-                'class' => 'WpdbDriverPDO',
+                'class' => WpdbDriverPDO::class,
                 'queries' => ['SET NAMES utf8mb4 COLLATE utf8mb4_bin'],
             ],
             json_decode($result['stdout'], true)

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -180,17 +180,17 @@ class CurlTimeoutRecoveryTest extends TestCase
         );
     }
 
-    public function testSqlDownloadRetriesHttp418ThenCompletes()
+    public function testSqlDownloadRetriesHttp400ThenCompletes()
     {
         if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
             $this->markTestSkipped('HTTP retry coverage requires PHP curl and pcntl.');
         }
 
         $cursor = base64_encode('{"table":"wp_posts","pk":42}');
-        $http418 = $this->httpResponse(
-            "418 I'm a teapot",
+        $http400 = $this->httpResponse(
+            '400 Bad Request',
             'text/html',
-            '<!doctype html><title>Temporary bot response</title>',
+            '<!doctype html><title>Temporary upstream response</title>',
         );
         $boundary = 'http-retry-test';
         $completion_body = "--{$boundary}\r\n"
@@ -202,7 +202,7 @@ class CurlTimeoutRecoveryTest extends TestCase
             . "\r\n"
             . "--{$boundary}--\r\n";
         $server = $this->startSqlResponseServer([
-            $http418,
+            $http400,
             $this->httpResponse(
                 '200 OK',
                 "multipart/mixed; boundary={$boundary}",

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -214,6 +214,10 @@ class DiagnoseHttpErrorTest extends TestCase
     public function testPotentiallyTransientHttpErrorClassification()
     {
         $this->assertTrue($this->isPotentiallyTransientHttpError(
+            400,
+            '<!doctype html><title>Temporary upstream response</title>',
+        ));
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
             418,
             '<!doctype html><title>Temporary bot response</title>',
         ));
@@ -228,6 +232,10 @@ class DiagnoseHttpErrorTest extends TestCase
         $this->assertTrue($this->isPotentiallyTransientHttpError(
             503,
             '{"error":"Upstream service is temporarily unavailable"}',
+        ));
+        $this->assertFalse($this->isPotentiallyTransientHttpError(
+            400,
+            '{"error":"Invalid request","code":400}',
         ));
         $this->assertFalse($this->isPotentiallyTransientHttpError(
             403,

--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -16,8 +16,8 @@ if (!backendUrlString || !requestLogPath) {
 const backendUrl = new URL(backendUrlString);
 
 // Return two different upstream errors before allowing each streaming endpoint
-// through. Together these cover every status in the importer's general
-// potentially transient list while staying below the three-failure limit.
+// through. This exercises every endpoint while staying below the three-failure
+// limit. HTTP 400 has focused wire coverage.
 const injectedStatusesByEndpoint = new Map([
     ['file_index', [408, 418]],
     ['file_fetch', [425, 429]],


### PR DESCRIPTION
An unmarked HTTP 400 received during a streaming pull now repeats the request from the last durable cursor, up to the existing three-failure no-progress limit.

Reprint JSON errors whose numeric `code` is `400` still stop immediately. This keeps marked request-validation failures terminal while allowing unmarked 400 responses to recover.

The current trunk commit also added a wpdb fallback test with an unqualified class-name expectation. That class is namespaced, so this branch updates the test to expect its full class name and lets the PHPUnit matrix complete.

## Testing

The classifier tests cover unmarked and Reprint-marked 400 responses. The SQL wire test returns 400 once, then completes on the repeated request.

```
cd tests && ../vendor/bin/phpunit --testsuite 'Import Tests' --stop-on-failure
vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src
git diff --check
```
