### PR TITLE
[PHP] Wait for PHP 5.6 WordPress page readiness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -201,9 +201,13 @@ jobs:
           if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
             # API dispatch exits before index.php loads the plugin's WordPress
             # admin-registration file. A regular page request covers that path
-            # with the PHP 5.6 FPM worker too.
+            # with the PHP 5.6 FPM worker too. The API warmup accepts any HTTP
+            # response, so it does not prove that a regular WordPress request
+            # is ready yet. Retry transient HTTP failures while keeping a
+            # lasting plugin-load failure fatal.
             echo "=== Loading WordPress with the exporter on PHP 5.6 ==="
-            curl -fsS -o /dev/null -m 30 "http://127.0.0.1:8081/"
+            curl --retry 10 --retry-delay 1 --retry-connrefused \
+              -fsS -o /dev/null -m 30 "http://127.0.0.1:8081/"
           fi
 
           if [ "$IMPORTER_PHP" = "php7.4" ] || [ "$IMPORTER_PHP" = "php8.0" ]; then


### PR DESCRIPTION
Retries the PHP 5.6 WordPress page smoke request when the local test server returns a transient HTTP error.

## Background

The PHP 5.6 E2E job passed on PR #690. The merged commit has the same file tree, but its one normal-page request returned HTTP 503 and failed trunk. The next trunk run passed the same job.

The preceding API warmup accepts any HTTP response. It therefore does not guarantee that the normal WordPress page will succeed on the next request.

## This change

The normal-page request now uses curl’s bounded retry support. HTTP 503 and other transient HTTP failures are retried up to ten times with a one-second delay. A lasting plugin-load failure still exits nonzero and fails the job.

## Testing

There is no useful local substitute for this workflow’s PHP 5.6, PHP-FPM, nginx, and WordPress setup. Rely on the E2E matrix.