### PR TITLE
[PHP] Preserve multibyte text across oversized MySQL chunks

### DIFF
--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -57,12 +57,15 @@ class DatabaseRowsReader {
 
     /**
      * Column metadata cached by table and column name. Each column contains
-     * data_type (for example, varchar) and column_type (for example,
-     * varchar(255)).
+     * data_type (for example, varchar), column_type (for example,
+     * varchar(255)), and its nullable collation name.
      *
-     * @var array<string,array<string,array<string,string>>>
+     * @var array<string,array<string,array{data_type:string,column_type:string,collation:?string}>>
      */
     private $column_type_cache = [];
+
+    /** @var array<string,int> Maximum character bytes cached by collation. */
+    private $maximum_character_bytes_by_collation = [];
 
 
     /** @var array|null */
@@ -501,7 +504,7 @@ class DatabaseRowsReader {
         if ($this->is_numeric_type($data_type) || $this->is_binary_type($data_type)) {
             return $qualified_column;
         }
-        if (in_array($data_type, ["CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"], true)) {
+        if ($this->is_character_string_type($data_type)) {
             return $qualified_column;
         }
         return "CAST({$qualified_column} AS BINARY)";
@@ -630,6 +633,7 @@ class DatabaseRowsReader {
             $columns[$row["Field"]] = [
                 "data_type" => preg_replace('/[\s(].*$/', '', $column_type),
                 "column_type" => $column_type,
+                "collation" => $row["Collation"] ?? null,
             ];
             $row = $statement->fetch(PDO::FETCH_ASSOC);
         }
@@ -650,10 +654,22 @@ class DatabaseRowsReader {
     }
 
     /** Identifies binary columns which do not need a binary SELECT cast. */
-    private function is_binary_type($data_type)
+    public function is_binary_type($data_type)
     {
         $data_type = strtoupper($data_type);
         foreach (["BINARY", "VARBINARY", "TINYBLOB", "BLOB", "MEDIUMBLOB", "LONGBLOB"] as $type) {
+            if (strpos($data_type, $type) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Identifies character strings whose SQL substring ranges count characters. */
+    public function is_character_string_type($data_type)
+    {
+        $data_type = strtoupper($data_type);
+        foreach (["CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"] as $type) {
             if (strpos($data_type, $type) === 0) {
                 return true;
             }
@@ -672,6 +688,47 @@ class DatabaseRowsReader {
             );
         }
         return $this->current_column_types[$column]["data_type"];
+    }
+
+    /** Returns the declared character set's maximum bytes per character. */
+    public function get_maximum_character_bytes(string $column): int
+    {
+        if (!isset($this->current_column_types[$column])) {
+            throw new \RuntimeException(
+                "No column type info for '{$column}' in table " .
+                $this->quote_identifier($this->current_table) . "."
+            );
+        }
+
+        $collation = $this->current_column_types[$column]["collation"];
+        if ($collation === null) {
+            return 1;
+        }
+        if (isset($this->maximum_character_bytes_by_collation[$collation])) {
+            return $this->maximum_character_bytes_by_collation[$collation];
+        }
+
+        $statement = $this->db->prepare(
+            "SELECT character_sets.MAXLEN " .
+            "FROM information_schema.COLLATIONS AS collations " .
+            "JOIN information_schema.CHARACTER_SETS AS character_sets " .
+            "ON character_sets.CHARACTER_SET_NAME = collations.CHARACTER_SET_NAME " .
+            "WHERE collations.COLLATION_NAME = ?"
+        );
+        $statement->execute([$collation]);
+        $maximum_character_bytes = (int) $statement->fetchColumn();
+        if ($maximum_character_bytes < 1) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Database metadata errors are never HTML.
+            throw new \RuntimeException(
+                "Cannot determine the maximum character byte length for column " .
+                $this->quote_identifier($this->current_table) . "." .
+                $this->quote_identifier($column) . " with collation {$collation}."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+
+        $this->maximum_character_bytes_by_collation[$collation] = $maximum_character_bytes;
+        return $maximum_character_bytes;
     }
 
     /** Escapes backticks by doubling them: tricky`table becomes `tricky``table`. */

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -97,12 +97,13 @@ class MySQLDumpProducer
     /**
      * When a row is too large for a single INSERT, its big columns are split
      * into chunks and queued here. Each entry tracks the column name, its
-     * data type, the current byte offset into the value, and the total value
-     * length. The actual data is re-fetched from the database on demand via
-     * SUBSTRING queries, keeping cursors small (a few hundred bytes rather
-     * than megabytes of raw data).
+     * data type, the current byte offset into the value, and the total byte
+     * length. Character columns also track a character offset because MySQL's
+     * SUBSTRING() counts characters for those types. The actual data is
+     * re-fetched from the database on demand, keeping cursors small (a few
+     * hundred bytes rather than megabytes of raw data).
      *
-     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int}
+     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int, character_offset?: int}
      */
     private $oversized_queue = [];
 
@@ -596,12 +597,26 @@ class MySQLDumpProducer
                     "'column', 'data_type', 'byte_offset', and 'total_length' keys"
                 );
             }
-            $decoded[] = [
+            $decoded_item = [
                 'column' => $item['column'],
                 'data_type' => $item['data_type'],
                 'byte_offset' => (int) $item['byte_offset'],
                 'total_length' => (int) $item['total_length'],
             ];
+            if ($this->row_reader->is_character_string_type($item['data_type'])) {
+                if (!array_key_exists('character_offset', $item)) {
+                    if ((int) $item['byte_offset'] !== 0) {
+                        throw new \InvalidArgumentException(
+                            "The saved database pull cursor uses an earlier oversized text format. " .
+                            "Run db-pull --abort and start again."
+                        );
+                    }
+                    $decoded_item['character_offset'] = 0;
+                } else {
+                    $decoded_item['character_offset'] = (int) $item['character_offset'];
+                }
+            }
+            $decoded[] = $decoded_item;
         }
         return $decoded;
     }
@@ -871,7 +886,7 @@ class MySQLDumpProducer
             $projected_fragment_size - self::MAX_SQL_PART_BODY_BYTES
         );
         $saved_bytes = 0;
-        $skipped_non_byte_bounded_value = false;
+        $unchunkable_data_types = [];
 
         foreach ($sorted_sizes as $col => $size) {
             if (in_array($col, $this->row_reader->get_current_primary_key_columns())) {
@@ -892,21 +907,12 @@ class MySQLDumpProducer
             }
 
             $data_type = $this->row_reader->get_data_type($col);
-            // SUBSTRING counts characters for text columns. Only binary
-            // columns have byte-bounded chunks, which the part limit needs.
             $normalized_data_type = strtoupper($data_type);
-            $binary_type = false;
-            foreach (["BINARY", "VARBINARY", "TINYBLOB", "BLOB", "MEDIUMBLOB", "LONGBLOB"] as $type) {
-                if (strpos($normalized_data_type, $type) === 0) {
-                    $binary_type = true;
-                    break;
-                }
-            }
             if (
-                $projected_fragment_size - $saved_bytes > self::MAX_SQL_PART_BODY_BYTES &&
-                !$binary_type
+                !$this->row_reader->is_binary_type($normalized_data_type) &&
+                !$this->row_reader->is_character_string_type($normalized_data_type)
             ) {
-                $skipped_non_byte_bounded_value = true;
+                $unchunkable_data_types[$normalized_data_type] = true;
                 continue;
             }
             $value_length = strlen($raw_value);
@@ -917,21 +923,34 @@ class MySQLDumpProducer
                 $saved_bytes += $size - 2; // Saved bytes (size minus the '' replacement)
                 $excess -= $size - 2;
 
-                $this->oversized_queue[] = [
+                $queue_item = [
                     'column' => $col,
                     'data_type' => $data_type,
                     'byte_offset' => 0,
                     'total_length' => $value_length,
                 ];
+                if ($this->row_reader->is_character_string_type($data_type)) {
+                    $queue_item['character_offset'] = 0;
+                }
+                $this->oversized_queue[] = $queue_item;
             }
+        }
+
+        if ($excess > 0 && !empty($unchunkable_data_types)) {
+            $unchunkable_data_type = key($unchunkable_data_types);
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
+            throw new \RuntimeException(
+                "Row in table " . $this->row_reader->quote_identifier($this->row_reader->get_current_table()) .
+                " cannot use UPDATE ... CONCAT() chunks for data type {$unchunkable_data_type}."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
 
         if (
             $projected_statement_size - $saved_bytes >
                 $maximum_insert_statement_bytes ||
             $projected_fragment_size - $saved_bytes >
-                self::MAX_SQL_PART_BODY_BYTES ||
-            ($skipped_non_byte_bounded_value && $excess > 0)
+                self::MAX_SQL_PART_BODY_BYTES
         ) {
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
             throw new \RuntimeException(
@@ -1047,14 +1066,54 @@ class MySQLDumpProducer
         $total_length = $current['total_length'];
 
         $chunk_size = $this->compute_chunk_size($column);
+        $character_string = $this->row_reader->is_character_string_type($data_type);
+        if ($character_string) {
+            $value_offset = $current['character_offset'];
+            $value_length = max(
+                1,
+                integer_divide(
+                    $chunk_size,
+                    $this->row_reader->get_maximum_character_bytes($column)
+                )
+            );
+        } else {
+            $value_offset = $byte_offset;
+            $value_length = min($chunk_size, $total_length - $byte_offset);
+        }
 
-        // Fetch just the chunk we need from the database using SUBSTRING.
-        // MySQL's SUBSTRING is 1-indexed, so add 1 to our 0-based offset.
-        $chunk = $this->fetch_value_substring_from_the_current_oversized_row(
+        $chunk_result = $this->fetch_value_substring_from_the_current_oversized_row(
             $column,
-            $byte_offset + 1,
-            $chunk_size
+            $value_offset + 1,
+            $value_length,
+            $character_string
         );
+        $chunk = $chunk_result['value'];
+        $chunk_bytes = strlen($chunk);
+
+        if ($chunk_bytes === 0 && $byte_offset < $total_length) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
+            throw new \RuntimeException(
+                "Oversized column " .
+                $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . "." .
+                $this->row_reader->quote_identifier($column) .
+                " returned an empty chunk at byte offset {$byte_offset} before its saved" .
+                " {$total_length}-byte length. The source value changed during export;" .
+                " run db-pull --abort and start again."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+        if ($chunk_bytes > $total_length - $byte_offset) {
+            // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
+            throw new \RuntimeException(
+                "Oversized column " .
+                $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . "." .
+                $this->row_reader->quote_identifier($column) .
+                " returned {$chunk_bytes} bytes at byte offset {$byte_offset}, beyond its" .
+                " saved {$total_length}-byte length. The source value changed during export;" .
+                " run db-pull --abort and start again."
+            );
+            // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
 
         $formatted_chunk = $this->format_value($chunk, $data_type);
 
@@ -1070,7 +1129,10 @@ class MySQLDumpProducer
 
         $this->current_sql_fragment = $sql;
 
-        $this->oversized_queue[0]['byte_offset'] += strlen($chunk);
+        $this->oversized_queue[0]['byte_offset'] += $chunk_bytes;
+        if ($character_string) {
+            $this->oversized_queue[0]['character_offset'] += $chunk_result['value_length'];
+        }
         if ($this->oversized_queue[0]['byte_offset'] >= $total_length) {
             array_shift($this->oversized_queue);
         }
@@ -1082,11 +1144,23 @@ class MySQLDumpProducer
      * Fetches a substring of a column value from the current table using
      * the oversized row's primary key values.
      *
-     * Uses CAST(SUBSTRING(...) AS BINARY) to get raw bytes without charset
-     * re-encoding — matching the same CAST approach used in the main SELECT.
+     * Character strings use character ranges so a chunk never cuts a
+     * multibyte character. Binary strings cast before SUBSTRING so their
+     * ranges count bytes. Both return raw bytes for base64 encoding.
+     *
+     * @return array {
+     *     Fetched substring details.
+     *
+     *     @type string $value        Raw substring bytes.
+     *     @type int    $value_length Length in characters or bytes, matching the requested range.
+     * }
      */
-    private function fetch_value_substring_from_the_current_oversized_row(string $column, int $start, int $length): string
-    {
+    private function fetch_value_substring_from_the_current_oversized_row(
+        string $column,
+        int $start,
+        int $length,
+        bool $character_string
+    ): array {
         $quoted_table = $this->row_reader->quote_identifier($this->row_reader->get_current_table());
         $quoted_column = $this->row_reader->quote_identifier($column);
 
@@ -1096,11 +1170,14 @@ class MySQLDumpProducer
         }
         $where_clause = implode(" AND ", $where_parts);
 
-        $sql = "SELECT CAST(SUBSTRING({$quoted_column}, {$start}, {$length}) AS BINARY)"
+        $value_expression = $character_string
+            ? "SUBSTRING({$quoted_column}, {$start}, {$length})"
+            : "SUBSTRING(CAST({$quoted_column} AS BINARY), {$start}, {$length})";
+        $sql = "SELECT CAST({$value_expression} AS BINARY), CHAR_LENGTH({$value_expression})"
              . " FROM {$quoted_table} WHERE {$where_clause}";
         $stmt = $this->db->prepare($sql);
         $stmt->execute();
-        $result = $stmt->fetchColumn();
+        $result = $stmt->fetch(PDO::FETCH_NUM);
 
         if ($result === false) {
             throw new \RuntimeException(
@@ -1108,7 +1185,10 @@ class MySQLDumpProducer
             );
         }
 
-        return $result;
+        return [
+            'value' => $result[0],
+            'value_length' => (int) $result[1],
+        ];
     }
 
     /** @return bool */

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -1173,11 +1173,12 @@ class MySQLDumpProducer
         $value_expression = $character_string
             ? "SUBSTRING({$quoted_column}, {$start}, {$length})"
             : "SUBSTRING(CAST({$quoted_column} AS BINARY), {$start}, {$length})";
-        $sql = "SELECT CAST({$value_expression} AS BINARY), CHAR_LENGTH({$value_expression})"
+        $sql = "SELECT CAST({$value_expression} AS BINARY) AS value_chunk,"
+             . " CHAR_LENGTH({$value_expression}) AS value_length"
              . " FROM {$quoted_table} WHERE {$where_clause}";
         $stmt = $this->db->prepare($sql);
         $stmt->execute();
-        $result = $stmt->fetch(PDO::FETCH_NUM);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($result === false) {
             throw new \RuntimeException(
@@ -1186,8 +1187,8 @@ class MySQLDumpProducer
         }
 
         return [
-            'value' => $result[0],
-            'value_length' => (int) $result[1],
+            'value' => $result['value_chunk'],
+            'value_length' => (int) $result['value_length'],
         ];
     }
 

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -1066,6 +1066,13 @@ class MySQLDumpProducer
         $total_length = $current['total_length'];
 
         $chunk_size = $this->compute_chunk_size($column);
+
+        // MySQL SUBSTRING() counts characters for character strings, while
+        // $chunk_size is a byte budget. Every requested character may use the
+        // column character set's maximum byte length, so a fixed amount of
+        // spare space would not bound the result. Divide the byte budget by
+        // that per-character maximum to keep the raw chunk within its limit
+        // without splitting a character. Binary strings continue in bytes.
         $character_string = $this->row_reader->is_character_string_type($data_type);
         if ($character_string) {
             $value_offset = $current['character_offset'];

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -103,6 +103,227 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
     }
 
     /**
+     * @dataProvider oversizedCharacterColumnProvider
+     */
+    public function testLargeMultibyteCharacterColumnRoundTrips(
+        string $table,
+        string $column_type
+    ): void {
+        $this->pdo->exec("
+            CREATE TABLE `{$table}` (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                content {$column_type} CHARACTER SET utf8mb4
+            )
+        ");
+
+        $large_text = str_repeat("\xF0\x9F\x99\x82", 8000);
+        $statement = $this->pdo->prepare(
+            "INSERT INTO `{$table}` (content) VALUES (?)"
+        );
+        $statement->execute([$large_text]);
+
+        $max_statement_size = 10 * 1024;
+        $fragments = $this->collectFragmentsWithinSteps(
+            $this->createProducer(['max_statement_size' => $max_statement_size]),
+            100
+        );
+
+        $this->assertStringContainsString(
+            "UPDATE `{$table}` SET",
+            implode("\n", $fragments)
+        );
+        foreach ($fragments as $fragment) {
+            $this->assertLessThanOrEqual(
+                $max_statement_size,
+                strlen($fragment),
+                'Every emitted SQL fragment must fit max_statement_size.'
+            );
+        }
+
+        $import_pdo = $this->executeDumpInNewDatabase(implode("\n", $fragments));
+        $imported = $import_pdo
+            ->query("SELECT content FROM `{$table}` WHERE id = 1")
+            ->fetchColumn();
+        $this->assertSame($large_text, $imported);
+    }
+
+    public static function oversizedCharacterColumnProvider(): array
+    {
+        return [
+            'varchar' => ['oversized_varchar', 'VARCHAR(10000)'],
+            'text' => ['oversized_text', 'TEXT'],
+            'mediumtext' => ['oversized_mediumtext', 'MEDIUMTEXT'],
+            'longtext' => ['oversized_longtext', 'LONGTEXT'],
+        ];
+    }
+
+    public function testLargeMultibyteTextResumesAfterEveryFragment(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE resumed_multibyte_text (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                content LONGTEXT CHARACTER SET utf8mb4
+            )
+        ");
+
+        $large_text = str_repeat("A\xC3\xA9\xE6\xBC\xA2\xF0\x9F\x99\x82", 4000);
+        $statement = $this->pdo->prepare(
+            "INSERT INTO resumed_multibyte_text (content) VALUES (?)"
+        );
+        $statement->execute([$large_text]);
+
+        $options = [
+            'max_statement_size' => 10 * 1024,
+            'batch_size' => 1,
+        ];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        for ($step = 0; $step < 100; ++$step) {
+            if (!$producer->next_sql_fragment()) {
+                break;
+            }
+            $fragments[] = $producer->get_sql_fragment();
+            if (!$producer->is_finished()) {
+                $options['cursor'] = $producer->get_reentrancy_cursor();
+                $producer = $this->createProducer($options);
+            }
+        }
+
+        $this->assertTrue(
+            $producer->is_finished(),
+            'The resumed exporter must finish instead of requesting text past its final character.'
+        );
+        $import_pdo = $this->executeDumpInNewDatabase(implode("\n", $fragments));
+        $imported = $import_pdo
+            ->query("SELECT content FROM resumed_multibyte_text WHERE id = 1")
+            ->fetchColumn();
+        $this->assertSame($large_text, $imported);
+    }
+
+    public function testOldOversizedTextCursorWithProgressRequiresRestart(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE old_oversized_text_cursor (
+                id INT PRIMARY KEY,
+                content LONGTEXT
+            )
+        ");
+        $statement = $this->pdo->prepare(
+            "INSERT INTO old_oversized_text_cursor VALUES (1, ?)"
+        );
+        $statement->execute([str_repeat('a', 30 * 1024)]);
+
+        $options = ['max_statement_size' => 10 * 1024];
+        $producer = $this->createProducer($options);
+        do {
+            $this->assertTrue($producer->next_sql_fragment());
+        } while (strpos($producer->get_sql_fragment(), 'UPDATE `old_oversized_text_cursor`') !== 0);
+
+        $cursor = json_decode($producer->get_reentrancy_cursor(), true);
+        unset($cursor['oversized_queue'][0]['character_offset']);
+        $options['cursor'] = json_encode($cursor);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('earlier oversized text format');
+        $this->createProducer($options);
+    }
+
+    /**
+     * @dataProvider oversizedBinaryColumnProvider
+     */
+    public function testLargeBinaryColumnStillRoundTrips(
+        string $table,
+        string $column_type
+    ): void {
+        $this->pdo->exec("
+            CREATE TABLE `{$table}` (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                content {$column_type}
+            )
+        ");
+
+        $large_value = random_bytes(30 * 1024);
+        $statement = $this->pdo->prepare(
+            "INSERT INTO `{$table}` (content) VALUES (?)"
+        );
+        $statement->execute([$large_value]);
+
+        $sql = implode("\n", $this->collectFragmentsWithinSteps(
+            $this->createProducer(['max_statement_size' => 10 * 1024]),
+            100
+        ));
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $imported = $import_pdo
+            ->query("SELECT content FROM `{$table}` WHERE id = 1")
+            ->fetchColumn();
+        $this->assertSame($large_value, $imported);
+    }
+
+    public static function oversizedBinaryColumnProvider(): array
+    {
+        return [
+            'varbinary' => ['oversized_varbinary', 'VARBINARY(40000)'],
+            'blob' => ['oversized_blob', 'BLOB'],
+            'mediumblob' => ['oversized_mediumblob', 'MEDIUMBLOB'],
+            'longblob' => ['oversized_longblob', 'LONGBLOB'],
+        ];
+    }
+
+    public function testOversizedTextStopsWhenTheSourceValueShrinks(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE shrinking_oversized_text (
+                id INT PRIMARY KEY,
+                content LONGTEXT
+            )
+        ");
+        $statement = $this->pdo->prepare(
+            "INSERT INTO shrinking_oversized_text VALUES (1, ?)"
+        );
+        $statement->execute([str_repeat('a', 30 * 1024)]);
+
+        $producer = $this->createProducer(['max_statement_size' => 10 * 1024]);
+        do {
+            $this->assertTrue($producer->next_sql_fragment());
+            $fragment = $producer->get_sql_fragment();
+        } while (strpos($fragment, 'INSERT INTO `shrinking_oversized_text`') !== 0);
+
+        $this->pdo->exec(
+            "UPDATE shrinking_oversized_text SET content = '' WHERE id = 1"
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('returned an empty chunk at byte offset 0');
+        $producer->next_sql_fragment();
+    }
+
+    /** Geometry cannot be built from an empty value and partial byte strings. */
+    public function testOversizedGeometryIsRejectedBeforeInvalidSqlIsEmitted(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE oversized_geometry_value (
+                id INT PRIMARY KEY,
+                content GEOMETRY
+            )
+        ");
+        $points = [];
+        for ($point = 0; $point < 3000; ++$point) {
+            $points[] = $point . ' ' . $point;
+        }
+        $line_string = 'LINESTRING(' . implode(',', $points) . ')';
+        $statement = $this->pdo->prepare(
+            "INSERT INTO oversized_geometry_value VALUES (1, ST_GeomFromText(?))"
+        );
+        $statement->execute([$line_string]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'cannot use UPDATE ... CONCAT() chunks for data type GEOMETRY'
+        );
+        $this->getDumpSQL(['max_statement_size' => 10 * 1024]);
+    }
+
+    /**
      * Test multiple large columns in the same row.
      */
     public function testMultipleLargeColumns(): void
@@ -162,8 +383,8 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $this->getDumpSQL(['max_statement_size' => 64 * 1024 * 1024]);
     }
 
-    /** A text value skipped by the byte cap must not bypass the packet target. */
-    public function testMixedTextAndBlobDoNotExceedStatementLimit(): void
+    /** Text and binary chunks must both stay below the packet target. */
+    public function testMixedTextAndBlobStayWithinStatementLimit(): void
     {
         $this->pdo->exec("
             CREATE TABLE mixed_fragment_limits (
@@ -179,11 +400,24 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         );
         $stmt->execute([$value, $value]);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('cannot fit the SQL size limits');
-        $this->expectExceptionMessage('max_statement_size is 8388608 bytes');
+        $max_statement_size = 8 * 1024 * 1024;
+        $fragments = $this->collectAllFragments($this->createProducer([
+            'max_statement_size' => $max_statement_size,
+        ]));
+        foreach ($fragments as $fragment) {
+            $this->assertLessThanOrEqual(
+                $max_statement_size,
+                strlen($fragment),
+                'Every text and binary fragment must fit max_statement_size.'
+            );
+        }
 
-        $this->getDumpSQL(['max_statement_size' => 8 * 1024 * 1024]);
+        $import_pdo = $this->executeDumpInNewDatabase(implode("\n", $fragments));
+        $row = $import_pdo
+            ->query('SELECT text_value, blob_value FROM mixed_fragment_limits WHERE id = 1')
+            ->fetch();
+        $this->assertSame($value, $row['text_value']);
+        $this->assertSame($value, $row['blob_value']);
     }
 
     /**
@@ -870,5 +1104,24 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             "Encoded cursor must stay within the test's 8190-byte header-value limit, " .
             "got {$maxCursorSize} bytes"
         );
+    }
+
+    /** Collects a dump without allowing a broken cursor to loop forever. */
+    private function collectFragmentsWithinSteps(
+        MySQLDumpProducer $producer,
+        int $maximum_steps
+    ): array {
+        $fragments = [];
+        for ($step = 0; $step < $maximum_steps; ++$step) {
+            if (!$producer->next_sql_fragment()) {
+                break;
+            }
+            $fragments[] = $producer->get_sql_fragment();
+        }
+        $this->assertTrue(
+            $producer->is_finished(),
+            "The exporter did not finish within {$maximum_steps} steps."
+        );
+        return $fragments;
     }
 }


### PR DESCRIPTION
Oversized MySQL character columns now finish without skipping or repeatedly requesting the end of a multibyte value.

## Background

MySQL `SUBSTRING()` counts characters for text columns, while the exporter tracked progress with `strlen()`, which counts bytes. For example, two `utf8mb4` emoji are two characters but eight bytes. After exporting those emoji, the old code saved byte offset 8 and asked MySQL to continue at character 9. MySQL returned an empty string, the byte offset stayed at 8, and the exporter repeated that request until it timed out.

## This change

Character columns now keep separate byte and character offsets. The character offset selects the next MySQL substring. The returned chunk's `CHAR_LENGTH()` advances that offset, while its byte length advances the completion cursor.

The column collation supplies the maximum bytes per character. This bounds the requested character count so the encoded SQL stays within its byte limit. `VARCHAR`, `TEXT`, `MEDIUMTEXT`, and `LONGTEXT` use this path. `VARBINARY`, `BLOB`, `MEDIUMBLOB`, and `LONGBLOB` continue to use byte ranges by casting the value to binary before calling `SUBSTRING()`.

A saved cursor with partial character data from the old format cannot be converted safely, so it now asks the user to abort and restart the pull. An unexpected empty chunk before the saved byte length also stops with a clear error instead of looping. Only character and binary strings may use partial `CONCAT()` updates; an oversized `GEOMETRY` value is rejected before invalid SQL reaches the target database.

## Testing

The first commit contains only the regression tests. Against its parent implementation, the focused run reports eight failures and one error. The four binary controls pass.

The completed implementation passes 35 focused tests with 246 assertions. These cover all four character types and all four binary types, resume after every fragment, old cursors, a source value shrinking during export, mixed text and binary columns, statement byte limits, and oversized geometry rejection.

The full GitHub CI matrix passes, including PHP 5.6 through PHP 8.5, the PDO-less `wpdb` fallback, the pull pipeline benchmark, and Playground CLI E2E tests.
