### PR TITLE
Reprint Server: Namespace Reprint Server package classes

### DIFF
--- a/docs/PUSH-TERMINOLOGY.md
+++ b/docs/PUSH-TERMINOLOGY.md
@@ -106,8 +106,8 @@ Use these names verbatim:
 
 | Surface | Name |
 | --- | --- |
-| Exception class and file | `Site_Export_Push_Exception`, `class-push-exception.php` |
-| Session class and file | `Site_Export_Push_Session`, `class-push-session.php` |
+| Exception class and file | `WordPress\Reprint\Server\PushException`, `class-push-exception.php` |
+| Session class and file | `WordPress\Reprint\Server\PushSession`, `class-push-session.php` |
 | reprint directory | `$reprint_directory` |
 | Document root | `$docroot` |
 | Excluded paths | `$excluded_paths` |

--- a/packages/reprint-server/README.md
+++ b/packages/reprint-server/README.md
@@ -10,18 +10,31 @@ installed side by side. Consumers should require
 
 ## Loading it
 
-Composer's classmap covers every class in `src/`, so classes resolve after
-requiring `vendor/autoload.php`.
+Composer's classmap covers every canonical class in `src/`, so classes
+resolve after requiring `vendor/autoload.php`.
 
 Reprint's entry points load their utility functions internally. `src/utils.php`
 is an internal implementation file and is not a public autoload entry point.
+
+The Reprint Server plugin loads `src/compat.php` when it opens the server
+runtime so that released `Site_Export_*` server names continue to resolve
+without adding work to every request which loads the shared Composer
+autoloader.
+
+Standalone consumers which request a released server name before its canonical
+class must explicitly require `src/compat.php` after Composer's autoloader.
 
 `src/export.php` never autoloads, and that is deliberate. It declares functions
 rather than classes, so the classmap scan finds nothing in it to register. Keep
 it that way: requiring the file starts an output buffer and installs error,
 exception and shutdown handlers, all of which belong at dispatch time.
-`Site_Export_HTTP_Server::serve()` requires it at the right moment. Adding a
-class to `export.php` would make it autoloadable and break that.
+`WordPress\Reprint\Server\HTTPServer::serve()` requires it at the right moment.
+Adding a class to `export.php` would make it autoloadable and break that.
+
+Server classes use the `WordPress\Reprint\Server` namespace. The released
+`Site_Export_*` server names remain autoloadable aliases. The global
+`Site_Export_HMAC_Client` name and file remain unchanged because the Reprint
+client package consumes that class directly.
 
 ## Development
 

--- a/packages/reprint-server/src/class-hmac-client.php
+++ b/packages/reprint-server/src/class-hmac-client.php
@@ -5,10 +5,10 @@ use function WordPress\Reprint\Server\generate_random_bytes;
 require_once __DIR__ . '/utils.php';
 
 /**
- * HMAC Client for the Site Export API.
+ * HMAC client for the Reprint Server API.
  *
  * This class generates the required HMAC signatures for authenticating
- * requests to the Site Export API. The importing side uses this to sign
+ * requests to the Reprint Server API. The importing side uses this to sign
  * all outgoing requests.
  *
  * Usage:
@@ -22,7 +22,8 @@ class Site_Export_HMAC_Client {
     /**
      * Value of the X-Auth-Content-Hash header when the request body is
      * deliberately not signed: this literal string stands where a body hash
-     * would otherwise be. Must match Site_Export_HMAC_Server::UNSIGNED_PAYLOAD.
+     * would otherwise be. Must match
+     * WordPress\Reprint\Server\HMACServer::UNSIGNED_PAYLOAD.
      */
     public const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
 

--- a/packages/reprint-server/src/class-hmac-server.php
+++ b/packages/reprint-server/src/class-hmac-server.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
+use RuntimeException;
+
 /**
  * HMAC verifier for Reprint API requests.
  *
@@ -7,7 +11,7 @@
  * the required X-Auth-* headers and checks request freshness before hashing a
  * received body.
  */
