### PR TITLE
Reprint Server: Prefer canonical Reprint API URLs in the client

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8533,7 +8533,7 @@ class ImportClient
             $remote_parent_components[] = $missing_remote_path_components[$component_index];
             $path_prefix = wp_join_unix_paths("/", ...$remote_parent_components);
             // A parent above every export directory proves nothing: the next remote
-            // index never covered it, so its absence is not evidence of deletion.
+            // index never covered it, so its absence does not confirm deletion.
             if (
                 $stop_at_export_directory
                 && !path_is_same_as_or_descendant_of($path_prefix, $export_directories)
@@ -11429,7 +11429,7 @@ class ImportClient
                         "No --secret was provided. The remote site requires " .
                         "authentication.\n\n" .
                         "Pass --secret=YOUR_SECRET using the same secret " .
-                        "configured in the Site Export plugin on the remote site.",
+                        "configured in the Reprint Server plugin on the remote site.",
                 ];
             }
 
@@ -11453,8 +11453,8 @@ class ImportClient
                     'code' => 'AUTH_SECRET_MISMATCH',
                     'message' =>
                         "Wrong shared secret. The --secret value does not match " .
-                        "the one configured in the Site Export plugin settings " .
-                        "(wp-admin → Site Export).",
+                        "the one configured in the Reprint Server plugin settings " .
+                        "(wp-admin → Reprint Server).",
                 ];
             }
 
