### PR TITLE
[PHP] Read MySQL resume test state in one query

### DIFF
--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -278,13 +278,18 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
                 const targetDeadline = Date.now() + 60000;
                 while (Date.now() < targetDeadline) {
                     try {
-                        const [[importedRows]] = await interruptedTarget.query(
-                            `SELECT COUNT(*) AS rowCount FROM \`${table}\``
-                        );
+                        // Read both values in one statement. Separate reads may
+                        // straddle an import commit and pair the previous row
+                        // count with the next saved source cursor.
                         const [[savedPosition]] = await interruptedTarget.query(
-                            `SELECT source_cursor, file_byte_offset FROM \`${progressTable}\` WHERE id = 1`
+                            `SELECT
+                                (SELECT COUNT(*) FROM \`${table}\`) AS rowCount,
+                                source_cursor,
+                                file_byte_offset
+                            FROM \`${progressTable}\`
+                            WHERE id = 1`
                         );
-                        importedRowCount = Number(importedRows.rowCount);
+                        importedRowCount = Number(savedPosition?.rowCount ?? 0);
                         savedSourceCursor = savedPosition?.source_cursor ?? null;
                         if (savedPosition) {
                             assert.equal(savedPosition.file_byte_offset, null);


### PR DESCRIPTION
Reads the imported row count and saved source cursor in one MySQL statement so the interruption test cannot combine observations from two import commits.

## Background

The test previously ran `SELECT COUNT(*)` and then read the progress table in a second query. The importer could commit between those queries. CI observed 250 rows before such a commit and cursor 500 after it, then failed because those values did not describe the same moment.

## This change

The progress-table query now includes the row count as a scalar subquery. One database statement returns both values, removing the gap where the importer could advance.

## Testing

`node --check tests/e2e/tests/import-57-mysql-target-position.test.js`

`git diff --check`

The GitHub E2E matrix will run the interruption and resume test against the repository's PHP-FPM, nginx, and MySQL services.