-final class Site_Export_HMAC_Server {
+final class HMACServer {
 
     /**
      * Value of the X-Auth-Content-Hash header when the request body is
@@ -262,4 +266,8 @@ final class Site_Export_HMAC_Server {
             throw new RuntimeException('Cannot hash uploaded file.');
         }
     }
+}
+
+if (!class_exists('Site_Export_HMAC_Server', false)) {
+    class_alias(HMACServer::class, 'Site_Export_HMAC_Server');
 }

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -1,22 +1,22 @@
 <?php
 
-use WordPress\Reprint\Server\ResourceBudget;
+namespace WordPress\Reprint\Server;
 
-use function WordPress\Reprint\Server\parse_size;
+use InvalidArgumentException;
 
 require_once __DIR__ . '/utils.php';
 
 if (!class_exists('WordPress\\Reprint\\Server\\ResourceBudget', false)) {
     require_once __DIR__ . '/class-resource-budget.php';
 }
-if (!class_exists('Site_Export_Push_Configuration_Exception', false)) {
+if (!class_exists(PushConfigurationException::class, false)) {
     require_once __DIR__ . '/class-push-configuration-exception.php';
 }
 
 /**
- * HTTP dispatcher for the Site Export API.
+ * HTTP dispatcher for the Reprint Server API.
  */
-final class Site_Export_HTTP_Server {
+final class HTTPServer {
 
     private const PUSH_ENDPOINT_METHODS = [
         'push_create' => 'create',
@@ -41,7 +41,7 @@ final class Site_Export_HTTP_Server {
     /** @var string|null */
     private $default_directory;
 
-    /** @var Site_Export_Push_Endpoints|null */
+    /** @var PushEndpoints|null */
     private $push_endpoints;
 
     public function __construct(array $options = []) {
@@ -58,13 +58,13 @@ final class Site_Export_HTTP_Server {
                 if (!is_array($options['push'])) {
                     throw new InvalidArgumentException('The push HTTP server option must be an array.');
                 }
-                if (!class_exists('Site_Export_Push_Endpoints', false)) {
+                if (!class_exists(PushEndpoints::class, false)) {
                     require_once __DIR__ . '/class-push-endpoints.php';
                 }
-                $this->push_endpoints = new Site_Export_Push_Endpoints($options['push']);
+                $this->push_endpoints = new PushEndpoints($options['push']);
             } catch (InvalidArgumentException $exception) {
                 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This rethrows a trusted configuration error; it does not render output.
-                throw new Site_Export_Push_Configuration_Exception(
+                throw new PushConfigurationException(
                     $exception->getMessage(),
                     0,
                     $exception
@@ -172,14 +172,14 @@ final class Site_Export_HTTP_Server {
      * Equivalent to:
      *
      *     require_once __DIR__ . '/export.php';
-     *     $server = new Site_Export_HTTP_Server($options);
+     *     $server = new HTTPServer($options);
      *     $server->handle_request();
      *
      * export.php is only required once. Callers that need to run CORS
      * or their own authentication must do that before calling this method.
      *
      * @param array<string, mixed> $options Forwarded to the constructor.
-     * @throws Exception If request parsing or endpoint dispatch fails.
+     * @throws \Exception If request parsing or endpoint dispatch fails.
      */
     public static function serve(array $options = []): void {
         // endpoint_preflight is defined by export.php — use it as a
@@ -411,4 +411,8 @@ final class Site_Export_HTTP_Server {
     private function get_valid_endpoints_message(): string {
         return "'" . implode("', '", array_keys($this->handlers)) . "'";
     }
+}
+
+if (!class_exists('Site_Export_HTTP_Server', false)) {
+    class_alias(HTTPServer::class, 'Site_Export_HTTP_Server');
 }

--- a/packages/reprint-server/src/class-multipart-processor.php
+++ b/packages/reprint-server/src/class-multipart-processor.php
@@ -1,5 +1,11 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol errors become CLI or authenticated API values, never HTML output.
 
 /**
@@ -12,7 +18,7 @@
  *
  *     $multipart->append_bytes($bytes);
  *     while ($multipart->next_token()) {
- *         if ($multipart->get_token_type() === Site_Export_Multipart_Processor::TOKEN_BODY) {
+ *         if ($multipart->get_token_type() === MultipartProcessor::TOKEN_BODY) {
  *             fwrite($output, $multipart->get_current_body_piece());
  *         }
  *     }
@@ -39,7 +45,7 @@
  * The processor retains only one bounded input fragment, one bounded header
  * block, and one current body token. It never accumulates a complete part.
  */
-final class Site_Export_Multipart_Processor {
+final class MultipartProcessor {
 
     /** Token which exposes the normalized headers of a newly opened part. */
     public const TOKEN_PART_START = 'part-start';
@@ -747,4 +753,8 @@ final class Site_Export_Multipart_Processor {
         $json = json_encode($bytes);
         return $json === false ? '0x' . bin2hex($bytes) : $json;
     }
+}
+
+if (!class_exists('Site_Export_Multipart_Processor', false)) {
+    class_alias(MultipartProcessor::class, 'Site_Export_Multipart_Processor');
 }

--- a/packages/reprint-server/src/class-push-configuration-exception.php
+++ b/packages/reprint-server/src/class-push-configuration-exception.php
@@ -1,7 +1,15 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
+use InvalidArgumentException;
+
 /**
  * Reports invalid server-owned push endpoint configuration.
  */
-final class Site_Export_Push_Configuration_Exception extends InvalidArgumentException {
+final class PushConfigurationException extends InvalidArgumentException {
+}
+
+if (!class_exists('Site_Export_Push_Configuration_Exception', false)) {
+    class_alias(PushConfigurationException::class, 'Site_Export_Push_Configuration_Exception');
 }

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -1,14 +1,14 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped,WordPress.Security.EscapeOutput.OutputNotEscaped -- Authenticated protocol responses are JSON, never HTML output.
 // phpcs:disable WordPress.Security.ValidatedSanitizedInput -- Multipart parsing and request-body byte accounting require the request bytes unchanged.
 
-use function WordPress\Reprint\Server\assert_valid_path;
-use function WordPress\Reprint\Server\normalize_excluded_paths;
-use function WordPress\Reprint\Server\normalize_path;
-use function WordPress\Reprint\Server\parse_size;
-use function WordPress\Reprint\Server\path_is_same_as_or_descendant_of;
-use function WordPress\Reprint\Server\realpath_with_missing_tail;
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+use Throwable;
 
 require_once __DIR__ . '/utils.php';
 
@@ -20,12 +20,12 @@ require_once __DIR__ . '/utils.php';
  * maximum multipart part size, and bounded commit work for every request.
  * Authentication happens in the embedding router before these methods run.
  *
- * Upload requests pass php://input directly to Site_Export_Push_Session. The
+ * Upload requests pass php://input directly to PushSession. The
  * endpoint retains only the latest accepted change while the receiver reads
  * each multipart part in bounded fragments; it never buffers the request body
  * or a list of all parts.
  */
-final class Site_Export_Push_Endpoints {
+final class PushEndpoints {
 
     private const DEFAULT_MAXIMUM_PART_BYTES = 4194304;
     private const DEFAULT_MAXIMUM_COMMIT_ENTRIES = 256;
@@ -188,7 +188,7 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            Site_Export_Push_Session::create(
+            PushSession::create(
                 $this->reprint_directory,
                 $this->docroot,
                 $this->excluded_paths,
@@ -240,7 +240,7 @@ final class Site_Export_Push_Endpoints {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
             $content_type = (string) ( $_SERVER['CONTENT_TYPE'] ?? '' );
-            $boundary = Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
+            $boundary = MultipartProcessor::boundary_from_content_type($content_type);
             $declared_request_bytes = $_SERVER['CONTENT_LENGTH'] ?? null;
             if (
                 $this->post_max_bytes !== null
@@ -258,12 +258,12 @@ final class Site_Export_Push_Endpoints {
             }
             $input = fopen('php://input', 'rb');
             if ($input === false) {
-                throw new Site_Export_Push_Exception(
-                    Site_Export_Push_Session::ERROR_FILESYSTEM,
+                throw new PushException(
+                    PushSession::ERROR_FILESYSTEM,
                     'Could not open the multipart upload request body.'
                 );
             }
-            $push_session = Site_Export_Push_Session::open(
+            $push_session = PushSession::open(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
@@ -271,7 +271,7 @@ final class Site_Export_Push_Endpoints {
             );
             $push_session->accept_upload(
                 $input,
-                new Site_Export_Multipart_Processor($boundary),
+                new MultipartProcessor($boundary),
                 $this->maximum_part_bytes,
                 $this->post_max_bytes ?? PHP_INT_MAX
             );
@@ -303,7 +303,7 @@ final class Site_Export_Push_Endpoints {
                 'last_change' => $last_change,
             ]);
         } catch (Throwable $exception) {
-            if ($upload_open && $push_session instanceof Site_Export_Push_Session) {
+            if ($upload_open && $push_session instanceof PushSession) {
                 $push_session->finish_upload();
             }
             if (is_resource($input)) {
@@ -355,7 +355,7 @@ final class Site_Export_Push_Endpoints {
                     throw new InvalidArgumentException('path_b64 must be valid base64 text.');
                 }
             }
-            $push_session = Site_Export_Push_Session::open(
+            $push_session = PushSession::open(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
@@ -408,7 +408,7 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            $push_session = Site_Export_Push_Session::open(
+            $push_session = PushSession::open(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
@@ -428,12 +428,12 @@ final class Site_Export_Push_Endpoints {
         } catch (Throwable $exception) {
             if (
                 $this->commit_start_denial_detail !== null
-                && $exception instanceof Site_Export_Push_Exception
-                && $exception->get_error_code() === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND
+                && $exception instanceof PushException
+                && $exception->get_error_code() === PushSession::ERROR_PUSH_NOT_FOUND
             ) {
                 $this->respond(403, [
                     'status' => 'rejected',
-                    'reason' => Site_Export_Push_Session::ERROR_PUSH_DISABLED,
+                    'reason' => PushSession::ERROR_PUSH_DISABLED,
                     'detail' => $this->commit_start_denial_detail,
                 ]);
                 return;
@@ -462,7 +462,7 @@ final class Site_Export_Push_Endpoints {
         try {
             $this->assert_request_method('POST');
             $push_session_id = $this->read_push_session_id($config);
-            $remove_complete = Site_Export_Push_Session::remove(
+            $remove_complete = PushSession::remove(
                 $this->reprint_directory,
                 $this->docroot,
                 $push_session_id,
@@ -497,7 +497,7 @@ final class Site_Export_Push_Endpoints {
     /**
      * Reads the required push session identity from request parameters.
      *
-     * Site_Export_Push_Session performs the canonical 32-character lowercase
+     * PushSession performs the canonical 32-character lowercase
      * hexadecimal grammar check. This method only rejects missing or non-string
      * values before a factory method is selected.
      *
@@ -531,20 +531,20 @@ final class Site_Export_Push_Endpoints {
      * @param Throwable $exception Failure raised while handling an endpoint.
      */
     private function respond_to_failure(Throwable $exception): void {
-        if ($exception instanceof Site_Export_Push_Exception) {
+        if ($exception instanceof PushException) {
             $reason = $exception->get_error_code();
             $http_code = 409;
-            if ($reason === Site_Export_Push_Session::ERROR_PUSH_NOT_FOUND) {
+            if ($reason === PushSession::ERROR_PUSH_NOT_FOUND) {
                 $http_code = 404;
-            } elseif ($reason === Site_Export_Push_Session::ERROR_PUSH_DISABLED) {
+            } elseif ($reason === PushSession::ERROR_PUSH_DISABLED) {
                 $http_code = 403;
-            } elseif ($reason === Site_Export_Push_Session::ERROR_LOCK_ACQUISITION_FAILURE) {
+            } elseif ($reason === PushSession::ERROR_LOCK_ACQUISITION_FAILURE) {
                 $http_code = 423;
-            } elseif ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
+            } elseif ($reason === PushSession::ERROR_REQUEST_TOO_LARGE) {
                 $http_code = 413;
             } elseif (
-                $reason === Site_Export_Push_Session::ERROR_FILESYSTEM
-                || $reason === Site_Export_Push_Session::ERROR_CORRUPTED_PUSH_STATE
+                $reason === PushSession::ERROR_FILESYSTEM
+                || $reason === PushSession::ERROR_CORRUPTED_PUSH_STATE
             ) {
                 $http_code = 500;
             }
@@ -553,13 +553,13 @@ final class Site_Export_Push_Endpoints {
                 'reason' => $reason,
                 'detail' => $exception->getMessage(),
             ];
-            if ($reason === Site_Export_Push_Session::ERROR_COMMIT_REQUIRED) {
+            if ($reason === PushSession::ERROR_COMMIT_REQUIRED) {
                 $context = $exception->get_context();
                 if (is_string($context['blocking_push_session_id'] ?? null)) {
                     $response['blocking_push_session_id'] = $context['blocking_push_session_id'];
                 }
             }
-            if ($reason === Site_Export_Push_Session::ERROR_REQUEST_TOO_LARGE) {
+            if ($reason === PushSession::ERROR_REQUEST_TOO_LARGE) {
                 $context = $exception->get_context();
                 if (is_int($context['observed_request_body_bytes'] ?? null)) {
                     $response['observed_request_body_bytes'] = $context['observed_request_body_bytes'];
@@ -582,7 +582,7 @@ final class Site_Export_Push_Endpoints {
         }
         $this->respond(500, [
             'status' => 'rejected',
-            'reason' => Site_Export_Push_Session::ERROR_FILESYSTEM,
+            'reason' => PushSession::ERROR_FILESYSTEM,
             'detail' => 'The push endpoint failed while processing the request.',
         ]);
     }
@@ -609,4 +609,8 @@ final class Site_Export_Push_Endpoints {
         }
         echo $json;
     }
+}
+
+if (!class_exists('Site_Export_Push_Endpoints', false)) {
+    class_alias(PushEndpoints::class, 'Site_Export_Push_Endpoints');
 }

--- a/packages/reprint-server/src/class-push-exception.php
+++ b/packages/reprint-server/src/class-push-exception.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
+use RuntimeException;
+
 /**
  * Reports a classified push-session failure.
  *
@@ -13,7 +17,7 @@
  * exception. An ordinary RuntimeException remains unclassified and follows the
  * endpoint's `invalid_request` handling rather than leaking an accidental code.
  */
-final class Site_Export_Push_Exception extends RuntimeException {
+final class PushException extends RuntimeException {
 
     /**
      * Stable machine-readable classification selected by the throwing class.
@@ -84,4 +88,8 @@ final class Site_Export_Push_Exception extends RuntimeException {
     public function get_context(): array {
         return $this->context;
     }
+}
+
+if (!class_exists('Site_Export_Push_Exception', false)) {
+    class_alias(PushException::class, 'Site_Export_Push_Exception');
 }

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -1,21 +1,20 @@
 <?php
 
+namespace WordPress\Reprint\Server;
+
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Push errors become authenticated API JSON, never HTML output.
 
-use function WordPress\Reprint\Server\assert_valid_relative_path;
-use function WordPress\Reprint\Server\normalize_excluded_paths;
-use function WordPress\Reprint\Server\path_is_same_as_or_descendant_of;
-use function WordPress\Reprint\Server\path_remainder_under;
-use function WordPress\Reprint\Server\relative_path_under;
-use function WordPress\Reprint\Server\trim_right_slash;
-use function WordPress\Reprint\Server\wp_join_unix_paths;
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+use Throwable;
 
 require_once __DIR__ . '/utils.php';
 
-if (!class_exists('Site_Export_Multipart_Processor', false)) {
+if (!class_exists(MultipartProcessor::class, false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
 }
-if (!class_exists('Site_Export_Push_Exception', false)) {
+if (!class_exists(PushException::class, false)) {
     require_once __DIR__ . '/class-push-exception.php';
 }
 
@@ -57,7 +56,7 @@ if (!class_exists('Site_Export_Push_Exception', false)) {
  *     non_recoverable_commit_failure?:array{reason:'unexpected_docroot_mutation'|'same_device',detail:string,context:array<string,mixed>}
  * }
  */
-final class Site_Export_Push_Session {
+final class PushSession {
 
     public const ERROR_LOCK_ACQUISITION_FAILURE = 'lock_acquisition_failure';
     public const ERROR_OFFSET_GAP = 'offset_gap';
@@ -111,7 +110,7 @@ final class Site_Export_Push_Session {
     private $upload_lock = null;
     /** @var resource|null */
     private $upload_input = null;
-    /** @var Site_Export_Multipart_Processor|null */
+    /** @var MultipartProcessor|null */
     private $upload_processor = null;
     /** @var bool */
     private $current_upload_part_ended = false;
@@ -196,7 +195,7 @@ final class Site_Export_Push_Session {
             $push_session->with_commit_state_lock(function () use ($push_session): void {
                 $active_owner = $push_session->read_commit_owner();
                 if ($active_owner !== null && $active_owner !== $push_session->push_session_id) {
-                    throw new Site_Export_Push_Exception(
+                    throw new PushException(
                         self::ERROR_COMMIT_REQUIRED,
                         'Push session ' . $active_owner . ' must finish committing this document root before another push session can start.',
                         ['blocking_push_session_id' => $active_owner]
@@ -208,7 +207,7 @@ final class Site_Export_Push_Session {
                 '.removing-' . $push_session_id
             );
             if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
-                throw new Site_Export_Push_Exception(
+                throw new PushException(
                     self::ERROR_LOCK_ACQUISITION_FAILURE,
                     'Push session removal is incomplete. Retry create after remove finishes.'
                 );
@@ -221,11 +220,11 @@ final class Site_Export_Push_Session {
             }
             if (!@mkdir($push_session->work_files_directory, 0700, true)) {
                 self::remove_tree($push_session->push_directory);
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create the push work directories.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not create the push work directories.');
             }
             if (@file_put_contents($push_session->push_lock_path, '') === false || @file_put_contents($push_session->work_deletes_path, '') === false) {
                 self::remove_tree($push_session->push_directory);
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push session control files.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not create push session control files.');
             }
             try {
                 $push_session->require_same_device($push_session->work_files_directory, $push_session->docroot, 'receive', '');
@@ -331,7 +330,7 @@ final class Site_Export_Push_Session {
      * method validates that condition before any bytes are read from $input.
      *
      * @param resource $input Blocking stream containing one multipart request.
-     * @param Site_Export_Multipart_Processor $processor Parser configured with
+     * @param MultipartProcessor $processor Parser configured with
      *                                                   the request boundary.
      * @param int $maximum_part_bytes Largest Content-Length accepted for one part.
      * @param int $maximum_request_body_bytes Largest decoded request body accepted.
@@ -339,13 +338,13 @@ final class Site_Export_Push_Session {
      *
      * @throws LogicException If another upload is already open on this object.
      * @throws InvalidArgumentException If the stream or either byte limit is invalid.
-     * @throws Site_Export_Push_Exception If the push session is busy,
+     * @throws PushException If the push session is busy,
      *     malformed, unavailable, already committing, or the decoded request
      *     body exceeds its byte limit.
      */
     public function accept_upload(
         $input,
-        Site_Export_Multipart_Processor $processor,
+        MultipartProcessor $processor,
         int $maximum_part_bytes = PHP_INT_MAX,
         int $maximum_request_body_bytes = PHP_INT_MAX
     ): void {
@@ -368,7 +367,7 @@ final class Site_Export_Push_Session {
         try {
             $this->assert_push_configuration();
             if (is_file($this->commit_json_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_COMMIT_REQUIRED, 'Uploads are closed because this push session is committing.');
+                throw new PushException(self::ERROR_COMMIT_REQUIRED, 'Uploads are closed because this push session is committing.');
             }
             $this->upload_lock = $lock;
             $this->upload_input = $input;
@@ -425,7 +424,7 @@ final class Site_Export_Push_Session {
             if (!$this->next_upload_token()) {
                 return false;
             }
-            if ($this->upload_processor->get_token_type() !== Site_Export_Multipart_Processor::TOKEN_PART_START) {
+            if ($this->upload_processor->get_token_type() !== MultipartProcessor::TOKEN_PART_START) {
                 throw new LogicException('Expected a multipart part-start token before the next change.');
             }
             $headers = $this->upload_processor->get_current_headers();
@@ -565,7 +564,7 @@ final class Site_Export_Push_Session {
      *
      * @throws InvalidArgumentException If the requested path is reserved or
      *     overlaps an excluded path.
-     * @throws Site_Export_Push_Exception If the push session is busy,
+     * @throws PushException If the push session is busy,
      *     unavailable, corrupt, or no longer matches the document-root configuration.
      */
     public function get_status(?string $path = null): array {
@@ -649,7 +648,7 @@ final class Site_Export_Push_Session {
                 // push lock so a denied request cannot race another lifecycle
                 // operation into starting a new commit.
                 if ($commit_start_denial_detail !== null) {
-                    throw new Site_Export_Push_Exception(
+                    throw new PushException(
                         self::ERROR_PUSH_DISABLED,
                         $commit_start_denial_detail
                     );
@@ -664,7 +663,7 @@ final class Site_Export_Push_Session {
                         if (is_resource($handle)) {
                             fclose($handle);
                         }
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not inspect the final work delete byte.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not inspect the final work delete byte.');
                     }
                     $last_byte = fread($handle, 1);
                     fclose($handle);
@@ -686,7 +685,7 @@ final class Site_Export_Push_Session {
                 $this->write_json($this->commit_json_path, $commit_state);
             }
             if (isset($commit_state['non_recoverable_commit_failure'])) {
-                throw new Site_Export_Push_Exception(
+                throw new PushException(
                     $commit_state['non_recoverable_commit_failure']['reason'],
                     $commit_state['non_recoverable_commit_failure']['detail'],
                     $commit_state['non_recoverable_commit_failure']['context']
@@ -705,14 +704,14 @@ final class Site_Export_Push_Session {
             $this->with_commit_state_lock(function (): void {
                 $active_owner = $this->read_commit_owner();
                 if ($active_owner !== null && $active_owner !== $this->push_session_id) {
-                    throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Another push session is already committing this document root: ' . $active_owner . '.');
+                    throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Another push session is already committing this document root: ' . $active_owner . '.');
                 }
                 $this->write_atomic_file($this->commit_state_path, $this->push_session_id . "\n", 0600);
             });
             $maintenance_docroot_path = $this->docroot_path('.maintenance');
             $maintenance_identity = $this->lstat_path($maintenance_docroot_path);
             if ($maintenance_identity !== null && !$this->maintenance_marker_is_owned($maintenance_docroot_path, $this->push_session_id)) {
-                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
+                throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A foreign WordPress maintenance marker already exists. Retry after its owner removes it.');
             }
             $maintenance_contents = "<?php\n"
                 . "\$reprint_push_request = (isset(\$_GET['reprint-api']) || isset(\$_GET['site-export-api']))\n"
@@ -733,7 +732,7 @@ final class Site_Export_Push_Session {
                         $this->advance_installing_files($commit_state);
                     }
                 }
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (PushException $exception) {
                 if (in_array($exception->get_error_code(), [self::ERROR_UNEXPECTED_DOCROOT_MUTATION, self::ERROR_SAME_DEVICE], true)) {
                     $commit_state['non_recoverable_commit_failure'] = [
                         'reason' => $exception->get_error_code(),
@@ -778,13 +777,13 @@ final class Site_Export_Push_Session {
             try {
                 $commit_state = $this->read_json($this->commit_json_path);
                 if ($commit_state !== null && $commit_state['phase'] !== 'complete') {
-                    throw new Site_Export_Push_Exception(self::ERROR_COMMIT_REQUIRED, 'Document-root mutation has begun. Resume commit instead of removing this push session.');
+                    throw new PushException(self::ERROR_COMMIT_REQUIRED, 'Document-root mutation has begun. Resume commit instead of removing this push session.');
                 }
                 if (file_exists($removing_push_directory) || is_link($removing_push_directory)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A remove tombstone already exists for push session ' . $this->push_session_id . '.');
+                    throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'A remove tombstone already exists for push session ' . $this->push_session_id . '.');
                 }
                 if (!@rename($this->push_directory, $removing_push_directory)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not move the push directory to its removal tombstone.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not move the push directory to its removal tombstone.');
                 }
             } finally {
                 flock($lock, LOCK_UN);
@@ -816,10 +815,10 @@ final class Site_Export_Push_Session {
             throw new LogicException('Multipart input closed before the current part-end token.');
         }
         $type = $this->upload_processor->get_token_type();
-        if ($type === Site_Export_Multipart_Processor::TOKEN_BODY) {
+        if ($type === MultipartProcessor::TOKEN_BODY) {
             return $this->upload_processor->get_current_body_piece();
         }
-        if ($type === Site_Export_Multipart_Processor::TOKEN_PART_END) {
+        if ($type === MultipartProcessor::TOKEN_PART_END) {
             $this->current_upload_part_ended = true;
             return null;
         }
@@ -872,7 +871,7 @@ final class Site_Export_Push_Session {
      * @return string Next bounded request-body fragment, or an empty string at EOF.
      */
     private function read_upload_request_fragment(): string {
-        $maximum_fragment_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $maximum_fragment_bytes = MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES;
         $remaining_request_body_bytes = PHP_INT_MAX;
         if ($this->maximum_upload_request_body_bytes !== PHP_INT_MAX) {
             $remaining_request_body_bytes = $this->maximum_upload_request_body_bytes - $this->upload_request_body_bytes_read;
@@ -880,12 +879,12 @@ final class Site_Export_Push_Session {
         }
         $bytes = fread($this->upload_input, $maximum_fragment_bytes);
         if ($bytes === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read the multipart upload request body.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not read the multipart upload request body.');
         }
         $fragment_bytes = strlen($bytes);
         if ($fragment_bytes > $remaining_request_body_bytes) {
             $observed_request_body_bytes = $this->upload_request_body_bytes_read + $fragment_bytes;
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_REQUEST_TOO_LARGE,
                 'The decoded request body reached ' . $observed_request_body_bytes
                 . ' bytes, exceeding the target post_max_size of '
@@ -951,17 +950,17 @@ final class Site_Export_Push_Session {
             $data = $this->lstat_path($this->work_inflight_data_path);
             if ($data !== null) {
                 if ($data['type'] !== 'file' || $data['size'] !== $inflight['total_bytes']) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight file completion has an invalid data size.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight file completion has an invalid data size.');
                 }
                 $this->ensure_private_parent($work_path);
                 if ($work_identity !== null) {
                     $this->remove_work_path($work_path);
                 }
                 if (!@rename($this->work_inflight_data_path, $work_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not move in-flight file data to its work-file path.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not move in-flight file data to its work-file path.');
                 }
             } elseif ($work_identity === null || $work_identity['type'] !== 'file' || $work_identity['size'] !== $inflight['total_bytes']) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight file completion has neither data nor a matching work file.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight file completion has neither data nor a matching work file.');
             }
         } elseif ($inflight['type'] === 'directory') {
             if ($work_identity === null) {
@@ -969,21 +968,21 @@ final class Site_Export_Push_Session {
                 // The process umask filters 0777 to the document-root mode used by normal completion.
                 // Until commit, 0700 work ancestors deny group and other traversal.
                 if (!@mkdir($work_path, 0777)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create the in-flight directory at its work-file path.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not create the in-flight directory at its work-file path.');
                 }
             } elseif ($work_identity['type'] !== 'directory') {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight directory completion found an incompatible work value.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight directory completion found an incompatible work value.');
             }
         } elseif ($work_identity === null) {
             $this->ensure_private_parent($work_path);
             if (!@symlink(base64_decode($inflight['target_b64'], true), $work_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create the in-flight symlink at its work-file path.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not create the in-flight symlink at its work-file path.');
             }
         } elseif ($work_identity['type'] !== 'symlink' || @readlink($work_path) !== base64_decode($inflight['target_b64'], true)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight symlink completion found an incompatible work value.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'In-flight symlink completion found an incompatible work value.');
         }
         if (!@unlink($this->work_inflight_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work.');
         }
     }
 
@@ -1037,20 +1036,20 @@ final class Site_Export_Push_Session {
             return;
         }
         if ($inflight === null && $offset !== 0) {
-            throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but no matching in-flight file exists. Start at offset 0.');
+            throw new PushException(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but no matching in-flight file exists. Start at offset 0.');
         }
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
+            throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
         }
         if ($inflight === null || $offset === 0) {
             if ($inflight !== null && $this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard in-flight file data for restart.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not discard in-flight file data for restart.');
             }
             $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'file', 'total_bytes' => $total_bytes];
             $this->write_json($this->work_inflight_path, $inflight);
             $handle = @fopen($this->work_inflight_data_path, 'wb');
             if ($handle === false) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create in-flight file data for ' . base64_encode($path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not create in-flight file data for ' . base64_encode($path) . '.');
             }
             fclose($handle);
             $inflight['phase'] = 'receiving';
@@ -1058,16 +1057,16 @@ final class Site_Export_Push_Session {
             $actual_bytes = 0;
         } else {
             if ($inflight['type'] !== 'file' || $inflight['phase'] !== 'receiving' || $inflight['total_bytes'] !== $total_bytes) {
-                throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'In-flight file ' . base64_encode($path) . ' must be restarted at offset 0.');
+                throw new PushException(self::ERROR_OFFSET_GAP, 'In-flight file ' . base64_encode($path) . ' must be restarted at offset 0.');
             }
             $actual_bytes = $this->file_size($this->work_inflight_data_path);
             if ($offset !== $actual_bytes) {
-                throw new Site_Export_Push_Exception(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but in-flight data contains ' . $actual_bytes . ' bytes.');
+                throw new PushException(self::ERROR_OFFSET_GAP, 'File part for ' . base64_encode($path) . ' starts at offset ' . $offset . ', but in-flight data contains ' . $actual_bytes . ' bytes.');
             }
         }
         $handle = @fopen($this->work_inflight_data_path, 'ab');
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open in-flight file data for ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open in-flight file data for ' . base64_encode($path) . '.');
         }
         $received = 0;
         try {
@@ -1076,7 +1075,7 @@ final class Site_Export_Push_Session {
                 $this->write_all($handle, $piece, 'in-flight file data ' . base64_encode($path));
             }
             if (!fflush($handle)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not flush in-flight file data ' . base64_encode($path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not flush in-flight file data ' . base64_encode($path) . '.');
             }
         } finally {
             fclose($handle);
@@ -1090,10 +1089,10 @@ final class Site_Export_Push_Session {
                 $this->remove_work_path($complete_path);
             }
             if (!@rename($this->work_inflight_data_path, $complete_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not move in-flight file data to the work-file path ' . base64_encode($path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not move in-flight file data to the work-file path ' . base64_encode($path) . '.');
             }
             if (!@unlink($this->work_inflight_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
             }
             $state = 'complete';
         } else {
@@ -1130,7 +1129,7 @@ final class Site_Export_Push_Session {
         $this->finish_inflight_completion();
         $inflight = $this->read_inflight();
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
+            throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
         }
         $identity = $this->lstat_path($target);
         if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
@@ -1143,7 +1142,7 @@ final class Site_Export_Push_Session {
         $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'directory'];
         $this->write_json($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
         if ($identity !== null) {
             $this->remove_work_path($target);
@@ -1152,10 +1151,10 @@ final class Site_Export_Push_Session {
         $this->write_json($this->work_inflight_path, $inflight);
         $this->ensure_private_parent($target);
         if (!is_dir($target) && !@mkdir($target, 0777)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage explicit empty directory ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not stage explicit empty directory ' . base64_encode($path) . '.');
         }
         if (!@unlink($this->work_inflight_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
         }
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'directory', 'accepted_bytes' => 0];
     }
@@ -1200,7 +1199,7 @@ final class Site_Export_Push_Session {
         $this->finish_inflight_completion();
         $inflight = $this->read_inflight();
         if ($inflight !== null && base64_decode($inflight['path_b64'], true) !== $path) {
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
+            throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'In-flight work already occupies the slot: ' . $inflight['path_b64'] . '.');
         }
         $identity = $this->lstat_path($target);
         if ($identity !== null && $identity['type'] === 'directory' && $this->first_directory_entry($target) !== null) {
@@ -1213,7 +1212,7 @@ final class Site_Export_Push_Session {
         $inflight = ['phase' => 'preparing', 'path_b64' => base64_encode($path), 'type' => 'symlink', 'target_b64' => base64_encode($target_value)];
         $this->write_json($this->work_inflight_path, $inflight);
         if ($this->lstat_path($this->work_inflight_data_path) !== null && !@unlink($this->work_inflight_data_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not discard stale in-flight file data.');
         }
         if ($identity !== null) {
             $this->remove_work_path($target);
@@ -1222,10 +1221,10 @@ final class Site_Export_Push_Session {
         $this->write_json($this->work_inflight_path, $inflight);
         $this->ensure_private_parent($target);
         if (!@symlink($target_value, $target)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not stage symlink ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not stage symlink ' . base64_encode($path) . '.');
         }
         if (!@unlink($this->work_inflight_path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not clear in-flight metadata after completing work for ' . base64_encode($path) . '.');
         }
         $this->current_change = ['path_b64' => base64_encode($path), 'state' => 'complete', 'type' => 'symlink', 'accepted_bytes' => 0];
     }
@@ -1269,16 +1268,16 @@ final class Site_Export_Push_Session {
         }
         $handle = @fopen($this->work_deletes_path, 'r+b');
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the raw work delete stream.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open the raw work delete stream.');
         }
         try {
             $delete_stat = fstat($handle);
             if (!is_array($delete_stat) || !isset($delete_stat['size'])) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not determine the actual size of work delete stream.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not determine the actual size of work delete stream.');
             }
             $stored_bytes = (int) $delete_stat['size'];
             if ($offset > $stored_bytes) {
-                throw new Site_Export_Push_Exception(
+                throw new PushException(
                     self::ERROR_OFFSET_GAP,
                     'Delete-list part starts at offset ' . $offset . ', but the work delete stream has stored ' . $stored_bytes . ' bytes.'
                 );
@@ -1289,13 +1288,13 @@ final class Site_Export_Push_Session {
             } else {
                 $suffix_bytes = min($stored_bytes, self::MAX_PATH_BYTES + 1);
                 if (fseek($handle, $stored_bytes - $suffix_bytes) !== 0) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not inspect the work delete-stream suffix.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not inspect the work delete-stream suffix.');
                 }
                 $suffix = $this->read_exact($handle, $suffix_bytes, 'work delete-stream suffix');
                 $last_nul = strrpos($suffix, "\0");
                 $trailing_path = $last_nul === false ? $suffix : substr($suffix, $last_nul + 1);
                 if ($last_nul === false && $stored_bytes > self::MAX_PATH_BYTES) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The incomplete work delete path already exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The incomplete work delete path already exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
                 }
             }
             while (true) {
@@ -1307,7 +1306,7 @@ final class Site_Export_Push_Session {
                 $overlap = min(strlen($piece), max(0, $stored_bytes - $position));
                 if ($overlap > 0) {
                     if (fseek($handle, $position) !== 0) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not seek within the work delete stream for replay validation.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not seek within the work delete stream for replay validation.');
                     }
                     $stored = $this->read_exact($handle, $overlap, 'work delete replay');
                     if ($stored !== substr($piece, 0, $overlap)) {
@@ -1334,13 +1333,13 @@ final class Site_Export_Push_Session {
                         }
                     }
                     if (fseek($handle, 0, SEEK_END) !== 0) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not seek to the work delete stream end.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not seek to the work delete stream end.');
                     }
                     $this->write_all($handle, $append, 'work delete stream');
                     $stored_bytes += strlen($append);
                     $position += strlen($append);
                     if (!fflush($handle)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not flush the work delete stream.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not flush the work delete stream.');
                     }
                 }
             }
@@ -1353,7 +1352,7 @@ final class Site_Export_Push_Session {
         if ($complete) {
             $push_metadata = $this->read_json($this->push_json_path);
             if (!is_array($push_metadata)) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata is missing while completing the delete upload.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata is missing while completing the delete upload.');
             }
             $push_metadata['work_deletes_complete'] = true;
             $this->write_json($this->push_json_path, $push_metadata);
@@ -1394,14 +1393,14 @@ final class Site_Export_Push_Session {
                 return;
             }
             if ($work_deletes_byte_offset < 0 || $work_deletes_byte_offset > $delete_size) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Delete-consumption offset ' . $work_deletes_byte_offset . ' is outside the ' . $delete_size . '-byte stream.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Delete-consumption offset ' . $work_deletes_byte_offset . ' is outside the ' . $delete_size . '-byte stream.');
             }
             $handle = @fopen($this->work_deletes_path, 'rb');
             if ($handle === false || fseek($handle, $work_deletes_byte_offset) !== 0) {
                 if (is_resource($handle)) {
                     fclose($handle);
                 }
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not seek to the confirmed delete-consumption offset.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not seek to the confirmed delete-consumption offset.');
             }
             $path = '';
             $path_bytes = 0;
@@ -1409,14 +1408,14 @@ final class Site_Export_Push_Session {
                 while ($path_bytes <= self::MAX_PATH_BYTES) {
                     $byte = fread($handle, 1);
                     if ($byte === false) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read the work delete stream.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not read the work delete stream.');
                     }
                     if ($byte === '') {
-                        throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The work delete stream ended before its NUL record terminator.');
+                        throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The work delete stream ended before its NUL record terminator.');
                     }
                     if ($byte === "\0") {
                         if ($path === '') {
-                            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The work delete stream contains an empty record at offset ' . $work_deletes_byte_offset . '.');
+                            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The work delete stream contains an empty record at offset ' . $work_deletes_byte_offset . '.');
                         }
                         $this->assert_path_does_not_overlap_excluded_paths($path);
                         $commit_state['current_delete_path'] = base64_encode($path);
@@ -1429,7 +1428,7 @@ final class Site_Export_Push_Session {
             } finally {
                 fclose($handle);
             }
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'A work delete path exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'A work delete path exceeds ' . self::MAX_PATH_BYTES . ' bytes.');
         }
 
         $path = $this->decode_commit_path($commit_state['current_delete_path'], 'current delete');
@@ -1479,7 +1478,7 @@ final class Site_Export_Push_Session {
         }
         if ($identity['type'] === 'file' || $identity['type'] === 'symlink') {
             if (!@unlink($absolute_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove document-root ' . $identity['type'] . ' ' . base64_encode($relative_path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove document-root ' . $identity['type'] . ' ' . base64_encode($relative_path) . '.');
             }
             return;
         }
@@ -1489,7 +1488,7 @@ final class Site_Export_Push_Session {
         $entry = $this->first_directory_entry($absolute_path);
         if ($entry === null) {
             if (!@rmdir($absolute_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove empty document-root directory ' . base64_encode($relative_path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove empty document-root directory ' . base64_encode($relative_path) . '.');
             }
             return;
         }
@@ -1557,7 +1556,7 @@ final class Site_Export_Push_Session {
                         $this->throw_unexpected_docroot_mutation('install', $path, $path, 'directory', ['directory'], $docroot_identity);
                     }
                     if (!@rmdir($work_path)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not finish work ancestor directory cleanup for ' . base64_encode($path) . '.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not finish work ancestor directory cleanup for ' . base64_encode($path) . '.');
                     }
                 } elseif ($docroot_identity === null || $docroot_identity['type'] !== 'directory') {
                     $this->throw_unexpected_docroot_mutation('install', $path, $path, 'directory', ['directory'], $docroot_identity);
@@ -1596,26 +1595,26 @@ final class Site_Export_Push_Session {
         if ($entry === null) {
             if ($stack_size === 0) {
                 if ($commit_state['current_delete_path'] !== null || $commit_state['commit_cursor'] !== []) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion with active bounded work state.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion with active bounded work state.');
                 }
                 if ( (int) $commit_state['work_deletes_byte_offset'] !== $this->file_size($this->work_deletes_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion before consuming the complete delete stream.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion before consuming the complete delete stream.');
                 }
                 if ($this->first_directory_entry($this->work_files_directory) !== null) {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion while work/files still contains pending values.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit reached completion while work/files still contains pending values.');
                 }
                 $maintenance_docroot_path = $this->docroot_path('.maintenance');
                 $maintenance_identity = $this->lstat_path($maintenance_docroot_path);
                 if ($maintenance_identity !== null) {
                     if (!$this->maintenance_marker_is_owned($maintenance_docroot_path, $this->push_session_id)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'The push-session-owned maintenance marker was replaced by another owner.');
+                        throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'The push-session-owned maintenance marker was replaced by another owner.');
                     }
                     if (!@unlink($maintenance_docroot_path)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove the push-session-owned WordPress maintenance marker.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove the push-session-owned WordPress maintenance marker.');
                     }
                 }
                 if ($this->lstat_path($this->maintenance_copy_path) !== null && !@unlink($this->maintenance_copy_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove the private maintenance ownership marker.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove the private maintenance ownership marker.');
                 }
                 $commit_state['phase'] = 'complete';
                 $this->write_json($this->commit_json_path, $commit_state);
@@ -1630,7 +1629,7 @@ final class Site_Export_Push_Session {
             $commit_state['current_work_files_descendant'] = ['path_b64' => base64_encode($parent_path), 'expected_type' => 'directory'];
             $this->write_json($this->commit_json_path, $commit_state);
             if (!@rmdir($work_directory_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not consume empty work ancestor directory ' . base64_encode($parent_path) . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not consume empty work ancestor directory ' . base64_encode($parent_path) . '.');
             }
             $commit_state['current_work_files_descendant'] = null;
             array_pop($commit_state['commit_cursor']);
@@ -1643,7 +1642,7 @@ final class Site_Export_Push_Session {
         $work_path = wp_join_unix_paths($this->work_files_directory, $path);
         $identity = $this->lstat_path($work_path);
         if ($identity === null) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Selected work path disappeared before installing_files: ' . base64_encode($path) . '.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Selected work path disappeared before installing_files: ' . base64_encode($path) . '.');
         }
         if ($identity['type'] === 'directory' && $this->first_directory_entry($work_path) !== null) {
             $this->assert_path_is_not_excluded($path);
@@ -1655,7 +1654,7 @@ final class Site_Export_Push_Session {
             $docroot_identity = $this->lstat_path($docroot_value_path);
             if ($docroot_identity === null) {
                 if (!@mkdir($docroot_value_path, 0777) && !is_dir($docroot_value_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create document-root ancestor directory ' . base64_encode($path) . '.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not create document-root ancestor directory ' . base64_encode($path) . '.');
                 }
                 $docroot_identity = $this->lstat_path($docroot_value_path);
             }
@@ -1669,7 +1668,7 @@ final class Site_Export_Push_Session {
         }
         $this->assert_path_does_not_overlap_excluded_paths($path);
         if (!in_array($identity['type'], ['file', 'directory', 'symlink'], true)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Work path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Work path ' . base64_encode($path) . ' has unsupported type ' . $identity['type'] . '.');
         }
         $this->install_work_value($commit_state, $path, $identity['type'], false);
     }
@@ -1709,7 +1708,7 @@ final class Site_Export_Push_Session {
         $work_path = wp_join_unix_paths($this->work_files_directory, $path);
         $work_identity = $this->lstat_path($work_path);
         if ($work_identity === null || $work_identity['type'] !== $expected_type) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Work ' . $expected_type . ' ' . base64_encode($path) . ' is not present for installing_files.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Work ' . $expected_type . ' ' . base64_encode($path) . ' is not present for installing_files.');
         }
         $parent_device = $this->require_docroot_ancestors($path, 'install', $expected_type);
         $docroot_value_path = $this->docroot_path($path);
@@ -1740,7 +1739,7 @@ final class Site_Export_Push_Session {
             if (stripos($message, 'cross-device') !== false || stripos($message, 'exdev') !== false) {
                 $this->throw_same_device('install', $path, $work_identity['dev'], $parent_device);
             }
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_FILESYSTEM,
                 'Could not rename work ' . base64_encode($path) . ' directly into the document root'
                 . ( $message === '' ? '.' : ': ' . $message )
@@ -1760,7 +1759,7 @@ final class Site_Export_Push_Session {
     private function require_docroot_ancestors(string $path, string $operation, ?string $work_identity_type = null): ?int {
         $root = $this->lstat_path($this->docroot);
         if ($root === null || $root['type'] !== 'directory') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The document root is no longer a real directory.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The document root is no longer a real directory.');
         }
         $work_device = $this->work_device();
         if ($root['dev'] !== $work_device) {
@@ -1825,7 +1824,7 @@ final class Site_Export_Push_Session {
         if ($work_identity_type !== null) {
             $context['work_type'] = $work_identity_type;
         }
-        throw new Site_Export_Push_Exception(self::ERROR_UNEXPECTED_DOCROOT_MUTATION, $detail, $context);
+        throw new PushException(self::ERROR_UNEXPECTED_DOCROOT_MUTATION, $detail, $context);
     }
 
     /**
@@ -1843,7 +1842,7 @@ final class Site_Export_Push_Session {
      */
     private function throw_same_device(string $operation, string $path, int $work_device, int $docroot_device): void {
         $detail = 'The work value and document-root destination are on different filesystems. This push requires same-filesystem rename and has no copy fallback.';
-        throw new Site_Export_Push_Exception(self::ERROR_SAME_DEVICE, $detail, [
+        throw new PushException(self::ERROR_SAME_DEVICE, $detail, [
             'operation' => $operation,
             'path_b64' => base64_encode($path),
             'work_device' => $work_device,
@@ -1868,7 +1867,7 @@ final class Site_Export_Push_Session {
         $work = $this->lstat_path($work_path);
         $docroot_identity = $this->lstat_path($docroot_value_path);
         if ($work === null || $docroot_identity === null) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not determine the work and document-root filesystem devices.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not determine the work and document-root filesystem devices.');
         }
         if ($work['dev'] !== $docroot_identity['dev']) {
             $this->throw_same_device($operation, $relative_path, $work['dev'], $docroot_identity['dev']);
@@ -1887,7 +1886,7 @@ final class Site_Export_Push_Session {
     private function work_device(): int {
         $identity = $this->lstat_path($this->work_files_directory);
         if ($identity === null || $identity['type'] !== 'directory') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'work/files is not a real work directory.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'work/files is not a real work directory.');
         }
         return $identity['dev'];
     }
@@ -1910,7 +1909,7 @@ final class Site_Export_Push_Session {
         while ($result_bytes < $bytes) {
             $piece = fread($handle, $bytes - $result_bytes);
             if ($piece === false || $piece === '') {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read complete ' . $description . '; expected ' . $bytes . ' bytes and observed ' . $result_bytes . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not read complete ' . $description . '; expected ' . $bytes . ' bytes and observed ' . $result_bytes . '.');
             }
             $result .= $piece;
             $result_bytes += strlen($piece);
@@ -1931,7 +1930,7 @@ final class Site_Export_Push_Session {
     private function first_directory_entry(string $directory): ?string {
         $handle = @opendir($directory);
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read directory ' . $directory . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not read directory ' . $directory . '.');
         }
         try {
             while (true) {
@@ -2006,7 +2005,7 @@ final class Site_Export_Push_Session {
                 return;
             }
             if (!@unlink($this->commit_state_path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not release the commit-state owner.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not release the commit-state owner.');
             }
         });
     }
@@ -2024,11 +2023,11 @@ final class Site_Export_Push_Session {
     private function with_commit_state_lock(callable $callback): void {
         $lock = @fopen($this->commit_state_lock_path, 'c+b');
         if ($lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the commit-state lock.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open the commit-state lock.');
         }
         try {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
-                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'The commit-state owner is busy. Retry the request.');
+                throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'The commit-state owner is busy. Retry the request.');
             }
             $callback();
         } finally {
@@ -2050,14 +2049,14 @@ final class Site_Export_Push_Session {
             return null;
         }
         if ($identity['type'] !== 'file') {
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_CORRUPTED_PUSH_STATE,
                 'Reprint cannot identify the active push commit because its commit-state marker is not a regular file.'
             );
         }
         $active_owner = @file_get_contents($this->commit_state_path);
         if (!is_string($active_owner)) {
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_FILESYSTEM,
                 'Reprint could not read the active push commit from its commit-state marker.'
             );
@@ -2066,7 +2065,7 @@ final class Site_Export_Push_Session {
         try {
             self::require_push_session_id($active_owner);
         } catch (InvalidArgumentException $exception) {
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_CORRUPTED_PUSH_STATE,
                 'Reprint cannot identify the active push commit because its commit-state marker is malformed.'
             );
@@ -2106,41 +2105,41 @@ final class Site_Export_Push_Session {
     private function acquire_push_lock() {
         $push_session_identity = $this->lstat_path($this->push_directory);
         if ($push_session_identity === null) {
-            throw new Site_Export_Push_Exception(self::ERROR_PUSH_NOT_FOUND, 'The push session does not exist: ' . $this->push_session_id . '.');
+            throw new PushException(self::ERROR_PUSH_NOT_FOUND, 'The push session does not exist: ' . $this->push_session_id . '.');
         }
         if ($push_session_identity['type'] !== 'directory') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The push session path is not a real directory: ' . $this->push_directory . '.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The push session path is not a real directory: ' . $this->push_directory . '.');
         }
         $lock_identity = $this->lstat_path($this->push_lock_path);
         if ($lock_identity === null || $lock_identity['type'] !== 'file') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'The push lock is missing or not regular: ' . $this->push_lock_path . '.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'The push lock is missing or not regular: ' . $this->push_lock_path . '.');
         }
 
         $lock = @fopen($this->push_lock_path, 'r+b');
         if ($lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push lock.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open the push lock.');
         }
         if (!flock($lock, LOCK_EX | LOCK_NB)) {
             fclose($lock);
-            throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push session ' . $this->push_session_id . ' is busy. Retry the request.');
+            throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push session ' . $this->push_session_id . ' is busy. Retry the request.');
         }
         try {
             foreach ([$this->push_directory, $this->work_dir, $this->work_files_directory] as $directory) {
                 $identity = $this->lstat_path($directory);
                 if ($identity === null || $identity['type'] !== 'directory') {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push directory is missing or not real: ' . $directory . '.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push directory is missing or not real: ' . $directory . '.');
                 }
             }
             foreach ([$this->push_json_path, $this->push_lock_path, $this->work_deletes_path] as $file) {
                 $identity = $this->lstat_path($file);
                 if ($identity === null || $identity['type'] !== 'file') {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push file is missing or not regular: ' . $file . '.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Required push file is missing or not regular: ' . $file . '.');
                 }
             }
             foreach ([$this->commit_json_path, $this->maintenance_copy_path, $this->work_inflight_path, $this->work_inflight_data_path] as $optional_file) {
                 $identity = $this->lstat_path($optional_file);
                 if ($identity !== null && $identity['type'] !== 'file') {
-                    throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Optional push file has an unsupported type: ' . $optional_file . '.');
+                    throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Optional push file has an unsupported type: ' . $optional_file . '.');
                 }
             }
         } catch (Throwable $exception) {
@@ -2163,22 +2162,22 @@ final class Site_Export_Push_Session {
         $push_metadata = $this->read_json($this->push_json_path);
         if (!is_array($push_metadata) || ( $push_metadata['push_session_id'] ?? null ) !== $this->push_session_id
             || !is_bool($push_metadata['work_deletes_complete'] ?? null)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has an invalid push session ID or work-deletes completion state.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has an invalid push session ID or work-deletes completion state.');
         }
         if (!is_string($push_metadata['docroot_b64'] ?? null) || !is_array($push_metadata['excluded_paths_b64'] ?? null)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain the configured document root and excluded paths.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not contain the configured document root and excluded paths.');
         }
         $docroot = base64_decode($push_metadata['docroot_b64'], true);
         $excluded = [];
         foreach ($push_metadata['excluded_paths_b64'] as $encoded) {
             $decoded = is_string($encoded) ? base64_decode($encoded, true) : false;
             if (!is_string($decoded)) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata contains an invalid excluded path.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata contains an invalid excluded path.');
             }
             $excluded[] = $decoded;
         }
         if ($docroot !== $this->docroot || $excluded !== $this->excluded_paths) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not match the current push configuration.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata does not match the current push configuration.');
         }
         $this->require_same_device($this->work_files_directory, $this->docroot, 'receive', '');
     }
@@ -2200,15 +2199,15 @@ final class Site_Export_Push_Session {
             return null;
         }
         if ($identity['type'] !== 'file' || $identity['size'] > self::MAX_METADATA_BYTES) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' is not a bounded regular file.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' is not a bounded regular file.');
         }
         $contents = @file_get_contents($path);
         if (!is_string($contents)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read metadata file ' . $path . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not read metadata file ' . $path . '.');
         }
         $decoded = json_decode($contents, true);
         if (!is_array($decoded)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' does not contain a JSON object.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Metadata file ' . $path . ' does not contain a JSON object.');
         }
         return $decoded;
     }
@@ -2244,10 +2243,10 @@ final class Site_Export_Push_Session {
     private function write_json(string $path, array $value): void {
         $contents = json_encode($value, JSON_UNESCAPED_SLASHES);
         if (!is_string($contents)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Could not encode bounded push metadata.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Could not encode bounded push metadata.');
         }
         if (strlen($contents) > self::MAX_METADATA_BYTES) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Encoded push metadata exceeds the maximum of ' . self::MAX_METADATA_BYTES . ' bytes.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Encoded push metadata exceeds the maximum of ' . self::MAX_METADATA_BYTES . ' bytes.');
         }
         $this->write_atomic_file($path, $contents, 0600);
     }
@@ -2267,16 +2266,16 @@ final class Site_Export_Push_Session {
     private function write_atomic_file(string $path, string $contents, int $permissions): void {
         $temporary = $path . '.tmp-' . $this->push_session_id;
         if ($this->lstat_path($temporary) !== null && !@unlink($temporary)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not clear temporary metadata file ' . $temporary . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not clear temporary metadata file ' . $temporary . '.');
         }
         $handle = @fopen($temporary, 'xb');
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create temporary metadata file ' . $temporary . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not create temporary metadata file ' . $temporary . '.');
         }
         try {
             $this->write_all($handle, $contents, 'metadata file ' . $path);
             if (!fflush($handle)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not flush temporary metadata file ' . $temporary . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not flush temporary metadata file ' . $temporary . '.');
             }
         } finally {
             fclose($handle);
@@ -2284,7 +2283,7 @@ final class Site_Export_Push_Session {
         @chmod($temporary, $permissions);
         if (!@rename($temporary, $path)) {
             @unlink($temporary);
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not replace metadata file ' . $path . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not replace metadata file ' . $path . '.');
         }
     }
 
@@ -2305,7 +2304,7 @@ final class Site_Export_Push_Session {
         while ($offset < $length) {
             $written = fwrite($handle, substr($contents, $offset));
             if (!is_int($written) || $written <= 0) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not finish writing ' . $description . '; wrote ' . $offset . ' of ' . $length . ' bytes.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not finish writing ' . $description . '; wrote ' . $offset . ' of ' . $length . ' bytes.');
             }
             $offset += $written;
         }
@@ -2325,11 +2324,11 @@ final class Site_Export_Push_Session {
      */
     private function decode_commit_path($encoded, string $description): string {
         if (!is_string($encoded)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not base64 text.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not base64 text.');
         }
         $path = base64_decode($encoded, true);
         if (!is_string($path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not valid base64.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit ' . $description . ' path is not valid base64.');
         }
         $this->assert_path_not_reserved($path);
         return $path;
@@ -2356,11 +2355,11 @@ final class Site_Export_Push_Session {
             $encoded = $frame['component_b64'] ?? null;
             $component = is_string($encoded) ? base64_decode($encoded, true) : false;
             if (!is_string($component) || $component === '' || strpos($component, '/') !== false) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit cursor frame does not contain one valid base64 path component.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit cursor frame does not contain one valid base64 path component.');
             }
             $path = wp_join_unix_paths($path, $component);
             if (strlen($path) > self::MAX_PATH_BYTES) {
-                throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit cursor path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
+                throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Commit cursor path exceeds the maximum of ' . self::MAX_PATH_BYTES . ' bytes.');
             }
         }
         if ($path !== '') {
@@ -2381,7 +2380,7 @@ final class Site_Export_Push_Session {
     private function work_deletes_are_complete(): bool {
         $push_metadata = $this->read_json($this->push_json_path);
         if (!is_array($push_metadata) || !is_bool($push_metadata['work_deletes_complete'] ?? null)) {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has no valid work-deletes completion state.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Push metadata has no valid work-deletes completion state.');
         }
         return $push_metadata['work_deletes_complete'];
     }
@@ -2577,7 +2576,7 @@ final class Site_Export_Push_Session {
                     return;
                 }
                 if (!@mkdir($current, 0700)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create private work ancestor directory ' . $current . '.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not create private work ancestor directory ' . $current . '.');
                 }
                 continue;
             }
@@ -2650,12 +2649,12 @@ final class Site_Export_Push_Session {
                 throw new InvalidArgumentException('A work directory with descendants cannot be replaced by another logical value.');
             }
             if (!@rmdir($path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove an empty private work directory.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove an empty private work directory.');
             }
             return;
         }
         if (!@unlink($path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove a private work ' . $identity['type'] . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove a private work ' . $identity['type'] . '.');
         }
     }
 
@@ -2672,7 +2671,7 @@ final class Site_Export_Push_Session {
     private function file_size(string $path): int {
         $identity = $this->lstat_path($path);
         if ($identity === null || $identity['type'] !== 'file') {
-            throw new Site_Export_Push_Exception(self::ERROR_CORRUPTED_PUSH_STATE, 'Expected a regular file at ' . $path . '.');
+            throw new PushException(self::ERROR_CORRUPTED_PUSH_STATE, 'Expected a regular file at ' . $path . '.');
         }
         return $identity['size'];
     }
@@ -2690,7 +2689,7 @@ final class Site_Export_Push_Session {
     private static function create_push_sessions_directory(string $reprint_directory): string {
         $push_sessions_directory = wp_join_unix_paths($reprint_directory, '.reprint', 'push');
         if (!@mkdir($push_sessions_directory, 0700, true) && !is_dir($push_sessions_directory)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_sessions_directory . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not create push sessions directory ' . $push_sessions_directory . '.');
         }
         return self::require_directory($push_sessions_directory, 'push sessions', false);
     }
@@ -2708,11 +2707,11 @@ final class Site_Export_Push_Session {
     private static function acquire_create_remove_lock(string $push_sessions_directory, string $operation) {
         $create_remove_lock = @fopen(wp_join_unix_paths($push_sessions_directory, 'create-remove.lock'), 'c+b');
         if ($create_remove_lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open create-remove.lock for the ' . $operation . ' request.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open create-remove.lock for the ' . $operation . ' request.');
         }
         if (!flock($create_remove_lock, LOCK_EX | LOCK_NB)) {
             fclose($create_remove_lock);
-            throw new Site_Export_Push_Exception(
+            throw new PushException(
                 self::ERROR_LOCK_ACQUISITION_FAILURE,
                 'Another create or remove request holds create-remove.lock. Retry the ' . $operation . ' request.'
             );
@@ -2738,11 +2737,11 @@ final class Site_Export_Push_Session {
         $push_lock_path = wp_join_unix_paths($tombstone, 'push.lock');
         $lock = @fopen($push_lock_path, 'r+b');
         if ($lock === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not open the push removal tombstone lock.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not open the push removal tombstone lock.');
         }
         try {
             if (!flock($lock, LOCK_EX | LOCK_NB)) {
-                throw new Site_Export_Push_Exception(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push removal cleanup is busy. Retry remove.');
+                throw new PushException(self::ERROR_LOCK_ACQUISITION_FAILURE, 'Push removal cleanup is busy. Retry remove.');
             }
             // The push directory rename is durable before commit ownership is released.
             // Retry that release while the tombstone still preserves push state.
@@ -2757,7 +2756,7 @@ final class Site_Export_Push_Session {
             fclose($lock);
         }
         if (!@unlink($push_lock_path) || !@rmdir($tombstone)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove the completed push removal tombstone.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove the completed push removal tombstone.');
         }
         return true;
     }
@@ -2779,7 +2778,7 @@ final class Site_Export_Push_Session {
             throw new InvalidArgumentException('The ' . $description . ' must be an absolute directory; observed ' . json_encode($path) . '.');
         }
         if ($create && !is_dir($path) && !@mkdir($path, 0700, true) && !is_dir($path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not create ' . $description . ' directory ' . $path . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not create ' . $description . ' directory ' . $path . '.');
         }
         $real_path = realpath($path);
         if ($real_path === false || !is_dir($real_path) || is_link($path)) {
@@ -2818,7 +2817,7 @@ final class Site_Export_Push_Session {
     private static function remove_directory_entries(string $directory_path, int &$remaining_entries, bool $preserve_lock = false): bool {
         $handle = @opendir($directory_path);
         if ($handle === false) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read push removal directory: ' . $directory_path . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not read push removal directory: ' . $directory_path . '.');
         }
         try {
             while (true) {
@@ -2836,7 +2835,7 @@ final class Site_Export_Push_Session {
                 clearstatcache(true, $entry_path);
                 $stat = @lstat($entry_path);
                 if (!is_array($stat)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Work commit remove entry disappeared during cleanup: ' . $entry_path . '.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Work commit remove entry disappeared during cleanup: ' . $entry_path . '.');
                 }
                 $type = ( (int) ( $stat['mode'] ?? 0 ) ) & 0170000;
                 if ($type === 0040000) {
@@ -2847,10 +2846,10 @@ final class Site_Export_Push_Session {
                         return false;
                     }
                     if (!@rmdir($entry_path)) {
-                        throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove push removal directory: ' . $entry_path . '.');
+                        throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove push removal directory: ' . $entry_path . '.');
                     }
                 } elseif (!@unlink($entry_path)) {
-                    throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove push removal entry: ' . $entry_path . '.');
+                    throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove push removal entry: ' . $entry_path . '.');
                 }
                 --$remaining_entries;
             }
@@ -2879,7 +2878,7 @@ final class Site_Export_Push_Session {
         if ($type === 0040000) {
             $handle = @opendir($path);
             if ($handle === false) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not read push directory for removal: ' . $path . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not read push directory for removal: ' . $path . '.');
             }
             try {
                 while (true) {
@@ -2895,12 +2894,16 @@ final class Site_Export_Push_Session {
                 closedir($handle);
             }
             if (!@rmdir($path)) {
-                throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove push directory ' . $path . '.');
+                throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove push directory ' . $path . '.');
             }
             return;
         }
         if (!@unlink($path)) {
-            throw new Site_Export_Push_Exception(self::ERROR_FILESYSTEM, 'Could not remove push entry ' . $path . '.');
+            throw new PushException(self::ERROR_FILESYSTEM, 'Could not remove push entry ' . $path . '.');
         }
     }
+}
+
+if (!class_exists('Site_Export_Push_Session', false)) {
+    class_alias(PushSession::class, 'Site_Export_Push_Session');
 }

--- a/packages/reprint-server/src/compat.php
+++ b/packages/reprint-server/src/compat.php
@@ -1,0 +1,26 @@
+<?php
+/** Legacy global class names retained for existing Reprint Server consumers. */
+
+$reprint_server_class_aliases = [
+    'Site_Export_HMAC_Server' => \WordPress\Reprint\Server\HMACServer::class,
+    'Site_Export_HTTP_Server' => \WordPress\Reprint\Server\HTTPServer::class,
+    'Site_Export_Multipart_Processor' => \WordPress\Reprint\Server\MultipartProcessor::class,
+    'Site_Export_Push_Configuration_Exception' => \WordPress\Reprint\Server\PushConfigurationException::class,
+    'Site_Export_Push_Endpoints' => \WordPress\Reprint\Server\PushEndpoints::class,
+    'Site_Export_Push_Exception' => \WordPress\Reprint\Server\PushException::class,
+    'Site_Export_Push_Session' => \WordPress\Reprint\Server\PushSession::class,
+];
+
+spl_autoload_register(
+    static function ($requested_class) use ($reprint_server_class_aliases) {
+        if (
+            isset($reprint_server_class_aliases[$requested_class])
+            && !class_exists($requested_class, false)
+        ) {
+            $canonical_class = $reprint_server_class_aliases[$requested_class];
+            class_exists($canonical_class);
+        }
+    }
+);
+
+unset($reprint_server_class_aliases);

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -6,6 +6,7 @@
 use WordPress\Reprint\Server\FileIndexProcessor;
 use WordPress\Reprint\Server\FileTreeProducer;
 use WordPress\Reprint\Server\GzipOutputStream;
+use WordPress\Reprint\Server\HTTPServer;
 use WordPress\Reprint\Server\MySQLDumpProducer;
 use WordPress\Reprint\Server\PdoConstants;
 use WordPress\Reprint\Server\ResourceBudget;
@@ -397,7 +398,7 @@ function create_wpdb_pdo_adapter()
     return new WpdbDriverPDO($wpdb);
 }
 
-if (!class_exists('Site_Export_HTTP_Server', false)) {
+if (!class_exists(HTTPServer::class, false)) {
     require_once __DIR__ . "/class-http-server.php";
 }
 
@@ -3630,6 +3631,6 @@ function parse_http_config(): array
         $body = '';
     }
 
-    $server = new Site_Export_HTTP_Server();
+    $server = new HTTPServer();
     return $server->parse_http_config($_GET, $_POST, $_SERVER, $body);
 }

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -6,6 +6,10 @@
  * triggering any HTTP dispatch.
  */
 
+use WordPress\Reprint\Server\HMACServer;
+use WordPress\Reprint\Server\HTTPServer;
+use WordPress\Reprint\Server\PushConfigurationException;
+
 use function WordPress\Reprint\Server\relative_path_under;
 
 if (!defined('ABSPATH')) {
@@ -121,26 +125,34 @@ function _site_export_load_exporter_runtime(): ?string {
     $candidates = [
         [
             'autoload' => SITE_EXPORT_PLUGIN_DIR . 'vendor/autoload.php',
+            'compat' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/compat.php',
             'export' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/export.php',
         ],
         [
             'autoload' => $repo_root . '/vendor/autoload.php',
+            'compat' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/compat.php',
             'export' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/export.php',
         ],
     ];
 
     foreach ($candidates as $candidate) {
-        if (!file_exists($candidate['autoload']) || !file_exists($candidate['export'])) {
+        if (
+            !file_exists($candidate['autoload'])
+            || !file_exists($candidate['compat'])
+            || !file_exists($candidate['export'])
+        ) {
             continue;
         }
 
         $autoload_path = realpath($candidate['autoload']);
+        $compat_path = realpath($candidate['compat']);
         $export_path = realpath($candidate['export']);
-        if ($autoload_path === false || $export_path === false) {
+        if ($autoload_path === false || $compat_path === false || $export_path === false) {
             continue;
         }
 
         require_once $autoload_path;
+        require_once $compat_path;
         $loaded_export_path = $export_path;
         return $export_path;
     }
@@ -291,15 +303,15 @@ function _site_export_update_push_authorization(bool $enabled): bool {
  * matches AND that the HMAC is valid.
  */
 function _site_export_verify_hmac(string $secret): ?string {
-    if (!class_exists('Site_Export_HMAC_Server', false)) {
+    if (!class_exists(HMACServer::class, false)) {
         _site_export_load_exporter_runtime();
     }
 
-    if (!class_exists('Site_Export_HMAC_Server')) {
+    if (!class_exists(HMACServer::class)) {
         return 'Reprint Server runtime is incomplete. Run composer install in reprint-server-wp or rebuild the release package.';
     }
 
-    $server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
+    $server = new HMACServer($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
     return $server->verify_globals();
 }
 
@@ -388,10 +400,10 @@ function _site_export_handle_api_request(array $options = []): void {
     // credentials, so we must not require auth before CORS passes.
     // The class is loaded by the Composer autoloader on demand, but
     // load it eagerly in case the autoloader hasn't been required yet.
-    if (!class_exists('Site_Export_HTTP_Server', false)) {
+    if (!class_exists(HTTPServer::class, false)) {
         _site_export_load_exporter_runtime();
     }
-    Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('*');
+    HTTPServer::handle_cors_headers_and_terminate_on_options('*');
 
     // Buffer output so stray warnings don't corrupt the JSON response.
     ob_start();
@@ -455,10 +467,10 @@ function _site_export_handle_api_request(array $options = []): void {
         if (empty($secret) || !is_string($secret)) {
             _site_export_push_error(503, 'not_configured', 'Configure the shared secret in WordPress admin under Tools > Reprint Server.');
         }
-        if (!class_exists('Site_Export_HMAC_Server', false)) {
+        if (!class_exists(HMACServer::class, false)) {
             _site_export_load_exporter_runtime();
         }
-        if (!class_exists('Site_Export_HMAC_Server')) {
+        if (!class_exists(HMACServer::class)) {
             _site_export_push_error(500, 'filesystem_error', 'Reprint Server runtime is incomplete. Run composer install in reprint-server-wp or rebuild the release package.');
         }
         // These exact request-line values are covered by the HMAC; WordPress
@@ -467,7 +479,7 @@ function _site_export_handle_api_request(array $options = []): void {
         $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
         $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
-        $hmac_server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
+        $hmac_server = new HMACServer($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
         $auth_error = $hmac_server->verify_envelope($_SERVER, $request_method, $request_target);
         if ($auth_error !== null) {
             _site_export_push_error(403, 'auth_failed', $auth_error);
@@ -504,7 +516,7 @@ function _site_export_handle_api_request(array $options = []): void {
         );
     }
 
-    // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
+    // Ensure the Composer autoloader is loaded so HTTPServer
     // is resolvable. The class itself will require export.php on demand
     // via serve() below.
     if (_site_export_load_exporter_runtime() === null) {
@@ -517,7 +529,7 @@ function _site_export_handle_api_request(array $options = []): void {
     // -- Dispatch --
     try {
         $server_options = ['default_directory' => ABSPATH];
-        if (Site_Export_HTTP_Server::is_push_endpoint($endpoint)) {
+        if (HTTPServer::is_push_endpoint($endpoint)) {
             // Push changes the web server's document root. ABSPATH remains the
             // pull default because it may point at a separate shared core tree.
             if (array_key_exists('docroot', $options)) {
@@ -527,14 +539,14 @@ function _site_export_handle_api_request(array $options = []): void {
                 $configured_docroot = $_SERVER['DOCUMENT_ROOT'] ?? null;
             }
             if (!is_string($configured_docroot) || $configured_docroot === '') {
-                throw new Site_Export_Push_Configuration_Exception(
+                throw new PushConfigurationException(
                     'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
                     . json_encode($configured_docroot) . '.'
                 );
             }
             $canonical_docroot = realpath($configured_docroot);
             if ($canonical_docroot === false || !is_dir($canonical_docroot)) {
-                throw new Site_Export_Push_Configuration_Exception(
+                throw new PushConfigurationException(
                     'Push endpoints require docroot or DOCUMENT_ROOT to name an existing directory; observed '
                     . json_encode($configured_docroot) . '.'
                 );
@@ -546,7 +558,7 @@ function _site_export_handle_api_request(array $options = []): void {
             );
             $excluded_paths = $options['excluded_paths'] ?? [];
             if (!is_array($excluded_paths)) {
-                throw new Site_Export_Push_Configuration_Exception('excluded_paths must be an array.');
+                throw new PushConfigurationException('excluded_paths must be an array.');
             }
             $canonical_plugin_directory = realpath(SITE_EXPORT_PLUGIN_DIR);
             $plugin_directory = rtrim($canonical_plugin_directory === false ? SITE_EXPORT_PLUGIN_DIR : $canonical_plugin_directory, '/\\');
@@ -600,7 +612,7 @@ function _site_export_handle_api_request(array $options = []): void {
                         || $canonical_plugin_directory === false
                         || rtrim($resolved_logical_plugin_directory, '/\\') !== $plugin_directory
                     ) {
-                        throw new Site_Export_Push_Configuration_Exception(
+                        throw new PushConfigurationException(
                             'WordPress reports the Reprint Server plugin inside the document root at '
                             . json_encode($logical_plugin_directory_to_verify)
                             . ', but that path does not resolve to SITE_EXPORT_PLUGIN_DIR '
@@ -638,10 +650,10 @@ function _site_export_handle_api_request(array $options = []): void {
             }
             $server_options['push'] = $push_options;
         }
-        Site_Export_HTTP_Server::serve($server_options);
+        HTTPServer::serve($server_options);
     } catch (Exception $e) {
         if (_site_export_is_push_endpoint($endpoint)) {
-            if ($e instanceof Site_Export_Push_Configuration_Exception) {
+            if ($e instanceof PushConfigurationException) {
                 _site_export_push_error(503, 'not_configured', $e->getMessage());
             }
             if ($e instanceof InvalidArgumentException) {

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -8,7 +8,7 @@ final class ExportHttpServerTest extends TestCase
 {
     public function testParsesJsonBodyAndCastsKnownTypes(): void
     {
-        $server = new Site_Export_HTTP_Server();
+        $server = new \WordPress\Reprint\Server\HTTPServer();
         $config = $server->parse_http_config(
             ['endpoint' => 'file_index'],
             [],
@@ -30,7 +30,7 @@ final class ExportHttpServerTest extends TestCase
 
     public function testNormalizeConfigAppliesDefaultDirectoryAndDecodesCursorHeader(): void
     {
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'default_directory' => '/srv/site',
         ]);
         $cursor = base64_encode(json_encode(['offset' => 10]) ?: '');
@@ -46,7 +46,7 @@ final class ExportHttpServerTest extends TestCase
 
     public function testNormalizeConfigAppliesDefaultDirectoryEvenWhenListDirPresent(): void
     {
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'default_directory' => '/srv/site',
         ]);
 
@@ -61,7 +61,7 @@ final class ExportHttpServerTest extends TestCase
 
     public function testNormalizeConfigRejectsInvalidCursor(): void
     {
-        $server = new Site_Export_HTTP_Server();
+        $server = new \WordPress\Reprint\Server\HTTPServer();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cursor must be base64-encoded');
@@ -75,7 +75,7 @@ final class ExportHttpServerTest extends TestCase
     public function testDispatchRoutesPreflightWithoutBudget(): void
     {
         $calls = [];
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => [
                 'preflight' => function (array $config) use (&$calls): void {
                     $calls[] = ['preflight', $config];
@@ -93,7 +93,7 @@ final class ExportHttpServerTest extends TestCase
     public function testDispatchRoutesStreamingEndpointsWithCreatedBudget(): void
     {
         $calls = [];
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => [
                 'file_index' => function (array $config, $budget) use (&$calls): void {
                     $calls[] = [$config, $budget];
@@ -113,7 +113,7 @@ final class ExportHttpServerTest extends TestCase
 
     public function testClassifiesOnlyTheRegisteredPushEndpoints(): void
     {
-        $server = new Site_Export_HTTP_Server();
+        $server = new \WordPress\Reprint\Server\HTTPServer();
 
         $this->assertTrue(
             is_callable([$server, 'is_push_endpoint']),
@@ -137,14 +137,14 @@ final class ExportHttpServerTest extends TestCase
         mkdir($reprint_directory, 0700);
 
         try {
-            $server = new Site_Export_HTTP_Server([
+            $server = new \WordPress\Reprint\Server\HTTPServer([
                 'push' => [
                     'reprint_directory' => $reprint_directory,
                     'docroot' => $docroot,
                     'excluded_paths' => [],
                 ],
             ]);
-            $handlers_property = new ReflectionProperty(Site_Export_HTTP_Server::class, 'handlers');
+            $handlers_property = new ReflectionProperty(\WordPress\Reprint\Server\HTTPServer::class, 'handlers');
             $handlers_property->setAccessible(true);
             $handlers = $handlers_property->getValue($server);
             $registered_push_endpoint_methods = [];
@@ -153,7 +153,7 @@ final class ExportHttpServerTest extends TestCase
                     continue;
                 }
                 $this->assertIsArray($handler);
-                $this->assertInstanceOf(Site_Export_Push_Endpoints::class, $handler[0]);
+                $this->assertInstanceOf(\WordPress\Reprint\Server\PushEndpoints::class, $handler[0]);
                 $registered_push_endpoint_methods[$endpoint] = $handler[1];
             }
 
@@ -182,7 +182,7 @@ final class ExportHttpServerTest extends TestCase
             };
         }
         $budget_creations = 0;
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => $handlers,
             'budget_factory' => static function () use (&$budget_creations): array {
                 ++$budget_creations;
@@ -200,7 +200,7 @@ final class ExportHttpServerTest extends TestCase
 
     public function testDispatchRejectsUnknownEndpoints(): void
     {
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => [
                 'preflight' => static function (): void {},
             ],
@@ -215,7 +215,7 @@ final class ExportHttpServerTest extends TestCase
     public function testHandleRequestUsesParsedConfigAndDispatches(): void
     {
         $calls = [];
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => [
                 'preflight' => function (array $config) use (&$calls): void {
                     $calls[] = $config;
@@ -238,7 +238,7 @@ final class ExportHttpServerTest extends TestCase
         foreach (['push_create', 'push_upload', 'push_status', 'push_commit', 'push_remove', 'push_future_operation'] as $endpoint) {
             $body_reads = 0;
             $calls = [];
-            $server = new Site_Export_HTTP_Server([
+            $server = new \WordPress\Reprint\Server\HTTPServer([
                 'budget_factory' => static function (): stdClass {
                     return new stdClass();
                 },
@@ -276,7 +276,7 @@ final class ExportHttpServerTest extends TestCase
     public function testPushQueryParametersCannotBeOverriddenByPostData(): void
     {
         $calls = [];
-        $server = new Site_Export_HTTP_Server([
+        $server = new \WordPress\Reprint\Server\HTTPServer([
             'handlers' => [
                 'push_commit' => static function (array $config) use (&$calls): void {
                     $calls[] = $config;
@@ -307,9 +307,9 @@ final class ExportHttpServerTest extends TestCase
 
     public function testNonArrayPushOptionsThrowConfigurationException(): void
     {
-        $this->expectException(Site_Export_Push_Configuration_Exception::class);
+        $this->expectException(\WordPress\Reprint\Server\PushConfigurationException::class);
         $this->expectExceptionMessage('The push HTTP server option must be an array.');
 
-        new Site_Export_HTTP_Server(['push' => null]);
+        new \WordPress\Reprint\Server\HTTPServer(['push' => null]);
     }
 }

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -75,9 +75,11 @@ final class ExportLibraryLoadTest extends TestCase {
         $linked_plugin_directory = $tmp_dir . '/linked-plugin';
         $autoload_path = $physical_plugin_directory . '/vendor/autoload.php';
         $linked_autoload_path = $linked_plugin_directory . '/vendor/autoload.php';
+        $compatibility_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/compat.php';
         $export_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/export.php';
         mkdir(dirname($export_path), 0755, true);
         file_put_contents($autoload_path, "<?php\n");
+        file_put_contents($compatibility_path, "<?php\n");
         file_put_contents($export_path, "<?php\n");
 
         if (!symlink($physical_plugin_directory, $linked_plugin_directory)) {

--- a/tests/HmacServerTest.php
+++ b/tests/HmacServerTest.php
@@ -23,14 +23,14 @@ final class HmacServerTest extends TestCase
             'X-Auth-Content-Hash' => $content_hash,
         ];
 
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertNull($server->verify($headers, $body, [], 1700000001.0));
     }
 
     public function testMissingHeaderIsRejected(): void
     {
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Missing X-Auth-Signature header',
@@ -41,7 +41,7 @@ final class HmacServerTest extends TestCase
     public function testInvalidTimestampFormatIsRejected(): void
     {
         $headers = $this->buildHeadersForBody('', 'not-a-number');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Invalid timestamp format',
@@ -52,7 +52,7 @@ final class HmacServerTest extends TestCase
     public function testExpiredTimestampIsRejected(): void
     {
         $headers = $this->buildHeadersForBody('', '1700000000.000000');
-        $server = new Site_Export_HMAC_Server(self::SECRET, 300);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET, 300);
 
         $this->assertStringContainsString(
             'Request timestamp expired',
@@ -63,7 +63,7 @@ final class HmacServerTest extends TestCase
     public function testShortNonceIsRejected(): void
     {
         $headers = $this->buildHeadersForBody('', '1700000000.000000', 'shortnonce');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Nonce must be at least 16 characters',
@@ -75,7 +75,7 @@ final class HmacServerTest extends TestCase
     {
         $headers = $this->buildHeadersForBody('');
         $headers['X-Auth-Signature'] = str_repeat('0', 64);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'HMAC signature verification failed',
@@ -86,7 +86,7 @@ final class HmacServerTest extends TestCase
     public function testContentHashMismatchIsRejected(): void
     {
         $headers = $this->buildHeadersForBody('signed-body');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Content hash mismatch: body was modified in transit',
@@ -104,7 +104,7 @@ final class HmacServerTest extends TestCase
             $server_headers['HTTP_' . strtoupper(str_replace('-', '_', $name))] = $value;
         }
 
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertNull($server->verify($server_headers, $body, [], 1700000001.0));
     }
@@ -134,7 +134,7 @@ final class HmacServerTest extends TestCase
                 'a_file' => ['tmp_name' => $tmp_a],
             ];
 
-            $server = new Site_Export_HMAC_Server(self::SECRET);
+            $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
             $this->assertNull($server->verify($headers, 'ignored-body', $files, 1700000001.0));
         } finally {
@@ -147,7 +147,7 @@ final class HmacServerTest extends TestCase
     {
         $headers = $this->buildHeadersForBody('signed-body');
         $headers['X-Auth-Signature'] = str_repeat('0', 64);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'HMAC signature verification failed',
@@ -160,7 +160,7 @@ final class HmacServerTest extends TestCase
     public function testUploadedFileHashFailureReturnsVerificationError(): void
     {
         $headers = $this->buildHeadersForBody('signed-body');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Cannot hash uploaded file.',
@@ -175,7 +175,7 @@ final class HmacServerTest extends TestCase
         $client = new Site_Export_HMAC_Client(self::SECRET);
         $url = 'https://example.com/?reprint-api&endpoint=push_upload&push_session_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $headers = $client->get_envelope_auth_headers('POST', $url);
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertNull($server->verify_envelope(
             $headers,
@@ -189,7 +189,7 @@ final class HmacServerTest extends TestCase
     {
         $client = new Site_Export_HMAC_Client(self::SECRET);
         $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push_upload&push_session_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
         $now = (float) $headers['X-Auth-Timestamp'];
 
         $this->assertSame(
@@ -206,7 +206,7 @@ final class HmacServerTest extends TestCase
     public function testEnvelopeRequiresTheUnsignedPayloadHeader(): void
     {
         $headers = $this->buildHeadersForBody('{"command":"push"}');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'Envelope verification requires the literal UNSIGNED-PAYLOAD content hash',
@@ -218,7 +218,7 @@ final class HmacServerTest extends TestCase
     {
         $client = new Site_Export_HMAC_Client(self::SECRET);
         $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push_upload&push_session_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $this->assertSame(
             'HMAC signature verification failed',
@@ -230,7 +230,7 @@ final class HmacServerTest extends TestCase
     {
         $client = new Site_Export_HMAC_Client(self::SECRET);
         $headers = $client->get_envelope_auth_headers('POST', 'https://example.com/?endpoint=push_upload&push_session_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-        $server = new Site_Export_HMAC_Server(self::SECRET);
+        $server = new \WordPress\Reprint\Server\HMACServer(self::SECRET);
 
         $result = $server->verify_envelope(
             $headers,

--- a/tests/HttpServerCorsTest.php
+++ b/tests/HttpServerCorsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options —
+ * Tests \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options —
  * the static helper consumers call before authentication to emit CORS response
  * headers and short-circuit OPTIONS preflight.
  */
@@ -14,7 +14,7 @@ final class HttpServerCorsTest extends TestCase
     public function testEmitsWildcardOriginByDefault(): void
     {
         $emitted = [];
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             '*',
             '*',
             ['REQUEST_METHOD' => 'GET'],
@@ -31,7 +31,7 @@ final class HttpServerCorsTest extends TestCase
     public function testEmitsSpecificOrigin(): void
     {
         $emitted = [];
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             'https://playground.wordpress.net',
             '*',
             ['REQUEST_METHOD' => 'GET'],
@@ -49,7 +49,7 @@ final class HttpServerCorsTest extends TestCase
     public function testTrueMeansWildcard(): void
     {
         $emitted = [];
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             true,
             '*',
             ['REQUEST_METHOD' => 'GET'],
@@ -64,7 +64,7 @@ final class HttpServerCorsTest extends TestCase
     public function testEmitsCustomAllowHeaders(): void
     {
         $emitted = [];
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             '*',
             'Content-Type, X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp',
             ['REQUEST_METHOD' => 'GET'],
@@ -83,7 +83,7 @@ final class HttpServerCorsTest extends TestCase
     {
         $emitted = [];
         $terminated = false;
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             '*',
             '*',
             ['REQUEST_METHOD' => 'OPTIONS'],
@@ -104,7 +104,7 @@ final class HttpServerCorsTest extends TestCase
     public function testNonOptionsRequestDoesNotTerminate(): void
     {
         $terminated = false;
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(
             '*',
             '*',
             ['REQUEST_METHOD' => 'POST'],
@@ -122,13 +122,13 @@ final class HttpServerCorsTest extends TestCase
     public function testRejectsEmptyOrigin(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('', '*', ['REQUEST_METHOD' => 'GET']);
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options('', '*', ['REQUEST_METHOD' => 'GET']);
     }
 
     public function testRejectsInvalidOriginType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         /** @phpstan-ignore-next-line — intentionally passing wrong type */
-        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(false, '*', ['REQUEST_METHOD' => 'GET']);
+        \WordPress\Reprint\Server\HTTPServer::handle_cors_headers_and_terminate_on_options(false, '*', ['REQUEST_METHOD' => 'GET']);
     }
 }

--- a/tests/HttpServerServeTest.php
+++ b/tests/HttpServerServeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests Site_Export_HTTP_Server::serve() — the one-call convenience
+ * Tests \WordPress\Reprint\Server\HTTPServer::serve() — the one-call convenience
  * entry point that loads export.php, constructs the server, and
  * dispatches the current request.
  *
@@ -32,7 +32,7 @@ final class HttpServerServeTest extends TestCase
             exit;
         }
 
-        Site_Export_HTTP_Server::serve();
+        \WordPress\Reprint\Server\HTTPServer::serve();
 
         // serve() should have required export.php, which defines endpoint_preflight.
         echo function_exists('endpoint_preflight') ? "OK" : "FAIL: endpoint_preflight not defined";
@@ -55,7 +55,7 @@ final class HttpServerServeTest extends TestCase
 
         // Track require side-effect: if export.php was re-required, endpoint_preflight
         // would be re-declared which would be a fatal error.
-        Site_Export_HTTP_Server::serve();
+        \WordPress\Reprint\Server\HTTPServer::serve();
         echo "OK";
         PHP;
 
@@ -72,7 +72,7 @@ final class HttpServerServeTest extends TestCase
 
         // Override the default handler for 'preflight' to verify the
         // options were passed through to the constructor.
-        Site_Export_HTTP_Server::serve([
+        \WordPress\Reprint\Server\HTTPServer::serve([
             'handlers' => [
                 'preflight' => function (\$config) {
                     echo "handler-called:" . \$config['endpoint'];

--- a/tests/MultipartProcessorTest.php
+++ b/tests/MultipartProcessorTest.php
@@ -40,7 +40,7 @@ final class MultipartProcessorTest extends TestCase {
             'headers' => ['X-Chunk-Type' => 'file'],
             'body' => $body,
         ]]);
-        $processor = new Site_Export_Multipart_Processor($boundary);
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor($boundary);
         $body_bytes = 0;
         $body_tokens = 0;
         $largest_token = 0;
@@ -48,7 +48,7 @@ final class MultipartProcessorTest extends TestCase {
         for ($offset = 0; $offset < $message_bytes; $offset += 8192) {
             $processor->append_bytes(substr($message, $offset, 8192));
             while ($processor->next_token()) {
-                if ($processor->get_token_type() !== Site_Export_Multipart_Processor::TOKEN_BODY) {
+                if ($processor->get_token_type() !== \WordPress\Reprint\Server\MultipartProcessor::TOKEN_BODY) {
                     continue;
                 }
                 $piece = $processor->get_current_body_piece();
@@ -62,7 +62,7 @@ final class MultipartProcessorTest extends TestCase {
         $this->assertSame(strlen($body), $body_bytes);
         $this->assertGreaterThan(1, $body_tokens);
         $this->assertLessThanOrEqual(
-            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES,
+            \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES,
             $largest_token
         );
     }
@@ -84,7 +84,7 @@ final class MultipartProcessorTest extends TestCase {
     }
 
     public function testClosingBoundaryWithoutPartsIsComplete(): void {
-        $processor = new Site_Export_Multipart_Processor('empty');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('empty');
         $processor->append_bytes("--empty--\r\n");
 
         $this->assertFalse($processor->next_token());
@@ -94,7 +94,7 @@ final class MultipartProcessorTest extends TestCase {
     }
 
     public function testPauseAndResumeStatesDistinguishIncompleteInputFromCompletion(): void {
-        $processor = new Site_Export_Multipart_Processor('pause');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('pause');
         $processor->append_bytes('--pau');
 
         $this->assertFalse($processor->next_token());
@@ -110,19 +110,19 @@ final class MultipartProcessorTest extends TestCase {
     public function testParsesOnlyValidatedMultipartMixedContentTypes(): void {
         $this->assertSame(
             'plain-boundary',
-            Site_Export_Multipart_Processor::boundary_from_content_type(
+            \WordPress\Reprint\Server\MultipartProcessor::boundary_from_content_type(
                 'multipart/mixed; boundary=plain-boundary'
             )
         );
         $this->assertSame(
             'quoted-boundary',
-            Site_Export_Multipart_Processor::boundary_from_content_type(
+            \WordPress\Reprint\Server\MultipartProcessor::boundary_from_content_type(
                 'Multipart/Mixed; charset=binary; boundary="quoted-boundary"'
             )
         );
 
         try {
-            Site_Export_Multipart_Processor::boundary_from_content_type('multipart/form-data; boundary=x');
+            \WordPress\Reprint\Server\MultipartProcessor::boundary_from_content_type('multipart/form-data; boundary=x');
             $this->fail('A non-multipart/mixed media type was accepted.');
         } catch (InvalidArgumentException $exception) {
             $this->assertStringContainsString('Expected Content-Type multipart/mixed', $exception->getMessage());
@@ -130,7 +130,7 @@ final class MultipartProcessorTest extends TestCase {
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('more than one boundary');
-        Site_Export_Multipart_Processor::boundary_from_content_type(
+        \WordPress\Reprint\Server\MultipartProcessor::boundary_from_content_type(
             'multipart/mixed; boundary=one; boundary=two'
         );
     }
@@ -149,7 +149,7 @@ final class MultipartProcessorTest extends TestCase {
     public function testRejectsInvalidMultipartMixedBoundaries(string $content_type, string $expected_message): void {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expected_message);
-        Site_Export_Multipart_Processor::boundary_from_content_type($content_type);
+        \WordPress\Reprint\Server\MultipartProcessor::boundary_from_content_type($content_type);
     }
 
     /** @return array<string,array{0:string,1:string}> */
@@ -172,7 +172,7 @@ final class MultipartProcessorTest extends TestCase {
 
     #[DataProvider('invalid_grammar')]
     public function testRejectsFormsOutsideTheReprintGrammar(string $message, string $expected_message): void {
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes($message);
 
         $this->expectException(InvalidArgumentException::class);
@@ -195,7 +195,7 @@ final class MultipartProcessorTest extends TestCase {
 
     #[DataProvider('truncated_messages')]
     public function testFinishInputRejectsEveryIncompleteState(string $message, string $expected_message): void {
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes($message);
         while ($processor->next_token()) {
             $processor->get_token_type();
@@ -207,7 +207,7 @@ final class MultipartProcessorTest extends TestCase {
     }
 
     public function testRejectsAContinuationBeforeAHeaderAndBoundsTheAggregate(): void {
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes("--x\r\n orphan\r\nContent-Length: 0\r\n\r\n");
         try {
             while ($processor->next_token()) {
@@ -218,7 +218,7 @@ final class MultipartProcessorTest extends TestCase {
             $this->assertStringContainsString('continuation', $exception->getMessage());
         }
 
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $message = "--x\r\nX-Large: " . str_repeat('a', 8100) . "\r\n"
             . str_repeat(' ' . str_repeat('b', 8100) . "\r\n", 4)
             . "Content-Length: 0\r\n\r\n";
@@ -265,7 +265,7 @@ final class MultipartProcessorTest extends TestCase {
         ]])]);
         $this->assertCount(32, $parts[0]['headers']);
 
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes(
             "--x\r\n" . $maximum_line . "a\r\nContent-Length: 0\r\n\r\n"
         );
@@ -278,7 +278,7 @@ final class MultipartProcessorTest extends TestCase {
             $this->assertStringContainsString('exceeds 8192 bytes', $exception->getMessage());
         }
 
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes(
             "--x\r\n" . str_replace(str_repeat('d', 8162), str_repeat('d', 8163), $maximum_aggregate_headers)
         );
@@ -301,7 +301,7 @@ final class MultipartProcessorTest extends TestCase {
     }
 
     public function testRequiresEachAppendedFragmentToBeDrainedAndBounded(): void {
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes('--x');
         try {
             $processor->append_bytes("--\r\n");
@@ -310,37 +310,37 @@ final class MultipartProcessorTest extends TestCase {
             $this->assertStringContainsString('next_token', $exception->getMessage());
         }
 
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes(
             "--x\r\nContent-Length: "
-            . Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+            . \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES
             . "\r\n\r\n"
         );
         $this->assertTrue($processor->next_token());
-        $this->assertSame(Site_Export_Multipart_Processor::TOKEN_PART_START, $processor->get_token_type());
+        $this->assertSame(\WordPress\Reprint\Server\MultipartProcessor::TOKEN_PART_START, $processor->get_token_type());
         $this->assertFalse($processor->next_token());
-        $processor->append_bytes(str_repeat('a', Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES));
+        $processor->append_bytes(str_repeat('a', \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES));
         $this->assertTrue($processor->next_token());
         $this->assertSame(
-            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES,
+            \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES,
             strlen($processor->get_current_body_piece())
         );
         $this->assertTrue($processor->next_token());
-        $this->assertSame(Site_Export_Multipart_Processor::TOKEN_PART_END, $processor->get_token_type());
+        $this->assertSame(\WordPress\Reprint\Server\MultipartProcessor::TOKEN_PART_END, $processor->get_token_type());
         $this->assertFalse($processor->next_token());
         $processor->append_bytes("\r\n--x--\r\n");
         $this->assertFalse($processor->next_token());
         $processor->finish_input();
 
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage( (string) Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES);
-        $processor->append_bytes(str_repeat('a', Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1));
+        $this->expectExceptionMessage( (string) \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES);
+        $processor->append_bytes(str_repeat('a', \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES + 1));
     }
 
     public function testRejectsContentLengthOutsideTheRuntimeIntegerRange(): void {
         $too_large = (string) PHP_INT_MAX . '0';
-        $processor = new Site_Export_Multipart_Processor('x');
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor('x');
         $processor->append_bytes("--x\r\nContent-Length: {$too_large}\r\n\r\n");
 
         $this->expectException(InvalidArgumentException::class);
@@ -357,21 +357,21 @@ final class MultipartProcessorTest extends TestCase {
      * @return array<int,array{headers:array<string,string>,body:string}>
      */
     private function collect_parts(string $boundary, array $fragments): array {
-        $processor = new Site_Export_Multipart_Processor($boundary);
+        $processor = new \WordPress\Reprint\Server\MultipartProcessor($boundary);
         $parts = [];
         $current = null;
         foreach ($fragments as $fragment) {
             $processor->append_bytes($fragment);
             while ($processor->next_token()) {
                 $token_type = $processor->get_token_type();
-                if ($token_type === Site_Export_Multipart_Processor::TOKEN_PART_START) {
+                if ($token_type === \WordPress\Reprint\Server\MultipartProcessor::TOKEN_PART_START) {
                     $current = [
                         'headers' => $processor->get_current_headers(),
                         'body' => '',
                     ];
-                } elseif ($token_type === Site_Export_Multipart_Processor::TOKEN_BODY) {
+                } elseif ($token_type === \WordPress\Reprint\Server\MultipartProcessor::TOKEN_BODY) {
                     $current['body'] .= $processor->get_current_body_piece();
-                } elseif ($token_type === Site_Export_Multipart_Processor::TOKEN_PART_END) {
+                } elseif ($token_type === \WordPress\Reprint\Server\MultipartProcessor::TOKEN_PART_END) {
                     $parts[] = $current;
                     $current = null;
                 }

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -132,8 +132,8 @@ final class PushCommitTest extends TestCase {
                 'body' => "later\0",
             ]]);
             $this->fail('An offset gap was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
-            $this->assertSame(Site_Export_Push_Session::ERROR_OFFSET_GAP, $exception->get_error_code());
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
+            $this->assertSame(\WordPress\Reprint\Server\PushSession::ERROR_OFFSET_GAP, $exception->get_error_code());
             $this->assertStringContainsString('offset 99', $exception->getMessage());
             $this->assertStringContainsString('6 bytes', $exception->getMessage());
         }
@@ -416,7 +416,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->commit_all($push_session);
             $this->fail('An explicit empty directory replaced a non-empty docroot directory.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame(['absent'], $exception->get_context()['expected_docroot_types']);
         }
@@ -425,7 +425,7 @@ final class PushCommitTest extends TestCase {
         try {
             $push_session->commit(1);
             $this->fail('A non-recoverable commit failure allowed a forced retry.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
         }
     }
@@ -449,7 +449,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->commit_all($push_session);
             $this->fail('A symlink ancestor was traversed.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame('parent/file.txt', base64_decode($exception->get_context()['path_b64'], true));
             $this->assertSame('parent', base64_decode($exception->get_context()['conflict_path_b64'], true));
@@ -562,7 +562,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->reopen($push_session)->commit(1);
             $this->fail('Interrupted installing_files followed a symlink ancestor.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame('parent/installed.txt', base64_decode($exception->get_context()['path_b64'], true));
             $this->assertSame('parent', base64_decode($exception->get_context()['conflict_path_b64'], true));
@@ -583,7 +583,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->reopen($push_session)->commit(1);
             $this->fail('Missing work and docroot entries were treated as installed.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame('absent', $exception->get_context()['observed_docroot_identity']['type']);
         }
@@ -603,7 +603,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->reopen($push_session)->commit(1);
             $this->fail('An incompatible docroot directory completed a file installing_files.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame('directory', $exception->get_context()['observed_docroot_identity']['type']);
         }
@@ -690,7 +690,7 @@ final class PushCommitTest extends TestCase {
         try {
             $this->commit_all($push_session);
             $this->fail('A work file replaced an incompatible docroot directory.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
             $this->assertSame(['absent', 'file', 'symlink'], $exception->get_context()['expected_docroot_types']);
         }
@@ -700,7 +700,7 @@ final class PushCommitTest extends TestCase {
         try {
             $push_session->commit(1);
             $this->fail('A non-recoverable commit failure allowed a forced retry.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('unexpected_docroot_mutation', $exception->get_error_code());
         }
     }
@@ -756,7 +756,7 @@ final class PushCommitTest extends TestCase {
         try {
             $push_session->commit(1000);
             $this->fail('Commit reported success while another request held the commit-state lock.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         } finally {
             $this->assertSame(0, proc_close($process));
@@ -827,7 +827,7 @@ final class PushCommitTest extends TestCase {
         try {
             $push_session->commit(1000);
             $this->fail('Commit release was not blocked by valid commit-state lock contention.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         } finally {
             $this->assertSame(0, proc_close($completion_process));
@@ -856,7 +856,7 @@ final class PushCommitTest extends TestCase {
         try {
             $push_session->remove_push_directory();
             $this->fail('Push removal reported success while the commit-state lock was held.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         } finally {
             $this->assertSame(0, proc_close($remove_process));
@@ -870,8 +870,8 @@ final class PushCommitTest extends TestCase {
         $this->assertDirectoryDoesNotExist($tombstone);
     }
 
-    private function push_session(string $id): Site_Export_Push_Session {
-        return Site_Export_Push_Session::create(
+    private function push_session(string $id): \WordPress\Reprint\Server\PushSession {
+        return \WordPress\Reprint\Server\PushSession::create(
             $this->reprint_directory,
             $this->docroot,
             ['wp-content/plugins/reprint'],
@@ -879,8 +879,8 @@ final class PushCommitTest extends TestCase {
         );
     }
 
-    private function reopen(Site_Export_Push_Session $push_session): Site_Export_Push_Session {
-        return Site_Export_Push_Session::open(
+    private function reopen(\WordPress\Reprint\Server\PushSession $push_session): \WordPress\Reprint\Server\PushSession {
+        return \WordPress\Reprint\Server\PushSession::open(
             $this->reprint_directory,
             $this->docroot,
             $push_session->get_push_session_id(),
@@ -888,7 +888,7 @@ final class PushCommitTest extends TestCase {
         );
     }
 
-    private function push_file(Site_Export_Push_Session $push_session, string $path, string $contents): void {
+    private function push_file(\WordPress\Reprint\Server\PushSession $push_session, string $path, string $contents): void {
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'file',
@@ -901,7 +901,7 @@ final class PushCommitTest extends TestCase {
     }
 
     /** @return array<string,mixed> */
-    private function commit_state(Site_Export_Push_Session $push_session): array {
+    private function commit_state(\WordPress\Reprint\Server\PushSession $push_session): array {
         $commit_state = json_decode(
             (string) file_get_contents($push_session->get_push_directory() . '/commit.json'),
             true,
@@ -912,7 +912,7 @@ final class PushCommitTest extends TestCase {
         return $commit_state;
     }
 
-    private function set_current_work_files_descendant(Site_Export_Push_Session $push_session, string $path, string $type): void {
+    private function set_current_work_files_descendant(\WordPress\Reprint\Server\PushSession $push_session, string $path, string $type): void {
         $commit_state = $this->commit_state($push_session);
         $commit_state['current_work_files_descendant'] = ['path_b64' => base64_encode($path), 'expected_type' => $type];
         file_put_contents(
@@ -922,7 +922,7 @@ final class PushCommitTest extends TestCase {
     }
 
     /** @param array<int,array{headers:array<string,string>,body:string}> $parts */
-    private function push_parts(Site_Export_Push_Session $push_session, array $parts): void {
+    private function push_parts(\WordPress\Reprint\Server\PushSession $push_session, array $parts): void {
         $boundary = 'test-boundary';
         $body = '';
         foreach ($parts as $part) {
@@ -937,7 +937,7 @@ final class PushCommitTest extends TestCase {
         $input = fopen('php://temp', 'w+b');
         fwrite($input, $body);
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             while ($push_session->next_change()) {
             }
@@ -947,7 +947,7 @@ final class PushCommitTest extends TestCase {
         }
     }
 
-    private function commit_all(Site_Export_Push_Session $push_session): void {
+    private function commit_all(\WordPress\Reprint\Server\PushSession $push_session): void {
         if (!$push_session->get_status()['work_deletes_complete']) {
             $this->complete_work_deletes($push_session);
         }
@@ -956,7 +956,7 @@ final class PushCommitTest extends TestCase {
         } while ($result['send_next_request']);
     }
 
-    private function complete_work_deletes(Site_Export_Push_Session $push_session): void {
+    private function complete_work_deletes(\WordPress\Reprint\Server\PushSession $push_session): void {
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'delete-list',

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -922,7 +922,7 @@ final class PushEndpointsTest extends TestCase {
 
     public function testChunkedUploadDistinguishesEofTrailingDataAndRequestLimitAtTheFragmentBoundary(): void
     {
-        $maximum_request_body_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $maximum_request_body_bytes = \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES;
         $this->writeDocrootConfiguration([
             'document_root' => $this->docroot,
             'maximum_part_bytes' => $maximum_request_body_bytes,
@@ -1016,7 +1016,7 @@ final class PushEndpointsTest extends TestCase {
 
     public function testLogicExceptionUsesGenericServerFailureResponse(): void
     {
-        $endpoints = new Site_Export_Push_Endpoints([
+        $endpoints = new \WordPress\Reprint\Server\PushEndpoints([
             'reprint_directory' => $this->reprint_directory,
             'docroot' => $this->docroot,
             'excluded_paths' => [],
@@ -1039,7 +1039,7 @@ final class PushEndpointsTest extends TestCase {
 
     public function testFailureResponseDoesNotExposeInternalExceptionContext(): void
     {
-        $endpoints = new Site_Export_Push_Endpoints([
+        $endpoints = new \WordPress\Reprint\Server\PushEndpoints([
             'reprint_directory' => $this->reprint_directory,
             'docroot' => $this->docroot,
             'excluded_paths' => [],
@@ -1050,8 +1050,8 @@ final class PushEndpointsTest extends TestCase {
         ob_start();
         $respond_to_failure->invoke(
             $endpoints,
-            new Site_Export_Push_Exception(
-                Site_Export_Push_Session::ERROR_SAME_DEVICE,
+            new \WordPress\Reprint\Server\PushException(
+                \WordPress\Reprint\Server\PushSession::ERROR_SAME_DEVICE,
                 'The work and document-root filesystems differ.',
                 [
                     'status' => 'context-status',
@@ -1099,7 +1099,7 @@ final class PushEndpointsTest extends TestCase {
 
         foreach ($reprint_directories as $reprint_directory) {
             try {
-                new Site_Export_Push_Endpoints([
+                new \WordPress\Reprint\Server\PushEndpoints([
                     'reprint_directory' => $reprint_directory,
                     'docroot' => $this->docroot,
                     'excluded_paths' => [],

--- a/tests/PushSessionTest.php
+++ b/tests/PushSessionTest.php
@@ -21,7 +21,7 @@ final class PushSessionTest extends TestCase {
     }
 
     public function testClassifiedExceptionKeepsProtocolReasonAndContextSeparateFromThrowableCode(): void {
-        $exception = new Site_Export_Push_Exception('lock_acquisition_failure', 'The session is busy.', ['operation' => 'receive']);
+        $exception = new \WordPress\Reprint\Server\PushException('lock_acquisition_failure', 'The session is busy.', ['operation' => 'receive']);
 
         $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         $this->assertSame(0, $exception->getCode());
@@ -54,7 +54,7 @@ final class PushSessionTest extends TestCase {
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('at most 100 excluded paths; received 101');
-        Site_Export_Push_Session::create(
+        \WordPress\Reprint\Server\PushSession::create(
             $this->reprint_directory,
             $this->docroot,
             $excluded_paths,
@@ -94,7 +94,7 @@ final class PushSessionTest extends TestCase {
                     'body' => 'x',
                 ]]);
                 $this->fail('An in-flight file accepted cursor ' . $offset . ' while its data file contained 3 bytes.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('offset_gap', $exception->get_error_code());
             }
             $this->assertSame('old', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
@@ -183,7 +183,7 @@ final class PushSessionTest extends TestCase {
         fwrite($input, $body);
         rewind($input);
 
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             $this->assertNull($push_session->get_current_change());
             $expected_changes = [
@@ -216,7 +216,7 @@ final class PushSessionTest extends TestCase {
             . '--' . $boundary . "--\r\n"
         );
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             $this->assertTrue($push_session->next_change());
             $this->assertNotNull($push_session->get_current_change());
@@ -242,11 +242,11 @@ final class PushSessionTest extends TestCase {
         $input = fopen('php://temp', 'w+b');
         fwrite($input, $body);
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             $push_session->next_change();
             $this->fail('An offset gap was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('offset_gap', $exception->get_error_code());
             $this->assertStringContainsString('Start at offset 0', $exception->getMessage());
             $this->assertNull($push_session->get_current_change());
@@ -269,7 +269,7 @@ final class PushSessionTest extends TestCase {
                 'body' => "gone\0",
             ]]);
             $this->fail('A delete offset gap was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('offset_gap', $exception->get_error_code());
             $this->assertStringContainsString('work delete stream has stored 0 bytes', $exception->getMessage());
         }
@@ -337,7 +337,7 @@ final class PushSessionTest extends TestCase {
 
     public function testReprintDirectoryBelowDocumentRootIsExcludedAndRootCanBeReopened(): void {
         $reprint_directory = $this->docroot . '/private-work';
-        $push_session = Site_Export_Push_Session::create($reprint_directory, $this->docroot, [], str_repeat('a', 32));
+        $push_session = \WordPress\Reprint\Server\PushSession::create($reprint_directory, $this->docroot, [], str_repeat('a', 32));
         try {
             $this->push_parts($push_session, [[
                 'headers' => [
@@ -356,14 +356,14 @@ final class PushSessionTest extends TestCase {
         $this->push_file($push_session, 'private-workshop/allowed.php', 'safe');
         $this->assertSame('complete', $push_session->get_status('private-workshop/allowed.php')['path']['state']);
 
-        $root_session = Site_Export_Push_Session::create($this->reprint_directory, '/', [], str_repeat('b', 32));
-        $reopened = Site_Export_Push_Session::open($this->reprint_directory, '/', $root_session->get_push_session_id(), []);
+        $root_session = \WordPress\Reprint\Server\PushSession::create($this->reprint_directory, '/', [], str_repeat('b', 32));
+        $reopened = \WordPress\Reprint\Server\PushSession::open($this->reprint_directory, '/', $root_session->get_push_session_id(), []);
         $this->assertSame($root_session->get_push_directory(), $reopened->get_push_directory());
     }
 
     public function testRootReprintDirectoryKeepsPushSessionPathsAbsolute(): void {
         $push_session_id = str_repeat('c', 32);
-        $push_session = Site_Export_Push_Session::open(
+        $push_session = \WordPress\Reprint\Server\PushSession::open(
             '/',
             $this->docroot,
             $push_session_id,
@@ -457,7 +457,7 @@ final class PushSessionTest extends TestCase {
         try {
             $push_session->commit(1);
             $this->fail('A foreign maintenance marker was replaced.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
         $this->assertFileDoesNotExist($this->docroot . '/pending.txt');
@@ -496,7 +496,7 @@ final class PushSessionTest extends TestCase {
         try {
             $push_session->remove_push_directory();
             $this->fail('An active direct commit was removed.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('commit_required', $exception->get_error_code());
         }
 
@@ -506,24 +506,24 @@ final class PushSessionTest extends TestCase {
 
     public function testPushSessionLockExcludesOtherOperationsUntilUploadFinishes(): void {
         $push_session = $this->push_session('66666666666666666666666666666666');
-        $reopened = Site_Export_Push_Session::open(
+        $reopened = \WordPress\Reprint\Server\PushSession::open(
             $this->reprint_directory,
             $this->docroot,
             $push_session->get_push_session_id(),
             ['wp-content/plugins/reprint']
         );
         $input = fopen('php://temp', 'w+b');
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor('test-boundary'));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor('test-boundary'));
 
         try {
             $reopened->get_status();
             $this->fail('Status observed a session while an upload held its lock.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
 
         try {
-            $push_session->accept_upload($input, new Site_Export_Multipart_Processor('test-boundary'));
+            $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor('test-boundary'));
             $this->fail('One session object accepted two simultaneous uploads.');
         } catch (LogicException $exception) {
             $this->assertStringContainsString('already open', $exception->getMessage());
@@ -547,9 +547,9 @@ final class PushSessionTest extends TestCase {
         ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
         $script = '$configuration = json_decode(base64_decode($argv[1], true), true, 512, JSON_THROW_ON_ERROR);'
             . 'require $configuration["bootstrap_path"];'
-            . '$push_session = Site_Export_Push_Session::open($configuration["reprint_directory"], $configuration["docroot"], $configuration["push_session_id"], ["wp-content/plugins/reprint"]);'
+            . '$push_session = \WordPress\Reprint\Server\PushSession::open($configuration["reprint_directory"], $configuration["docroot"], $configuration["push_session_id"], ["wp-content/plugins/reprint"]);'
             . '$input = fopen("php://temp", "w+b");'
-            . '$push_session->accept_upload($input, new Site_Export_Multipart_Processor("dead-owner-boundary"));'
+            . '$push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor("dead-owner-boundary"));'
             . 'file_put_contents($configuration["ready_path"], "ready");'
             . 'sleep(30);';
         $process = proc_open(
@@ -572,7 +572,7 @@ final class PushSessionTest extends TestCase {
             try {
                 $push_session->get_status();
                 $this->fail('Status acquired the push lock while another process held an upload open.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
 
@@ -600,7 +600,7 @@ final class PushSessionTest extends TestCase {
             . "X-File-Size: 5\r\nX-Chunk-Offset: 0\r\nContent-Length: 5\r\n\r\nabc"
         );
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             $push_session->next_change();
             $this->fail('A truncated multipart body was accepted as a complete change.');
@@ -611,7 +611,7 @@ final class PushSessionTest extends TestCase {
             fclose($input);
         }
 
-        $reopened = Site_Export_Push_Session::open(
+        $reopened = \WordPress\Reprint\Server\PushSession::open(
             $this->reprint_directory,
             $this->docroot,
             $push_session->get_push_session_id(),
@@ -630,9 +630,9 @@ final class PushSessionTest extends TestCase {
 
         $push_session->accept_upload(
             $input,
-            new Site_Export_Multipart_Processor($boundary),
+            new \WordPress\Reprint\Server\MultipartProcessor($boundary),
             PHP_INT_MAX,
-            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+            \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES
         );
         try {
             $this->assertTrue($push_session->next_change());
@@ -652,23 +652,23 @@ final class PushSessionTest extends TestCase {
 
         $push_session->accept_upload(
             $input,
-            new Site_Export_Multipart_Processor($boundary),
+            new \WordPress\Reprint\Server\MultipartProcessor($boundary),
             PHP_INT_MAX,
-            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+            \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES
         );
         try {
             $this->assertTrue($push_session->next_change());
             try {
                 $push_session->next_change();
                 $this->fail('A byte beyond the decoded request-body limit was ignored after the closing boundary.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('request_too_large', $exception->get_error_code());
                 $this->assertSame(
-                    ['observed_request_body_bytes' => Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1],
+                    ['observed_request_body_bytes' => \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES + 1],
                     $exception->get_context()
                 );
                 $this->assertStringContainsString(
-                    (string) ( Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1 ) . ' bytes',
+                    (string) ( \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES + 1 ) . ' bytes',
                     $exception->getMessage()
                 );
             }
@@ -687,9 +687,9 @@ final class PushSessionTest extends TestCase {
 
         $push_session->accept_upload(
             $input,
-            new Site_Export_Multipart_Processor($boundary),
+            new \WordPress\Reprint\Server\MultipartProcessor($boundary),
             PHP_INT_MAX,
-            Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES + 1
+            \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES + 1
         );
         try {
             $this->assertTrue($push_session->next_change());
@@ -791,7 +791,7 @@ final class PushSessionTest extends TestCase {
         $input = fopen('php://temp', 'w+b');
         fwrite($input, $body);
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary), 1);
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary), 1);
         try {
             $push_session->next_change();
             $this->fail('A part above the configured byte ceiling was accepted.');
@@ -810,7 +810,7 @@ final class PushSessionTest extends TestCase {
         try {
             $push_metadata_session->get_status();
             $this->fail('Malformed push metadata was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
         }
 
@@ -822,7 +822,7 @@ final class PushSessionTest extends TestCase {
         try {
             $shape_session->get_status();
             $this->fail('Push metadata with a scalar excluded-path list was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('excluded paths', $exception->getMessage());
         }
@@ -834,7 +834,7 @@ final class PushSessionTest extends TestCase {
         try {
             $symlink_session->get_status();
             $this->fail('A symlink replaced the private completed-files directory.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('not real', $exception->getMessage());
         }
@@ -846,7 +846,7 @@ final class PushSessionTest extends TestCase {
         try {
             $malformed_session->get_status();
             $this->fail('Malformed in-flight JSON was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('does not contain a JSON object', $exception->getMessage());
         }
@@ -856,7 +856,7 @@ final class PushSessionTest extends TestCase {
         try {
             $oversized_session->get_status();
             $this->fail('Oversized in-flight JSON was accepted.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('not a bounded regular file', $exception->getMessage());
         }
@@ -866,7 +866,7 @@ final class PushSessionTest extends TestCase {
         try {
             $wrong_type_session->get_status();
             $this->fail('A directory was accepted as in-flight file data.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('unsupported type', $exception->getMessage());
         }
@@ -887,13 +887,13 @@ final class PushSessionTest extends TestCase {
         $push_session = $this->push_session('45674567456745674567456745674567');
         $other_docroot = $this->root . '/other-docroot';
         mkdir($other_docroot, 0700);
-        $changed_docroot = Site_Export_Push_Session::open(
+        $changed_docroot = \WordPress\Reprint\Server\PushSession::open(
             $this->reprint_directory,
             $other_docroot,
             $push_session->get_push_session_id(),
             ['wp-content/plugins/reprint']
         );
-        $changed_protection = Site_Export_Push_Session::open(
+        $changed_protection = \WordPress\Reprint\Server\PushSession::open(
             $this->reprint_directory,
             $this->docroot,
             $push_session->get_push_session_id(),
@@ -904,7 +904,7 @@ final class PushSessionTest extends TestCase {
             try {
                 $reopened->get_status();
                 $this->fail('A session reopened with different immutable configuration.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('corrupted_push_state', $exception->get_error_code());
                 $this->assertStringContainsString('does not match', $exception->getMessage());
             }
@@ -915,14 +915,14 @@ final class PushSessionTest extends TestCase {
         $push_session = $this->push_session('45674567456745674567456745674568');
 
         try {
-            Site_Export_Push_Session::create(
+            \WordPress\Reprint\Server\PushSession::create(
                 $this->reprint_directory,
                 $this->docroot,
                 ['wp-content/plugins/reprint', 'wp-config.php'],
                 $push_session->get_push_session_id()
             );
             $this->fail('Repeated create accepted different immutable excluded paths.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('corrupted_push_state', $exception->get_error_code());
             $this->assertStringContainsString('does not match', $exception->getMessage());
         }
@@ -1066,7 +1066,7 @@ final class PushSessionTest extends TestCase {
                 'body' => 'c',
             ]]);
             $this->fail('A completed file accepted a stale replay cursor.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('offset_gap', $exception->get_error_code());
         }
     }
@@ -1097,7 +1097,7 @@ final class PushSessionTest extends TestCase {
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => '']]);
                 $this->fail('An in-flight file became the parent of a completed ' . $type . '.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
             $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
@@ -1143,7 +1143,7 @@ final class PushSessionTest extends TestCase {
             try {
                 $this->push_parts($push_session, [['headers' => $headers, 'body' => $body]]);
                 $this->fail('A completed ' . $type . ' hid an in-flight descendant.');
-            } catch (Site_Export_Push_Exception $exception) {
+            } catch (\WordPress\Reprint\Server\PushException $exception) {
                 $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
             }
             $this->assertSame('a', file_get_contents($push_session->get_push_directory() . '/work/inflight.data'));
@@ -1174,7 +1174,7 @@ final class PushSessionTest extends TestCase {
                 ],
             ]);
             $this->fail('A different path replaced in-flight work in the same request.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
 
@@ -1453,7 +1453,7 @@ final class PushSessionTest extends TestCase {
         try {
             $second->commit(1);
             $this->fail('A second push session committed while the document root was claimed.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
         $this->assertFileDoesNotExist($this->docroot . '/second.txt');
@@ -1491,13 +1491,13 @@ final class PushSessionTest extends TestCase {
         $failure = null;
         try {
             $push_session->remove_push_directory();
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $failure = $exception;
         } finally {
             $this->stop_lock_process($lock_process);
         }
 
-        $this->assertInstanceOf(Site_Export_Push_Exception::class, $failure);
+        $this->assertInstanceOf(\WordPress\Reprint\Server\PushException::class, $failure);
         $this->assertSame('lock_acquisition_failure', $failure->get_error_code());
         $this->assertDirectoryExists($push_directory);
         $this->assertFileDoesNotExist(dirname($push_directory) . '/.removing-' . $push_session->get_push_session_id());
@@ -1528,7 +1528,7 @@ final class PushSessionTest extends TestCase {
         try {
             $this->push_session($push_session_id);
             $this->fail('A push session was recreated while its removal tombstone remained.');
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $this->assertSame('lock_acquisition_failure', $exception->get_error_code());
         }
         $this->assertDirectoryDoesNotExist($push_directory);
@@ -1537,12 +1537,12 @@ final class PushSessionTest extends TestCase {
         $failure = null;
         try {
             $push_session->remove_push_directory();
-        } catch (Site_Export_Push_Exception $exception) {
+        } catch (\WordPress\Reprint\Server\PushException $exception) {
             $failure = $exception;
         } finally {
             $this->stop_lock_process($lock_process);
         }
-        $this->assertInstanceOf(Site_Export_Push_Exception::class, $failure);
+        $this->assertInstanceOf(\WordPress\Reprint\Server\PushException::class, $failure);
         $this->assertSame('lock_acquisition_failure', $failure->get_error_code());
         $this->assertDirectoryExists($tombstone);
 
@@ -1568,14 +1568,14 @@ final class PushSessionTest extends TestCase {
      * production method wrote before the failed call, without rewriting private
      * push-session files in the test.
      *
-     * @param Site_Export_Push_Session $push_session Push session to reopen in the child process.
+     * @param \WordPress\Reprint\Server\PushSession $push_session Push session to reopen in the child process.
      * @param array<int,array{headers:array<string,string>,body:string}> $parts Multipart parts to upload.
      * @param string $operation One of unlink, mkdir, or symlink.
      * @param string $path_suffix Absolute-path suffix whose operation must fail.
      * @return array{class:string,reason:string|null,message:string} Classified child-process exception.
      */
     private function run_upload_with_filesystem_fault(
-        Site_Export_Push_Session $push_session,
+        \WordPress\Reprint\Server\PushSession $push_session,
         array $parts,
         string $operation,
         string $path_suffix
@@ -1658,13 +1658,13 @@ final class PushSessionTest extends TestCase {
         $exit_code = proc_close($process);
         $this->assertSame(73, $exit_code, "The requested filesystem call did not fail.\nstdout: " . $stdout . "\nstderr: " . $stderr);
         $failure = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
-        $this->assertSame(Site_Export_Push_Exception::class, $failure['class']);
+        $this->assertSame(\WordPress\Reprint\Server\PushException::class, $failure['class']);
         $this->assertSame('filesystem_error', $failure['reason']);
         return $failure;
     }
 
-    private function push_session(string $id): Site_Export_Push_Session {
-        return Site_Export_Push_Session::create(
+    private function push_session(string $id): \WordPress\Reprint\Server\PushSession {
+        return \WordPress\Reprint\Server\PushSession::create(
             $this->reprint_directory,
             $this->docroot,
             ['wp-content/plugins/reprint'],
@@ -1677,7 +1677,7 @@ final class PushSessionTest extends TestCase {
         $boundary = 'fragment-limit-boundary';
         $path = 'fragment-limit.bin';
         $suffix = "\r\n--" . $boundary . "--\r\n";
-        $payload_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES;
+        $payload_bytes = \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES;
         do {
             $previous_payload_bytes = $payload_bytes;
             $prefix = '--' . $boundary . "\r\n"
@@ -1686,13 +1686,13 @@ final class PushSessionTest extends TestCase {
                 . 'X-File-Size: ' . $payload_bytes . "\r\n"
                 . "X-Chunk-Offset: 0\r\n"
                 . 'Content-Length: ' . $payload_bytes . "\r\n\r\n";
-            $payload_bytes = Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES
+            $payload_bytes = \WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES
                 - strlen($prefix)
                 - strlen($suffix);
         } while ($payload_bytes !== $previous_payload_bytes);
 
         $body = $prefix . str_repeat('x', $payload_bytes) . $suffix;
-        $this->assertSame(Site_Export_Multipart_Processor::MAX_INPUT_FRAGMENT_BYTES, strlen($body));
+        $this->assertSame(\WordPress\Reprint\Server\MultipartProcessor::MAX_INPUT_FRAGMENT_BYTES, strlen($body));
         return [$boundary, $body];
     }
 
@@ -1727,7 +1727,7 @@ final class PushSessionTest extends TestCase {
         proc_close($process);
     }
 
-    private function push_file(Site_Export_Push_Session $push_session, string $path, string $contents): void {
+    private function push_file(\WordPress\Reprint\Server\PushSession $push_session, string $path, string $contents): void {
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'file',
@@ -1740,7 +1740,7 @@ final class PushSessionTest extends TestCase {
     }
 
     /** @param array<int,array{headers:array<string,string>,body:string}> $parts */
-    private function push_parts(Site_Export_Push_Session $push_session, array $parts): void {
+    private function push_parts(\WordPress\Reprint\Server\PushSession $push_session, array $parts): void {
         $boundary = 'test-boundary';
         $body = '';
         foreach ($parts as $part) {
@@ -1754,7 +1754,7 @@ final class PushSessionTest extends TestCase {
         $input = fopen('php://temp', 'w+b');
         fwrite($input, $body);
         rewind($input);
-        $push_session->accept_upload($input, new Site_Export_Multipart_Processor($boundary));
+        $push_session->accept_upload($input, new \WordPress\Reprint\Server\MultipartProcessor($boundary));
         try {
             while ($push_session->next_change()) {
             }
@@ -1764,7 +1764,7 @@ final class PushSessionTest extends TestCase {
         }
     }
 
-    private function commit_all(Site_Export_Push_Session $push_session): void {
+    private function commit_all(\WordPress\Reprint\Server\PushSession $push_session): void {
         if (!$push_session->get_status()['work_deletes_complete']) {
             $this->complete_work_deletes($push_session);
         }
@@ -1773,7 +1773,7 @@ final class PushSessionTest extends TestCase {
         } while ($result['send_next_request']);
     }
 
-    private function complete_work_deletes(Site_Export_Push_Session $push_session): void {
+    private function complete_work_deletes(\WordPress\Reprint\Server\PushSession $push_session): void {
         $this->push_parts($push_session, [[
             'headers' => [
                 'X-Chunk-Type' => 'delete-list',

--- a/tests/ReprintServerNamespaceTest.php
+++ b/tests/ReprintServerNamespaceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ReprintServerNamespaceTest extends TestCase {
+    /** @return iterable<string,array{string,string}> */
+    public static function renamedServerClasses(): iterable
+    {
+        yield 'HMAC server' => [
+            WordPress\Reprint\Server\HMACServer::class,
+            'Site_Export_HMAC_Server',
+        ];
+        yield 'HTTP server' => [
+            WordPress\Reprint\Server\HTTPServer::class,
+            'Site_Export_HTTP_Server',
+        ];
+        yield 'multipart processor' => [
+            WordPress\Reprint\Server\MultipartProcessor::class,
+            'Site_Export_Multipart_Processor',
+        ];
+        yield 'push configuration exception' => [
+            WordPress\Reprint\Server\PushConfigurationException::class,
+            'Site_Export_Push_Configuration_Exception',
+        ];
+        yield 'push endpoints' => [
+            WordPress\Reprint\Server\PushEndpoints::class,
+            'Site_Export_Push_Endpoints',
+        ];
+        yield 'push exception' => [
+            WordPress\Reprint\Server\PushException::class,
+            'Site_Export_Push_Exception',
+        ];
+        yield 'push session' => [
+            WordPress\Reprint\Server\PushSession::class,
+            'Site_Export_Push_Session',
+        ];
+    }
+
+    #[DataProvider('renamedServerClasses')]
+    public function testCanonicalClassAndLegacyAliasBothAutoload(string $canonical_class, string $legacy_class): void
+    {
+        $this->assertTrue(class_exists($canonical_class));
+        $this->assertTrue(class_exists($legacy_class));
+        $this->assertSame($canonical_class, ( new ReflectionClass($legacy_class) )->getName());
+    }
+
+    #[DataProvider('renamedServerClasses')]
+    public function testCompatibilityLoaderResolvesLegacyAliasBeforeCanonicalClass(
+        string $canonical_class,
+        string $legacy_class
+    ): void
+    {
+        $autoload_path = realpath(__DIR__ . '/../vendor/autoload.php');
+        $this->assertNotFalse($autoload_path, 'Composer autoload.php must exist.');
+        $compatibility_path = realpath(__DIR__ . '/../packages/reprint-server/src/compat.php');
+        $this->assertNotFalse($compatibility_path, 'The compatibility loader must exist.');
+        $script = <<<'PHP'
+require $argv[1];
+require $argv[2];
+$legacy_class = $argv[3];
+if (!class_exists($legacy_class)) {
+    fwrite(STDERR, 'Could not autoload ' . $legacy_class . '.');
+    exit(1);
+}
+echo (new ReflectionClass($legacy_class))->getName();
+PHP;
+        $process = proc_open(
+            [PHP_BINARY, '-r', $script, $autoload_path, $compatibility_path, $legacy_class],
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process, 'Failed to start the legacy class autoload subprocess.');
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->assertSame(0, proc_close($process), $stderr ?: 'The legacy class autoload subprocess failed.');
+        $this->assertSame($canonical_class, $stdout);
+    }
+
+    public function testClientHmacClassKeepsItsReleasedNameAndFile(): void
+    {
+        $this->assertTrue(class_exists('Site_Export_HMAC_Client'));
+        $this->assertFalse(class_exists('WordPress\\Reprint\\Server\\HMACClient'));
+        $reflection = new ReflectionClass('Site_Export_HMAC_Client');
+        $this->assertSame(
+            realpath(__DIR__ . '/../packages/reprint-server/src/class-hmac-client.php'),
+            $reflection->getFileName()
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,27 +20,27 @@ if (!class_exists('Site_Export_HMAC_Client', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-hmac-client.php';
 }
 
-if (!class_exists('Site_Export_HMAC_Server', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\HMACServer', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-hmac-server.php';
 }
 
-if (!class_exists('Site_Export_HTTP_Server', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\HTTPServer', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-http-server.php';
 }
 
-if (!class_exists('Site_Export_Multipart_Processor', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\MultipartProcessor', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-multipart-processor.php';
 }
 
-if (!class_exists('Site_Export_Push_Exception', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\PushException', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-push-exception.php';
 }
 
-if (!class_exists('Site_Export_Push_Endpoints', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\PushEndpoints', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-push-endpoints.php';
 }
 
-if (!class_exists('Site_Export_Push_Session', false)) {
+if (!class_exists('WordPress\\Reprint\\Server\\PushSession', false)) {
     require_once __DIR__ . '/../packages/reprint-server/src/class-push-session.php';
 }
 

--- a/tests/fixtures/run-push-session-upload.php
+++ b/tests/fixtures/run-push-session-upload.php
@@ -5,7 +5,7 @@
 require_once dirname(__DIR__) . '/bootstrap.php';
 
 $reprint_test_configuration = json_decode(base64_decode($argv[1], true), true, 512, JSON_THROW_ON_ERROR);
-$reprint_test_push_session = Site_Export_Push_Session::open(
+$reprint_test_push_session = \WordPress\Reprint\Server\PushSession::open(
     $reprint_test_configuration['reprint_directory'],
     $reprint_test_configuration['docroot'],
     $reprint_test_configuration['push_session_id'],
@@ -17,7 +17,7 @@ rewind($reprint_test_input);
 $reprint_test_upload_open = false;
 
 try {
-    $reprint_test_push_session->accept_upload($reprint_test_input, new Site_Export_Multipart_Processor($reprint_test_configuration['boundary']));
+    $reprint_test_push_session->accept_upload($reprint_test_input, new \WordPress\Reprint\Server\MultipartProcessor($reprint_test_configuration['boundary']));
     $reprint_test_upload_open = true;
     while (true) {
         if (!$reprint_test_push_session->next_change()) {
@@ -36,7 +36,7 @@ try {
     fclose($reprint_test_input);
     echo json_encode([
         'class' => get_class($exception),
-        'reason' => $exception instanceof Site_Export_Push_Exception ? $exception->get_error_code() : null,
+        'reason' => $exception instanceof \WordPress\Reprint\Server\PushException ? $exception->get_error_code() : null,
         'message' => $exception->getMessage(),
     ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     exit(73);


### PR DESCRIPTION
Move the Reprint Server lib code from the global namespace to its own, and replace site exporter terminology with reprint server.