### PR TITLE
Safeguard against commonly-disabled functions

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2942,6 +2942,23 @@ class ImportClient
             $all_pass = false;
         }
 
+        // 6. Response streaming won't be double-compressed
+        $limits = $data["limits"] ?? null;
+        $stream_ok = true;
+        if (is_array($limits) && isset($limits["zlib_output_compression_can_be_disabled"])) {
+            $stream_ok = $limits["zlib_output_compression_can_be_disabled"] !== false;
+        }
+        $checks[] = [
+            "label" => "Response streaming won't be double-compressed",
+            "pass" => $stream_ok,
+            "detail" => $stream_ok
+                ? "zlib.output_compression can be disabled"
+                : "zlib.output_compression is on and cannot be disabled",
+        ];
+        if (!$stream_ok) {
+            $all_pass = false;
+        }
+
         // We do not check for any encoding issues here. We'll move over
         // the entire database as it is.
 

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -643,9 +643,11 @@ function prepare_streaming_response(): void
      * entire point of this plugin is to stream the response, therefore we use a custom
      * GzipOutputStream.
      */
-    @ini_set("zlib.output_compression", "0");
-    @ini_set("output_buffering", "0");
-    @ini_set("implicit_flush", "1");
+    if (function_exists("ini_set")) {
+        @ini_set("zlib.output_compression", "0");
+        @ini_set("output_buffering", "0");
+        @ini_set("implicit_flush", "1");
+    }
 
     @ob_implicit_flush(true);
 }
@@ -1647,8 +1649,8 @@ function endpoint_preflight(array $config): array
                 }
             }
             if ($openable) {
-                $disk_free = @disk_free_space($dir);
-                $disk_total = @disk_total_space($dir);
+                $disk_free = function_exists("disk_free_space") ? @disk_free_space($dir) : false;
+                $disk_total = function_exists("disk_total_space") ? @disk_total_space($dir) : false;
             }
             $dir_checks[] = [
                 "path" => $dir,
@@ -2453,7 +2455,7 @@ function endpoint_preflight(array $config): array
         ],
         "php" => [
             "version" => PHP_VERSION,
-            "sapi" => php_sapi_name(),
+            "sapi" => function_exists("php_sapi_name") ? php_sapi_name() : null,
             "timezone" => date_default_timezone_get(),
             "extensions" => $extensions,
             "extension_versions" => $extension_versions,
@@ -2501,7 +2503,7 @@ function endpoint_preflight(array $config): array
             // overrides.  This captures the full configuration without
             // needing to read the .ini files themselves.
             "ini_get_all" => ini_get_all(null, false),
-            "temp_dir" => sys_get_temp_dir(),
+            "temp_dir" => function_exists("sys_get_temp_dir") ? sys_get_temp_dir() : null,
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,
             "cwd" => getcwd() ?: null,

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2434,6 +2434,24 @@ function endpoint_preflight(array $config): array
         array_keys($environment_variables)
     )));
 
+    // -- Probe whether streaming responses can avoid double compression --
+    $current_output_compression = ini_get("zlib.output_compression");
+    $output_compression_is_on = ! in_array($current_output_compression, [false, "", "0"], true);
+
+    $output_compression_can_be_disabled = true;
+    if ($output_compression_is_on) {
+        $output_compression_can_be_disabled = false;
+
+        if (function_exists("ini_set")) {
+            @ini_set("zlib.output_compression", "0");
+
+            $probed = ini_get("zlib.output_compression");
+            $output_compression_can_be_disabled = in_array($probed, [false, "", "0"], true);
+
+            @ini_set("zlib.output_compression", $current_output_compression);
+        }
+    }
+
     // -- Assemble and return the preflight response --
     $ok =
         $preflight_error === null &&
@@ -2473,8 +2491,8 @@ function endpoint_preflight(array $config): array
             "upload_max_bytes" => $upload_max_bytes,
             "max_request_bytes" => $max_request_bytes,
             "output_buffering" => ini_get("output_buffering") ?: null,
-            "zlib_output_compression" =>
-                ini_get("zlib.output_compression") ?: null,
+            "zlib_output_compression" => ini_get("zlib.output_compression") ?: null,
+            "zlib_output_compression_can_be_disabled" => $output_compression_can_be_disabled,
             "disable_functions" => ini_get("disable_functions") ?: null,
             "allow_url_fopen" => ini_get("allow_url_fopen") ?: null,
             "open_basedir" => ini_get("open_basedir") ?: null,

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -356,8 +356,10 @@ function _site_export_default_authenticate(): void {
 function _site_export_handle_api_request(array $options = []): void {
     // Revert WordPress error display settings (wp_debug_mode may
     // have enabled display_errors based on WP_DEBUG_DISPLAY).
-    @ini_set('display_errors', '0');
-    @ini_set('html_errors', '0');
+    if (function_exists('ini_set')) {
+        @ini_set('display_errors', '0');
+        @ini_set('html_errors', '0');
+    }
 
     // Clear any output buffering WordPress started.
     while (ob_get_level()) {


### PR DESCRIPTION
Observed in the wild:

> The remote server crashed: Error: Call to undefined function disk_free_space()

Since PHP 8, a function listed in `disable_functions` is removed from the function table entirely, and calling it throws a fatal error. On PHP 7 the same call would only emit a warning and return null, which the `@` alone would have handled fine.

This PR adds some guarding for functions that are known to be disabled sometimes:

- `disk_free_space()` & `disk_total_space()`
- `ini_set()`
- Some rare-but-easy-to-protect ones: `php_sapi_name()` / `sys_get_temp_dir()`