### PR TITLE
[PHP] Bound database pull SQL groups with 16 MiB INSERTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,11 +410,19 @@ The three modes:
 |------|-------------|-------------|
 | `file` (default) | Writes SQL to `$STATE_DIR/db.sql` | `db.sql` |
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
-| `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
+| `mysql` | Connects through mysqli and executes complete statements one at a time | none |
 
 When a source response stops mid-stream, the same importer asks for the
-remaining SQL and keeps an unfinished statement in memory. Direct MySQL
-output stores the last committed cursor in the target table
+remaining SQL and keeps an unfinished statement in memory. Each decoded SQL
+multipart body is at most 16 MiB. Each INSERT statement is also at most 16 MiB.
+When a batch contains complete statements followed by an unfinished statement,
+the source sends the complete prefix first so the importer can save its cursor.
+That split can leave at most 16 MiB after the checkpoint, and finishing the
+current bounded INSERT can add at most another 16 MiB. The next complete
+checkpoint is therefore at most 32 MiB away. A `db.sql` group adds one
+separator newline before its cursor marker.
+
+Direct MySQL output stores the last committed group cursor in the target table
 `__reprint_db_pull_progress_<uuid>`. The UUID makes an accidental name clash
 unlikely and changes whenever the table schema changes. Reprint logs and excludes
 that internal name from the source dump.
@@ -425,18 +433,20 @@ group at a time and sends it through the same database importer for MySQL and
 SQLite. The target stores the exporter cursor and matching `db.sql` byte offset.
 A replacement process reads that row and seeks directly to the next group.
 
-Existing SQL statement-size, fragment, time, and memory budgets still decide
-how much SQL belongs to a group. For transactional target tables, the group and
-its next cursor are committed together. SQLite uses this transaction for every
-group. Table replacement and oversized-value updates remain separate groups. If
-a MySQL process stops, its replacement waits for the old target connection,
-reruns `db-session-setup.sql`, and continues from the cursor stored in MySQL. A
-repeated INSERT skips rows identified by a non-null unique key, so this also
-works for keyed MyISAM tables. Reprint cannot continue a nontransactional table
-without such a key, or while an oversized value is being appended in separate
-UPDATE statements; those cases require aborting and starting the database
-import again. After `db-apply` finishes, it removes its internal cursor table
-from the imported database.
+For direct MySQL output and later `db-apply`, the MySQL importer executes the
+statements in a complete group one at a time. It stores the group cursor only
+after every statement in that group succeeds.
+
+For transactional target tables, the group and its next cursor are committed
+together. SQLite uses this transaction for every group. Table replacement and
+oversized-value updates remain separate groups. If a MySQL process stops, its
+replacement waits for the old target connection, reruns `db-session-setup.sql`,
+and continues from the cursor stored in MySQL. A repeated INSERT skips rows
+identified by a non-null unique key, so this also works for keyed MyISAM tables.
+Reprint cannot continue a nontransactional table without such a key, or while
+an oversized value is being appended in separate UPDATE statements; those cases
+require aborting and starting the database import again. After `db-apply`
+finishes, it removes its internal cursor table from the imported database.
 
 The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
 `--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -6889,36 +6889,6 @@ class ImportClient
     }
 
     /**
-     * Parses one exporter group and applies URL replacements to its statements.
-     *
-     * @return array { Rewritten SQL followed by the number of statements. }
-     */
-    private function prepare_mysql_sql_group(
-        string $sql,
-        ?SqlStatementRewriter $stmt_rewriter
-    ): array {
-        $query_stream = new \WP_MySQL_FastQueryStream();
-        $query_stream->append_sql($sql);
-        $query_stream->mark_input_complete();
-        $mysql_sql = "";
-        $statement_count = 0;
-        while ($query_stream->next_query()) {
-            $query = $query_stream->get_query();
-            if ($stmt_rewriter !== null) {
-                $query = $stmt_rewriter->rewrite($query);
-            }
-            $mysql_sql .= $query . "\n";
-            ++$statement_count;
-        }
-        if ($statement_count === 0) {
-            throw new RuntimeException(
-                "db.sql contains an SQL group with no complete statement. Run db-pull again.",
-            );
-        }
-        return [$mysql_sql, $statement_count];
-    }
-
-    /**
      * Executes one complete exporter group and saves its next position in the target.
      *
      * @param DatabaseConnection $connection Open target connection.
@@ -6935,11 +6905,26 @@ class ImportClient
         ?SqlStatementRewriter $stmt_rewriter = null
     ): int {
         if ($target_engine === 'mysql') {
-            [$mysql_sql, $statement_count] = $this->prepare_mysql_sql_group(
-                $sql,
-                $stmt_rewriter,
-            );
-            $connection->exec($mysql_sql);
+            $query_stream = new \WP_MySQL_FastQueryStream();
+            $query_stream->append_sql($sql);
+            $query_stream->mark_input_complete();
+            $statement_count = 0;
+            while ($query_stream->next_query()) {
+                $query = $query_stream->get_query();
+                if ($stmt_rewriter !== null) {
+                    $query = $stmt_rewriter->rewrite($query);
+                }
+                // The exporter applies its packet-size cap to each statement.
+                // Keep each MySQL command within that cap even when one
+                // resumable group contains several complete statements.
+                $connection->exec($query);
+                ++$statement_count;
+            }
+            if ($statement_count === 0) {
+                throw new RuntimeException(
+                    "db.sql contains an SQL group with no complete statement. Run db-pull again.",
+                );
+            }
             $this->save_database_import_position(
                 $connection,
                 $source_hash,

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -45,10 +45,10 @@ class MySQLDumpProducer
     /**
      * Maximum decoded SQL body bytes for one multipart part.
      *
-     * The producer uses this limit to split or reject one oversized row
-     * fragment. The exporter uses the same limit to stop grouping fragments
-     * before the complete multipart part becomes oversized, then checks its
-     * final byte length before writing it.
+     * The producer closes a multi-row INSERT at this limit, or splits or
+     * rejects one oversized row fragment. The exporter uses the same limit to
+     * stop grouping fragments before the complete multipart part becomes
+     * oversized, then checks its final byte length before writing it.
      */
     public const MAX_SQL_PART_BODY_BYTES = 16 * 1024 * 1024;
 
