### PR TITLE
Reprint Server: Canonicalize E2E Reprint Server fixtures and finish documentation

### DIFF
--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -71,9 +71,10 @@ change from stranding a partial commit and its maintenance marker.
 Personal consent stores only the current connection token's SHA-256
 fingerprint. Rotating the token therefore revokes push access. A hosting
 provider may override local consent by defining the boolean
-`SITE_EXPORT_PUSH_ENABLED` constant before active plugins load or by setting
-the environment variable of the same name. Managed `true` enables push and
-managed `false` hard-disables push without abandoning durable commit recovery.
+`WordPress\Reprint\Server\Plugin\PUSH_ENABLED` constant before active plugins
+load or by setting `REPRINT_SERVER_PUSH_ENABLED` in the environment. Managed
+`true` enables push and managed `false` hard-disables push without abandoning
+durable commit recovery.
 
 ## Change detection: local machine compared against itself
 
@@ -207,7 +208,7 @@ request can resume from a durable checkpoint instead of repeating a delete.
 
 ## The push session
 
-`Site_Export_Push_Session` stores each session at
+`WordPress\Reprint\Server\PushSession` stores each session at
 `<reprint-directory>/.reprint/push/<push-session-id>/`. `push.json` is the
 push identity and policy plus whether the work-delete stream is complete.
 `commit.json` holds the bounded commit cursor. Both are atomically replaced
@@ -285,8 +286,9 @@ cursor before continuing.
 
 The WordPress plugin passes the platform-supplied `docroot` to push endpoints,
 defaulting to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