@@ -13378,7 +13378,7 @@ if (
      * Shows the download URL for the Reprint Server plugin matching this
      * version of reprint, and step-by-step installation instructions.
      */
-    function _cli_render_install_exporter(): void
+    function _cli_render_install_server(): void
     {
         $version = get_importer_version();
         $is_dev = str_contains($version, '-trunk') || $version === 'v0.0.0';
@@ -13406,6 +13406,7 @@ if (
             echo "  {$dim}composer build:server-plugin{$reset}\n";
             echo "\n";
             echo "  Then upload reprint-exporter-wp.zip through wp-admin,\n";
+            echo "  (the legacy filename is retained so existing plugin installs upgrade),\n";
             echo "  or symlink reprint-server-wp/ into wp-content/plugins/.\n";
         } else {
             echo "  {$cyan}{$zip_url}{$reset}\n";
@@ -13416,7 +13417,7 @@ if (
         echo "\n";
         echo "  1. Log in to wp-admin\n";
         echo "  2. Go to Plugins → Add New Plugin → Upload Plugin\n";
-        echo "  3. Upload reprint-exporter-wp.zip and activate it\n";
+        echo "  3. Upload reprint-exporter-wp.zip and activate Reprint Server\n";
         echo "\n";
         echo "{$bold}Step 3: Configure the shared secret{$reset}\n";
         echo "\n";
@@ -13518,7 +13519,7 @@ if (
                 "interrupted, re-run the same command to resume from where it left off.\n" .
                 "Running pull again after completion performs a delta sync.\n" .
                 "\n" .
-                "The ?site-export-api query parameter is added automatically if missing,\n" .
+                "The ?reprint-api query parameter is added automatically if missing,\n" .
                 "so you can pass just the site URL.\n",
             "extra" =>
                 "Examples:\n" .
@@ -13979,7 +13980,7 @@ if (
     // install-server is a standalone guide — no URL, state-dir, or filesystem root needed.
     // Handle it before per-command --help so it always shows the full guide.
     if ($command === "install-server") {
-        _cli_render_install_exporter();
+        _cli_render_install_server();
         exit(0);
     }
 

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -747,15 +747,30 @@ class Pull
     }
 
     /**
-     * Append ?site-export-api to bare site URLs so users can pass
-     * https://example.com instead of https://example.com/?site-export-api.
+     * Append ?reprint-api to bare site URLs so users can pass
+     * https://example.com instead of https://example.com/?reprint-api.
+     * Explicit legacy endpoint URLs remain unchanged.
      */
     private function normalize_url(): void
     {
         $url = $this->client->remote_reprint_api_url;
-        if (strpos($url, 'site-export-api') === false) {
+        $query = parse_url($url, PHP_URL_QUERY);
+        $query_parameters = [];
+        if (is_string($query)) {
+            parse_str($query, $query_parameters);
+        }
+        if (
+            !array_key_exists('reprint-api', $query_parameters)
+            && !array_key_exists('site-export-api', $query_parameters)
+        ) {
+            $fragment_position = strpos($url, '#');
+            $fragment = '';
+            if ($fragment_position !== false) {
+                $fragment = substr($url, $fragment_position);
+                $url = substr($url, 0, $fragment_position);
+            }
             $separator = strpos($url, '?') === false ? '?' : '&';
-            $this->client->remote_reprint_api_url = $url . $separator . 'site-export-api';
+            $this->client->remote_reprint_api_url = $url . $separator . 'reprint-api' . $fragment;
         }
     }
 

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -166,7 +166,7 @@ class DiagnoseHttpErrorTest extends TestCase
 
     public function testExportNotConfigured503()
     {
-        $body = '{"error":"Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export."}';
+        $body = '{"error":"Export not configured. Please configure the shared secret in WordPress admin under Tools > Reprint Server."}';
         $result = $this->diagnose(503, $body);
         $this->assertSame('EXPORT_NOT_CONFIGURED', $result['code']);
         $this->assertStringContainsString('not configured', $result['message']);

--- a/tests/Import/FilesDiffCommandTest.php
+++ b/tests/Import/FilesDiffCommandTest.php
@@ -25,7 +25,7 @@ final class FilesDiffCommandTest extends TestCase
     private string $root;
     private string $stateDirectory;
     private string $filesystemRoot;
-    private string $remoteReprintApiUrl = 'https://example.test/export.php?site-export-api';
+    private string $remoteReprintApiUrl = 'https://example.test/export.php?reprint-api';
     private ?string $invalidBytePathInIndex = null;
 
     /** @var array<string,string> */

--- a/tests/Import/FilesPullDiffCheckpointTest.php
+++ b/tests/Import/FilesPullDiffCheckpointTest.php
@@ -85,7 +85,7 @@ final class FilesPullDiffCheckpointTest extends TestCase
     private string $pullStateDirectory;
     private string $filesystemRoot;
     private string $remoteReprintApiUrl =
-        'https://example.com/?site-export-api';
+        'https://example.com/?reprint-api';
 
     protected function setUp(): void
     {

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -1793,7 +1793,7 @@ PHP,
             $connection = @fsockopen('127.0.0.1', $port, $errorNumber, $errorMessage, 0.1);
             if (is_resource($connection)) {
                 fclose($connection);
-                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+                return 'http://127.0.0.1:' . $port . '/export.php?reprint-api';
             }
             usleep(100000);
         }

--- a/tests/Import/IndexLifecycleOwnershipTest.php
+++ b/tests/Import/IndexLifecycleOwnershipTest.php
@@ -15,7 +15,7 @@ final class IndexLifecycleOwnershipTest extends TestCase
     private string $stateDirectory;
     private string $filesystemRoot;
     private string $remoteReprintApiUrl =
-        'https://example.test/export.php?site-export-api';
+        'https://example.test/export.php?reprint-api';
 
     protected function setUp(): void
     {

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -130,7 +130,7 @@ PHP, var_export($requestsLog, true)));
             $socket = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
             if ($socket) {
                 fclose($socket);
-                return "http://127.0.0.1:{$port}/export.php?site-export-api";
+                return "http://127.0.0.1:{$port}/export.php?reprint-api";
             }
             usleep(100000);
         }
@@ -200,13 +200,13 @@ PHP, var_export($requestsLog, true)));
         // Both forms fail later (unreachable host) but must not be rejected as
         // an unknown option.
         $equals = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--include=:wp-content:', '--include=:wp-uploads:/2025'),
+            array('files-pull', 'http://fake.invalid/?reprint-api', '--include=:wp-content:', '--include=:wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $equals);
 
         $space = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--include', ':wp-content:', '--include', ':wp-uploads:/2025'),
+            array('files-pull', 'http://fake.invalid/?reprint-api', '--include', ':wp-content:', '--include', ':wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $space);
@@ -221,13 +221,13 @@ PHP, var_export($requestsLog, true)));
         );
 
         $equals = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--only=:wp-content:', '--only=:wp-uploads:/2025'),
+            array('files-pull', 'http://fake.invalid/?reprint-api', '--only=:wp-content:', '--only=:wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $equals);
 
         $space = $this->runCli(array_merge(
-            array('files-pull', 'http://fake.invalid/?site-export-api', '--only', ':wp-content:', '--only', ':wp-uploads:/2025'),
+            array('files-pull', 'http://fake.invalid/?reprint-api', '--only', ':wp-content:', '--only', ':wp-uploads:/2025'),
             $tail
         ));
         $this->assertStringNotContainsString('Unknown option', $space);
@@ -239,11 +239,11 @@ PHP, var_export($requestsLog, true)));
         // succeed because :wp-content: is resolvable. Preserving both values
         // forces resolution of :abspath:, which this preflight intentionally
         // omits.
-        $this->writePreflightState('http://fake.invalid/?site-export-api');
+        $this->writePreflightState('http://fake.invalid/?reprint-api');
 
         $output = $this->runCli(array(
             'files-pull',
-            'http://fake.invalid/?site-export-api',
+            'http://fake.invalid/?reprint-api',
             '--include',
             ':abspath:/wp-admin',
             '--include',
@@ -275,7 +275,7 @@ PHP, var_export($requestsLog, true)));
     {
         $output = $this->runCli(array(
             'pull',
-            'http://fake.invalid/?site-export-api',
+            'http://fake.invalid/?reprint-api',
             '--runtime=none',
             '--state-dir=' . $this->tempDir . '/state',
             '--fs-root=' . $this->tempDir . '/fs',
@@ -302,7 +302,7 @@ PHP, var_export($requestsLog, true)));
     {
         $output = $this->runCli(array(
             'pull-files',
-            'http://fake.invalid/?site-export-api',
+            'http://fake.invalid/?reprint-api',
             '--state-dir=' . $this->tempDir . '/state',
             '--fs-root=' . $this->tempDir . '/fs',
         ));
@@ -396,11 +396,11 @@ PHP, var_export($requestsLog, true)));
     {
         // --abort runs after --include resolution, avoiding a network request while
         // still proving the CLI did not split the SOURCE at the comma.
-        $this->writePreflightState('http://fake.invalid/?site-export-api');
+        $this->writePreflightState('http://fake.invalid/?reprint-api');
 
         $output = $this->runCli(array(
             'files-pull',
-            'http://fake.invalid/?site-export-api',
+            'http://fake.invalid/?reprint-api',
             '--include',
             ':wp-content:/plugins,custom',
             '--abort',

--- a/tests/Import/PullIndexWalTest.php
+++ b/tests/Import/PullIndexWalTest.php
@@ -22,7 +22,7 @@ final class PullIndexWalTest extends TestCase
             . '/pull-index-wal-'
             . bin2hex(random_bytes(6));
         $this->stateDirectory = $this->root . '/state';
-        $remoteReprintApiUrl = 'https://example.com/?site-export-api';
+        $remoteReprintApiUrl = 'https://example.com/?reprint-api';
         $this->pullStateDirectory =
             $this->stateDirectory
             . '/remotes/'
@@ -264,7 +264,7 @@ final class PullIndexWalTest extends TestCase
     private function client(): \ImportClient
     {
         return new \ImportClient(
-            'https://example.com/?site-export-api',
+            'https://example.com/?reprint-api',
             $this->stateDirectory,
             $this->fileRoot
         );

--- a/tests/Import/PullUrlNormalizationTest.php
+++ b/tests/Import/PullUrlNormalizationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ImportTests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+final class PullUrlNormalizationTest extends TestCase {
+    /** @return iterable<string,array{string,string}> */
+    public static function urls(): iterable
+    {
+        yield 'bare site URL' => ['https://example.test', 'https://example.test?reprint-api'];
+        yield 'existing query' => ['https://example.test?foo=bar', 'https://example.test?foo=bar&reprint-api'];
+        yield 'fragment' => ['https://example.test/path#section', 'https://example.test/path?reprint-api#section'];
+        yield 'canonical endpoint' => ['https://example.test?reprint-api=1', 'https://example.test?reprint-api=1'];
+        yield 'legacy endpoint' => ['https://example.test?site-export-api', 'https://example.test?site-export-api'];
+        yield 'legacy text in path' => [
+            'https://example.test/site-export-api/info',
+            'https://example.test/site-export-api/info?reprint-api',
+        ];
+        yield 'similar query key' => [
+            'https://example.test?not-site-export-api=1',
+            'https://example.test?not-site-export-api=1&reprint-api',
+        ];
+    }
+
+    #[DataProvider('urls')]
+    public function testCanonicalQueryKeyIsAddedWithoutChangingExplicitLegacyEndpoints(
+        string $input,
+        string $expected
+    ): void {
+        $client = ( new ReflectionClass(\ImportClient::class) )->newInstanceWithoutConstructor();
+        $client->remote_reprint_api_url = $input;
+        $pull = ( new ReflectionClass(\Pull::class) )->newInstanceWithoutConstructor();
+        $client_property = new ReflectionProperty(\Pull::class, 'client');
+        $client_property->setValue($pull, $client);
+        $normalize_url = new ReflectionMethod(\Pull::class, 'normalize_url');
+
+        $normalize_url->invoke($pull);
+
+        $this->assertSame($expected, $client->remote_reprint_api_url);
+    }
+}

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -27,7 +27,7 @@ final class ReprintProcessLockTest extends TestCase
 
     public function testLocalStateLayoutUsesMatchingDirectoriesAndFileNames(): void
     {
-        $remote_reprint_api_url = 'https://example.com/?site-export-api';
+        $remote_reprint_api_url = 'https://example.com/?reprint-api';
         $process_lock = new \ReprintProcessLock($this->root . '/state');
         $client = new \ImportClient(
             $remote_reprint_api_url,
@@ -88,10 +88,10 @@ final class ReprintProcessLockTest extends TestCase
         $this->assertSame(
             $canonical_state_directory_target
                 . '/remotes/'
-                . md5('https://example.com/?site-export-api')
+                . md5('https://example.com/?reprint-api')
                 . '/push',
             \ImportClient::resolve_push_state_directory(
-                'https://example.com/?site-export-api',
+                'https://example.com/?reprint-api',
                 $state_directory_link,
                 $this->root . '/files',
                 'files-diff'
@@ -103,7 +103,7 @@ final class ReprintProcessLockTest extends TestCase
     {
         $process_lock = new \ReprintProcessLock($this->root . '/state');
         $client = new \ImportClient(
-            'https://example.com/?site-export-api',
+            'https://example.com/?reprint-api',
             $this->root . '/state',
             $this->root . '/files'
         );

--- a/tests/Import/RuntimeFilesRootPathTest.php
+++ b/tests/Import/RuntimeFilesRootPathTest.php
@@ -171,7 +171,7 @@ PHP, json_encode(
             );
             if (is_resource($connection)) {
                 fclose($connection);
-                return 'http://127.0.0.1:' . $port . '/export.php?site-export-api';
+                return 'http://127.0.0.1:' . $port . '/export.php?reprint-api';
             }
             usleep(100000);
         }

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -147,7 +147,7 @@ final class SortIndexFileTest extends TestCase
     public function testImporterRejectsAMissingNextRemoteIndex(): void
     {
         $client = new \ImportClient(
-            'https://example.test/?site-export-api',
+            'https://example.test/?reprint-api',
             $this->temporary_directory . '/state',
             $this->temporary_directory . '/files'
         );


### PR DESCRIPTION
Canonicalize the server API URL to `reprint-api`, ensuring the previous `site-export-api` is still supported for backwards-compatibility.