@@ -111,6 +111,17 @@ class MySQLDumpProducer
 
     /** @var int */
     private $current_statement_size = 0;
+
+    /**
+     * Reader cursor from before a fetched row which must begin the next INSERT.
+     *
+     * The live producer retains that row in memory. A serialized producer
+     * cursor uses this earlier reader position so a new process fetches the
+     * row again instead of skipping it.
+     *
+     * @var array|null
+     */
+    private $reader_cursor_before_retained_record = null;
 
     /**
      * @param PDO $db Database connection — either a real PDO (MySQL) or a
@@ -240,9 +251,12 @@ class MySQLDumpProducer
      */
     private function emit_insert_header()
     {
-        if (!$this->row_reader->next_record()) {
-            $this->state = self::STATE_NEXT_TABLE;
-            return false;
+        $this->rows_in_batch = 0;
+        if ($this->row_reader->get_current_record() === null) {
+            if (!$this->row_reader->next_record()) {
+                $this->state = self::STATE_NEXT_TABLE;
+                return false;
+            }
         }
 
         $column_list = implode(
@@ -260,9 +274,10 @@ class MySQLDumpProducer
             $this->row_reader->get_current_record(),
             $this->current_statement_size
         );
-        $this->current_statement_size += strlen($first_row_sql) + 1;
+        $this->current_statement_size += strlen($first_row_sql);
 
         $this->row_reader->clear_current_record();
+        $this->reader_cursor_before_retained_record = null;
         $this->rows_in_batch = 1;
 
         // Oversized updates require closing this INSERT with a semicolon so the
@@ -294,6 +309,7 @@ class MySQLDumpProducer
     /** Emits one row with a leading comma, or closes the open INSERT when no row remains. */
     private function emit_row()
     {
+        $reader_cursor_before_current_record = $this->row_reader->get_cursor_state();
         if (!$this->row_reader->next_record()) {
             $this->current_sql_fragment = $this->on_duplicate_key() . ';';
             $this->current_statement_size = 0;
@@ -301,12 +317,34 @@ class MySQLDumpProducer
             return true;
         }
 
+        $row_tuple_bytes = $this->estimate_formatted_row_tuple_bytes(
+            $this->row_reader->get_current_record()
+        );
+        $maximum_insert_statement_bytes = min(
+            $this->max_statement_size,
+            self::MAX_SQL_PART_BODY_BYTES
+        );
+        if (
+            $this->current_statement_size + 1 + $row_tuple_bytes >
+                $maximum_insert_statement_bytes
+        ) {
+            // This row fits as the first row of another INSERT, but not in the
+            // current one. Keep it in memory for the live producer. A resumed
+            // producer uses the earlier cursor and fetches it again.
+            $this->reader_cursor_before_retained_record = $reader_cursor_before_current_record;
+            $this->current_sql_fragment = $this->on_duplicate_key() . ';';
+            $this->current_statement_size = 0;
+            $this->rows_in_batch = 0;
+            $this->state = self::STATE_START_INSERT;
+            return true;
+        }
+
         $current_record_ends_query_batch = $this->row_reader->is_current_record_at_query_batch_boundary();
         $row_sql = $this->format_row_for_insert(
             $this->row_reader->get_current_record(),
-            strlen($this->on_duplicate_key())
+            strlen($this->on_duplicate_key()) + 1
         );
-        $this->current_statement_size += strlen($row_sql) + 2;
+        $this->current_statement_size += strlen($row_sql) + 1;
         $this->row_reader->clear_current_record();
         $this->rows_in_batch++;
 
@@ -482,6 +520,7 @@ class MySQLDumpProducer
             $this->oversized_queue = [];
             $this->oversized_pk_values = null;
             $this->current_statement_size = 0;
+            $this->reader_cursor_before_retained_record = null;
         }
         return $has_table;
     }
@@ -501,7 +540,8 @@ class MySQLDumpProducer
      */
     public function get_reentrancy_cursor()
     {
-        $cursor_data = $this->row_reader->get_cursor_state();
+        $cursor_data = $this->reader_cursor_before_retained_record ??
+            $this->row_reader->get_cursor_state();
         unset(
             $cursor_data["current_row"],
             $cursor_data["current_row_ends_query_batch"],
@@ -768,13 +808,19 @@ class MySQLDumpProducer
             $estimated_sizes[$col] = $this->estimate_formatted_size($value, $data_type);
         }
 
-        // Estimate the size of "(val1,val2,val3)," — values + commas between them + parens + terminator
-        $row_size_est = array_sum($estimated_sizes) + count($estimated_sizes) + 3;
-        $projected_statement_size = $this->current_statement_size + $row_size_est;
-        $projected_fragment_size = $sql_fragment_fixed_bytes + $row_size_est;
+        $row_tuple_bytes = $this->estimate_formatted_row_tuple_bytes($row);
+        $row_separator_bytes = $this->rows_in_batch > 0 ? 1 : 0;
+        $maximum_insert_statement_bytes = min(
+            $this->max_statement_size,
+            self::MAX_SQL_PART_BODY_BYTES
+        );
+        $projected_statement_size =
+            $this->current_statement_size + $row_separator_bytes + $row_tuple_bytes;
+        $projected_fragment_size =
+            $sql_fragment_fixed_bytes + $row_separator_bytes + $row_tuple_bytes;
 
         if (
-            $projected_statement_size <= $this->max_statement_size &&
+            $projected_statement_size <= $maximum_insert_statement_bytes &&
             $projected_fragment_size <= self::MAX_SQL_PART_BODY_BYTES
         ) {
             $formatted_values = [];
@@ -821,7 +867,7 @@ class MySQLDumpProducer
         $chunked_columns = [];
 
         $excess = max(
-            $projected_statement_size - $this->max_statement_size,
+            $projected_statement_size - $maximum_insert_statement_bytes,
             $projected_fragment_size - self::MAX_SQL_PART_BODY_BYTES
         );
         $saved_bytes = 0;
@@ -881,6 +927,8 @@ class MySQLDumpProducer
         }
 
         if (
+            $projected_statement_size - $saved_bytes >
+                $maximum_insert_statement_bytes ||
             $projected_fragment_size - $saved_bytes >
                 self::MAX_SQL_PART_BODY_BYTES ||
             ($skipped_non_byte_bounded_value && $excess > 0)
@@ -910,6 +958,24 @@ class MySQLDumpProducer
         }
 
         return "(" . implode(",", array_values($formatted_values)) . ")";
+    }
+
+    /** Returns the exact SQL bytes used by one formatted VALUES tuple. */
+    private function estimate_formatted_row_tuple_bytes($row)
+    {
+        $tuple_bytes = 2;
+        $column_index = 0;
+        foreach ($this->row_reader->get_current_column_names() as $column) {
+            if ($column_index > 0) {
+                ++$tuple_bytes;
+            }
+            $tuple_bytes += $this->estimate_formatted_size(
+                $row[$column] ?? null,
+                $this->row_reader->get_data_type($column)
+            );
+            ++$column_index;
+        }
+        return $tuple_bytes;
     }
 
     /**

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -883,25 +883,6 @@ function endpoint_sql_chunk(
         $gz->sync();
     }
 
-    $emit_sql_multipart_part = function (
-        string $sql,
-        bool $query_complete,
-        string $cursor
-    ) use ($gz, $boundary): void {
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/sql\r\n" .
-            "Content-Length: " . strlen($sql) . "\r\n" .
-            "X-Chunk-Type: sql\r\n" .
-            "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
-            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-            "\r\n"
-        );
-        $gz->write($sql);
-        $gz->write("\r\n");
-        $gz->sync();
-    };
-
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch
     // as one or two multipart parts. Stop when the producer is exhausted or the
@@ -927,7 +908,6 @@ function endpoint_sql_chunk(
             /** @var string|null Cursor after the last fragment included in this batch. */
             $last_fragment_cursor = null;
             $sql_ends_with_complete_statement = false;
-            $complete_prefix_fragment_count = 0;
             $complete_prefix_byte_length = 0;
             /** @var string|null Cursor after the last complete statement in this batch. */
             $complete_prefix_cursor = null;
@@ -943,7 +923,6 @@ function endpoint_sql_chunk(
                 $sql_ends_with_complete_statement =
                     $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
                 if ($sql_ends_with_complete_statement) {
-                    $complete_prefix_fragment_count = 1;
                     $complete_prefix_byte_length = $sql_batch_bytes;
                     $complete_prefix_cursor = $deferred_fragment_cursor;
                 }
@@ -1015,7 +994,6 @@ function endpoint_sql_chunk(
                         $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
                     if ($sql_ends_with_complete_statement) {
                         $cursor = $fragment_cursor;
-                        $complete_prefix_fragment_count = count($sql_fragments);
                         $complete_prefix_byte_length = $sql_batch_bytes;
                         $complete_prefix_cursor = $fragment_cursor;
                     }
@@ -1036,7 +1014,8 @@ function endpoint_sql_chunk(
                 }
             }
 
-            if (empty($sql_fragments) || $sql_batch_bytes === 0) {
+            $sql = implode("", $sql_fragments);
+            if ($sql === '') {
                 break;
             }
             // Does this assembled SQL body end on a complete statement boundary?
@@ -1047,17 +1026,13 @@ function endpoint_sql_chunk(
                 $cursor = $last_fragment_cursor;
             }
 
-            $test_sql = null;
             // E2E test hook: before SQL batch is emitted
             if (getenv('SITE_EXPORT_TEST_MODE')) {
-                $test_sql = implode("", $sql_fragments);
-                $hook_args = [&$test_sql, $cursor];
+                $hook_args = [&$sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
-            if ($test_sql !== null) {
-                $sql_batch_bytes = strlen($test_sql);
-            }
+            $sql_batch_bytes = strlen($sql);
             if (
                 $sql_batch_bytes > MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
             ) {
@@ -1069,43 +1044,47 @@ function endpoint_sql_chunk(
                 );
             }
             $sql_bytes_processed += $sql_batch_bytes;
+            // Keep only the assembled bounded batch while it is split and emitted.
+            unset($sql_fragments);
 
             if (
                 !$query_complete
-                && $complete_prefix_fragment_count > 0
+                && $complete_prefix_byte_length > 0
                 && $complete_prefix_cursor !== null
             ) {
                 // Expose the last complete statement boundary before the
                 // incomplete suffix. The importer can save that cursor instead
                 // of retaining earlier statements with the suffix.
-                $sql = $test_sql !== null
-                    ? substr($test_sql, 0, $complete_prefix_byte_length)
-                    : implode(
-                        "",
-                        array_slice($sql_fragments, 0, $complete_prefix_fragment_count)
-                    );
-                $emit_sql_multipart_part(
-                    $sql,
-                    true,
-                    $complete_prefix_cursor
+                $complete_sql_prefix = substr($sql, 0, $complete_prefix_byte_length);
+                $gz->write(
+                    "--{$boundary}\r\n" .
+                    "Content-Type: application/sql\r\n" .
+                    "Content-Length: " . strlen($complete_sql_prefix) . "\r\n" .
+                    "X-Chunk-Type: sql\r\n" .
+                    "X-Query-Complete: 1\r\n" .
+                    "X-Cursor: " . base64_encode($complete_prefix_cursor) . "\r\n" .
+                    "\r\n"
                 );
-                unset($sql);
+                $gz->write($complete_sql_prefix);
+                $gz->write("\r\n");
+                $gz->sync();
+                unset($complete_sql_prefix);
 
-                $sql = $test_sql !== null
-                    ? substr($test_sql, $complete_prefix_byte_length)
-                    : implode(
-                        "",
-                        array_slice($sql_fragments, $complete_prefix_fragment_count)
-                    );
-            } else {
-                $sql = $test_sql ?? implode("", $sql_fragments);
+                $sql = substr($sql, $complete_prefix_byte_length);
             }
 
-            $emit_sql_multipart_part(
-                $sql,
-                $query_complete,
-                $cursor
+            $gz->write(
+                "--{$boundary}\r\n" .
+                "Content-Type: application/sql\r\n" .
+                "Content-Length: " . strlen($sql) . "\r\n" .
+                "X-Chunk-Type: sql\r\n" .
+                "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
+                "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+                "\r\n"
             );
+            $gz->write($sql);
+            $gz->write("\r\n");
+            $gz->sync();
 
             $batches_processed++;
 

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -883,9 +883,28 @@ function endpoint_sql_chunk(
         $gz->sync();
     }
 
+    $emit_sql_multipart_part = function (
+        string $sql,
+        bool $query_complete,
+        string $cursor
+    ) use ($gz, $boundary): void {
+        $gz->write(
+            "--{$boundary}\r\n" .
+            "Content-Type: application/sql\r\n" .
+            "Content-Length: " . strlen($sql) . "\r\n" .
+            "X-Chunk-Type: sql\r\n" .
+            "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
+            "X-Cursor: " . base64_encode($cursor) . "\r\n" .
+            "\r\n"
+        );
+        $gz->write($sql);
+        $gz->write("\r\n");
+        $gz->sync();
+    };
+
     // -- Stream SQL fragments --
     // Pull SQL fragments from the producer in batches, writing each batch
-    // as a multipart part. Stop when the producer is exhausted or the
+    // as one or two multipart parts. Stop when the producer is exhausted or the
     // resource budget (time/memory) runs out.
     $batches_processed = 0;
     $sql_bytes_processed = 0;
@@ -903,22 +922,31 @@ function endpoint_sql_chunk(
             $budget->has_remaining()
         ) {
             $sql_fragments = [];
-            $sql_part_body_bytes = 0;
+            $sql_batch_bytes = 0;
             $cursor = null;
-            /** @var string|null Cursor after the last fragment included in this part. */
+            /** @var string|null Cursor after the last fragment included in this batch. */
             $last_fragment_cursor = null;
             $sql_ends_with_complete_statement = false;
+            $complete_prefix_fragment_count = 0;
+            $complete_prefix_byte_length = 0;
+            /** @var string|null Cursor after the last complete statement in this batch. */
+            $complete_prefix_cursor = null;
 
             $i = 0;
             $part_must_end = false;
             if ($deferred_fragment !== null) {
                 $sql_fragments[] = $deferred_fragment;
-                $sql_part_body_bytes = strlen($deferred_fragment);
+                $sql_batch_bytes = strlen($deferred_fragment);
                 $cursor = $deferred_fragment_cursor;
                 $last_fragment_cursor = $deferred_fragment_cursor;
                 $trimmed_fragment = rtrim($deferred_fragment);
                 $sql_ends_with_complete_statement =
                     $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
+                if ($sql_ends_with_complete_statement) {
+                    $complete_prefix_fragment_count = 1;
+                    $complete_prefix_byte_length = $sql_batch_bytes;
+                    $complete_prefix_cursor = $deferred_fragment_cursor;
+                }
                 $part_must_end = $deferred_fragment_must_be_its_own_part;
                 $i = 1;
                 $deferred_fragment = null;
@@ -948,11 +976,11 @@ function endpoint_sql_chunk(
 
                     if (
                         !empty($sql_fragments) &&
-                        $sql_part_body_bytes + $fragment_bytes >
+                        $sql_batch_bytes + $fragment_bytes >
                             MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
                     ) {
                         // The producer has already advanced. Retain this fragment
-                        // and its cursor while this part keeps its earlier cursor.
+                        // and its cursor while this batch keeps its earlier cursor.
                         $deferred_fragment = $fragment;
                         $deferred_fragment_cursor = $fragment_cursor;
                         $deferred_fragment_must_be_its_own_part =
@@ -978,7 +1006,7 @@ function endpoint_sql_chunk(
                     }
 
                     $sql_fragments[] = $fragment;
-                    $sql_part_body_bytes += $fragment_bytes;
+                    $sql_batch_bytes += $fragment_bytes;
                     $last_fragment_cursor = $fragment_cursor;
                     $i++;
 
@@ -987,6 +1015,9 @@ function endpoint_sql_chunk(
                         $trimmed_fragment !== '' && substr($trimmed_fragment, -1) === ';';
                     if ($sql_ends_with_complete_statement) {
                         $cursor = $fragment_cursor;
+                        $complete_prefix_fragment_count = count($sql_fragments);
+                        $complete_prefix_byte_length = $sql_batch_bytes;
+                        $complete_prefix_cursor = $fragment_cursor;
                     }
 
                     if ($reader->current_fragment_must_be_its_own_part()) {
@@ -1005,50 +1036,76 @@ function endpoint_sql_chunk(
                 }
             }
 
-            $sql = implode("", $sql_fragments);
-            if ($sql === '') {
+            if (empty($sql_fragments) || $sql_batch_bytes === 0) {
                 break;
             }
-            // Does this chunk end on a complete statement boundary?
+            // Does this assembled SQL body end on a complete statement boundary?
             // A complete SQL statement ends with ";"; a fragment from an open
             // INSERT does not.
-            $trimmed = rtrim($sql);
-            $query_complete = $trimmed !== "" && substr($trimmed, -1) === ";";
+            $query_complete = $sql_ends_with_complete_statement;
             if (!$query_complete || $cursor === null) {
                 $cursor = $last_fragment_cursor;
             }
 
+            $test_sql = null;
             // E2E test hook: before SQL batch is emitted
             if (getenv('SITE_EXPORT_TEST_MODE')) {
-                $hook_args = [&$sql, $cursor];
+                $test_sql = implode("", $sql_fragments);
+                $hook_args = [&$test_sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
 
-            $sql_part_body_bytes = strlen($sql);
+            if ($test_sql !== null) {
+                $sql_batch_bytes = strlen($test_sql);
+            }
             if (
-                $sql_part_body_bytes > MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
+                $sql_batch_bytes > MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES
             ) {
                 throw new RuntimeException(
-                    "The decoded SQL part body is {$sql_part_body_bytes} bytes; " .
+                    "The decoded SQL part body is {$sql_batch_bytes} bytes; " .
                     "the limit is " .
                     MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES .
                     " bytes."
                 );
             }
-            $sql_bytes_processed += $sql_part_body_bytes;
+            $sql_bytes_processed += $sql_batch_bytes;
 
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/sql\r\n" .
-                "Content-Length: " . $sql_part_body_bytes . "\r\n" .
-                "X-Chunk-Type: sql\r\n" .
-                "X-Query-Complete: " . ($query_complete ? "1" : "0") . "\r\n" .
-                "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                "\r\n"
+            if (
+                !$query_complete
+                && $complete_prefix_fragment_count > 0
+                && $complete_prefix_cursor !== null
+            ) {
+                // Expose the last complete statement boundary before the
+                // incomplete suffix. The importer can save that cursor instead
+                // of retaining earlier statements with the suffix.
+                $sql = $test_sql !== null
+                    ? substr($test_sql, 0, $complete_prefix_byte_length)
+                    : implode(
+                        "",
+                        array_slice($sql_fragments, 0, $complete_prefix_fragment_count)
+                    );
+                $emit_sql_multipart_part(
+                    $sql,
+                    true,
+                    $complete_prefix_cursor
+                );
+                unset($sql);
+
+                $sql = $test_sql !== null
+                    ? substr($test_sql, $complete_prefix_byte_length)
+                    : implode(
+                        "",
+                        array_slice($sql_fragments, $complete_prefix_fragment_count)
+                    );
+            } else {
+                $sql = $test_sql ?? implode("", $sql_fragments);
+            }
+
+            $emit_sql_multipart_part(
+                $sql,
+                $query_complete,
+                $cursor
             );
-            $gz->write($sql);
-            $gz->write("\r\n");
-            $gz->sync();
 
             $batches_processed++;
 

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -186,8 +186,20 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $this->getDumpSQL(['max_statement_size' => 8 * 1024 * 1024]);
     }
 
-    /** A multipart boundary may split one larger INSERT between row fragments. */
-    public function testUnkeyedInsertMayExceedPartBodyLimit(): void
+    /**
+     * A multi-row INSERT must close before its SQL exceeds one part body.
+     *
+     * The exporter limits each SQL multipart part to 16 MiB, but one INSERT
+     * may span several parts. A part ending inside that statement cannot close
+     * the client's current SQL group. Without a statement limit, many bounded
+     * parts can therefore become one SQL group which db-apply reads into one
+     * PHP string.
+     *
+     * Each row below fits comfortably in one part. Together, the formatted
+     * rows exceed one part body. The producer must start another INSERT, and
+     * the resulting dump must still restore all 160 rows.
+     */
+    public function testUnkeyedInsertDoesNotExceedPartBodyLimit(): void
     {
         $this->pdo->exec("
             CREATE TABLE unkeyed_large_insert (
@@ -208,16 +220,32 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $fragments = $this->collectAllFragments($producer);
         $sql = implode('', $fragments);
 
+        $insert_prefix = 'INSERT INTO `unkeyed_large_insert` ';
+        $current_insert_bytes = null;
+        $insert_statement_bytes = [];
+        foreach ($fragments as $fragment) {
+            if (strncmp($fragment, $insert_prefix, strlen($insert_prefix)) === 0) {
+                $current_insert_bytes = 0;
+            }
+            if ($current_insert_bytes !== null) {
+                $current_insert_bytes += strlen($fragment);
+                if (substr($fragment, -1) === ';') {
+                    $insert_statement_bytes[] = $current_insert_bytes;
+                    $current_insert_bytes = null;
+                }
+            }
+        }
+
         $this->assertGreaterThan(
             MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
-            strlen($sql)
+            array_sum($insert_statement_bytes),
+            'The formatted rows must exceed one part body for this regression test.'
         );
-        foreach ($fragments as $fragment) {
-            $this->assertLessThan(
-                MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
-                strlen($fragment)
-            );
-        }
+        $this->assertLessThanOrEqual(
+            MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
+            max($insert_statement_bytes),
+            'Every complete INSERT must fit within one SQL part body.'
+        );
 
         $importPdo = $this->executeDumpInNewDatabase($sql);
         $rowCount = $importPdo->query(

--- a/tests/MySQLDumpProducer/ReentrancyTest.php
+++ b/tests/MySQLDumpProducer/ReentrancyTest.php
@@ -316,6 +316,84 @@ class ReentrancyTest extends MySQLDumpProducerTestBase
         $this->assertGreaterThan(0, count($insertFragments));
     }
 
+    /** A cursor at a byte-driven INSERT boundary must not skip the retained next row. */
+    public function testResumeAfterInsertByteLimitRetainsNextRow(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE byte_limited_resume (
+                id INT NOT NULL PRIMARY KEY,
+                payload MEDIUMBLOB NOT NULL
+            )
+        ");
+
+        $payloads = [];
+        $statement = $this->pdo->prepare(
+            "INSERT INTO byte_limited_resume (id, payload) VALUES (?, ?)"
+        );
+        for ($id = 1; $id <= 4; ++$id) {
+            $payloads[$id] = "payload-{$id}-" . str_repeat(chr(96 + $id), 700);
+            $statement->execute([$id, $payloads[$id]]);
+        }
+
+        // Two formatted rows fit below this limit. Fetching row 3 closes the
+        // current INSERT and retains that row for the next INSERT.
+        $options = [
+            "batch_size" => 250,
+            "max_statement_size" => 2500,
+        ];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        $insert_started = false;
+        while ($producer->next_sql_fragment()) {
+            $fragment = $producer->get_sql_fragment();
+            $fragments[] = $fragment;
+            if (strpos($fragment, "INSERT INTO `byte_limited_resume`") === 0) {
+                $insert_started = true;
+            }
+            if (
+                $insert_started &&
+                substr(rtrim($fragment), -1) === ";"
+            ) {
+                break;
+            }
+        }
+
+        $cursor = $producer->get_reentrancy_cursor();
+        $this->assertStringNotContainsString(
+            base64_encode($payloads[3]),
+            $cursor,
+            "The cursor must store the position before the retained row, not the row itself."
+        );
+
+        $options["cursor"] = $cursor;
+        $resumed_producer = $this->createProducer($options);
+        $fragments = array_merge(
+            $fragments,
+            $this->collectAllFragments($resumed_producer)
+        );
+        $sql = implode("", $fragments);
+
+        $this->assertSame(
+            2,
+            substr_count($sql, "INSERT INTO `byte_limited_resume`"),
+            "The byte limit must split these four rows into two INSERT statements."
+        );
+        foreach ($payloads as $payload) {
+            $this->assertSame(
+                1,
+                substr_count($sql, base64_encode($payload)),
+                "Every row must be emitted exactly once across the resume boundary."
+            );
+        }
+
+        $importPdo = $this->executeDumpInNewDatabase($sql);
+        $this->assertDatabasesEqual(
+            $this->pdo,
+            $importPdo,
+            ["byte_limited_resume"]
+        );
+    }
+
     /**
      * Test very small batch size with many iterations.
      */

--- a/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
+++ b/tests/e2e/tests/import-58-budgeted-mysql-sql-groups.test.js
@@ -1,6 +1,6 @@
 /**
- * Direct MySQL output keeps fragment and byte budgets while ending a SQL
- * group before the next table replacement starts.
+ * SQL groups expose every usable statement checkpoint while keeping both
+ * multipart bodies and the bytes between checkpoints bounded.
  */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -33,7 +33,10 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
                     `CREATE TABLE \`${firstTable}\` (`
                     + '`id` INT NOT NULL PRIMARY KEY, `value` VARCHAR(64) NOT NULL) ENGINE=InnoDB'
                 );
-                const rows = Array.from({ length: 600 }, (_, index) => [
+                // One table comment plus three complete 250-row INSERTs uses
+                // 751 fragments. A 1,000-fragment batch then ends after 249
+                // rows of the fourth INSERT, leaving an unfinished suffix.
+                const rows = Array.from({ length: 1001 }, (_, index) => [
                     index + 1,
                     `row-${index + 1}`,
                 ]);
@@ -53,13 +56,13 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
                     `CREATE TABLE \`${boundedPayloadTable}\` (`
                     + '`id` INT NOT NULL PRIMARY KEY, `payload` MEDIUMBLOB NOT NULL) ENGINE=InnoDB'
                 );
-                // The reader closes its first INSERT after 250 rows. The next
-                // INSERT makes the grouped SQL body cross 16 MiB, so the body
-                // limit must end a part while that second INSERT is still open.
-                for (let id = 1; id <= 400; id++) {
+                // These 200 rows remain inside one 250-row query batch, but
+                // their formatted SQL is about 21 MiB. The producer must close
+                // the INSERT on bytes before the query batch ends.
+                for (let id = 1; id <= 200; id++) {
                     await connection.query(
                         `INSERT INTO \`${boundedPayloadTable}\` (id, payload) `
-                        + 'VALUES (?, REPEAT(CHAR(65 + MOD(?, 26)), 32 * 1024))',
+                        + 'VALUES (?, REPEAT(CHAR(65 + MOD(?, 26)), 80 * 1024))',
                         [id, id],
                     );
                 }
@@ -109,14 +112,18 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         }
     }, 300000);
 
-    async function sqlParts(fragmentsPerBatch) {
+    async function sqlParts(fragmentsPerBatch, cursor = null) {
+        const request = {
+            directory: getSiteDir(site),
+            fragments_per_batch: fragmentsPerBatch,
+            skip_tables: skippedTables,
+        };
+        if (cursor !== null) {
+            request.cursor = cursor;
+        }
         const response = await apiRequest(site, 'sql_chunk', {}, {
             method: 'POST',
-            body: JSON.stringify({
-                directory: getSiteDir(site),
-                fragments_per_batch: fragmentsPerBatch,
-                skip_tables: skippedTables,
-            }),
+            body: JSON.stringify(request),
         });
         assert.equal(
             response.status,
@@ -162,8 +169,28 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         }
     }
 
-    it('allows the existing fragment budget to group complete INSERT statements', async () => {
+    function assertBoundedBytesBetweenCheckpoints(parts) {
+        let bytesSinceCheckpoint = 0;
+        for (const part of parts) {
+            bytesSinceCheckpoint += Buffer.byteLength(part.body);
+            assert.ok(
+                bytesSinceCheckpoint <= 2 * maximumSqlPartBodyBytes,
+                `SQL group reached ${bytesSinceCheckpoint} bytes before its next checkpoint`,
+            );
+            if (part.headers['x-query-complete'] === '1') {
+                bytesSinceCheckpoint = 0;
+            }
+        }
+        assert.equal(
+            bytesSinceCheckpoint,
+            0,
+            'A complete SQL response must end at a statement checkpoint',
+        );
+    }
+
+    it('checkpoints a complete SQL prefix before its unfinished batch suffix', async () => {
         const parts = await sqlParts(1000);
+        assertBoundedBytesBetweenCheckpoints(parts);
         const firstTableInsertPart = parts.find(
             part => part.body.includes(`INSERT INTO \`${firstTable}\``)
         );
@@ -172,6 +199,36 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             firstTableInsertPart.body.match(new RegExp('INSERT INTO `' + firstTable + '`', 'g'))?.length,
             3,
             'Expected the three producer INSERT statements in one budgeted SQL part',
+        );
+        assert.equal(
+            firstTableInsertPart.headers['x-query-complete'],
+            '1',
+            'The complete prefix should expose a cursor before the unfinished suffix',
+        );
+        const firstTableInsertPartIndex = parts.indexOf(firstTableInsertPart);
+        const incompleteSuffixPart = parts[firstTableInsertPartIndex + 1];
+        assert.equal(
+            incompleteSuffixPart?.headers['x-query-complete'],
+            '0',
+            'The unfinished INSERT suffix should follow the complete prefix',
+        );
+        assert.ok(
+            incompleteSuffixPart.body.includes(`INSERT INTO \`${firstTable}\``),
+            'The unfinished suffix should contain the next INSERT statement',
+        );
+        assert.ok(
+            !incompleteSuffixPart.body.includes(';'),
+            'The unfinished suffix must not retain a complete statement',
+        );
+        const resumedParts = await sqlParts(
+            1000,
+            firstTableInsertPart.headers['x-cursor'],
+        );
+        assertBoundedBytesBetweenCheckpoints(resumedParts);
+        assert.equal(
+            resumedParts.map(part => part.body).join(''),
+            parts.slice(firstTableInsertPartIndex + 1).map(part => part.body).join(''),
+            'The complete-prefix cursor must resume at the unfinished suffix',
         );
         assert.ok(
             !firstTableInsertPart.body.includes(`DROP TABLE IF EXISTS \`${secondTable}\``),
@@ -187,7 +244,7 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         );
     });
 
-    it('bounds grouped SQL payloads and resumes before the deferred fragment', async () => {
+    it('bounds INSERT statements and resumes at their byte checkpoint', async () => {
         const requestBody = {
             directory: getSiteDir(site),
             fragments_per_batch: 1000,
@@ -208,6 +265,12 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         const parts = response.chunks.filter(
             chunk => chunk.headers['x-chunk-type'] === 'sql'
         );
+        assert.ok(
+            parts.reduce((bytes, part) => bytes + Buffer.byteLength(part.body), 0)
+                > maximumSqlPartBodyBytes,
+            'The fixture must exceed one SQL part body',
+        );
+        assertBoundedBytesBetweenCheckpoints(parts);
         const completion = response.chunks.find(
             chunk => chunk.headers['x-chunk-type'] === 'completion'
         );
@@ -220,16 +283,16 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
         const firstInsertPart = parts[firstInsertPartIndex];
         assert.equal(
             firstInsertPart.headers['x-query-complete'],
-            '0',
-            'The byte boundary should split the INSERT before its final row',
+            '1',
+            'The INSERT byte limit should expose a checkpoint before the 250-row batch ends',
         );
         const expectedResumedSql = parts
             .slice(firstInsertPartIndex + 1)
             .map(part => part.body)
             .join('');
         assert.ok(
-            expectedResumedSql.includes('ON DUPLICATE KEY UPDATE'),
-            'Expected the rest of the INSERT in following SQL parts',
+            expectedResumedSql.includes(`INSERT INTO \`${boundedPayloadTable}\``),
+            'Rows after the byte checkpoint should begin another INSERT',
         );
 
         const encodedCursor = firstInsertPart.headers['x-cursor'];
@@ -253,10 +316,15 @@ describe('Import: budgeted MySQL SQL groups', { timeout: 120000 }, () => {
             .filter(chunk => chunk.headers['x-chunk-type'] === 'sql')
             .map(part => part.body)
             .join('');
+        assertBoundedBytesBetweenCheckpoints(
+            resumedResponse.chunks.filter(
+                chunk => chunk.headers['x-chunk-type'] === 'sql'
+            ),
+        );
         assert.equal(
             resumedSql,
             expectedResumedSql,
-            'Resume must begin with the fragment deferred by the byte boundary',
+            'Resume must begin with the unfinished INSERT suffix after the byte checkpoint',
         );
     }, 300000);
 


### PR DESCRIPTION
Prevents normal database pulls from placing hundreds of megabytes of SQL between two `db.sql` cursor markers.

## Failure example

The reported 740 MB SQL group is not available. The table names, values, and cursors below are representative and shortened. The HTTP entity is gzip-encoded; this shows the decoded multipart shape consumed by the client, not a packet capture.

The producer made one `INSERT` for each fetched group of up to 250 rows. In one example of a crash, a 16 MiB SQL multipart part held about 92 rows:

```text
--reprint-boundary
Content-Type: application/sql
Content-Length: <about 16 MiB>
X-Chunk-Type: sql
X-Query-Complete: 0
X-Cursor: <base64 cursor after row 92>

INSERT INTO `wp_postmeta` (`meta_id`,`post_id`,`meta_key`,`meta_value`) VALUES
(1,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>')),
...
(92,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>'))

--reprint-boundary
Content-Type: application/sql
Content-Length: <about 16 MiB>
X-Chunk-Type: sql
X-Query-Complete: 0
X-Cursor: <base64 cursor after row 184>

,(93,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>')),
...
,(184,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>'))

--reprint-boundary
Content-Type: application/sql
Content-Length: <about 16 MiB>
X-Chunk-Type: sql
X-Query-Complete: 0
X-Cursor: <base64 cursor after row 276>

,(185,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>')),
...
,(250,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>'))
ON DUPLICATE KEY UPDATE `meta_id` = `meta_id`;
INSERT INTO `wp_postmeta` (`meta_id`,`post_id`,`meta_key`,`meta_value`) VALUES
(251,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>')),
...
(276,100,FROM_BASE64('<meta key>'),FROM_BASE64('<large value>'))
```

The third multipart chunk contains the final semicolon for the INSERT query `;` and then it immediately starts the next INSERT query. The endpoint only inspected the final byte in each part, so the third multipart chunk falsely advertises `X-Query-Complete: 0`. The client therefore did not write a marker after row 250.

The client, lacking a complete query, kept buffering the SQL in memory. Once it reached 740MB, it exceeded 512 MiB PHP memory limit and crashed.

## This change

## This change

The producer now closes a multi-row `INSERT` before it grows beyond 16 MiB. The endpoint also remembers the last completed SQL statement in each batch.

If a batch contains a completed `INSERT` followed by the beginning of another `INSERT`, the endpoint sends them as separate multipart parts. The completed part gets `X-Query-Complete: 1`. The unfinished part gets `X-Query-Complete: 0`.

For example, after gzip decoding, the client receives:

```text
--boundary-0123456789abcdef0123456789abcdef
Content-Type: application/sql
Content-Length: 147
X-Chunk-Type: sql
X-Query-Complete: 1
X-Cursor: <base64 cursor after row 250>

,(185,100,FROM_BASE64('a2V5'),FROM_BASE64('QQ==')),(250,100,FROM_BASE64('a2V5'),FROM_BASE64('Qg=='))
ON DUPLICATE KEY UPDATE `meta_id` = `meta_id`;
--boundary-0123456789abcdef0123456789abcdef
Content-Type: application/sql
Content-Length: 178
X-Chunk-Type: sql
X-Query-Complete: 0
X-Cursor: <base64 cursor after row 276>

INSERT INTO `wp_postmeta` (`meta_id`,`post_id`,`meta_key`,`meta_value`) VALUES
(251,100,FROM_BASE64('a2V5'),FROM_BASE64('Qw==')),(276,100,FROM_BASE64('a2V5'),FROM_BASE64('RA=='))
```

The client writes the first body, followed by a group marker because it has `X-Query-Complete: 1`. It then writes the unfinished second body after that marker:

```sql
,(185,100,FROM_BASE64('a2V5'),FROM_BASE64('QQ==')),(250,100,FROM_BASE64('a2V5'),FROM_BASE64('Qg=='))
ON DUPLICATE KEY UPDATE `meta_id` = `meta_id`;
-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 <base64 cursor after row 250>
INSERT INTO `wp_postmeta` (`meta_id`,`post_id`,`meta_key`,`meta_value`) VALUES
(251,100,FROM_BASE64('a2V5'),FROM_BASE64('Qw==')),(276,100,FROM_BASE64('a2V5'),FROM_BASE64('RA=='))
```

The second body does not produce another marker because it has `X-Query-Complete: 0`.

## Testing

The producer regression makes a 17,479,460-byte `INSERT` on trunk. This change emits multiple statements within the 16,777,216-byte limit and restores every row. A resume test stops at that new boundary and checks that the row which caused the rollover appears exactly once.

The endpoint E2E test creates the two protocol shapes above. It checks `X-Query-Complete: 1` for the complete prefix, `0` for the unfinished suffix, byte-for-byte resume from the prefix cursor, the 16 MiB multipart limit, and the 32 MiB checkpoint bound.
