### PR TITLE
Some adjustments for the wpdb fallback

### DIFF
--- a/packages/reprint-server/src/class-wpdb-driver-pdo.php
+++ b/packages/reprint-server/src/class-wpdb-driver-pdo.php
@@ -128,6 +128,7 @@ class WpdbDriverPDOStatement
         $this->clear_last_error();
 
         $rows = $this->wpdb->get_results($sql, 'ARRAY_A');
+        $this->discard_query_log();
         $last_error = $this->get_last_error();
 
         if ($last_error !== '') {
@@ -199,6 +200,17 @@ class WpdbDriverPDOStatement
     private function clear_last_error(): void
     {
         $this->wpdb->last_error = '';
+    }
+
+    /**
+     * Drop the wpdb query log in case it's active.
+     * We don't want these stacking up and consuming memory.
+     */
+    private function discard_query_log(): void
+    {
+        if (isset($this->wpdb->queries) && is_array($this->wpdb->queries)) {
+            $this->wpdb->queries = [];
+        }
     }
 
     private function get_last_error(): string

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -1682,8 +1682,11 @@ function endpoint_preflight(array $config): array
     }
 
     if ($creds !== null) {
-        $required_ext = ($creds["db_engine"] ?? "mysql") === "sqlite" ? "pdo_sqlite" : "pdo_mysql";
-        if (!extension_loaded($required_ext)) {
+        $db_engine = $creds["db_engine"] ?? "mysql";
+        $required_ext = $db_engine === "sqlite" ? "pdo_sqlite" : "pdo_mysql";
+        $wpdb_available = $db_engine !== "sqlite" && isset($GLOBALS["wpdb"]) && is_object($GLOBALS["wpdb"]);
+
+        if (!extension_loaded($required_ext) && !$wpdb_available) {
             $db["error"] = "{$required_ext} extension not loaded";
         } else {
             try {

--- a/tests/CreateDbConnectionTest.php
+++ b/tests/CreateDbConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use WordPress\Reprint\Server\SqliteDriverPDO;
+use WordPress\Reprint\Server\WpdbDriverPDO;
 
 final class CreateDbConnectionTest extends TestCase {
     public function testMysqlSessionUsesStableCharsetAndCollation(): void
@@ -80,13 +81,17 @@ final class CreateDbConnectionTest extends TestCase {
         }
         class WpdbSessionTestDouble {
             public $last_error = '';
+            public $executed = [];
+            // Retained unconditionally, the way a db.php drop-in may, rather
+            // than only under SAVEQUERIES the way core does.
             public $queries = [];
             public function suppress_errors($suppress = true) {
             }
             public function hide_errors() {
             }
             public function get_results($query, $output) {
-                $this->queries[] = [$query, $output];
+                $this->executed[] = [$query, $output];
+                $this->queries[] = [$query, 0.0, 'caller', 0.0, []];
                 return [];
             }
         }
@@ -103,7 +108,10 @@ final class CreateDbConnectionTest extends TestCase {
                 'db_password' => 'unused',
             ]
         );
-        fwrite(STDOUT, json_encode($wpdb->queries));
+        fwrite(STDOUT, json_encode([
+            'executed' => $wpdb->executed,
+            'retained_queries' => $wpdb->queries,
+        ]));
         PHP;
 
         $result = $this->runPhpProcess([
@@ -122,10 +130,16 @@ final class CreateDbConnectionTest extends TestCase {
         );
         $this->assertSame(
             [
-                [
-                    "SET NAMES utf8mb4 COLLATE utf8mb4_bin",
-                    'ARRAY_A',
+                'executed' => [
+                    [
+                        "SET NAMES utf8mb4 COLLATE utf8mb4_bin",
+                        'ARRAY_A',
+                    ],
                 ],
+                // An export runs one query per row batch and one per
+                // oversized-value chunk, so anything wpdb retains per query
+                // outgrows the request. The adapter drops the log after each.
+                'retained_queries' => [],
             ],
             json_decode($result['stdout'], true)
         );
@@ -144,13 +158,13 @@ final class CreateDbConnectionTest extends TestCase {
         $connection_script = <<<'PHP'
         class WpdbFallbackTestDouble {
             public $last_error = '';
-            public $queries = [];
+            public $executed = [];
             public function suppress_errors($suppress = true) {
             }
             public function hide_errors() {
             }
             public function get_results($query, $output) {
-                $this->queries[] = $query;
+                $this->executed[] = $query;
                 return [];
             }
         }
@@ -170,7 +184,7 @@ final class CreateDbConnectionTest extends TestCase {
         );
         fwrite(STDOUT, json_encode([
             'class' => get_class($connection),
-            'queries' => $wpdb->queries,
+            'executed' => $wpdb->executed,
         ]));
         PHP;
 
@@ -188,8 +202,8 @@ final class CreateDbConnectionTest extends TestCase {
         );
         $this->assertSame(
             [
-                'class' => 'WpdbDriverPDO',
-                'queries' => ['SET NAMES utf8mb4 COLLATE utf8mb4_bin'],
+                'class' => WpdbDriverPDO::class,
+                'executed' => ['SET NAMES utf8mb4 COLLATE utf8mb4_bin'],
             ],
             json_decode($result['stdout'], true)
         );

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -12,6 +12,7 @@ REGISTRY="${SCRIPT_DIR}/../site-registry.json"
 SITE_ROOT=$(jq -r '.siteRoot' "$REGISTRY")
 FPM_SOCKET="/run/php/e2e.sock"
 OPEN_BASEDIR_FPM_SOCKET="/run/php/e2e-open-basedir.sock"
+NO_PDO_MYSQL_FPM_SOCKET="/run/php/e2e-no-pdo-mysql.sock"
 
 echo "=== Setting up infrastructure with PHP ${PHP_VERSION} ==="
 
@@ -127,6 +128,73 @@ php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
 env[SITE_EXPORT_TEST_MODE] = 1
 EOF
 
+# ---------- PHP-FPM master without pdo_mysql ----------
+# Sites flagged noPdoMysql are served from here so they take
+# create_db_connection()'s PDO-less route and export through $wpdb. PHP loads
+# extensions per master rather than per pool, so this cannot be another pool.
+echo "=== Configuring PHP-FPM master without pdo_mysql ==="
+NO_PDO_MYSQL_CONF_D="/etc/php/${PHP_VERSION}/fpm-no-pdo-mysql-conf.d"
+sudo rm -rf "$NO_PDO_MYSQL_CONF_D"
+sudo cp -rL "/etc/php/${PHP_VERSION}/fpm/conf.d" "$NO_PDO_MYSQL_CONF_D"
+sudo rm -f "$NO_PDO_MYSQL_CONF_D"/*pdo_mysql.ini
+
+# The whole point of this master is that pdo_mysql is gone. If the ini were
+# named differently, or the extension were built in, every test on these sites
+# would quietly run on the ordinary PDO path and still pass.
+if ! sudo env PHP_INI_SCAN_DIR="$NO_PDO_MYSQL_CONF_D" "php${PHP_VERSION}" \
+    -r 'exit(extension_loaded("pdo_mysql") ? 1 : 0);'; then
+    echo "pdo_mysql is still loaded in ${NO_PDO_MYSQL_CONF_D}; the no-pdo-mysql sites would not test the wpdb path." >&2
+    exit 1
+fi
+
+cat <<EOF | sudo tee "/etc/php/${PHP_VERSION}/fpm/php-fpm-no-pdo-mysql.conf" >/dev/null
+[global]
+pid = /run/php/e2e-no-pdo-mysql.pid
+error_log = /tmp/php-e2e-no-pdo-mysql.log
+daemonize = no
+
+[e2e-no-pdo-mysql]
+user = nginx
+group = nginx
+listen = ${NO_PDO_MYSQL_FPM_SOCKET}
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+
+pm = ondemand
+pm.max_children = 8
+
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 120
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M
+php_admin_value[error_reporting] = E_ALL
+php_admin_value[display_errors] = Off
+php_admin_value[log_errors] = On
+php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
+
+env[SITE_EXPORT_TEST_MODE] = 1
+EOF
+
+cat <<EOF | sudo tee /etc/systemd/system/php-e2e-no-pdo-mysql.service >/dev/null
+[Unit]
+Description=PHP-FPM master for E2E sites without pdo_mysql
+After=network.target
+
+[Service]
+Type=simple
+Environment=PHP_INI_SCAN_DIR=${NO_PDO_MYSQL_CONF_D}
+ExecStart=/usr/sbin/php-fpm${PHP_VERSION} --nodaemonize --fpm-config /etc/php/${PHP_VERSION}/fpm/php-fpm-no-pdo-mysql.conf
+Restart=no
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+
 # ---------- Nginx config ----------
 echo "=== Configuring Nginx ==="
 sudo mkdir -p "${SITE_ROOT}"
@@ -159,10 +227,13 @@ sudo rm -f /etc/nginx/conf.d/default.conf
 
 # Read site definitions from registry (single source of truth)
 # Standard sites — each gets the same fastcgi template on its own port.
-jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
+jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false), (.value.noPdoMysql // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir no_pdo_mysql; do
     site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
         site_fpm_socket="$OPEN_BASEDIR_FPM_SOCKET"
+    fi
+    if [ "$no_pdo_mysql" = "true" ]; then
+        site_fpm_socket="$NO_PDO_MYSQL_FPM_SOCKET"
     fi
     cat <<VHOST | sudo tee "/etc/nginx/conf.d/e2e-${site}.conf" >/dev/null
 server {
@@ -261,6 +332,7 @@ done
 # ---------- Start services ----------
 echo "=== Starting services ==="
 sudo systemctl restart "php${PHP_VERSION}-fpm"
+sudo systemctl restart php-e2e-no-pdo-mysql
 
 # Kill anything lingering on our ports before starting Nginx
 for port in $(jq -r '.sites[].port' "$REGISTRY"); do
@@ -275,6 +347,7 @@ sudo systemctl start nginx
 # ---------- Verify ----------
 echo "=== Verifying services ==="
 sudo systemctl is-active --quiet "php${PHP_VERSION}-fpm" && echo "php${PHP_VERSION}-fpm: active" || { echo "php${PHP_VERSION}-fpm: FAILED"; exit 1; }
+sudo systemctl is-active --quiet php-e2e-no-pdo-mysql && echo "php-e2e-no-pdo-mysql: active" || { echo "php-e2e-no-pdo-mysql: FAILED"; exit 1; }
 sudo systemctl is-active --quiet nginx        && echo "nginx: active"      || { echo "nginx: FAILED"; exit 1; }
 sudo systemctl is-active --quiet mariadb      && echo "mariadb: active"    || { echo "mariadb: FAILED"; exit 1; }
 

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 PHP_VERSION="${PHP_VERSION:-8.2}"
 FPM_SOCKET="/run/php/e2e.sock"
 OPEN_BASEDIR_FPM_SOCKET="/run/php/e2e-open-basedir.sock"
+NO_PDO_MYSQL_FPM_SOCKET="/run/php/e2e-no-pdo-mysql.sock"
 REGISTRY="/app/tests/e2e/site-registry.json"
 SITE_ROOT=$(jq -r '.siteRoot' "$REGISTRY")
 
@@ -82,9 +83,61 @@ EOF
 rm -f "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 "php-fpm${PHP_VERSION}" --nodaemonize &
 
+# A second PHP-FPM master with ext-pdo_mysql left out, so sites pointed at it
+# take create_db_connection()'s PDO-less route and export through $wpdb. PHP
+# loads extensions per master rather than per pool, which is why this cannot
+# be another pool alongside the ones above. WordPress itself is unaffected: it
+# connects over mysqli.
+NO_PDO_MYSQL_CONF_D="/etc/php/${PHP_VERSION}/fpm-no-pdo-mysql-conf.d"
+rm -rf "$NO_PDO_MYSQL_CONF_D"
+cp -rL "/etc/php/${PHP_VERSION}/fpm/conf.d" "$NO_PDO_MYSQL_CONF_D"
+rm -f "$NO_PDO_MYSQL_CONF_D"/*pdo_mysql.ini
+
+# The whole point of this master is that pdo_mysql is gone. If the ini were
+# named differently, or the extension were built in, every test on these sites
+# would quietly run on the ordinary PDO path and still pass.
+if ! PHP_INI_SCAN_DIR="$NO_PDO_MYSQL_CONF_D" "php${PHP_VERSION}" \
+    -r 'exit(extension_loaded("pdo_mysql") ? 1 : 0);'; then
+    echo "pdo_mysql is still loaded in ${NO_PDO_MYSQL_CONF_D}; the no-pdo-mysql sites would not test the wpdb path." >&2
+    exit 1
+fi
+
+cat > "/etc/php/${PHP_VERSION}/fpm/php-fpm-no-pdo-mysql.conf" <<EOF
+[global]
+pid = /run/php/e2e-no-pdo-mysql.pid
+error_log = /tmp/php-e2e-no-pdo-mysql.log
+daemonize = no
+
+[e2e-no-pdo-mysql]
+user = nginx
+group = nginx
+listen = ${NO_PDO_MYSQL_FPM_SOCKET}
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+pm = ondemand
+pm.max_children = 8
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 120
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[post_max_size] = 50M
+php_admin_value[error_reporting] = E_ALL
+php_admin_value[display_errors] = Off
+php_admin_value[log_errors] = On
+php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
+env[SITE_EXPORT_TEST_MODE] = 1
+EOF
+
+PHP_INI_SCAN_DIR="$NO_PDO_MYSQL_CONF_D" "php-fpm${PHP_VERSION}" \
+    --nodaemonize \
+    --fpm-config "/etc/php/${PHP_VERSION}/fpm/php-fpm-no-pdo-mysql.conf" &
+
 # Wait for FPM socket
 for i in $(seq 1 30); do
-    if [ -S "$FPM_SOCKET" ] && [ -S "$OPEN_BASEDIR_FPM_SOCKET" ]; then break; fi
+    if [ -S "$FPM_SOCKET" ] && [ -S "$OPEN_BASEDIR_FPM_SOCKET" ] \
+       && [ -S "$NO_PDO_MYSQL_FPM_SOCKET" ]; then break; fi
     sleep 0.5
 done
 
@@ -114,10 +167,13 @@ rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 
 # Standard sites — serve from WordPress root so that index.php
 # bootstraps WordPress and the site-export plugin handles the request.
-jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir; do
+jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false), (.value.noPdoMysql // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir no_pdo_mysql; do
     site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
         site_fpm_socket="$OPEN_BASEDIR_FPM_SOCKET"
+    fi
+    if [ "$no_pdo_mysql" = "true" ]; then
+        site_fpm_socket="$NO_PDO_MYSQL_FPM_SOCKET"
     fi
     cat > "/etc/nginx/conf.d/e2e-${site}.conf" <<VHOST
 server {

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -15,6 +15,20 @@ let
     all.ctype
   ]);
 
+  # Same PHP without pdo_mysql, for sites flagged noPdoMysql in the registry.
+  # They take create_db_connection()'s PDO-less route and export through $wpdb.
+  phpPackageNoPdoMysql = pkgs.php82.withExtensions ({ enabled, all }: enabled ++ [
+    all.pdo_sqlite
+    all.zlib
+    all.curl
+    all.mbstring
+    all.openssl
+    all.simplexml
+    all.tokenizer
+    all.filter
+    all.ctype
+  ]);
+
   # Read site definitions from registry (single source of truth)
   registry = builtins.fromJSON (builtins.readFile ./site-registry.json);
   siteRoot = registry.siteRoot;
@@ -31,7 +45,9 @@ let
 
   # Generate Nginx virtualHost config for standard sites
   makeVhost = name: cfg: let
-    fpmSocket = if (cfg.openBasedir or false)
+    fpmSocket = if (cfg.noPdoMysql or false)
+      then config.services.phpfpm.pools."e2e-no-pdo-mysql".socket
+      else if (cfg.openBasedir or false)
       then config.services.phpfpm.pools."e2e-open-basedir".socket
       else config.services.phpfpm.pools.e2e.socket;
   in {
@@ -180,6 +196,32 @@ in {
       "pm.start_servers" = 4;
       "pm.min_spare_servers" = 2;
       "pm.max_spare_servers" = 8;
+      "php_admin_value[memory_limit]" = "512M";
+      "php_admin_value[max_execution_time]" = "120";
+      "php_admin_value[upload_max_filesize]" = "50M";
+      "php_admin_value[post_max_size]" = "50M";
+      "php_admin_value[error_reporting]" = "E_ALL";
+      "php_admin_value[display_errors]" = "Off";
+      "php_admin_value[log_errors]" = "On";
+      "php_admin_value[error_log]" = "/tmp/php-e2e-errors.log";
+      "php_admin_value[user_ini.cache_ttl]" = "0";
+      "php_admin_value[realpath_cache_ttl]" = "0";
+    };
+    phpEnv = {
+      SITE_EXPORT_TEST_MODE = "1";
+    };
+  };
+
+  # Sites without pdo_mysql, so create_db_connection() exports through $wpdb.
+  services.phpfpm.pools."e2e-no-pdo-mysql" = {
+    user = "nginx";
+    group = "nginx";
+    phpPackage = phpPackageNoPdoMysql;
+    settings = {
+      "listen.owner" = "nginx";
+      "listen.group" = "nginx";
+      "pm" = "ondemand";
+      "pm.max_children" = 8;
       "php_admin_value[memory_limit]" = "512M";
       "php_admin_value[max_execution_time]" = "120";
       "php_admin_value[upload_max_filesize]" = "50M";

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -168,6 +168,18 @@
     },
     "outbound-application-firewall": {
       "port": 8134
+    },
+    "basic-no-pdo-mysql": {
+      "port": 8135,
+      "noPdoMysql": true
+    },
+    "sql-data-fidelity-no-pdo-mysql": {
+      "port": 8136,
+      "noPdoMysql": true
+    },
+    "adversarial-database-no-pdo-mysql": {
+      "port": 8137,
+      "noPdoMysql": true
     }
   }
 }

--- a/tests/e2e/tests/import-02-sql-sync.test.js
+++ b/tests/e2e/tests/import-02-sql-sync.test.js
@@ -10,18 +10,22 @@ import { execSync } from 'node:child_process';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    getDbName, compareDatabases, createMysqlConnection,
+    getDbName, compareDatabases, createMysqlConnection, apiRequest,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: SQL Sync', () => {
-    const site = 'basic';
+// Run the same export twice: once on a site with ext-pdo_mysql, and once on a
+// site whose PHP-FPM master was started without it, where create_db_connection()
+// exports through WordPress's own $wpdb instead. Both must produce the same dump.
+describe.each([
+    ['basic', 'e2e_basic_import_02'],
+    ['basic-no-pdo-mysql', 'e2e_basic_no_pdo_mysql_import_02'],
+])('Import: SQL Sync (%s)', (site, importDb) => {
     let tempDir;
-    const importDb = 'e2e_basic_import_02';
 
     beforeAll(async () => {
         await ensureSite(site);
-        tempDir = createTempDir('e2e-import-sql');
+        tempDir = createTempDir(`e2e-import-sql-${site}`);
         // Ensure import DB doesn't exist
         const conn = await createMysqlConnection();
         await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
@@ -38,6 +42,34 @@ describe('Import: SQL Sync', () => {
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
+
+    // Guards the setup rather than the export. If a -no-pdo-mysql site were
+    // ever served by the ordinary FPM master — a renamed ini, a runner that
+    // doesn't read noPdoMysql — everything below would still pass while
+    // exercising the PDO path, and the wpdb route would silently lose its
+    // coverage. pdo_mysql being absent is what sends create_db_connection()
+    // through $wpdb, so asserting the extension and a working database
+    // together pins which route the export took.
+    it('exports over the database driver this site is meant to use', async () => {
+        const response = await apiRequest(site, 'preflight', {
+            directory: getSiteDir(site),
+        });
+        const preflight = response.json;
+        const hasPdoMysql = preflight.php.extensions.includes('pdo_mysql');
+
+        if (site.endsWith('-no-pdo-mysql')) {
+            assert.equal(hasPdoMysql, false,
+                'Expected pdo_mysql to be absent so the export runs through $wpdb; ' +
+                'this site is being served by the wrong PHP-FPM master.');
+        } else {
+            assert.equal(hasPdoMysql, true,
+                'Expected pdo_mysql to be present for the ordinary PDO path.');
+        }
+
+        assert.ok(preflight.database.connected,
+            `Expected a usable database, got error: ${preflight.database.error}`);
+        assert.ok(preflight.database.can_query, 'Expected can_query=true');
+    });
 
     it('db-pull completes and produces db.sql', () => {
         const result = runImporter(importUrl(), tempDir, 'db-pull', {

--- a/tests/e2e/tests/import-09-resume-sql.test.js
+++ b/tests/e2e/tests/import-09-resume-sql.test.js
@@ -15,14 +15,18 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: Resume SQL', { timeout: 120000 }, () => {
-    const site = 'basic';
+// Also runs on a site whose PHP-FPM master has no pdo_mysql, where the export
+// streams through WordPress's $wpdb. Resuming rebuilds the keyset WHERE clause
+// from primary key values, so both connections must quote them alike.
+describe.each([
+    ['basic', 'e2e_basic_import_09'],
+    ['basic-no-pdo-mysql', 'e2e_basic_no_pdo_mysql_import_09'],
+])('Import: Resume SQL (%s)', { timeout: 120000 }, (site, importDb) => {
     let tempDir;
-    const importDb = 'e2e_basic_import_09';
 
     beforeAll(async () => {
         await ensureSite(site);
-        tempDir = createTempDir('e2e-import-resume-sql');
+        tempDir = createTempDir(`e2e-import-resume-sql-${site}`);
         const conn = await createMysqlConnection();
         await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
         await conn.end();

--- a/tests/e2e/tests/import-23-sql-data-fidelity.test.js
+++ b/tests/e2e/tests/import-23-sql-data-fidelity.test.js
@@ -12,13 +12,18 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    createMysqlConnection,
+    getDbName, createMysqlConnection,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: SQL Data Fidelity', () => {
-    const site = 'http-errors';
-    const importDb = 'e2e_http_errors_import_23';
+// Also runs on a site whose PHP-FPM master has no pdo_mysql, where the export
+// streams through WordPress's $wpdb. Byte fidelity is the thing most likely to
+// differ between a PDO connection and a mysqli-backed one, so both produce the
+// dump and both are compared against the source.
+describe.each([
+    ['http-errors', 'e2e_http_errors_import_23'],
+    ['sql-data-fidelity-no-pdo-mysql', 'e2e_sql_data_fidelity_no_pdo_mysql_import_23'],
+])('Import: SQL Data Fidelity (%s)', (site, importDb) => {
     let tempDir;
 
     beforeAll(async () => {
@@ -225,7 +230,7 @@ CREATE TABLE wp_edge_cases (
     });
 
     it('row count matches between source and import', async () => {
-        const sourceConn = await createMysqlConnection('e2e_http_errors');
+        const sourceConn = await createMysqlConnection(getDbName(site));
         const importConn = await createMysqlConnection(importDb);
 
         const [[srcCount]] = await sourceConn.query('SELECT COUNT(*) as cnt FROM wp_edge_cases');

--- a/tests/e2e/tests/import-53-adversarial-database-pull.test.js
+++ b/tests/e2e/tests/import-53-adversarial-database-pull.test.js
@@ -20,9 +20,14 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: Adversarial database pull', { timeout: 300000 }, () => {
-    const site = 'adversarial-database';
-    const importDb = 'e2e_adversarial_database_import_53';
+// Also runs on a site whose PHP-FPM master has no pdo_mysql, where the export
+// streams through WordPress's $wpdb. Arbitrary bytes in primary keys travel
+// through the connection's own quoting on every cursor, which is where the two
+// connections would diverge if they were going to.
+describe.each([
+    ['adversarial-database', 'e2e_adversarial_database_import_53'],
+    ['adversarial-database-no-pdo-mysql', 'e2e_adversarial_no_pdo_mysql_import_53'],
+])('Import: Adversarial database pull (%s)', { timeout: 300000 }, (site, importDb) => {
     const adversarialTables = [
         'aa_binary_primary_keys',
         'ab_composite_binary_primary_key',


### PR DESCRIPTION
Followup to https://github.com/WordPress/reprint/pull/626

- Allow preflight to succeed even when the `pdo_mysql` extension is unavailable (as long as the wpdb fallback will work)
- Clear `wpdb->queries`, preventing them from stacking up in memory if SAVEQUERIES is enabled.
- Update e2e tests so that they run through both the PDO driver and the wpdb driver.