-trusted API-options array through the early `site_export_api_options` filter; a
-direct embedder passes the same array to `_site_export_handle_api_request()`.
+trusted API-options array through the early `reprint_server_api_options` filter;
+a direct embedder passes the same array to
+`WordPress\Reprint\Server\Plugin\handle_api_request()`.
 The document-root path must resolve to an existing directory. `ABSPATH` remains
 the default only for pull endpoints because it may point at a separate shared
 WordPress core tree. Push work lives in a document-root-specific private

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -686,7 +686,8 @@ final class FileIndexProcessor {
 
         // Tests may change the scanned names to exercise traversal boundaries.
         // Production traversal has no hook and uses scandir() results directly.
-        if (getenv("SITE_EXPORT_TEST_MODE") && function_exists("_e2e_call_hook")) {
+        $test_mode_enabled = getenv("REPRINT_SERVER_TEST_MODE") || getenv("SITE_EXPORT_TEST_MODE");
+        if ($test_mode_enabled && function_exists("_e2e_call_hook")) {
             $hook_arguments = [$canonical_directory, &$directory_names];
             _e2e_call_hook("test_hook_during_dir_scan", $hook_arguments);
         }

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -556,11 +556,12 @@ register_shutdown_function(function () {
 });
 
 // ============================================================================
-// E2E Test Hook System (only active when SITE_EXPORT_TEST_MODE env var is set)
+// E2E Test Hook System (only active when REPRINT_SERVER_TEST_MODE is set;
+// SITE_EXPORT_TEST_MODE remains a compatibility alias).
 // We don't want anyone to interfere with the export process, which is why those
 // hooks are not registered in production.
 // ============================================================================
-if (getenv('SITE_EXPORT_TEST_MODE')) {
+if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
     /**
      * Load test hooks from a well-known path relative to the site root.
      * The hook file can define callback functions that are called at key
@@ -584,6 +585,10 @@ if (getenv('SITE_EXPORT_TEST_MODE')) {
         if (isset($config['directory'])) {
             $dirs = is_array($config['directory']) ? $config['directory'] : [$config['directory']];
             foreach ($dirs as $d) {
+                $candidates[] = wp_join_unix_paths(
+                    $d,
+                    'wp-content/plugins/reprint-server/test-hooks.php'
+                );
                 $candidates[] = wp_join_unix_paths(
                     $d,
                     'wp-content/plugins/site-export/test-hooks.php'
@@ -861,7 +866,7 @@ function endpoint_sql_chunk(
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(true);
 
     // E2E test hook: after gzip stream initialization
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
         $hook_args = [$gz, $boundary];
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
@@ -1027,7 +1032,7 @@ function endpoint_sql_chunk(
             }
 
             // E2E test hook: before SQL batch is emitted
-            if (getenv('SITE_EXPORT_TEST_MODE')) {
+            if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
                 $hook_args = [&$sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
@@ -1110,7 +1115,7 @@ function endpoint_sql_chunk(
         : ($reader->is_finished() && $deferred_fragment === null ? "complete" : "partial");
 
     // E2E test hook: before completion chunk
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         $hook_args = [$status, $gz, $boundary];
         _e2e_call_hook('test_hook_before_completion', $hook_args);
     }
@@ -1164,7 +1169,7 @@ function endpoint_db_index(
 
     $creds = resolve_db_credentials();
 
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
     }
 
@@ -1286,7 +1291,7 @@ function endpoint_db_index(
 
     $completion_failure = null;
     try {
-        if (getenv('SITE_EXPORT_TEST_MODE')) {
+        if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
             $hook_status = $aborted ? "partial" : $status;
             $hook_args = [$hook_status, $gz, $boundary];
             _e2e_call_hook('test_hook_before_completion', $hook_args);
@@ -2566,7 +2571,7 @@ function stream_file_producer(
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(false, $gzip);
 
     // E2E test hook: after gzip stream initialization (file producer)
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
         $hook_args = [$gz, $boundary];
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
@@ -2742,7 +2747,7 @@ function stream_file_producer(
                 $gz->sync();
             } else {
                 // E2E test hook: before file chunk is emitted
-                if (getenv('SITE_EXPORT_TEST_MODE')) {
+                if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
                     $hook_data = $chunk["data"];
                     $hook_args = [$chunk["path"], $chunk["offset"], &$hook_data];
                     _e2e_call_hook('test_hook_before_file_chunk', $hook_args);
@@ -2827,7 +2832,7 @@ function stream_file_producer(
         $status = $is_complete ? "complete" : "partial";
 
         // E2E test hook: before completion chunk (file producer)
-        if (getenv('SITE_EXPORT_TEST_MODE')) {
+        if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
             $hook_args = [$status, $gz, $boundary];
             _e2e_call_hook('test_hook_before_completion', $hook_args);
         }
@@ -2961,7 +2966,7 @@ function endpoint_file_index(
         );
     }
 
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
     }
 
@@ -3142,7 +3147,7 @@ function emit_file_index_batch(
     array &$batch_items,
     FileIndexProcessor $file_index
 ): void {
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE') || getenv('SITE_EXPORT_TEST_MODE')) {
         $directory_stack = [];
         foreach ($file_index->get_cursor()["stack"] as $encoded_frame) {
             $directory_stack[] = [

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -145,6 +145,74 @@ final class ExportLibraryLoadTest extends TestCase {
         $this->assertFalse($symbols['canonical_query_added']);
     }
 
+    public function testCanonicalTestModePrefersCanonicalPluginHookPath(): void
+    {
+        $tmp_dir = sys_get_temp_dir() . '/reprint-server-test-hook-' . uniqid('', true);
+        $canonical_hook_directory = $tmp_dir . '/wp-content/plugins/reprint-server';
+        $legacy_hook_directory = $tmp_dir . '/wp-content/plugins/site-export';
+        mkdir($canonical_hook_directory, 0755, true);
+        mkdir($legacy_hook_directory, 0755, true);
+        file_put_contents(
+            $canonical_hook_directory . '/test-hooks.php',
+            "<?php function reprint_server_test_hook_marker(): void { echo 'canonical'; }\n"
+        );
+        file_put_contents(
+            $legacy_hook_directory . '/test-hooks.php',
+            "<?php function reprint_server_test_hook_marker(): void { echo 'legacy'; }\n"
+        );
+
+        $export_path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($export_path, 'export.php must exist');
+
+        try {
+            $php_code = '<?php' . "\n"
+                . 'putenv(\'SITE_EXPORT_TEST_MODE\');' . "\n"
+                . 'putenv(\'REPRINT_SERVER_TEST_MODE=1\');' . "\n"
+                . 'require base64_decode(\'' . base64_encode($export_path) . '\', true);' . "\n"
+                . '_e2e_load_test_hooks_if_needed([\'directory\' => base64_decode(\''
+                . base64_encode($tmp_dir) . '\', true)]);' . "\n"
+                . 'reprint_server_test_hook_marker();' . "\n";
+
+            $result = $this->runPhpCode($php_code);
+
+            $this->assertSame(0, $result['status'], $result['output']);
+            $this->assertSame('canonical', trim($result['output']));
+        } finally {
+            $this->removePath($tmp_dir);
+        }
+    }
+
+    public function testLegacyTestModeAndPluginHookPathRemainAvailable(): void
+    {
+        $tmp_dir = sys_get_temp_dir() . '/site-export-test-hook-' . uniqid('', true);
+        $legacy_hook_directory = $tmp_dir . '/wp-content/plugins/site-export';
+        mkdir($legacy_hook_directory, 0755, true);
+        file_put_contents(
+            $legacy_hook_directory . '/test-hooks.php',
+            "<?php function reprint_server_test_hook_marker(): void { echo 'legacy'; }\n"
+        );
+
+        $export_path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($export_path, 'export.php must exist');
+
+        try {
+            $php_code = '<?php' . "\n"
+                . 'putenv(\'REPRINT_SERVER_TEST_MODE\');' . "\n"
+                . 'putenv(\'SITE_EXPORT_TEST_MODE=1\');' . "\n"
+                . 'require base64_decode(\'' . base64_encode($export_path) . '\', true);' . "\n"
+                . '_e2e_load_test_hooks_if_needed([\'directory\' => base64_decode(\''
+                . base64_encode($tmp_dir) . '\', true)]);' . "\n"
+                . 'reprint_server_test_hook_marker();' . "\n";
+
+            $result = $this->runPhpCode($php_code);
+
+            $this->assertSame(0, $result['status'], $result['output']);
+            $this->assertSame('legacy', trim($result['output']));
+        } finally {
+            $this->removePath($tmp_dir);
+        }
+    }
+
     /**
      * @return array {
      *     Export runner result.

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -8,21 +8,60 @@ use function WordPress\Reprint\Server\relative_path_under;
 
 require_once dirname(__DIR__) . '/packages/reprint-server/src/class-file-index-processor.php';
 
+$GLOBALS['reprint_server_directory_scan_hook_calls'] = 0;
+if (!function_exists('_e2e_call_hook')) {
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Production test-hook stub.
+    function _e2e_call_hook(string $name, array &$arguments = []): void
+    {
+        if ($name === 'test_hook_during_dir_scan' && isset($arguments[1])) {
+            ++$GLOBALS['reprint_server_directory_scan_hook_calls'];
+        }
+    }
+}
+
+// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Test stub mirrors the production hook.
 final class FileIndexProcessorTest extends TestCase {
 
     private string $tempDir;
+
+    /** @var string|false */
+    private $originalCanonicalTestMode;
+
+    /** @var string|false */
+    private $originalLegacyTestMode;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/file-index-processor-' . uniqid();
         mkdir($this->tempDir, 0755, true);
+        $this->originalCanonicalTestMode = getenv('REPRINT_SERVER_TEST_MODE');
+        $this->originalLegacyTestMode = getenv('SITE_EXPORT_TEST_MODE');
+        putenv('REPRINT_SERVER_TEST_MODE');
+        putenv('SITE_EXPORT_TEST_MODE');
+        $GLOBALS['reprint_server_directory_scan_hook_calls'] = 0;
     }
 
     protected function tearDown(): void
     {
         $this->deleteTree($this->tempDir);
+        $this->restoreEnvironment('REPRINT_SERVER_TEST_MODE', $this->originalCanonicalTestMode);
+        $this->restoreEnvironment('SITE_EXPORT_TEST_MODE', $this->originalLegacyTestMode);
         parent::tearDown();
+    }
+
+    public function testCanonicalTestModeRunsDirectoryScanHook(): void
+    {
+        putenv('REPRINT_SERVER_TEST_MODE=1');
+
+        $this->assertDirectoryScanHookRuns();
+    }
+
+    public function testLegacyTestModeStillRunsDirectoryScanHook(): void
+    {
+        putenv('SITE_EXPORT_TEST_MODE=1');
+
+        $this->assertDirectoryScanHookRuns();
     }
 
     public function testResumeAfterEveryStepMatchesOneOpenProcessor(): void
@@ -503,6 +542,33 @@ final class FileIndexProcessorTest extends TestCase {
             $includeCaches,
             $storagePath
         );
+    }
+
+    private function assertDirectoryScanHookRuns(): void
+    {
+        $docroot = $this->tempDir . '/test-mode-site';
+        mkdir($docroot, 0755, true);
+        file_put_contents($docroot . '/index.php', '<?php');
+        $processor = $this->startProcessor([$docroot], $docroot, false, true, '');
+
+        try {
+            $this->assertTrue($processor->next_index_step());
+            $this->assertGreaterThan(0, $GLOBALS['reprint_server_directory_scan_hook_calls']);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    /**
+     * @param string|false $value Original environment value.
+     */
+    private function restoreEnvironment(string $name, $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+            return;
+        }
+        putenv($name . '=' . $value);
     }
 
     /**

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -98,7 +98,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 
 ; Keep open_basedir in its own worker pool. A request-level value can remain
 ; active when the same worker handles a request for another test site.
@@ -125,7 +125,7 @@ php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 # ---------- PHP-FPM master without pdo_mysql ----------
@@ -175,7 +175,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 cat <<EOF | sudo tee /etc/systemd/system/php-e2e-no-pdo-mysql.service >/dev/null
@@ -250,7 +250,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -282,7 +282,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -319,7 +319,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_buffering on;
         fastcgi_buffer_size 128k;

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -54,7 +54,7 @@ php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 
 ; Keep open_basedir in its own worker pool. A request-level value can remain
 ; active when the same worker handles a request for another test site.
@@ -78,7 +78,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 rm -f "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 "php-fpm${PHP_VERSION}" --nodaemonize &
@@ -127,7 +127,7 @@ php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 PHP_INI_SCAN_DIR="$NO_PDO_MYSQL_CONF_D" "php-fpm${PHP_VERSION}" \
@@ -166,7 +166,7 @@ NGINXCONF
 rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 
 # Standard sites — serve from WordPress root so that index.php
-# bootstraps WordPress and the site-export plugin handles the request.
+# bootstraps WordPress and the Reprint Server plugin handles the request.
 jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false), (.value.noPdoMysql // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir no_pdo_mysql; do
     site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
@@ -186,7 +186,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -215,7 +215,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -246,7 +246,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_buffering on;
         fastcgi_buffer_size 128k;

--- a/tests/e2e/lib/hmac-client.js
+++ b/tests/e2e/lib/hmac-client.js
@@ -1,5 +1,5 @@
 /**
- * HMAC authentication client for Site Export API.
+ * HMAC authentication client for the Reprint Server API.
  * JavaScript implementation matching the PHP Site_Export_HMAC_Client.
  *
  * Signature = HMAC-SHA256(nonce + timestamp + SHA256(body), secret)

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -241,13 +241,13 @@ export async function ensureSite(name, options = {}) {
     // Copy the built plugin bundle, including its bundled Composer vendor tree.
     cpSync(
         PLUGIN_SRC,
-        join(siteDir, 'wp-content', 'plugins', 'site-export'),
+        join(siteDir, 'wp-content', 'plugins', 'reprint-server'),
         { recursive: true }
     );
 
     // Write secret.php after copying the plugin bundle so the target directory exists.
     writeFileSync(
-        join(siteDir, 'wp-content', 'plugins', 'site-export', 'secret.php'),
+        join(siteDir, 'wp-content', 'plugins', 'reprint-server', 'secret.php'),
         `<?php return '${secret}';\n`
     );
     log('Files copied');
@@ -268,8 +268,8 @@ export async function ensureSite(name, options = {}) {
         wpCoreInstall(siteDir, siteUrl, name);
         log('wp core install done');
 
-        // Activate the site-export plugin so WordPress loads index.php on requests.
-        wpPluginActivate(siteDir, 'site-export');
+        // Activate the reprint-server plugin so WordPress loads index.php on requests.
+        wpPluginActivate(siteDir, 'reprint-server');
 
         // Run customDb hook to add extra tables on top of real WP
         if (options.customDb) {

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -560,7 +560,7 @@ export async function compareDatabases(sourceDb, importDb) {
  * Write a test-hooks.php file for a site.
  */
 export function writeTestHooks(siteName, phpCode) {
-    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'site-export', 'test-hooks.php');
+    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'reprint-server', 'test-hooks.php');
     const code = `<?php
 // PHP hooks and Node assertions can touch this file at the same time. Write
 // the complete next JSON value beside the old one, then replace it in one
@@ -592,7 +592,7 @@ ${phpCode}
  * Remove test-hooks.php for a site.
  */
 export function removeTestHooks(siteName) {
-    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'site-export', 'test-hooks.php');
+    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'reprint-server', 'test-hooks.php');
     try {
         execSync(`sudo rm -f ${JSON.stringify(hookPath)}`);
     } catch {

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -65,7 +65,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';
@@ -97,7 +97,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';
@@ -122,7 +122,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             # Enable proxy buffering to simulate Apache-like buffering
             fastcgi_buffering on;
@@ -208,7 +208,7 @@ in {
       "php_admin_value[realpath_cache_ttl]" = "0";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 
@@ -234,7 +234,7 @@ in {
       "php_admin_value[realpath_cache_ttl]" = "0";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 
@@ -262,7 +262,7 @@ in {
       "php_admin_value[open_basedir]" = "${siteRoot}/open-basedir:/tmp";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -22,8 +22,8 @@ describe('Import: Custom WP Content', () => {
     beforeAll(async () => {
         await ensureSite(site, {
             afterCreate: async (siteDir) => {
-                const customPlugin = join(siteDir, 'custom-content', 'plugins', 'site-export');
-                const srcPlugin = join(siteDir, 'wp-content', 'plugins', 'site-export');
+                const customPlugin = join(siteDir, 'custom-content', 'plugins', 'reprint-server');
+                const srcPlugin = join(siteDir, 'wp-content', 'plugins', 'reprint-server');
                 mkdirSync(join(siteDir, 'custom-content', 'plugins'), { recursive: true });
                 cpSync(srcPlugin, customPlugin, { recursive: true });
             },

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -84,7 +84,7 @@ describe('Import: Follow Symlinks', () => {
             // Start a PHP built-in server for this site as a fallback.
         }
 
-        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'reprint-server');
         fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8101', '-t', fsRoot], {
             stdio: 'ignore',
         });

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -123,9 +123,9 @@ async function ensureSqliteSite(site, pluginVersion) {
             );
             rmSync(join(siteDir, '.maintenance'), { force: true });
 
-            // Activate the site-export plugin.
+            // Activate the reprint-server plugin.
             execSync(
-                `php /tmp/wp-cli.phar plugin activate site-export` +
+                `php /tmp/wp-cli.phar plugin activate reprint-server` +
                 ` --path=${JSON.stringify(siteDir)}` +
                 allowRoot,
                 { timeout: 30000, stdio: 'pipe' },

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -55,32 +55,32 @@ describe('Import: Atomic-style split roots (__wp__ + document root)', () => {
                 writeFileSync(join(siteDir, 'wp-load.php'), '<?php /* stub */ ?>');
                 writeFileSync(join(siteDir, 'wp-config.php'), '<?php /* stub config */ ?>');
 
-                // index.php loads the exporter directly, bypassing WordPress.
-                // lib.php's _site_export_handle_api_request() authenticates
+                // index.php loads Reprint Server directly, bypassing WordPress.
+                // lib.php's namespaced request handler authenticates
                 // via HMAC and dispatches the request — same path as the
                 // WordPress plugin, just without WP bootstrapped.
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('ABSPATH', __DIR__ . '/__wp__/');
-define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');
-define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+define('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR', __DIR__ . '/wp-content/plugins/reprint-server/');
+define('WordPress\\Reprint\\Server\\Plugin\\SECRET_FILE', constant('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR') . 'secret.php');
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }
 }
-require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';
-_site_export_handle_api_request();
+require_once constant('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR') . 'lib.php';
+\\WordPress\\Reprint\\Server\\Plugin\\handle_api_request();
 `);
 
                 // Create site's own wp-content
