### PR TITLE
[PHP] Rewrite bare pull URLs and reject incompatible exporter protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ That's it. Reprint will:
 1. **Preflight** the remote site (check connectivity, detect WordPress version and hosting environment)
 2. **Download all files** (themes, plugins, uploads, core) into `--fs-root`
 3. **Download the database** as a SQL dump
-4. **Generate server config** for PHP's built-in server
-5. **Start the local server** and print the URL
+4. **Import the database** into SQLite and rewrite the source site URLs to `http://localhost:8881`
+5. **Generate server config** for PHP's built-in server
+6. **Start the local server** and print the URL
 
 The output looks like:
 
@@ -59,7 +60,9 @@ Pulling example.com
 
 ### Options
 
-**Database import** — add target database options and reprint will also import the SQL with URL rewriting:
+**Database target and site URL** — the bare command imports into SQLite and
+rewrites both source URL schemes to `http://localhost:8881`. Pass target
+options to use MySQL or choose a different local URL:
 
 ```bash
 # MySQL

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2887,26 +2887,13 @@ class ImportClient
         }
 
         // 3. Protocol version
-        $remote_ver = $this->get_state()->remote_protocol_version ?? null;
-        if ($remote_ver === null) {
-            $proto_ok = false;
-            $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
-        } elseif ($remote_ver < PULL_PROTOCOL_VERSION) {
-            $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the export plugin.";
-        } elseif ($remote_ver > PULL_PROTOCOL_VERSION) {
-            $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} does not match client protocol v" . PULL_PROTOCOL_VERSION . ". Update the Reprint client.";
-        } else {
-            $proto_ok = true;
-            $proto_detail = "remote v{$remote_ver}, client v" . PULL_PROTOCOL_VERSION;
-        }
+        $protocol_check = $this->preflight_protocol_check();
         $checks[] = [
             "label" => "Protocol compatible",
-            "pass" => $proto_ok,
-            "detail" => $proto_detail,
+            "pass" => $protocol_check['pass'],
+            "detail" => $protocol_check['detail'],
         ];
-        if (!$proto_ok) {
+        if (!$protocol_check['pass']) {
             $all_pass = false;
         }
 
@@ -2963,6 +2950,46 @@ class ImportClient
 
         $this->write_progress_file($all_pass ? null : "Preflight assertions failed");
         exit($all_pass ? 0 : 1);
+    }
+
+    /**
+     * Compare the export plugin's wire protocol with this client.
+     *
+     * @return array {
+     *     Protocol compatibility result.
+     *
+     *     @type bool   $pass   Whether the protocol versions match.
+     *     @type string $detail Human-readable version detail or update instruction.
+     * }
+     */
+    public function preflight_protocol_check(): array
+    {
+        $remote_protocol_version = $this->get_state()->remote_protocol_version;
+        if ($remote_protocol_version === null) {
+            return [
+                'pass' => false,
+                'detail' => 'Remote export plugin does not report a protocol version. Update the export plugin.',
+            ];
+        }
+        if ($remote_protocol_version < PULL_PROTOCOL_VERSION) {
+            return [
+                'pass' => false,
+                'detail' => "Remote protocol v{$remote_protocol_version} does not match client protocol v" .
+                    PULL_PROTOCOL_VERSION . '. Update the export plugin.',
+            ];
+        }
+        if ($remote_protocol_version > PULL_PROTOCOL_VERSION) {
+            return [
+                'pass' => false,
+                'detail' => "Remote protocol v{$remote_protocol_version} does not match client protocol v" .
+                    PULL_PROTOCOL_VERSION . '. Update the Reprint client.',
+            ];
+        }
+
+        return [
+            'pass' => true,
+            'detail' => "remote v{$remote_protocol_version}, client v" . PULL_PROTOCOL_VERSION,
+        ];
     }
 
     /**
@@ -4804,21 +4831,12 @@ class ImportClient
         // the CLI, derive from the first URL rewrite target (saved by
         // db-apply). This way the dev server listens on the same address
         // the database was rewritten to.
-        $host = $options["host"] ?? null;
-        $port = $options["port"] ?? null;
-        if ($host === null || $port === null) {
-            $rewrite_map = $this->get_state()->apply->rewrite_url ?? [];
-            $first_target = !empty($rewrite_map) ? reset($rewrite_map) : null;
-            if (is_string($first_target)) {
-                $parsed = parse_url($first_target);
-                if ($host === null) {
-                    $host = $parsed["host"] ?? null;
-                }
-                if ($port === null && isset($parsed["port"])) {
-                    $port = $parsed["port"];
-                }
-            }
-        }
+        $runtime_address = resolve_runtime_host_and_port(
+            $options,
+            $this->get_state()->apply->rewrite_url ?? [],
+        );
+        $host = $runtime_address['host'];
+        $port = $runtime_address['port'];
 
         // Resolve the path to WordPress's index.php. On standard hosts it
         // lives in the filesystem root. On WPCloud the ABSPATH is a different
@@ -13276,7 +13294,7 @@ if (
                 "  1. Preflight — probe the remote site environment\n" .
                 "  2. Files     — download all remote files into --fs-root\n" .
                 "  3. Database  — download the SQL dump\n" .
-                "  4. Apply     — apply SQL to a local database (if --target-db)\n" .
+                "  4. Apply     — apply SQL to SQLite by default, or to a configured database\n" .
                 "  5. Flatten   — reassemble into standard WP layout (if --flatten-to)\n" .
                 "  6. Runtime   — generate server config (default: php-builtin)\n" .
                 "  7. Start     — launch the selected runtime when supported\n" .
@@ -13289,7 +13307,7 @@ if (
                 "so you can pass just the site URL.\n",
             "extra" =>
                 "Examples:\n" .
-                "  # Download files and database without applying SQL:\n" .
+                "  # Full local clone with default SQLite and URL rewriting:\n" .
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files\n" .
                 "\n" .

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -373,6 +373,9 @@ class Pull
             $this->print_stage_header($stage);
 
             try {
+                if ($i === $start_index && $stage !== 'preflight') {
+                    $this->assert_protocol_compatible(true);
+                }
                 $this->run_stage($stage, $options, $step, $total);
             } catch (\Exception $e) {
                 $this->report_failure($command, $stage, $stages, $i, $e);
@@ -420,6 +423,7 @@ class Pull
                     $this->client->exit_code = 1;
                     throw new RuntimeException($preflight["error"] ?? "Preflight check failed");
                 }
+                $this->assert_protocol_compatible();
                 $summary = null;
                 $data = $preflight["data"] ?? null;
                 if (is_array($data)) {
@@ -486,6 +490,34 @@ class Pull
                     $state->active_resumable_command->command_name !== 'db-apply' ||
                     $state->active_resumable_command->completion_state !== 'complete'
                 ) {
+                    $database_apply_started =
+                        $state->active_resumable_command->command_name === 'db-apply' &&
+                        in_array(
+                            $state->active_resumable_command->completion_state,
+                            ['in_progress', 'partial'],
+                            true,
+                        ) &&
+                        in_array(
+                            $state->active_resumable_command->current_stage,
+                            ['sql', 'database-cleanup'],
+                            true,
+                        );
+                    if (
+                        !$database_apply_started &&
+                        isset($options['runtime']) &&
+                        $options['runtime'] === 'php-builtin' &&
+                        empty($options['new_site_url']) &&
+                        empty($options['rewrite_url'])
+                    ) {
+                        $runtime_address = resolve_runtime_host_and_port($options, []);
+                        $host = $runtime_address['host'] ?? PhpBuiltinApplier::DEFAULT_HOST;
+                        $port = $runtime_address['port'] ?? PhpBuiltinApplier::DEFAULT_PORT;
+                        $options['new_site_url'] = sprintf(
+                            'http://%s:%d',
+                            $host,
+                            $port,
+                        );
+                    }
                     $this->run_until_complete('db-apply', function () use ($options) {
                         $this->client->run_db_apply($options);
                     });
@@ -507,6 +539,23 @@ class Pull
             case 'start':
                 $this->start_server($options);
                 break;
+        }
+    }
+
+    /**
+     * Stop before a pipeline stage uses state from an incompatible exporter.
+     */
+    private function assert_protocol_compatible(bool $resuming = false): void
+    {
+        $protocol_check = $this->client->preflight_protocol_check();
+        if (!$protocol_check['pass']) {
+            $this->client->exit_code = 1;
+            $detail = $protocol_check['detail'];
+            if ($resuming) {
+                $detail .= ' Then rerun this command with --abort and start it again.';
+            }
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Remote compatibility detail is CLI text.
+            throw new RuntimeException($detail);
         }
     }
 
@@ -889,8 +938,12 @@ class Pull
             );
         }
 
-        $host = $options['host'] ?? 'localhost';
-        $port = (int) ($options['port'] ?? 8881);
+        $runtime_address = resolve_runtime_host_and_port(
+            $options,
+            $this->client->get_state()->apply->rewrite_url ?? [],
+        );
+        $host = $runtime_address['host'] ?? PhpBuiltinApplier::DEFAULT_HOST;
+        $port = $runtime_address['port'] ?? PhpBuiltinApplier::DEFAULT_PORT;
         $url = "http://{$host}:{$port}";
 
         // Mark pull complete BEFORE the server blocks so killing the

--- a/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
+++ b/packages/reprint-client/src/lib/target-runtime/class-php-builtin-applier.php
@@ -19,10 +19,13 @@ use function WordPress\Filesystem\wp_join_unix_paths;
  */
 class PhpBuiltinApplier implements RuntimeApplier
 {
+    public const DEFAULT_HOST = 'localhost';
+    public const DEFAULT_PORT = 8881;
+
     public function apply(RuntimeManifest $manifest, string $filesystem_root, string $output_dir, array $options = []): array
     {
-        $host = $options['host'] ?? 'localhost';
-        $port = (int) ($options['port'] ?? 8881);
+        $host = $options['host'] ?? self::DEFAULT_HOST;
+        $port = (int) ($options['port'] ?? self::DEFAULT_PORT);
 
         $summary = [];
 

--- a/packages/reprint-client/src/lib/target-runtime/functions.php
+++ b/packages/reprint-client/src/lib/target-runtime/functions.php
@@ -39,6 +39,47 @@ function runtime_applier_for(string $runtime): RuntimeApplier
 }
 
 /**
+ * Resolve a runtime address from explicit options or the saved URL target.
+ *
+ * @param array $options {
+ *     Runtime options.
+ *
+ *     @type string|null $host Runtime host.
+ *     @type int|null    $port Runtime port.
+ * }
+ * @param array<string,string> $rewrite_map Saved source-to-target URL map.
+ * @return array {
+ *     Resolved runtime address.
+ *
+ *     @type string|null $host Runtime host.
+ *     @type int|null    $port Runtime port.
+ * }
+ */
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Matches the runtime helper API in this file.
+function resolve_runtime_host_and_port(array $options, array $rewrite_map): array
+{
+    $host = $options['host'] ?? null;
+    $port = $options['port'] ?? null;
+    if ($host === null || $port === null) {
+        $first_target = !empty($rewrite_map) ? reset($rewrite_map) : null;
+        if (is_string($first_target)) {
+            $parsed_target = parse_url($first_target);
+            if ($host === null) {
+                $host = $parsed_target['host'] ?? null;
+            }
+            if ($port === null && isset($parsed_target['port'])) {
+                $port = $parsed_target['port'];
+            }
+        }
+    }
+
+    return [
+        'host' => $host,
+        'port' => $port === null ? null : (int) $port,
+    ];
+}
+
+/**
  * Generate the base runtime.php content: constants, server vars, and
  * route handlers.
  *

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -13,6 +13,7 @@ class PullFilterFakeClient extends \ImportClient
     public int $files_pull_runs = 0;
     public int $db_sync_runs = 0;
     public int $db_apply_runs = 0;
+    public ?array $db_apply_options = null;
     public array $progress_events = [];
     public array $progress_file_errors = [];
 
@@ -90,6 +91,7 @@ class PullFilterFakeClient extends \ImportClient
                 ],
             ],
         ]);
+        $state->remote_protocol_version = PULL_PROTOCOL_VERSION;
         $state->active_resumable_command->completion_state = "complete";
         $this->save_state();
     }
@@ -128,6 +130,7 @@ class PullFilterFakeClient extends \ImportClient
     public function run_db_apply(array $options): void
     {
         $this->db_apply_runs++;
+        $this->db_apply_options = $options;
         $state = $this->get_state();
         $state->active_resumable_command->command_name = "db-apply";
         $state->active_resumable_command->completion_state = "complete";
@@ -153,6 +156,16 @@ class PullFailingPreflightFakeClient extends PullFilterFakeClient
     }
 }
 
+class PullOlderProtocolFakeClient extends PullFilterFakeClient
+{
+    public function run_preflight(): void
+    {
+        parent::run_preflight();
+        $this->get_state()->remote_protocol_version = PULL_PROTOCOL_VERSION - 1;
+        $this->save_state();
+    }
+}
+
 /**
  * Fake client that records the options the pull pipeline hands to
  * apply-runtime, so we can assert the flatten_to -> flat_document_root
@@ -162,6 +175,17 @@ class PullBridgeFakeClient extends PullFilterFakeClient
 {
     public ?array $apply_runtime_options = null;
 
+    public function run_db_apply(array $options): void
+    {
+        parent::run_db_apply($options);
+        if (!empty($options['new_site_url'])) {
+            $this->get_state()->apply->rewrite_url = [
+                'http://fake.invalid' => $options['new_site_url'],
+            ];
+            $this->save_state();
+        }
+    }
+
     public function run_flat_document_root(array $options): void
     {
     }
@@ -169,6 +193,12 @@ class PullBridgeFakeClient extends PullFilterFakeClient
     public function run_apply_runtime(array $options): void
     {
         $this->apply_runtime_options = $options;
+        $output_dir = $options['output_dir'];
+        if (!is_dir($output_dir)) {
+            mkdir($output_dir, 0755, true);
+        }
+        file_put_contents($output_dir . '/start.sh', "#!/bin/sh\nexit 0\n");
+        chmod($output_dir . '/start.sh', 0755);
     }
 }
 
@@ -240,6 +270,9 @@ class PullFilterOptionTest extends TestCase
 
     private function writeState(array $state): void
     {
+        if (!array_key_exists('remote_protocol_version', $state)) {
+            $state['remote_protocol_version'] = PULL_PROTOCOL_VERSION;
+        }
         \write_current_pull_state($this->makeClient(), $state);
     }
 
@@ -301,6 +334,187 @@ class PullFilterOptionTest extends TestCase
             static fn ($error): bool => $error !== null,
         ));
         $this->assertSame(["Exporter unavailable"], $progress_file_errors);
+    }
+
+    public function testPullDoesNotTransferFilesWithAnOlderExportPlugin(): void
+    {
+        $client = new PullOlderProtocolFakeClient($this->stateDir, $this->filesystem_root);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected pull to stop on the incompatible protocol');
+        } catch (\RuntimeException $e) {
+            $this->assertSame(
+                'Remote protocol v' . (PULL_PROTOCOL_VERSION - 1) .
+                ' does not match client protocol v' . PULL_PROTOCOL_VERSION .
+                '. Update the export plugin.',
+                $e->getMessage(),
+            );
+        } finally {
+            ob_end_clean();
+        }
+
+        $state = $this->readState();
+        $this->assertSame(0, $client->files_pull_runs);
+        $this->assertSame(0, $client->db_sync_runs);
+        $this->assertNull($state["pull_pipeline"]["last_completed_stage"]);
+    }
+
+    public function testResumedPullDoesNotTransferFilesWithAnOlderExportPlugin(): void
+    {
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "files-pull",
+                "completion_state" => "in_progress",
+                "current_stage" => "fetch",
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "last_completed_stage" => "preflight",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+            "remote_protocol_version" => PULL_PROTOCOL_VERSION - 1,
+        ]);
+
+        $client = $this->makeClient();
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected resumed pull to stop on the incompatible protocol');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Update the export plugin.', $e->getMessage());
+            $this->assertStringContainsString('rerun this command with --abort', $e->getMessage());
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame(0, $client->preflight_runs);
+        $this->assertSame(0, $client->files_pull_runs);
+        $this->assertSame(0, $client->db_sync_runs);
+    }
+
+    /**
+     * @dataProvider phpBuiltinServerProvider
+     */
+    public function testBarePullRewritesTheDatabaseToThePhpBuiltinServer(
+        array $runtime_options,
+        string $expected_url
+    ): void
+    {
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root);
+
+        ob_start();
+        $client->run(array_merge([
+            "command" => "pull",
+            "start_runtime" => "none",
+        ], $runtime_options));
+        ob_end_clean();
+
+        $this->assertSame($expected_url, $client->db_apply_options['new_site_url'] ?? null);
+    }
+
+    public static function phpBuiltinServerProvider(): array
+    {
+        return [
+            'default address' => [[], 'http://localhost:8881'],
+            'custom address' => [[
+                'host' => '127.0.0.1',
+                'port' => 9999,
+            ], 'http://127.0.0.1:9999'],
+        ];
+    }
+
+    public function testBarePullKeepsExplicitRewritePairs(): void
+    {
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root);
+        $rewrite_url = [[
+            'https://source.example',
+            'https://local.example',
+        ]];
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "start_runtime" => "none",
+            "rewrite_url" => $rewrite_url,
+        ]);
+        ob_end_clean();
+
+        $this->assertSame($rewrite_url, $client->db_apply_options['rewrite_url'] ?? null);
+        $this->assertArrayNotHasKey('new_site_url', $client->db_apply_options);
+    }
+
+    public function testStartedServerUsesTheExplicitNewSiteUrl(): void
+    {
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "new_site_url" => "http://127.0.0.1:9999",
+        ]);
+        ob_end_clean();
+
+        $server_events = array_values(array_filter(
+            $client->progress_events,
+            static fn (array $event): bool => ($event['event'] ?? null) === 'server_starting',
+        ));
+        $this->assertCount(1, $server_events);
+        $this->assertSame('http://127.0.0.1:9999', $server_events[0]['url']);
+    }
+
+    /**
+     * @dataProvider databaseApplyStageProvider
+     */
+    public function testDatabaseApplyAddsTheDefaultUrlOnlyBeforeSqlStarts(
+        string $current_stage,
+        bool $expects_default
+    ): void
+    {
+        $this->writeState([
+            "active_resumable_command" => [
+                "command_name" => "db-apply",
+                "completion_state" => "partial",
+                "current_stage" => $current_stage,
+            ],
+            "pull_pipeline" => [
+                "started_by_command" => "pull",
+                "last_completed_stage" => "db-pull",
+            ],
+            "preflight" => ["http_code" => 200, "data" => ["ok" => true]],
+        ]);
+        file_put_contents($this->stateDir . '/db.sql', "SELECT 1;\n");
+        $client = new PullBridgeFakeClient($this->stateDir, $this->filesystem_root);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "start_runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        if ($expects_default) {
+            $this->assertSame('http://localhost:8881', $client->db_apply_options['new_site_url'] ?? null);
+        } else {
+            $this->assertArrayNotHasKey('new_site_url', $client->db_apply_options);
+        }
+    }
+
+    public static function databaseApplyStageProvider(): array
+    {
+        return [
+            'database setup may restart safely' => ['database-start', true],
+            'SQL import keeps its original mapping' => ['sql', false],
+            'database cleanup keeps its original mapping' => ['database-cleanup', false],
+        ];
     }
 
     public function testPullResumesAfterFilesPullCompletedBeforePipelineStageWasMarked(): void


### PR DESCRIPTION
A bare `reprint pull` now imports the database into SQLite, rewrites both source URL schemes to the local PHP server address, and stops before transfer when the exporter protocol is incompatible.

## Background

The high-level pull command checked only whether preflight returned HTTP 200 and `ok`. A protocol v3 client could continue against a protocol v1 exporter, report the remote index count as pulled, and receive no files. The same command generated a PHP server at `http://localhost:8881` while leaving WordPress URLs pointed at the source site.

## This change

High-level pull pipelines now use the same exact protocol check as `preflight-assert`, including resumed pipelines.

A fresh PHP built-in pull supplies its server address as the database rewrite target unless the caller supplied an explicit mapping. An apply already executing SQL keeps its saved mapping, so a resumed database cannot mix two URL policies.

Runtime generation and the start message use one address resolver, so custom host, port, and saved rewrite targets stay aligned. The command help and README now describe the SQLite default and URL rewrite.

## Testing

The focused pull, URL rewrite, SQLite, lifecycle, and CLI help tests pass. PHPStan, PHP compatibility checks, the PHP 5.6 release build, and diff checks also pass.
