### PR TITLE
Reprint Server: Canonical plugin configuration with legacy migration.

### DIFF
--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -72,11 +72,12 @@ that token revokes the grant and requires fresh consent.
 Hosts can manage push access before active plugins load with an immutable boolean:
 
 ```php
-define('SITE_EXPORT_PUSH_ENABLED', true);
+define('WordPress\\Reprint\\Server\\Plugin\\PUSH_ENABLED', true);
 ```
 
-The `SITE_EXPORT_PUSH_ENABLED` environment variable accepts the same boolean
-policy. The constant wins when both are present. `true` enables push without a
+The `REPRINT_SERVER_PUSH_ENABLED` environment variable and global constant
+accept the same boolean policy. The namespaced constant wins when more than one
+surface is present. `true` enables push without a
 local grant; `false` hard-disables push even when a local grant exists. The sole
 recovery exception lets an authenticated caller finish a commit which already
 has a durable checkpoint, so revocation cannot strand a partially changed
@@ -130,8 +131,9 @@ array argument and do not use the WordPress filter.
 - `TIMESTAMP_TOLERANCE` — max request age in seconds (default 300)
 
 For compatibility, the plugin still accepts `?site-export-api`, applies the
-legacy `site_export_api_options` filter before the canonical filter, and
-exposes the released `_site_export_*()` functions and `SITE_EXPORT_*`
+legacy `site_export_api_options` filter before the canonical filter, migrates
+the old `site_export_*` options, recognizes `SITE_EXPORT_PUSH_ENABLED`,
+and exposes the released `_site_export_*()` functions and `SITE_EXPORT_*`
 constants. New integrations should use the Reprint Server names. `compat.php`
 owns the compatibility names; canonical request and library code use only the
 Reprint Server runtime API.

--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -125,9 +125,9 @@ array argument and do not use the WordPress filter.
 
 - `VERSION` — plugin version string
 - `PLUGIN_DIR` — absolute path to the plugin directory
-- `SECRET_FILE` — optional path to a PHP file that overrides the stored HMAC shared secret
-- `SECRET_OPTION` — WordPress site option name used for the stored HMAC shared secret
-- `PUSH_AUTHORIZATION_OPTION` — WordPress site option containing the token fingerprint granted personal push access
+- `CONNECTION_TOKEN_FILE` — optional path to a PHP file that overrides the stored connection token
+- `CONNECTION_TOKEN_OPTION` — WordPress site option name used for the stored connection token
+- `PUSH_AUTHORIZATION_OPTION` — WordPress site option containing the connection-token fingerprint granted personal push access
 - `TIMESTAMP_TOLERANCE` — max request age in seconds (default 300)
 
 For compatibility, the plugin still accepts `?site-export-api`, applies the

--- a/reprint-server-wp/compat.php
+++ b/reprint-server-wp/compat.php
@@ -67,6 +67,25 @@ function reprint_server_compat_expose_legacy_names(): void {
         },
         -PHP_INT_MAX
     );