-                mkdirSync(join(siteDir, 'wp-content', 'plugins', 'site-export'), { recursive: true });
+                mkdirSync(join(siteDir, 'wp-content', 'plugins', 'reprint-server'), { recursive: true });
                 mkdirSync(join(siteDir, 'wp-content', 'themes'), { recursive: true });
 
                 // Copy server plugin
-                const pluginSrc = join(wpDir, 'wp-content', 'plugins', 'site-export');
+                const pluginSrc = join(wpDir, 'wp-content', 'plugins', 'reprint-server');
                 if (existsSync(pluginSrc)) {
-                    execSync(`cp -a "${pluginSrc}/." "${join(siteDir, 'wp-content', 'plugins', 'site-export')}/"`)
+                    execSync(`cp -a "${pluginSrc}/." "${join(siteDir, 'wp-content', 'plugins', 'reprint-server')}/"`)
                 }
                 writeFileSync(
-                    join(siteDir, 'wp-content', 'plugins', 'site-export', 'secret.php'),
+                    join(siteDir, 'wp-content', 'plugins', 'reprint-server', 'secret.php'),
                     `<?php return 'test-secret-${site}';\n`
                 );
 

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -179,8 +179,8 @@ describe('Import: SiteGround plugin stripping', () => {
             );
             // Confirm non-SG plugins survived.
             assert.ok(
-                raw.includes('site-export'),
-                `active_plugins should still contain site-export, got: ${raw}`,
+                raw.includes('reprint-server'),
+                `active_plugins should still contain reprint-server, got: ${raw}`,
             );
         });
 
@@ -241,8 +241,8 @@ describe('Import: SiteGround plugin stripping', () => {
         it('unrelated plugins are preserved on disk', () => {
             const flatDir = join(tempDir, 'flattened');
             assert.ok(
-                existsSync(join(flatDir, 'wp-content', 'plugins', 'site-export')),
-                'site-export plugin should still exist after apply-runtime',
+                existsSync(join(flatDir, 'wp-content', 'plugins', 'reprint-server')),
+                'reprint-server plugin should still exist after apply-runtime',
             );
         });
     });

--- a/tests/e2e/tests/import-47-plugin-auth.test.js
+++ b/tests/e2e/tests/import-47-plugin-auth.test.js
@@ -1,7 +1,7 @@
 /**
  * Test 47: WordPress plugin authentication
  *
- * Installs the site-export plugin in a stock WordPress site — no custom
+ * Installs the reprint-server plugin in a stock WordPress site — no custom
  * setup, no afterCreate hooks — and verifies the default authentication
  * behaviour via HTTP.
  *

--- a/tests/e2e/tests/import-60-preflight-open-basedir.test.js
+++ b/tests/e2e/tests/import-60-preflight-open-basedir.test.js
@@ -109,7 +109,7 @@ describe('Import: Pull with an open_basedir boundary', { timeout: 180000 }, () =
         const importedWpContent = join(importedSiteDir, 'wp-content');
         assert.ok(existsSync(importedWpContent), `Expected ${importedWpContent} to exist`);
         assert.equal(
-            readFileSync(join(importedWpContent, 'plugins', 'site-export', 'secret.php'), 'utf-8'),
+            readFileSync(join(importedWpContent, 'plugins', 'reprint-server', 'secret.php'), 'utf-8'),
             `<?php return '${getSiteSecret(site)}';\n`,
         );
         assert.ok(!existsSync(join(importedSiteDir, 'wp-load.php')),


### PR DESCRIPTION
This moves E2E sites and test hooks to the canonical Reprint Server plugin path and test-mode configuration, preserves the released Site Export aliases, and updates the push documentation to reference the namespaced API.