+
+    // TODO: This filter should be deleted after September 2026, as it should no longer be relevant by then.
+    add_filter(
+        'reprint_server_managed_push_enabled',
+        static function ($enabled) {
+            if ($enabled !== null) {
+                return $enabled;
+            }
+            if (defined('SITE_EXPORT_PUSH_ENABLED')) {
+                return constant('SITE_EXPORT_PUSH_ENABLED') === true;
+            }
+            $environment_value = getenv('SITE_EXPORT_PUSH_ENABLED');
+            if ($environment_value === false) {
+                return null;
+            }
+            return filter_var($environment_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === true;
+        },
+        -PHP_INT_MAX
+    );
 }
 
 /**
@@ -121,7 +140,12 @@ function reprint_server_compat_migrate_legacy_options(): void {
             continue;
         }
 
-        if (get_option($canonical_name, $missing_option) === $missing_option) {
+        // An empty canonical value counts as missing: writing the connection
+        // token fires the settings listener which revokes push authorization,
+        // and that stores an empty fingerprint before the entry below moves
+        // the granted one.
+        $canonical_value = get_option($canonical_name, $missing_option);
+        if ($canonical_value === $missing_option || $canonical_value === '') {
             update_option($canonical_name, $legacy_value, false);
         }
         delete_option($legacy_name);

--- a/reprint-server-wp/compat.php
+++ b/reprint-server-wp/compat.php
@@ -9,8 +9,8 @@ function reprint_server_compat_constants(): array {
     return [
         'SITE_EXPORT_VERSION' => 'WordPress\\Reprint\\Server\\Plugin\\VERSION',
         'SITE_EXPORT_PLUGIN_DIR' => 'WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR',
-        'SITE_EXPORT_SECRET_FILE' => 'WordPress\\Reprint\\Server\\Plugin\\SECRET_FILE',
-        'SITE_EXPORT_SECRET_OPTION' => 'WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION',
+        'SITE_EXPORT_SECRET_FILE' => 'WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE',
+        'SITE_EXPORT_SECRET_OPTION' => 'WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION',
         'SITE_EXPORT_PUSH_AUTHORIZATION_OPTION' =>
             'WordPress\\Reprint\\Server\\Plugin\\PUSH_AUTHORIZATION_OPTION',
         'SITE_EXPORT_TIMESTAMP_TOLERANCE' => 'WordPress\\Reprint\\Server\\Plugin\\TIMESTAMP_TOLERANCE',
@@ -118,14 +118,14 @@ function reprint_server_compat_migrate_legacy_options(): void {
         !function_exists('get_option')
         || !function_exists('update_option')
         || !function_exists('delete_option')
-        || !defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION')
+        || !defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION')
         || !defined('WordPress\\Reprint\\Server\\Plugin\\PUSH_AUTHORIZATION_OPTION')
     ) {
         return;
     }
 
     $legacy_option_names = [
-        'site_export_secret' => constant('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'),
+        'site_export_secret' => constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'),
         'site_export_push_authorized_token_fingerprint' =>
             constant('WordPress\\Reprint\\Server\\Plugin\\PUSH_AUTHORIZATION_OPTION'),
     ];
@@ -173,23 +173,23 @@ function _site_export_load_exporter_runtime(): ?string {
 }
 
 function _site_export_has_secret_file(): bool {
-    return \WordPress\Reprint\Server\Plugin\has_secret_file();
+    return \WordPress\Reprint\Server\Plugin\has_connection_token_file();
 }
 
 function _site_export_get_file_secret(): ?string {
-    return \WordPress\Reprint\Server\Plugin\get_file_secret();
+    return \WordPress\Reprint\Server\Plugin\get_file_connection_token();
 }
 
 function _site_export_get_option_secret(): string {
-    return \WordPress\Reprint\Server\Plugin\get_option_secret();
+    return \WordPress\Reprint\Server\Plugin\get_option_connection_token();
 }
 
 function _site_export_get_shared_secret(): ?string {
-    return \WordPress\Reprint\Server\Plugin\get_shared_secret();
+    return \WordPress\Reprint\Server\Plugin\get_connection_token();
 }
 
 function _site_export_update_shared_secret(string $secret): bool {
-    return \WordPress\Reprint\Server\Plugin\update_shared_secret($secret);
+    return \WordPress\Reprint\Server\Plugin\update_connection_token($secret);
 }
 
 function _site_export_get_managed_push_enabled(): ?bool {

--- a/reprint-server-wp/compat.php
+++ b/reprint-server-wp/compat.php
@@ -129,23 +129,25 @@ function reprint_server_compat_migrate_legacy_options(): void {
         'site_export_push_authorized_token_fingerprint' =>
             constant('WordPress\\Reprint\\Server\\Plugin\\PUSH_AUTHORIZATION_OPTION'),
     ];
-    $missing_option = new stdClass();
     foreach ($legacy_option_names as $legacy_name => $canonical_name) {
         if ($canonical_name === $legacy_name) {
             continue;
         }
 
-        $legacy_value = get_option($legacy_name, $missing_option);
-        if ($legacy_value === $missing_option) {
+        // WordPress stores no option as null, so it marks a missing one.
+        $legacy_value = get_option($legacy_name, null);
+        if ($legacy_value === null) {
             continue;
         }
 
-        // An empty canonical value counts as missing: writing the connection
-        // token fires the settings listener which revokes push authorization,
-        // and that stores an empty fingerprint before the entry below moves
-        // the granted one.
-        $canonical_value = get_option($canonical_name, $missing_option);
-        if ($canonical_value === $missing_option || $canonical_value === '') {
+        // An empty canonical value counts as missing. The plugin migrates
+        // while lib.php loads, before the settings page registers the
+        // listener which revokes push authorization when the connection token
+        // option appears. A project which embeds lib.php after that listener
+        // exists writes an empty fingerprint here, and the entry below then
+        // restores the granted one.
+        $canonical_value = get_option($canonical_name, null);
+        if ($canonical_value === null || $canonical_value === '') {
             update_option($canonical_name, $legacy_value, false);
         }
         delete_option($legacy_name);

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -228,21 +228,32 @@ function update_shared_secret(string $secret): bool {
 /**
  * Returns the hosting provider's push policy, or null when the site controls it.
  *
- * An early boolean SITE_EXPORT_PUSH_ENABLED constant takes precedence over the
- * environment variable of the same name. Any unrecognized value fails closed.
+ * A canonical constant takes precedence over global configuration. Any
+ * unrecognized environment value fails closed.
  */
 function get_managed_push_enabled(): ?bool {
-    if (defined('SITE_EXPORT_PUSH_ENABLED')) {
-        return SITE_EXPORT_PUSH_ENABLED === true;
+    if (defined(__NAMESPACE__ . '\\PUSH_ENABLED')) {
+        return constant(__NAMESPACE__ . '\\PUSH_ENABLED') === true;
+    }
+    if (defined('REPRINT_SERVER_PUSH_ENABLED')) {
+        return constant('REPRINT_SERVER_PUSH_ENABLED') === true;
+    }
+    $environment_value = getenv('REPRINT_SERVER_PUSH_ENABLED');
+    if ($environment_value !== false) {
+        $enabled = filter_var($environment_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        return $enabled === true;
     }
 
-    $environment_value = getenv('SITE_EXPORT_PUSH_ENABLED');
-    if ($environment_value === false) {
-        return null;
+    if (function_exists('apply_filters')) {
+        /**
+         * Filters the managed push policy when canonical configuration is absent.
+         *
+         * @param bool|null $enabled Whether push is managed and enabled, or null when site-controlled.
+         */
+        $enabled = apply_filters('reprint_server_managed_push_enabled', null);
+        return $enabled === true ? true : ( $enabled === null ? null : false );
     }
-
-    $enabled = filter_var($environment_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-    return $enabled === true;
+    return null;
 }
 
 /** Returns whether the current connection token is authorized for push. */
@@ -256,7 +267,7 @@ function get_push_authorization_error(): ?string {
     if ($managed_enabled !== null) {
         return $managed_enabled
             ? null
-            : 'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.';
+            : 'Push access is disabled by the hosting provider through REPRINT_SERVER_PUSH_ENABLED.';
     }
 
     $secret = get_shared_secret();
@@ -291,7 +302,7 @@ function update_push_authorization(bool $enabled): bool {
     if ($enabled) {
         $fingerprint = hash('sha256', $secret);
     }
-    if (function_exists('get_option') && get_option(PUSH_AUTHORIZATION_OPTION, '') === $fingerprint) {
+    if (function_exists('get_option') && get_option(PUSH_AUTHORIZATION_OPTION, null) === $fingerprint) {
         return true;
     }
 

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -30,11 +30,11 @@ if (!defined(__NAMESPACE__ . '\\VERSION')) {
 if (!defined(__NAMESPACE__ . '\\PLUGIN_DIR')) {
     define(__NAMESPACE__ . '\\PLUGIN_DIR', plugin_dir_path(__FILE__));
 }
-if (!defined(__NAMESPACE__ . '\\SECRET_FILE')) {
-    define(__NAMESPACE__ . '\\SECRET_FILE', PLUGIN_DIR . 'secret.php');
+if (!defined(__NAMESPACE__ . '\\CONNECTION_TOKEN_FILE')) {
+    define(__NAMESPACE__ . '\\CONNECTION_TOKEN_FILE', PLUGIN_DIR . 'secret.php');
 }
-if (!defined(__NAMESPACE__ . '\\SECRET_OPTION')) {
-    define(__NAMESPACE__ . '\\SECRET_OPTION', 'reprint_server_secret');
+if (!defined(__NAMESPACE__ . '\\CONNECTION_TOKEN_OPTION')) {
+    define(__NAMESPACE__ . '\\CONNECTION_TOKEN_OPTION', 'reprint_server_connection_token');
 }
 if (!defined(__NAMESPACE__ . '\\PUSH_AUTHORIZATION_OPTION')) {
     define(__NAMESPACE__ . '\\PUSH_AUTHORIZATION_OPTION', 'reprint_server_push_authorized_token_fingerprint');
@@ -170,59 +170,57 @@ function load_server_runtime(): ?string {
     return null;
 }
 
-/** Returns whether the legacy secret.php override exists. */
-function has_secret_file(): bool {
-    return file_exists(SECRET_FILE);
+/** Returns whether the legacy secret.php connection-token override exists. */
+function has_connection_token_file(): bool {
+    return file_exists(CONNECTION_TOKEN_FILE);
 }
 
 /**
- * Reads the legacy secret.php override when present.
+ * Reads the connection token from the legacy secret.php override when present.
  *
- * @return string|null String secret when the file is valid, otherwise null.
+ * @return string|null Connection token when the file is valid, otherwise null.
  */
-function get_file_secret(): ?string {
-    if (!has_secret_file()) {
+function get_file_connection_token(): ?string {
+    if (!has_connection_token_file()) {
         return null;
     }
 
-    $secret = require SECRET_FILE;
-    return is_string($secret) ? $secret : null;
+    $connection_token = require CONNECTION_TOKEN_FILE;
+    return is_string($connection_token) ? $connection_token : null;
 }
 
-/** Reads the option-backed shared secret. */
-function get_option_secret(): string {
+/** Reads the option-backed connection token. */
+function get_option_connection_token(): string {
     if (!function_exists('get_option')) {
         return '';
     }
 
-    $secret = get_option(SECRET_OPTION, '');
-    return is_string($secret) ? $secret : '';
+    $connection_token = get_option(CONNECTION_TOKEN_OPTION, '');
+    return is_string($connection_token) ? $connection_token : '';
 }
 
 /**
- * Returns the effective shared secret.
+ * Returns the effective connection token.
  *
  * The legacy secret.php file takes precedence when present; otherwise the
  * site option is used.
  */
-function get_shared_secret(): ?string {
-    if (has_secret_file()) {
-        return get_file_secret();
+function get_connection_token(): ?string {
+    if (has_connection_token_file()) {
+        return get_file_connection_token();
     }
 
-    $secret = get_option_secret();
-    return $secret === '' ? null : $secret;
+    $connection_token = get_option_connection_token();
+    return $connection_token === '' ? null : $connection_token;
 }
 
-/**
- * Updates only the option-backed shared secret used by the settings UI and REST API.
- */
-function update_shared_secret(string $secret): bool {
+/** Updates only the option-backed connection token used by the settings UI and REST API. */
+function update_connection_token(string $connection_token): bool {
     if (!function_exists('update_option')) {
         return false;
     }
 
-    return (bool) update_option(SECRET_OPTION, $secret, false);
+    return (bool) update_option(CONNECTION_TOKEN_OPTION, $connection_token, false);
 }
 
 /**
@@ -270,15 +268,15 @@ function get_push_authorization_error(): ?string {
             : 'Push access is disabled by the hosting provider through REPRINT_SERVER_PUSH_ENABLED.';
     }
 
-    $secret = get_shared_secret();
-    if ($secret === null || !function_exists('get_option')) {
+    $connection_token = get_connection_token();
+    if ($connection_token === null || !function_exists('get_option')) {
         return 'Push access is disabled for the current connection token.';
     }
 
     $authorized_fingerprint = get_option(PUSH_AUTHORIZATION_OPTION, '');
     $authorized = is_string($authorized_fingerprint)
         && $authorized_fingerprint !== ''
-        && hash_equals(hash('sha256', $secret), $authorized_fingerprint);
+        && hash_equals(hash('sha256', $connection_token), $authorized_fingerprint);
     return $authorized ? null : 'Push access is disabled for the current connection token.';
 }
 
@@ -293,14 +291,14 @@ function update_push_authorization(bool $enabled): bool {
         return false;
     }
 
-    $secret = get_shared_secret();
-    if ($enabled && $secret === null) {
+    $connection_token = get_connection_token();
+    if ($enabled && $connection_token === null) {
         return false;
     }
 
     $fingerprint = '';
     if ($enabled) {
-        $fingerprint = hash('sha256', $secret);
+        $fingerprint = hash('sha256', $connection_token);
     }
     if (function_exists('get_option') && get_option(PUSH_AUTHORIZATION_OPTION, null) === $fingerprint) {
         return true;
@@ -339,25 +337,25 @@ function verify_hmac(string $secret): ?string {
 /**
  * Default HMAC authentication handler.
  *
- * Reads the shared secret from secret.php when present, otherwise from the
+ * Reads the connection token from secret.php when present, otherwise from the
  * site option, and verifies the request's HMAC signature.
  * Calls error() on failure.
  */
 function default_authenticate(): void {
-    if (has_secret_file()) {
-        $secret = get_file_secret();
-        if (empty($secret)) {
-            error(503, 'Invalid secret.php configuration. Please remove it or replace it with a valid shared secret.');
+    if (has_connection_token_file()) {
+        $connection_token = get_file_connection_token();
+        if (empty($connection_token)) {
+            error(503, 'Invalid secret.php configuration. Please remove it or replace it with a valid connection token.');
         }
     } else {
-        $secret = get_option_secret();
+        $connection_token = get_option_connection_token();
     }
 
-    if (empty($secret) || !is_string($secret)) {
-        error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Reprint Server.');
+    if (empty($connection_token) || !is_string($connection_token)) {
+        error(503, 'Export not configured. Please configure the connection token in WordPress admin under Tools > Reprint Server.');
     }
 
-    $auth_error = verify_hmac($secret);
+    $auth_error = verify_hmac($connection_token);
     if ($auth_error !== null) {
         error(403, $auth_error);
     }
@@ -477,16 +475,16 @@ function handle_api_request(array $options = []): void {
     if ($authenticate !== null) {
         $authenticate();
     } elseif (is_push_endpoint($endpoint)) {
-        if (has_secret_file()) {
-            $secret = get_file_secret();
-            if (empty($secret)) {
-                push_error(503, 'not_configured', 'Invalid secret.php configuration. Remove it or replace it with a valid shared secret.');
+        if (has_connection_token_file()) {
+            $connection_token = get_file_connection_token();
+            if (empty($connection_token)) {
+                push_error(503, 'not_configured', 'Invalid secret.php configuration. Remove it or replace it with a valid connection token.');
             }
         } else {
-            $secret = get_option_secret();
+            $connection_token = get_option_connection_token();
         }
-        if (empty($secret) || !is_string($secret)) {
-            push_error(503, 'not_configured', 'Configure the shared secret in WordPress admin under Tools > Reprint Server.');
+        if (empty($connection_token) || !is_string($connection_token)) {
+            push_error(503, 'not_configured', 'Configure the connection token in WordPress admin under Tools > Reprint Server.');
         }
         if (!class_exists(HMACServer::class, false)) {
             load_server_runtime();
@@ -500,7 +498,7 @@ function handle_api_request(array $options = []): void {
         $request_method = (string) ( $_SERVER['REQUEST_METHOD'] ?? '' );
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
         $request_target = (string) ( $_SERVER['REQUEST_URI'] ?? '' );
-        $hmac_server = new HMACServer($secret, TIMESTAMP_TOLERANCE);
+        $hmac_server = new HMACServer($connection_token, TIMESTAMP_TOLERANCE);
         $auth_error = $hmac_server->verify_envelope($_SERVER, $request_method, $request_target);
         if ($auth_error !== null) {
             push_error(403, 'auth_failed', $auth_error);

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -129,7 +129,7 @@ final class ExportLibraryLoadTest extends TestCase {
             . 'echo json_encode([' . "\n"
             . '    \'canonical_function\' => function_exists(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\handle_api_request\'),' . "\n"
             . '    \'released_function\' => function_exists(\'_site_export_handle_api_request\'),' . "\n"
-            . '    \'canonical_option\' => constant(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\SECRET_OPTION\'),' . "\n"
+            . '    \'canonical_option\' => constant(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\CONNECTION_TOKEN_OPTION\'),' . "\n"
             . '    \'released_option\' => constant(\'SITE_EXPORT_SECRET_OPTION\'),' . "\n"
             . '    \'canonical_query_added\' => isset($_GET[\'reprint-api\']),' . "\n"
             . '], JSON_THROW_ON_ERROR);' . "\n";
@@ -140,7 +140,7 @@ final class ExportLibraryLoadTest extends TestCase {
         $symbols = json_decode(trim($result['output']), true, 512, JSON_THROW_ON_ERROR);
         $this->assertTrue($symbols['canonical_function']);
         $this->assertTrue($symbols['released_function']);
-        $this->assertSame('reprint_server_secret', $symbols['canonical_option']);
+        $this->assertSame('reprint_server_connection_token', $symbols['canonical_option']);
         $this->assertSame($symbols['canonical_option'], $symbols['released_option']);
         $this->assertFalse($symbols['canonical_query_added']);
     }
@@ -206,7 +206,7 @@ final class ExportLibraryLoadTest extends TestCase {
         $stored_options = json_decode(trim($result['output']), true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame(
             [
-                'reprint_server_secret' => 'legacy-token',
+                'reprint_server_connection_token' => 'legacy-token',
                 'reprint_server_push_authorized_token_fingerprint' => 'legacy-fingerprint',
             ],
             $stored_options

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -166,7 +166,7 @@ class DiagnoseHttpErrorTest extends TestCase
 
     public function testExportNotConfigured503()
     {
-        $body = '{"error":"Export not configured. Please configure the shared secret in WordPress admin under Tools > Reprint Server."}';
+        $body = '{"error":"Export not configured. Please configure the connection token in WordPress admin under Tools > Reprint Server."}';
         $result = $this->diagnose(503, $body);
         $this->assertSame('EXPORT_NOT_CONFIGURED', $result['code']);
         $this->assertStringContainsString('not configured', $result['message']);

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -257,7 +257,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(403, $managed_disabled['http_code'], $managed_disabled['body']);
         $this->assertSame('push_disabled', $managed_disabled['response']['reason']);
         $this->assertSame(
-            'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.',
+            'Push access is disabled by the hosting provider through REPRINT_SERVER_PUSH_ENABLED.',
             $managed_disabled['response']['detail']
         );
     }

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -297,7 +297,7 @@ final class SiteExportSecretTest extends TestCase
         parent::tearDown();
     }
 
-    public function testSharedSecretFallsBackToOptionWhenSecretFileMissing(): void
+    public function testConnectionTokenFallsBackToOptionWhenSecretFileMissing(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
 
@@ -337,17 +337,25 @@ final class SiteExportSecretTest extends TestCase
     public function testCanonicalPluginSymbolsArePrimaryAndReleasedCompatibilityNamesRemainAvailable(): void
     {
         $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\VERSION'));
-        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'));
+        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'));
+        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'));
         $this->assertSame(
-            'reprint_server_secret',
-            constant('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION')
+            'reprint_server_connection_token',
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION')
         );
         $this->assertSame(
-            constant('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'),
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'),
             SITE_EXPORT_SECRET_OPTION
         );
+        $this->assertSame(
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'),
+            SITE_EXPORT_SECRET_FILE
+        );
+        $this->assertFalse(defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'));
         $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\handle_api_request'));
-        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_shared_secret'));
+        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_connection_token'));
+        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\update_connection_token'));
+        $this->assertFalse(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_shared_secret'));
         $this->assertTrue(function_exists('_site_export_handle_api_request'));
         $this->assertTrue(function_exists('_site_export_get_shared_secret'));
         $this->assertTrue(class_exists('Site_Export_Plugin'));
@@ -362,7 +370,10 @@ final class SiteExportSecretTest extends TestCase
 
         reprint_server_compat_migrate_legacy_options();
 
-        $this->assertSame('legacy-token', $GLOBALS['site_export_test_options']['reprint_server_secret']);
+        $this->assertSame(
+            'legacy-token',
+            $GLOBALS['site_export_test_options']['reprint_server_connection_token']
+        );
         $this->assertSame(
             'legacy-fingerprint',
             $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
@@ -378,7 +389,7 @@ final class SiteExportSecretTest extends TestCase
     public function testCanonicalOptionsTakePrecedenceDuringLegacyMigration(): void
     {
         $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['site_export_test_options']['reprint_server_secret'] = 'canonical-token';
+        $GLOBALS['site_export_test_options']['reprint_server_connection_token'] = 'canonical-token';
         $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
             'legacy-fingerprint';
         $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint'] =
@@ -386,7 +397,10 @@ final class SiteExportSecretTest extends TestCase
 
         reprint_server_compat_migrate_legacy_options();
 
-        $this->assertSame('canonical-token', $GLOBALS['site_export_test_options']['reprint_server_secret']);
+        $this->assertSame(
+            'canonical-token',
+            $GLOBALS['site_export_test_options']['reprint_server_connection_token']
+        );
         $this->assertSame(
             'canonical-fingerprint',
             $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
@@ -398,7 +412,7 @@ final class SiteExportSecretTest extends TestCase
         );
     }
 
-    public function testSecretFileOverridesSiteOptionWhenPresent(): void
+    public function testSecretFileConnectionTokenOverridesSiteOptionWhenPresent(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-secret';\n");
@@ -406,14 +420,14 @@ final class SiteExportSecretTest extends TestCase
         $this->assertSame('file-secret', _site_export_get_shared_secret());
     }
 
-    public function testUpdatingSharedSecretOnlyTouchesTheSiteOption(): void
+    public function testUpdatingConnectionTokenOnlyTouchesTheSiteOption(): void
     {
         $this->assertTrue(_site_export_update_shared_secret('new-secret'));
         $this->assertSame('new-secret', $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION]);
         $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
     }
 
-    public function testPluginRegistersSecretOptionForCoreSettingsRestEndpoint(): void
+    public function testPluginRegistersConnectionTokenOptionForCoreSettingsRestEndpoint(): void
     {
         Site_Export_Plugin::get_instance()->register_settings();
 
@@ -532,7 +546,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
-    public function testRestSettingsTokenRotationPermanentlyRevokesPushAuthorization(): void
+    public function testRestSettingsConnectionTokenRotationPermanentlyRevokesPushAuthorization(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
         $this->assertTrue(_site_export_update_push_authorization(true));
@@ -545,7 +559,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
-    public function testAddingAFormerSecretFileTokenCannotRestorePushAuthorization(): void
+    public function testAddingAFormerSecretFileConnectionTokenCannotRestorePushAuthorization(): void
     {
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'token-a';\n");
         $this->assertTrue(_site_export_update_push_authorization(true));
@@ -559,7 +573,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
-    public function testRestSettingsOptionChangePreservesAuthorizationForSecretFileToken(): void
+    public function testRestSettingsOptionChangePreservesAuthorizationForSecretFileConnectionToken(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
@@ -606,7 +620,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringNotContainsString('name="site_export_push_enabled" value="1" checked', $html);
     }
 
-    public function testOptedInAdminCopyShowsCurrentTokenCanPush(): void
+    public function testOptedInAdminCopyShowsCurrentConnectionTokenCanPush(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertTrue(_site_export_update_push_authorization(true));

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -30,9 +30,11 @@ if (!function_exists('plugin_dir_path')) {
 
 if (!function_exists('get_option')) {
     function get_option(string $name, $default = false) {
-        return array_key_exists($name, $GLOBALS['site_export_test_options'])
-            ? $GLOBALS['site_export_test_options'][$name]
-            : $default;
+        if (array_key_exists($name, $GLOBALS['site_export_test_options'])) {
+            return $GLOBALS['site_export_test_options'][$name];
+        }
+        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Generic WordPress option test stub.
+        return apply_filters('default_option_' . $name, $default, $name, true);
     }
 }
 
@@ -250,6 +252,9 @@ final class SiteExportSecretTest extends TestCase
     /** @var string|false */
     private $original_push_enabled_environment;
 
+    /** @var string|false */
+    private $original_reprint_server_push_enabled_environment;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -263,6 +268,7 @@ final class SiteExportSecretTest extends TestCase
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
         $this->original_post = $_POST;
         $this->original_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
+        $this->original_reprint_server_push_enabled_environment = getenv('REPRINT_SERVER_PUSH_ENABLED');
 
         $GLOBALS['site_export_test_options'] = [];
         $GLOBALS['site_export_registered_settings'] = [];
@@ -272,6 +278,7 @@ final class SiteExportSecretTest extends TestCase
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
         $_POST = [];
         putenv('SITE_EXPORT_PUSH_ENABLED');
+        putenv('REPRINT_SERVER_PUSH_ENABLED');
 
         if (file_exists(SITE_EXPORT_SECRET_FILE)) {
             unlink(SITE_EXPORT_SECRET_FILE);
@@ -296,6 +303,11 @@ final class SiteExportSecretTest extends TestCase
         } else {
             putenv('SITE_EXPORT_PUSH_ENABLED=' . $this->original_push_enabled_environment);
         }
+        if ($this->original_reprint_server_push_enabled_environment === false) {
+            putenv('REPRINT_SERVER_PUSH_ENABLED');
+        } else {
+            putenv('REPRINT_SERVER_PUSH_ENABLED=' . $this->original_reprint_server_push_enabled_environment);
+        }
 
         parent::tearDown();
     }
@@ -305,28 +317,6 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
 
         $this->assertSame('option-secret', _site_export_get_shared_secret());
-    }
-
-    public function testLegacyStoredSecretMovesToTheCanonicalOptionAndIsDeleted(): void
-    {
-        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame('legacy-token', $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION]);
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
-        $this->assertSame('legacy-token', _site_export_get_shared_secret());
-    }
-
-    public function testLegacyStoredSecretIsDiscardedWhenTheCanonicalOptionAlreadyHasAValue(): void
-    {
-        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame('current-token', $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION]);
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
     }
 
     public function testMigrationCreatesNoOptionsWhenNoLegacyOptionExists(): void
@@ -359,7 +349,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
-    public function testCanonicalPluginSymbolsAndReleasedCompatibilityNamesRemainAvailable(): void
+    public function testCanonicalPluginSymbolsArePrimaryAndReleasedCompatibilityNamesRemainAvailable(): void
     {
         $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\VERSION'));
         $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'));
@@ -377,6 +367,50 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(function_exists('_site_export_get_shared_secret'));
         $this->assertTrue(class_exists('Site_Export_Plugin'));
         $this->assertFalse(class_exists('WordPress\\Reprint\\Server\\Plugin\\SettingsPage'));
+    }
+
+    public function testLegacyOptionsMigrateWithoutChangingTheirValues(): void
+    {
+        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
+            'legacy-fingerprint';
+
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame('legacy-token', $GLOBALS['site_export_test_options']['reprint_server_secret']);
+        $this->assertSame(
+            'legacy-fingerprint',
+            $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
+        );
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
+        $this->assertArrayNotHasKey(
+            'site_export_push_authorized_token_fingerprint',
+            $GLOBALS['site_export_test_options']
+        );
+        $this->assertSame('legacy-token', _site_export_get_shared_secret());
+    }
+
+    public function testCanonicalOptionsTakePrecedenceDuringLegacyMigration(): void
+    {
+        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['site_export_test_options']['reprint_server_secret'] = 'canonical-token';
+        $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
+            'legacy-fingerprint';
+        $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint'] =
+            'canonical-fingerprint';
+
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame('canonical-token', $GLOBALS['site_export_test_options']['reprint_server_secret']);
+        $this->assertSame(
+            'canonical-fingerprint',
+            $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
+        );
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
+        $this->assertArrayNotHasKey(
+            'site_export_push_authorized_token_fingerprint',
+            $GLOBALS['site_export_test_options']
+        );
     }
 
     public function testSecretFileOverridesSiteOptionWhenPresent(): void
@@ -429,6 +463,10 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertTrue(_site_export_update_push_authorization(true));
         $this->assertTrue(_site_export_is_push_authorized());
+        $this->assertSame(
+            hash('sha256', 'current-token'),
+            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+        );
 
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'rotated-token';
         $this->assertFalse(_site_export_is_push_authorized());
@@ -446,6 +484,39 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
+    public function testCanonicalManagedEnvironmentTakesPrecedenceOverLegacyEnvironment(): void
+    {
+        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
+
+        $this->assertFalse(_site_export_get_managed_push_enabled());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testCanonicalGlobalManagedConstantTakesPrecedenceOverCanonicalEnvironment(): void
+    {
+        define('REPRINT_SERVER_PUSH_ENABLED', false);
+        putenv('REPRINT_SERVER_PUSH_ENABLED=true');
+
+        $this->assertFalse(_site_export_get_managed_push_enabled());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testNamespacedManagedConstantTakesPrecedenceOverGlobalConfiguration(): void
+    {
+        define('WordPress\\Reprint\\Server\\Plugin\\PUSH_ENABLED', true);
+        define('REPRINT_SERVER_PUSH_ENABLED', false);
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
+
+        $this->assertTrue(_site_export_get_managed_push_enabled());
+    }
+
     public function testPresentEmptyManagedEnvironmentFailsClosed(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
@@ -456,7 +527,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_get_managed_push_enabled());
         $this->assertFalse(_site_export_is_push_authorized());
         $this->assertSame(
-            'Push access is disabled by the hosting provider through SITE_EXPORT_PUSH_ENABLED.',
+            'Push access is disabled by the hosting provider through REPRINT_SERVER_PUSH_ENABLED.',
             _site_export_get_push_authorization_error()
         );
     }

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -313,9 +313,11 @@ final class SiteExportSecretTest extends TestCase
 
     public function testMigrationKeepsPushAuthorizationGrantedUnderTheLegacyOptionNames(): void
     {
-        // The settings listeners revoke authorization when the connection
-        // token option changes, so they must be registered for this test to
-        // show that migrating both options is not read as a token rotation.
+        // The plugin migrates before the settings page registers its
+        // listeners. Registering them first models a project which embeds
+        // lib.php later in the request, where the listener revoking
+        // authorization for the appearing connection token runs during the
+        // migration.
         Site_Export_Plugin::get_instance();
         $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
         $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -20,7 +20,6 @@ $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
 $GLOBALS['site_export_settings_errors'] = [];
 $GLOBALS['site_export_test_actions'] = [];
-$GLOBALS['site_export_test_filters'] = [];
 
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(string $file): string {
@@ -95,25 +94,11 @@ if (!function_exists('add_action')) {
 
 if (!function_exists('add_filter')) {
     function add_filter(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
-        $GLOBALS['site_export_test_filters'][$hook_name][] = [
+        $GLOBALS['reprint_test_filters'][$hook_name][] = [
             'callback' => $callback,
             'priority' => $priority,
             'accepted_args' => $accepted_args,
         ];
-    }
-}
-
-if (!function_exists('apply_filters')) {
-    function apply_filters(string $hook_name, $value, ...$extra_args) {
-        $filters = $GLOBALS['site_export_test_filters'][$hook_name] ?? [];
-        usort($filters, static function (array $left, array $right): int {
-            return $left['priority'] <=> $right['priority'];
-        });
-        foreach ($filters as $filter) {
-            $args = array_slice(array_merge([$value], $extra_args), 0, $filter['accepted_args']);
-            $value = call_user_func_array($filter['callback'], $args);
-        }
-        return $value;
     }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,23 @@
 // Load Composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
 
+$GLOBALS['reprint_test_filters'] = [];
+
+if (!function_exists('apply_filters')) {
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Shared WordPress test stub.
+    function apply_filters(string $hook_name, $value, ...$extra_args) {
+        $filters = $GLOBALS['reprint_test_filters'][$hook_name] ?? [];
+        usort($filters, static function (array $left, array $right): int {
+            return $left['priority'] <=> $right['priority'];
+        });
+        foreach ($filters as $filter) {
+            $args = array_slice(array_merge([$value], $extra_args), 0, $filter['accepted_args']);
+            $value = call_user_func_array($filter['callback'], $args);
+        }
+        return $value;
+    }
+}
+
 // Load the MySQLDumpProducer class
 require_once __DIR__ . '/../packages/reprint-server/src/class-mysql-dump-producer.php';
 

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -84,7 +84,7 @@ function plugin_basename(string $file): string {
 }
 
 function get_option(string $name, $fallback = false) {
-    if ($name === 'reprint_server_secret') {
+    if ($name === 'reprint_server_connection_token') {
         return trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_SECRET_CONFIG') ) );
     }
     if ($name === 'reprint_server_push_authorized_token_fingerprint') {

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -62,7 +62,7 @@ if (is_string($reprint_push_test_docroot_configuration['wp_plugin_dir'] ?? null)
 
 $reprint_push_test_managed_state = trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_MANAGED_PUSH_CONFIG') ) );
 if ($reprint_push_test_managed_state !== '') {
-    define('SITE_EXPORT_PUSH_ENABLED', $reprint_push_test_managed_state === 'true');
+    define('REPRINT_SERVER_PUSH_ENABLED', $reprint_push_test_managed_state === 'true');
 }
 
 function plugin_dir_path(string $file): string {
@@ -152,6 +152,10 @@ function add_action(string $hook_name, $callback, int $priority = 10, int $accep
 }
 function do_action(string $hook_name, ...$args): void {
     apply_filters($hook_name, null, ...$args);
+}
+// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- WordPress test stub signature.
+function update_option(string $name, $value, $autoload = null): bool {
+    return true;
 }
 
 add_filter('site_export_api_options', static function (): array {


### PR DESCRIPTION
Namespace and match the latest terminology in the plugin configuration, making sure old values are still read for backwards compatibility.