### PR TITLE
[PHP] Rewrite URLs through shortcode syntax and WPBakery codecs

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -141,6 +141,12 @@ class Base64ValueScanner
         return self::encoded_payload_could_decode_to_http_scheme($this->entries[$this->cursor]['encoded_value']);
     }
 
+    /** Return the Base64 payload at the current cursor without decoding it. */
+    public function get_encoded_payload(): string
+    {
+        return $this->entries[$this->cursor]['encoded_value'];
+    }
+
     /**
      * Replace the decoded value at the current cursor position.
      * The new value will be base64-encoded when get_result() rebuilds the SQL.

--- a/packages/reprint-client/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -138,7 +138,7 @@ class Base64ValueScanner
             return strpos($value, 'http') !== false;
         }
 
-        return self::encoded_payload_could_decode_to_http_scheme($this->entries[$this->cursor]['encoded_value']);
+        return self::encoded_text_could_decode_to_http_scheme($this->entries[$this->cursor]['encoded_value']);
     }
 
     /** Return the Base64 payload at the current cursor without decoding it. */
@@ -324,11 +324,18 @@ class Base64ValueScanner
         }
     }
 
-    private static function encoded_payload_could_decode_to_http_scheme(string $payload): bool
+    /**
+     * Return whether Base64 text may decode to a lowercase http or https scheme.
+     *
+     * The four fragments cover both schemes at every possible three-byte
+     * alignment. A match may be incidental, but a real lowercase scheme cannot
+     * be rejected before decoding.
+     */
+    public static function encoded_text_could_decode_to_http_scheme(string $encoded_text): bool
     {
-        return strpos($payload, 'aHR0') !== false
-            || strpos($payload, 'dHA6') !== false
-            || strpos($payload, 'dHBz') !== false
-            || strpos($payload, 'dHRw') !== false;
+        return strpos($encoded_text, 'aHR0') !== false
+            || strpos($encoded_text, 'dHA6') !== false
+            || strpos($encoded_text, 'dHBz') !== false
+            || strpos($encoded_text, 'dHRw') !== false;
     }
 }

--- a/packages/reprint-client/src/lib/url-rewrite/class-shortcode-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-shortcode-processor.php
@@ -571,8 +571,8 @@ class ShortcodeProcessor {
 	 *
 	 * Existing quotes are retained when possible. An unquoted value gains
 	 * quotes only when the replacement cannot be represented unquoted. The
-	 * method refuses values containing both quote delimiters when quoting is
-	 * required, because WordPress shortcode syntax has no reliable quote escape.
+	 * method refuses values containing both unescaped quote delimiters when
+	 * quoting is required.
 	 *
 	 * @param string $value Replacement attribute value.
 	 * @return bool Whether the update was enqueued.
@@ -589,9 +589,9 @@ class ShortcodeProcessor {
 		$quote  = $attribute['quote'];
 
 		if ( null !== $quote ) {
-			if ( false !== strpos( $value, $quote ) ) {
+			if ( $this->contains_unescaped_quote( $value, $quote ) ) {
 				$alternate_quote = '"' === $quote ? "'" : '"';
-				if ( false !== strpos( $value, $alternate_quote ) ) {
+				if ( $this->contains_unescaped_quote( $value, $alternate_quote ) ) {
 					return false;
 				}
 
@@ -612,9 +612,9 @@ class ShortcodeProcessor {
 			}
 
 			if ( $requires_quotes ) {
-				if ( false === strpos( $value, '"' ) ) {
+				if ( ! $this->contains_unescaped_quote( $value, '"' ) ) {
 					$text = '"' . $value . '"';
-				} elseif ( false === strpos( $value, "'" ) ) {
+				} elseif ( ! $this->contains_unescaped_quote( $value, "'" ) ) {
 					$text = "'" . $value . "'";
 				} else {
 					return false;
@@ -630,6 +630,32 @@ class ShortcodeProcessor {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Returns whether a value contains a quote not escaped by a backslash.
+	 *
+	 * @param string $value Value to inspect.
+	 * @param string $quote Single or double quote delimiter.
+	 * @return bool Whether an unescaped delimiter was found.
+	 */
+	private function contains_unescaped_quote( string $value, string $quote ): bool {
+		$consecutive_backslashes = 0;
+		$length                  = strlen( $value );
+		for ( $at = 0; $at < $length; ++$at ) {
+			if ( '\\' === $value[ $at ] ) {
+				++$consecutive_backslashes;
+				continue;
+			}
+
+			if ( $quote === $value[ $at ] && 0 === $consecutive_backslashes % 2 ) {
+				return true;
+			}
+
+			$consecutive_backslashes = 0;
+		}
+
+		return false;
 	}
 
 	/**

--- a/packages/reprint-client/src/lib/url-rewrite/class-shortcode-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-shortcode-processor.php
@@ -1,0 +1,1201 @@
+<?php
+
+// Copied from php-toolkit PR 300 at commit 0b47bd42dd207454a9920bb2afc32cffc8b3697f.
+// Keep the upstream namespace so a released php-toolkit class can replace this copy.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+namespace WordPress\DataLiberation\Shortcode;
+
+/**
+ * Tokenizes and minimally rewrites shortcode-like markup.
+ *
+ * This processor follows the pull-based, single-pass model of
+ * WP_HTML_Tag_Processor. It walks a source string as a stream of `#shortcode`
+ * and `#text` tokens, records byte offsets instead of building a document
+ * tree, and defers lexical updates until get_updated_text() is called.
+ *
+ * It is deliberately a tokenizer, not a shortcode renderer. It does not
+ * require registered WordPress shortcode callbacks and does not attempt to
+ * reproduce do_shortcode(). Opening and closing tokens are reported
+ * independently, which allows consumers to handle same-name nesting and
+ * builder-specific structures without the limitations of the regular
+ * expression used by WordPress Core.
+ *
+ * Attribute parsing is tolerant of builder data stored inside quoted values,
+ * including CSS, HTML, JSON, and square brackets. Getters return the exact
+ * source bytes between the attribute delimiters. Updates replace only the
+ * corresponding lexical span and preserve all unrelated whitespace, quotes,
+ * text, and markup.
+ *
+ * Square-bracket syntax is ambiguous without information from the surrounding
+ * storage format. For example, `[hidden]` may be a shortcode or a CSS attribute
+ * selector. Callers should first isolate a shortcode-bearing region and, where
+ * possible, query for registered tag names or known builder prefixes.
+ */
+class ShortcodeProcessor {
+
+	const TOKEN_SHORTCODE = '#shortcode';
+	const TOKEN_TEXT      = '#text';
+
+	/**
+	 * Source text being processed.
+	 *
+	 * @var string
+	 */
+	private $text;
+
+	/**
+	 * Source text length in bytes.
+	 *
+	 * @var int
+	 */
+	private $length;
+
+	/**
+	 * Byte offset of the final closing square bracket, or false when absent.
+	 *
+	 * @var int|false
+	 */
+	private $last_closing_bracket_at;
+
+	/**
+	 * Byte offset at which the next token scan begins.
+	 *
+	 * @var int
+	 */
+	private $at = 0;
+
+	/**
+	 * Current token type.
+	 *
+	 * @var string|null
+	 */
+	private $token_type = null;
+
+	/**
+	 * Byte offset at which the current token starts.
+	 *
+	 * @var int|null
+	 */
+	private $token_starts_at = null;
+
+	/**
+	 * Current token length in bytes.
+	 *
+	 * @var int|null
+	 */
+	private $token_length = null;
+
+	/**
+	 * Byte offset at which the current shortcode tag name starts.
+	 *
+	 * @var int|null
+	 */
+	private $tag_name_starts_at = null;
+
+	/**
+	 * Current shortcode tag name length in bytes.
+	 *
+	 * @var int|null
+	 */
+	private $tag_name_length = null;
+
+	/**
+	 * Whether the current shortcode token is a closing token.
+	 *
+	 * @var bool
+	 */
+	private $is_closing_tag = false;
+
+	/**
+	 * Whether the current shortcode token has a self-closing solidus.
+	 *
+	 * @var bool
+	 */
+	private $has_self_closing_flag = false;
+
+	/**
+	 * Whether the current shortcode token has two opening square brackets.
+	 *
+	 * @var bool
+	 */
+	private $has_escaped_opening_bracket = false;
+
+	/**
+	 * Whether the current shortcode token has two closing square brackets.
+	 *
+	 * @var bool
+	 */
+	private $has_escaped_closing_bracket = false;
+
+	/**
+	 * Parsed attributes on the current shortcode opener.
+	 *
+	 * Each attribute records source byte spans instead of allocating a
+	 * normalized copy of the complete token.
+	 *
+	 * @var array[]
+	 * @phpstan-var array<int, array{
+	 *     name: string|null,
+	 *     comparable_name: string|null,
+	 *     start: int,
+	 *     length: int,
+	 *     value_start: int,
+	 *     value_length: int,
+	 *     quote: string|null
+	 * }>
+	 */
+	private $attributes = array();
+
+	/**
+	 * Index of the current attribute.
+	 *
+	 * @var int
+	 */
+	private $attribute_index = -1;
+
+	/**
+	 * Lexical replacements keyed by the token and field that owns the update.
+	 *
+	 * @var array[]
+	 * @phpstan-var array<string, array{
+	 *     start: int,
+	 *     length: int,
+	 *     text: string,
+	 *     value?: string
+	 * }>
+	 */
+	private $lexical_updates = array();
+
+	/**
+	 * Byte offset at which scanning may resume after a failed candidate.
+	 *
+	 * @var int|null
+	 */
+	private $scan_at_after_failure = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $text Text containing possible shortcode markup.
+	 */
+	public function __construct( string $text ) {
+		$this->text                    = $text;
+		$this->length                  = strlen( $text );
+		$this->last_closing_bracket_at = strrpos( $text, ']' );
+	}
+
+	/**
+	 * Finds the next shortcode matching an optional query.
+	 *
+	 * A string query matches an exact, case-sensitive shortcode tag name.
+	 * An array query may contain:
+	 *
+	 * - `tag_name`: exact, case-sensitive tag name.
+	 * - `tag_prefix`: case-sensitive tag-name prefix.
+	 * - `tag_closers`: `visit` (default) or `skip`.
+	 * - `match_offset`: one-based index of the matching token to return.
+	 * - `escaped`: whether the token must use the complete `[[tag]]` form.
+	 *
+	 * @param array|string|null $query Optional shortcode query.
+	 * @return bool Whether a matching shortcode token was found.
+	 */
+	public function next_shortcode( $query = null ): bool {
+		$tag_name     = null;
+		$tag_prefix   = null;
+		$tag_closers  = 'visit';
+		$match_offset = 1;
+		$escaped      = null;
+
+		if ( is_string( $query ) ) {
+			$tag_name = $query;
+		} elseif ( is_array( $query ) ) {
+			$tag_name     = isset( $query['tag_name'] ) ? (string) $query['tag_name'] : null;
+			$tag_prefix   = isset( $query['tag_prefix'] ) ? (string) $query['tag_prefix'] : null;
+			$tag_closers  = isset( $query['tag_closers'] ) ? (string) $query['tag_closers'] : 'visit';
+			$match_offset = isset( $query['match_offset'] ) ? max( 1, (int) $query['match_offset'] ) : 1;
+			$escaped      = isset( $query['escaped'] ) ? (bool) $query['escaped'] : null;
+		}
+
+		$matches = 0;
+		while ( $this->next_token() ) {
+			if ( self::TOKEN_SHORTCODE !== $this->token_type ) {
+				continue;
+			}
+
+			if ( 'skip' === $tag_closers && $this->is_closing_tag ) {
+				continue;
+			}
+
+			$current_tag = $this->get_tag();
+			if ( null !== $tag_name && $current_tag !== $tag_name ) {
+				continue;
+			}
+
+			if (
+				null !== $tag_prefix &&
+				0 !== strncmp( $current_tag, $tag_prefix, strlen( $tag_prefix ) )
+			) {
+				continue;
+			}
+
+			if ( null !== $escaped && $this->is_escaped() !== $escaped ) {
+				continue;
+			}
+
+			++$matches;
+			if ( $matches >= $match_offset ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Advances to the next shortcode or text token.
+	 *
+	 * The processor searches forward for a complete shortcode candidate.
+	 * Invalid or truncated candidates remain part of a text token.
+	 *
+	 * @return bool Whether another token was found.
+	 */
+	public function next_token(): bool {
+		$this->after_token();
+
+		if ( $this->at >= $this->length ) {
+			return false;
+		}
+
+		$scan_at = $this->at;
+		while ( $scan_at < $this->length ) {
+			$candidate_at = strpos( $this->text, '[', $scan_at );
+			if ( false === $candidate_at ) {
+				break;
+			}
+
+			if (
+				false === $this->last_closing_bracket_at ||
+				$candidate_at > $this->last_closing_bracket_at
+			) {
+				// The remaining `[` bytes cannot begin complete shortcode tokens.
+				break;
+			}
+
+			$shortcode = $this->scan_shortcode_at( $candidate_at );
+			if ( false === $shortcode ) {
+				$scan_at = null === $this->scan_at_after_failure
+					? $candidate_at + 1
+					: $this->scan_at_after_failure;
+				continue;
+			}
+
+			if ( $candidate_at > $this->at ) {
+				$this->token_type      = self::TOKEN_TEXT;
+				$this->token_starts_at = $this->at;
+				$this->token_length    = $candidate_at - $this->at;
+				$this->at              = $candidate_at;
+
+				return true;
+			}
+
+			$this->set_shortcode_token( $shortcode );
+			$this->at = $candidate_at + $shortcode['length'];
+
+			return true;
+		}
+
+		$this->token_type      = self::TOKEN_TEXT;
+		$this->token_starts_at = $this->at;
+		$this->token_length    = $this->length - $this->at;
+		$this->at              = $this->length;
+
+		return true;
+	}
+
+	/**
+	 * Returns the current token type.
+	 *
+	 * @return string|null `#shortcode`, `#text`, or null when not on a token.
+	 */
+	public function get_token_type(): ?string {
+		return $this->token_type;
+	}
+
+	/**
+	 * Returns the exact source bytes of the current token.
+	 *
+	 * @return string|null Current token text, or null when not on a token.
+	 */
+	public function get_token_text(): ?string {
+		if ( null === $this->token_starts_at || null === $this->token_length ) {
+			return null;
+		}
+
+		return substr( $this->text, $this->token_starts_at, $this->token_length );
+	}
+
+	/**
+	 * Returns the current shortcode tag name exactly as written.
+	 *
+	 * Shortcode tag names are case-sensitive.
+	 *
+	 * @return string|null Current shortcode tag name, or null on a text token.
+	 */
+	public function get_tag(): ?string {
+		if (
+			self::TOKEN_SHORTCODE !== $this->token_type ||
+			null === $this->tag_name_starts_at ||
+			null === $this->tag_name_length
+		) {
+			return null;
+		}
+
+		return substr( $this->text, $this->tag_name_starts_at, $this->tag_name_length );
+	}
+
+	/**
+	 * Indicates whether the current shortcode token is a closing token.
+	 *
+	 * @return bool Whether the current token is a shortcode closer.
+	 */
+	public function is_tag_closer(): bool {
+		return self::TOKEN_SHORTCODE === $this->token_type && $this->is_closing_tag;
+	}
+
+	/**
+	 * Indicates whether the current shortcode token has a self-closing flag.
+	 *
+	 * @return bool Whether the current token is self-closing.
+	 */
+	public function has_self_closing_flag(): bool {
+		return (
+			self::TOKEN_SHORTCODE === $this->token_type &&
+			$this->has_self_closing_flag
+		);
+	}
+
+	/**
+	 * Indicates whether the current shortcode uses complete `[[tag]]` escaping.
+	 *
+	 * @return bool Whether both the opening and closing brackets are doubled.
+	 */
+	public function is_escaped(): bool {
+		return (
+			self::TOKEN_SHORTCODE === $this->token_type &&
+			$this->has_escaped_opening_bracket &&
+			$this->has_escaped_closing_bracket
+		);
+	}
+
+	/**
+	 * Returns the current token's byte offset.
+	 *
+	 * @return int|null Current token start, or null when not on a token.
+	 */
+	public function get_token_start(): ?int {
+		return $this->token_starts_at;
+	}
+
+	/**
+	 * Returns the current token's byte length.
+	 *
+	 * @return int|null Current token length, or null when not on a token.
+	 */
+	public function get_token_length(): ?int {
+		return $this->token_length;
+	}
+
+	/**
+	 * Advances to the next attribute on the current shortcode opener.
+	 *
+	 * Named and positional attributes are both reported. Positional attributes
+	 * return null from get_attribute_name().
+	 *
+	 * @return bool Whether another attribute was found.
+	 */
+	public function next_attribute(): bool {
+		if (
+			self::TOKEN_SHORTCODE !== $this->token_type ||
+			$this->is_closing_tag
+		) {
+			return false;
+		}
+
+		if ( $this->attribute_index + 1 >= count( $this->attributes ) ) {
+			$this->attribute_index = count( $this->attributes );
+			return false;
+		}
+
+		++$this->attribute_index;
+		return true;
+	}
+
+	/**
+	 * Returns the current attribute name exactly as written.
+	 *
+	 * @return string|null Attribute name, or null for positional attributes and
+	 *                     when not positioned on an attribute.
+	 */
+	public function get_attribute_name(): ?string {
+		$attribute = $this->get_current_attribute();
+		return null === $attribute ? null : $attribute['name'];
+	}
+
+	/**
+	 * Returns the current attribute value without surrounding quotes.
+	 *
+	 * The value is returned as exact source bytes. Unlike shortcode_parse_atts(),
+	 * this method does not call stripcslashes() or normalize whitespace.
+	 *
+	 * @return string|null Current attribute value.
+	 */
+	public function get_attribute_value(): ?string {
+		$attribute = $this->get_current_attribute();
+		if ( null === $attribute ) {
+			return null;
+		}
+
+		$update_key = $this->get_attribute_update_key( $this->attribute_index );
+		if ( isset( $this->lexical_updates[ $update_key ]['value'] ) ) {
+			return $this->lexical_updates[ $update_key ]['value'];
+		}
+
+		return substr(
+			$this->text,
+			$attribute['value_start'],
+			$attribute['value_length']
+		);
+	}
+
+	/**
+	 * Returns the quote delimiting the current attribute value.
+	 *
+	 * @return string|null Single quote, double quote, or null for an unquoted
+	 *                     value and when not positioned on an attribute.
+	 */
+	public function get_attribute_quote(): ?string {
+		$attribute = $this->get_current_attribute();
+		return null === $attribute ? null : $attribute['quote'];
+	}
+
+	/**
+	 * Returns the current attribute's byte offset.
+	 *
+	 * @return int|null Current attribute start.
+	 */
+	public function get_attribute_start(): ?int {
+		$attribute = $this->get_current_attribute();
+		return null === $attribute ? null : $attribute['start'];
+	}
+
+	/**
+	 * Returns the current attribute's byte length.
+	 *
+	 * @return int|null Current attribute length.
+	 */
+	public function get_attribute_length(): ?int {
+		$attribute = $this->get_current_attribute();
+		return null === $attribute ? null : $attribute['length'];
+	}
+
+	/**
+	 * Returns the last value of a named shortcode attribute.
+	 *
+	 * Attribute names are compared ASCII-case-insensitively, matching
+	 * shortcode_parse_atts(). When an attribute is repeated, the last value
+	 * wins.
+	 *
+	 * @param string $name Attribute name.
+	 * @return string|null Attribute value, or null if not present.
+	 */
+	public function get_attribute( string $name ): ?string {
+		if (
+			self::TOKEN_SHORTCODE !== $this->token_type ||
+			$this->is_closing_tag
+		) {
+			return null;
+		}
+
+		$comparable_name = strtolower( $name );
+		for ( $i = count( $this->attributes ) - 1; $i >= 0; --$i ) {
+			if ( $this->attributes[ $i ]['comparable_name'] !== $comparable_name ) {
+				continue;
+			}
+
+			$update_key = $this->get_attribute_update_key( $i );
+			if ( isset( $this->lexical_updates[ $update_key ]['value'] ) ) {
+				return $this->lexical_updates[ $update_key ]['value'];
+			}
+
+			return substr(
+				$this->text,
+				$this->attributes[ $i ]['value_start'],
+				$this->attributes[ $i ]['value_length']
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns unique lowercase attribute names matching a prefix.
+	 *
+	 * @param string $prefix Attribute-name prefix.
+	 * @return array|null Matching names, or null when not on a shortcode opener.
+	 */
+	public function get_attribute_names_with_prefix( string $prefix ): ?array {
+		if (
+			self::TOKEN_SHORTCODE !== $this->token_type ||
+			$this->is_closing_tag
+		) {
+			return null;
+		}
+
+		$prefix  = strtolower( $prefix );
+		$matches = array();
+		foreach ( $this->attributes as $attribute ) {
+			$name = $attribute['comparable_name'];
+			if (
+				null !== $name &&
+				0 === strncmp( $name, $prefix, strlen( $prefix ) )
+			) {
+				$matches[ $name ] = true;
+			}
+		}
+
+		return array_keys( $matches );
+	}
+
+	/**
+	 * Replaces the current attribute value with minimal lexical changes.
+	 *
+	 * Existing quotes are retained when possible. An unquoted value gains
+	 * quotes only when the replacement cannot be represented unquoted. The
+	 * method refuses values containing both quote delimiters when quoting is
+	 * required, because WordPress shortcode syntax has no reliable quote escape.
+	 *
+	 * @param string $value Replacement attribute value.
+	 * @return bool Whether the update was enqueued.
+	 */
+	public function set_attribute_value( string $value ): bool {
+		$attribute = $this->get_current_attribute();
+		if ( null === $attribute ) {
+			return false;
+		}
+
+		$start  = $attribute['value_start'];
+		$length = $attribute['value_length'];
+		$text   = $value;
+		$quote  = $attribute['quote'];
+
+		if ( null !== $quote ) {
+			if ( false !== strpos( $value, $quote ) ) {
+				$alternate_quote = '"' === $quote ? "'" : '"';
+				if ( false !== strpos( $value, $alternate_quote ) ) {
+					return false;
+				}
+
+				$start  = $attribute['value_start'] - 1;
+				$length = $attribute['value_length'] + 2;
+				$text   = $alternate_quote . $value . $alternate_quote;
+			}
+		} else {
+			$requires_quotes = ! $this->can_use_unquoted_attribute_value( $value );
+			if (
+				! $requires_quotes &&
+				! $this->has_self_closing_flag &&
+				count( $this->attributes ) - 1 === $this->attribute_index &&
+				'' !== $value &&
+				'/' === $value[ strlen( $value ) - 1 ]
+			) {
+				$requires_quotes = true;
+			}
+
+			if ( $requires_quotes ) {
+				if ( false === strpos( $value, '"' ) ) {
+					$text = '"' . $value . '"';
+				} elseif ( false === strpos( $value, "'" ) ) {
+					$text = "'" . $value . "'";
+				} else {
+					return false;
+				}
+			}
+		}
+
+		$this->lexical_updates[ $this->get_attribute_update_key( $this->attribute_index ) ] = array(
+			'start'  => $start,
+			'length' => $length,
+			'text'   => $text,
+			'value'  => $value,
+		);
+
+		return true;
+	}
+
+	/**
+	 * Returns the exact text represented by the current text token.
+	 *
+	 * @return string|null Current text, or null on a shortcode token.
+	 */
+	public function get_modifiable_text(): ?string {
+		if ( self::TOKEN_TEXT !== $this->token_type ) {
+			return null;
+		}
+
+		$update_key = $this->get_text_update_key();
+		if ( isset( $this->lexical_updates[ $update_key ] ) ) {
+			return $this->lexical_updates[ $update_key ]['text'];
+		}
+
+		return $this->get_token_text();
+	}
+
+	/**
+	 * Replaces the current text token without applying HTML escaping.
+	 *
+	 * Text regions may contain CSS, HTML, block markup, another structured
+	 * language, or ordinary prose. The caller owns that nested grammar, so this
+	 * method records the supplied bytes exactly.
+	 *
+	 * @param string $text Replacement text.
+	 * @return bool Whether the update was enqueued.
+	 */
+	public function set_modifiable_text( string $text ): bool {
+		if (
+			self::TOKEN_TEXT !== $this->token_type ||
+			null === $this->token_starts_at ||
+			null === $this->token_length
+		) {
+			return false;
+		}
+
+		$this->lexical_updates[ $this->get_text_update_key() ] = array(
+			'start'  => $this->token_starts_at,
+			'length' => $this->token_length,
+			'text'   => $text,
+		);
+
+		return true;
+	}
+
+	/**
+	 * Returns the source text with all enqueued lexical updates applied.
+	 *
+	 * @return string Updated text.
+	 */
+	public function get_updated_text(): string {
+		if ( empty( $this->lexical_updates ) ) {
+			return $this->text;
+		}
+
+		$updates = array_values( $this->lexical_updates );
+		usort(
+			$updates,
+			static function ( array $a, array $b ): int {
+				return $a['start'] - $b['start'];
+			}
+		);
+
+		$output               = '';
+		$bytes_already_copied = 0;
+		foreach ( $updates as $update ) {
+			if ( $update['start'] < $bytes_already_copied ) {
+				continue;
+			}
+
+			$output .= substr(
+				$this->text,
+				$bytes_already_copied,
+				$update['start'] - $bytes_already_copied
+			);
+			$output .= $update['text'];
+
+			$bytes_already_copied = $update['start'] + $update['length'];
+		}
+
+		$output .= substr( $this->text, $bytes_already_copied );
+
+		return $output;
+	}
+
+	/**
+	 * Returns the updated source text.
+	 *
+	 * @return string Updated text.
+	 */
+	public function __toString(): string {
+		return $this->get_updated_text();
+	}
+
+	/**
+	 * Scans a shortcode candidate at a given byte offset.
+	 *
+	 * @param int $start Candidate start offset.
+	 * @return array|false Parsed token metadata, or false for plain text.
+	 * @phpstan-return array{
+	 *     start: int,
+	 *     length: int,
+	 *     tag_name_start: int,
+	 *     tag_name_length: int,
+	 *     is_closing: bool,
+	 *     self_closing: bool,
+	 *     escaped_opening: bool,
+	 *     escaped_closing: bool,
+	 *     attributes: array
+	 * }|false
+	 */
+	private function scan_shortcode_at( int $start ) {
+		$this->scan_at_after_failure = null;
+
+		$at = $start + 1;
+		if ( $at >= $this->length ) {
+			return false;
+		}
+
+		$escaped_opening = false;
+		if ( '[' === $this->text[ $at ] ) {
+			$escaped_opening = true;
+			++$at;
+		}
+
+		$is_closing = false;
+		if ( $at < $this->length && '/' === $this->text[ $at ] ) {
+			$is_closing = true;
+			++$at;
+		}
+
+		$tag_name_start = $at;
+		while (
+			$at < $this->length &&
+			$this->is_shortcode_tag_name_byte( $this->text[ $at ] )
+		) {
+			++$at;
+		}
+
+		$tag_name_length = $at - $tag_name_start;
+		if ( 0 === $tag_name_length ) {
+			return false;
+		}
+
+		if (
+			$at < $this->length &&
+			! $this->is_shortcode_whitespace_at( $at ) &&
+			'"' !== $this->text[ $at ] &&
+			"'" !== $this->text[ $at ] &&
+			'/' !== $this->text[ $at ] &&
+			']' !== $this->text[ $at ]
+		) {
+			return false;
+		}
+
+		if ( $is_closing ) {
+			$at = $this->skip_shortcode_whitespace( $at, $this->length );
+			if ( $at >= $this->length || ']' !== $this->text[ $at ] ) {
+				return false;
+			}
+
+			++$at;
+			$escaped_closing = $at < $this->length && ']' === $this->text[ $at ];
+			if ( $escaped_closing ) {
+				++$at;
+			}
+
+			return array(
+				'start'           => $start,
+				'length'          => $at - $start,
+				'tag_name_start'  => $tag_name_start,
+				'tag_name_length' => $tag_name_length,
+				'is_closing'      => true,
+				'self_closing'    => false,
+				'escaped_opening' => $escaped_opening,
+				'escaped_closing' => $escaped_closing,
+				'attributes'      => array(),
+			);
+		}
+
+		$attributes_start = $at;
+		$first_quote_at   = null;
+		$quote            = null;
+		while ( $at < $this->length ) {
+			$byte = $this->text[ $at ];
+
+			if ( null !== $quote ) {
+				if ( '\\' === $byte && $at + 1 < $this->length ) {
+					$at += 2;
+					continue;
+				}
+
+				if ( $byte === $quote ) {
+					$quote = null;
+				}
+
+				++$at;
+				continue;
+			}
+
+			if ( '"' === $byte || "'" === $byte ) {
+				if ( null === $first_quote_at ) {
+					$first_quote_at = $at;
+				}
+				$quote = $byte;
+				++$at;
+				continue;
+			}
+
+			if ( ']' !== $byte ) {
+				++$at;
+				continue;
+			}
+
+			$attributes_end = $at;
+			$self_closing   = (
+				$attributes_end > $attributes_start &&
+				'/' === $this->text[ $attributes_end - 1 ]
+			);
+			if ( $self_closing ) {
+				--$attributes_end;
+			}
+
+			++$at;
+			$escaped_closing = $at < $this->length && ']' === $this->text[ $at ];
+			if ( $escaped_closing ) {
+				++$at;
+			}
+
+			return array(
+				'start'           => $start,
+				'length'          => $at - $start,
+				'tag_name_start'  => $tag_name_start,
+				'tag_name_length' => $tag_name_length,
+				'is_closing'      => false,
+				'self_closing'    => $self_closing,
+				'escaped_opening' => $escaped_opening,
+				'escaped_closing' => $escaped_closing,
+				'attributes'      => $this->parse_attributes(
+					$attributes_start,
+					$attributes_end
+				),
+			);
+		}
+
+		if ( null !== $first_quote_at ) {
+			/*
+			 * No candidate before this quote can close before it: this scan would
+			 * already have stopped at that closing bracket. Resume inside the
+			 * quoted region so a standalone candidate there can still be recovered
+			 * without rescanning the entire preceding suffix.
+			 */
+			$this->scan_at_after_failure = $first_quote_at + 1;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parses attributes from a complete shortcode opener.
+	 *
+	 * @param int $start Attribute-list start offset.
+	 * @param int $end   Attribute-list end offset.
+	 * @return array Parsed attribute metadata.
+	 */
+	private function parse_attributes( int $start, int $end ): array {
+		$attributes = array();
+		$at         = $start;
+
+		while ( $at < $end ) {
+			$at = $this->skip_shortcode_whitespace( $at, $end );
+			if ( $at >= $end ) {
+				break;
+			}
+
+			$attribute_start = $at;
+			$quote           = $this->text[ $at ];
+			if ( '"' === $quote || "'" === $quote ) {
+				$value_start = $at + 1;
+				$value_end   = $this->find_quote_end( $value_start, $end, $quote );
+				if ( false === $value_end ) {
+					break;
+				}
+
+				$at           = $value_end + 1;
+				$attributes[] = array(
+					'name'            => null,
+					'comparable_name' => null,
+					'start'           => $attribute_start,
+					'length'          => $at - $attribute_start,
+					'value_start'     => $value_start,
+					'value_length'    => $value_end - $value_start,
+					'quote'           => $quote,
+				);
+				continue;
+			}
+
+			$word_start = $at;
+			while (
+				$at < $end &&
+				! $this->is_shortcode_whitespace_at( $at ) &&
+				'=' !== $this->text[ $at ] &&
+				'"' !== $this->text[ $at ] &&
+				"'" !== $this->text[ $at ]
+			) {
+				++$at;
+			}
+
+			$word_end = $at;
+			if ( $word_start === $word_end ) {
+				++$at;
+				continue;
+			}
+
+			$after_word = $this->skip_shortcode_whitespace( $at, $end );
+			if ( $after_word >= $end || '=' !== $this->text[ $after_word ] ) {
+				$attributes[] = array(
+					'name'            => null,
+					'comparable_name' => null,
+					'start'           => $attribute_start,
+					'length'          => $word_end - $attribute_start,
+					'value_start'     => $word_start,
+					'value_length'    => $word_end - $word_start,
+					'quote'           => null,
+				);
+
+				$at = $word_end;
+				continue;
+			}
+
+			$name = substr( $this->text, $word_start, $word_end - $word_start );
+			$at   = $this->skip_shortcode_whitespace( $after_word + 1, $end );
+
+			if ( $at < $end && ( '"' === $this->text[ $at ] || "'" === $this->text[ $at ] ) ) {
+				$quote       = $this->text[ $at ];
+				$value_start = $at + 1;
+				$value_end   = $this->find_quote_end( $value_start, $end, $quote );
+				if ( false === $value_end ) {
+					break;
+				}
+				$at = $value_end + 1;
+			} else {
+				$quote       = null;
+				$value_start = $at;
+				while ( $at < $end && ! $this->is_shortcode_whitespace_at( $at ) ) {
+					++$at;
+				}
+				$value_end = $at;
+			}
+
+			$attributes[] = array(
+				'name'            => $name,
+				'comparable_name' => strtolower( $name ),
+				'start'           => $attribute_start,
+				'length'          => $at - $attribute_start,
+				'value_start'     => $value_start,
+				'value_length'    => $value_end - $value_start,
+				'quote'           => $quote,
+			);
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Finds an attribute's closing quote.
+	 *
+	 * Backslash-quoted values are accepted as a builder-tolerant extension. The
+	 * tokenizer does not decode them.
+	 *
+	 * @param int    $start Value start offset.
+	 * @param int    $end   Attribute-list end offset.
+	 * @param string $quote Quote delimiter.
+	 * @return int|false Closing quote offset, or false.
+	 */
+	private function find_quote_end( int $start, int $end, string $quote ) {
+		$at = $start;
+		while ( $at < $end ) {
+			if ( '\\' === $this->text[ $at ] && $at + 1 < $end ) {
+				$at += 2;
+				continue;
+			}
+
+			if ( $quote === $this->text[ $at ] ) {
+				return $at;
+			}
+
+			++$at;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Applies parsed shortcode metadata as the current token.
+	 *
+	 * @param array $shortcode Parsed shortcode metadata.
+	 */
+	private function set_shortcode_token( array $shortcode ): void {
+		$this->token_type                  = self::TOKEN_SHORTCODE;
+		$this->token_starts_at             = $shortcode['start'];
+		$this->token_length                = $shortcode['length'];
+		$this->tag_name_starts_at          = $shortcode['tag_name_start'];
+		$this->tag_name_length             = $shortcode['tag_name_length'];
+		$this->is_closing_tag              = $shortcode['is_closing'];
+		$this->has_self_closing_flag       = $shortcode['self_closing'];
+		$this->has_escaped_opening_bracket = $shortcode['escaped_opening'];
+		$this->has_escaped_closing_bracket = $shortcode['escaped_closing'];
+		$this->attributes                  = $shortcode['attributes'];
+	}
+
+	/**
+	 * Clears state belonging to the previous token.
+	 */
+	private function after_token(): void {
+		$this->token_type                  = null;
+		$this->token_starts_at             = null;
+		$this->token_length                = null;
+		$this->tag_name_starts_at          = null;
+		$this->tag_name_length             = null;
+		$this->is_closing_tag              = false;
+		$this->has_self_closing_flag       = false;
+		$this->has_escaped_opening_bracket = false;
+		$this->has_escaped_closing_bracket = false;
+		$this->attributes                  = array();
+		$this->attribute_index             = -1;
+	}
+
+	/**
+	 * Returns the current attribute metadata.
+	 *
+	 * @return array|null Current attribute metadata.
+	 */
+	private function get_current_attribute(): ?array {
+		if (
+			$this->attribute_index < 0 ||
+			$this->attribute_index >= count( $this->attributes )
+		) {
+			return null;
+		}
+
+		return $this->attributes[ $this->attribute_index ];
+	}
+
+	/**
+	 * Returns a stable lexical-update key for an attribute.
+	 *
+	 * @param int $attribute_index Attribute index in the current token.
+	 * @return string Update key.
+	 */
+	private function get_attribute_update_key( int $attribute_index ): string {
+		return 'attribute:' . $this->token_starts_at . ':' . $attribute_index;
+	}
+
+	/**
+	 * Returns a stable lexical-update key for the current text token.
+	 *
+	 * @return string Update key.
+	 */
+	private function get_text_update_key(): string {
+		return 'text:' . $this->token_starts_at;
+	}
+
+	/**
+	 * Checks whether a replacement can remain unquoted.
+	 *
+	 * @param string $value Replacement value.
+	 * @return bool Whether the value can remain unquoted.
+	 */
+	private function can_use_unquoted_attribute_value( string $value ): bool {
+		if ( '' === $value || false !== strpbrk( $value, " \t\v\f\r\n\"'[]" ) ) {
+			return false;
+		}
+
+		return (
+			false === strpos( $value, "\u{00A0}" ) &&
+			false === strpos( $value, "\u{200B}" )
+		);
+	}
+
+	/**
+	 * Checks whether a byte may appear in a practical shortcode tag name.
+	 *
+	 * Builder and WordPress shortcode tags conventionally use ASCII letters,
+	 * digits, underscores, hyphens, colons, and periods. Non-ASCII bytes are
+	 * accepted so the tokenizer does not split UTF-8 names. Restricting the
+	 * ASCII punctuation prevents CSS attribute selectors such as `[href^=]`
+	 * from being reported as shortcode tokens.
+	 *
+	 * @param string $byte Byte to inspect.
+	 * @return bool Whether the byte can occur in a tag name.
+	 */
+	private function is_shortcode_tag_name_byte( string $byte ): bool {
+		$ord = ord( $byte );
+		if ( $ord >= 0x80 ) {
+			return true;
+		}
+
+		return (
+			( $ord >= 0x30 && $ord <= 0x39 ) ||
+			( $ord >= 0x41 && $ord <= 0x5A ) ||
+			( $ord >= 0x61 && $ord <= 0x7A ) ||
+			'_' === $byte ||
+			'-' === $byte ||
+			':' === $byte ||
+			'.' === $byte
+		);
+	}
+
+	/**
+	 * Checks for shortcode whitespace at a byte offset.
+	 *
+	 * The shortcode_parse_atts() function normalizes U+00A0 NO-BREAK SPACE and U+200B
+	 * ZERO WIDTH SPACE to ordinary spaces before parsing. Treating them as
+	 * separators here provides the same attribute boundaries without changing
+	 * the source bytes.
+	 *
+	 * @param int $at Byte offset.
+	 * @return bool Whether whitespace begins at the offset.
+	 */
+	private function is_shortcode_whitespace_at( int $at ): bool {
+		if ( $at >= $this->length ) {
+			return false;
+		}
+
+		if ( false !== strpos( " \t\v\f\r\n", $this->text[ $at ] ) ) {
+			return true;
+		}
+
+		return (
+			0 === substr_compare( $this->text, "\u{00A0}", $at, 2 ) ||
+			0 === substr_compare( $this->text, "\u{200B}", $at, 3 )
+		);
+	}
+
+	/**
+	 * Advances past shortcode whitespace.
+	 *
+	 * @param int $at  Starting byte offset.
+	 * @param int $end Exclusive end offset.
+	 * @return int First non-whitespace byte offset.
+	 */
+	private function skip_shortcode_whitespace( int $at, int $end ): int {
+		while ( $at < $end ) {
+			$ascii_length = strspn( $this->text, " \t\v\f\r\n", $at, $end - $at );
+			if ( $ascii_length > 0 ) {
+				$at += $ascii_length;
+				continue;
+			}
+
+			if ( 0 === substr_compare( $this->text, "\u{00A0}", $at, 2 ) ) {
+				$at += 2;
+				continue;
+			}
+
+			if ( 0 === substr_compare( $this->text, "\u{200B}", $at, 3 ) ) {
+				$at += 3;
+				continue;
+			}
+
+			break;
+		}
+
+		return $at;
+	}
+}

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -131,10 +131,7 @@ class SqlStatementRewriter
         // un-rewritten; the four prefixes above are the minimum set that
         // covers every alignment×scheme combination.
         if (
-            strpos($sql, 'aHR0') === false
-            && strpos($sql, 'dHA6') === false
-            && strpos($sql, 'dHBz') === false
-            && strpos($sql, 'dHRw') === false
+            !Base64ValueScanner::encoded_text_could_decode_to_http_scheme($sql)
             && !$this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url($sql)
         ) {
             return $sql;
@@ -197,10 +194,13 @@ class SqlStatementRewriter
         $content_type = $column !== null
             ? $this->get_content_type($table, $column)
             : null;
-        $might_contain_hidden_shortcode_url = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-            && $this->url_rewriter->value_might_contain_hidden_shortcode_url($value);
-
-        if (strpos($value, 'http') === false && !$might_contain_hidden_shortcode_url) {
+        if (
+            strpos($value, 'http') === false
+            && (
+                $content_type !== StructuredDataUrlRewriter::BLOCK_MARKUP
+                || !$this->url_rewriter->value_might_contain_hidden_shortcode_url($value)
+            )
+        ) {
             return $value;
         }
 
@@ -241,16 +241,15 @@ class SqlStatementRewriter
             $content_type = $column_name !== null
                 ? $this->get_content_type($value_to_column_map['table'], $column_name)
                 : null;
-            $encoded_payload_might_contain_hidden_shortcode_url =
-                $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-                && $this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url(
-                    $scanner->get_encoded_payload()
-                );
-            if (
-                !$scanner->encoded_payload_could_contain_http_scheme()
-                && !$encoded_payload_might_contain_hidden_shortcode_url
-            ) {
-                continue;
+            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
+                if (
+                    $content_type !== StructuredDataUrlRewriter::BLOCK_MARKUP
+                    || !$this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url(
+                        $scanner->get_encoded_payload()
+                    )
+                ) {
+                    continue;
+                }
             }
 
             $value = $scanner->get_value();

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -83,8 +83,9 @@ class SqlStatementRewriter
      * Rewrite URLs in a SQL statement.
      *
      * NOTE: base64-encoded values that contain neither the string "http" nor
-     * a registered shortcode body are skipped entirely. Column resolution and
-     * the StructuredDataUrlRewriter pipeline are never run for those values.
+     * a shortcode codec which may hide URLs are skipped entirely. Column
+     * resolution and the StructuredDataUrlRewriter pipeline are never run for
+     * those values.
      *
      * @param string $sql The SQL statement.
      * @return string The modified SQL statement.
@@ -96,9 +97,9 @@ class SqlStatementRewriter
             return $sql;
         }
 
-        // Quick check: if none of the base64 encodings of "http" or a
-        // registered shortcode body appear in the statement, no value can
-        // carry a rewritable URL known to this rewriter.
+        // Quick check: if none of the base64 encodings of "http" or a shortcode
+        // codec which may hide URLs appear in the statement, no value can carry
+        // a rewritable URL known to this rewriter.
         //
         // base64 encodes 3 source bytes into 4 output chars, so the encoding
         // of "http://" or "https://" depends on which byte boundary the
@@ -119,10 +120,11 @@ class SqlStatementRewriter
         // 15 MB dump). On URL-heavy dumps the four strpos calls hit on the
         // first match and stay within measurement noise.
         //
-        // Registered shortcode bodies are the exception: their codec may hide
-        // the URL one layer deeper. StructuredDataUrlRewriter derives matching
-        // Base64 signals from the same body-codec registry, so adding another
-        // body codec does not require a second list in this SQL layer.
+        // Some shortcode codecs are the exception: a body or attribute codec
+        // may hide the URL under one or more encoding layers.
+        // StructuredDataUrlRewriter derives matching Base64 signals from the
+        // same codec registry, so adding another hidden codec does not require
+        // a second list in this SQL layer.
         //
         // False positives are tolerable — they cost an extra rewrite pass
         // that finds nothing. False negatives would silently leave URLs
@@ -133,7 +135,7 @@ class SqlStatementRewriter
             && strpos($sql, 'dHA6') === false
             && strpos($sql, 'dHBz') === false
             && strpos($sql, 'dHRw') === false
-            && !$this->url_rewriter->encoded_text_might_contain_known_shortcode_body($sql)
+            && !$this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url($sql)
         ) {
             return $sql;
         }
@@ -195,17 +197,10 @@ class SqlStatementRewriter
         $content_type = $column !== null
             ? $this->get_content_type($table, $column)
             : null;
-        $might_contain_known_shortcode_body = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-            && $this->url_rewriter->value_might_contain_known_shortcode_body($value);
+        $might_contain_hidden_shortcode_url = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+            && $this->url_rewriter->value_might_contain_hidden_shortcode_url($value);
 
-        if (strpos($value, 'http') === false && !$might_contain_known_shortcode_body) {
-            return $value;
-        }
-
-        if (
-            !$this->url_rewriter->value_might_contain_source_domain($value)
-            && !$might_contain_known_shortcode_body
-        ) {
+        if (strpos($value, 'http') === false && !$might_contain_hidden_shortcode_url) {
             return $value;
         }
 
@@ -246,14 +241,14 @@ class SqlStatementRewriter
             $content_type = $column_name !== null
                 ? $this->get_content_type($value_to_column_map['table'], $column_name)
                 : null;
-            $encoded_payload_might_contain_known_shortcode_body =
+            $encoded_payload_might_contain_hidden_shortcode_url =
                 $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-                && $this->url_rewriter->encoded_text_might_contain_known_shortcode_body(
+                && $this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url(
                     $scanner->get_encoded_payload()
                 );
             if (
                 !$scanner->encoded_payload_could_contain_http_scheme()
-                && !$encoded_payload_might_contain_known_shortcode_body
+                && !$encoded_payload_might_contain_hidden_shortcode_url
             ) {
                 continue;
             }

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -26,6 +26,9 @@ class SqlStatementRewriter
 {
     private StructuredDataUrlRewriter $url_rewriter;
 
+    /** Base64 fragments which signal a shortcode codec that may hide URLs. */
+    private string $encoded_shortcode_signal_pattern;
+
     /** @var array<string, array<string, string>> full_table_name => [column_name => content_type] */
     private array $db_columns_with_block_markup;
 
@@ -61,6 +64,24 @@ class SqlStatementRewriter
     public function __construct(StructuredDataUrlRewriter $url_rewriter, string $table_prefix = 'wp_', array $extra_db_columns_with_block_markup = [])
     {
         $this->url_rewriter = $url_rewriter;
+        $encoded_shortcode_signals = array();
+        foreach ($url_rewriter->get_shortcode_prefixes_that_may_hide_urls() as $shortcode_prefix) {
+            for ($alignment = 0; $alignment < 3; $alignment++) {
+                $skip = $alignment === 0 ? 0 : 3 - $alignment;
+                $signal_length = strlen($shortcode_prefix) - $skip;
+                $signal_length -= $signal_length % 3;
+                if ($signal_length < 3) {
+                    continue;
+                }
+
+                $encoded_shortcode_signals[] = base64_encode(
+                    substr($shortcode_prefix, $skip, $signal_length)
+                );
+            }
+        }
+        $this->encoded_shortcode_signal_pattern = '~(?:'
+            . implode('|', array_map('preg_quote', $encoded_shortcode_signals))
+            . ')~';
 
         // Merge WP defaults with consumer hints (both keyed by suffix),
         // then prepend the table prefix to build full table names.
@@ -122,9 +143,9 @@ class SqlStatementRewriter
         //
         // Some shortcode codecs are the exception: a body or attribute codec
         // may hide the URL under one or more encoding layers.
-        // StructuredDataUrlRewriter derives matching Base64 signals from the
-        // same codec registry, so adding another hidden codec does not require
-        // a second list in this SQL layer.
+        // SqlStatementRewriter derives matching Base64 signals from the
+        // structured rewriter's codec registry, so adding another hidden codec
+        // does not require a second list in this SQL layer.
         //
         // False positives are tolerable — they cost an extra rewrite pass
         // that finds nothing. False negatives would silently leave URLs
@@ -132,7 +153,7 @@ class SqlStatementRewriter
         // covers every alignment×scheme combination.
         if (
             !Base64ValueScanner::encoded_text_could_decode_to_http_scheme($sql)
-            && !$this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url($sql)
+            && !$this->encoded_text_might_contain_hidden_shortcode_url($sql)
         ) {
             return $sql;
         }
@@ -244,7 +265,7 @@ class SqlStatementRewriter
             if (!$scanner->encoded_payload_could_contain_http_scheme()) {
                 if (
                     $content_type !== StructuredDataUrlRewriter::BLOCK_MARKUP
-                    || !$this->url_rewriter->encoded_text_might_contain_hidden_shortcode_url(
+                    || !$this->encoded_text_might_contain_hidden_shortcode_url(
                         $scanner->get_encoded_payload()
                     )
                 ) {
@@ -267,6 +288,19 @@ class SqlStatementRewriter
         }
 
         return $scanner->get_result();
+    }
+
+    /**
+     * Return whether Base64 text may decode to a shortcode codec which hides URLs.
+     *
+     * Each signal contains only complete three-byte groups from the shortcode
+     * prefix. This makes one signal stable for each possible byte alignment of
+     * the prefix inside the decoded value. A match may be incidental, but a
+     * real registered prefix cannot be rejected before Base64 decoding.
+     */
+    private function encoded_text_might_contain_hidden_shortcode_url(string $encoded_text): bool
+    {
+        return preg_match($this->encoded_shortcode_signal_pattern, $encoded_text) === 1;
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -82,10 +82,9 @@ class SqlStatementRewriter
     /**
      * Rewrite URLs in a SQL statement.
      *
-     * NOTE: base64-encoded values that do not contain the string "http" are
-     * skipped entirely — column resolution and the StructuredDataUrlRewriter
-     * pipeline are never run for them. This means URLs stored in base64
-     * without an http/https scheme will not be rewritten.
+     * NOTE: base64-encoded values that contain neither the string "http" nor
+     * a registered shortcode body are skipped entirely. Column resolution and
+     * the StructuredDataUrlRewriter pipeline are never run for those values.
      *
      * @param string $sql The SQL statement.
      * @return string The modified SQL statement.
@@ -97,8 +96,9 @@ class SqlStatementRewriter
             return $sql;
         }
 
-        // Quick check: if none of the base64 encodings of "http" appear in
-        // the statement, no value can carry a rewritable URL.
+        // Quick check: if none of the base64 encodings of "http" or a
+        // registered shortcode body appear in the statement, no value can
+        // carry a rewritable URL known to this rewriter.
         //
         // base64 encodes 3 source bytes into 4 output chars, so the encoding
         // of "http://" or "https://" depends on which byte boundary the
@@ -119,15 +119,21 @@ class SqlStatementRewriter
         // 15 MB dump). On URL-heavy dumps the four strpos calls hit on the
         // first match and stay within measurement noise.
         //
+        // Registered shortcode bodies are the exception: their codec may hide
+        // the URL one layer deeper. StructuredDataUrlRewriter derives matching
+        // Base64 signals from the same body-codec registry, so adding another
+        // body codec does not require a second list in this SQL layer.
+        //
         // False positives are tolerable — they cost an extra rewrite pass
         // that finds nothing. False negatives would silently leave URLs
         // un-rewritten; the four prefixes above are the minimum set that
-        // covers every alignment×scheme combination, so no real URL escapes.
+        // covers every alignment×scheme combination.
         if (
             strpos($sql, 'aHR0') === false
             && strpos($sql, 'dHA6') === false
             && strpos($sql, 'dHBz') === false
             && strpos($sql, 'dHRw') === false
+            && !$this->url_rewriter->encoded_text_might_contain_known_shortcode_body($sql)
         ) {
             return $sql;
         }
@@ -186,17 +192,22 @@ class SqlStatementRewriter
     /** Rewrite one decoded database value with the same column rules as rewrite(). */
     public function rewrite_value(string $value, string $table, ?string $column): string
     {
-        if (strpos($value, 'http') === false) {
-            return $value;
-        }
-
-        if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
-            return $value;
-        }
-
         $content_type = $column !== null
             ? $this->get_content_type($table, $column)
             : null;
+        $might_contain_known_shortcode_body = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+            && $this->url_rewriter->value_might_contain_known_shortcode_body($value);
+
+        if (strpos($value, 'http') === false && !$might_contain_known_shortcode_body) {
+            return $value;
+        }
+
+        if (
+            !$this->url_rewriter->value_might_contain_source_domain($value)
+            && !$might_contain_known_shortcode_body
+        ) {
+            return $value;
+        }
 
         // Rewrite URLs in the value. Known block-markup columns go through
         // the structured block parser so alternate URL spellings (for example
@@ -223,20 +234,6 @@ class SqlStatementRewriter
     private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
     {
         while ($scanner->next_value()) {
-            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
-                continue;
-            }
-
-            $value = $scanner->get_value();
-
-            if (strpos($value, 'http') === false) {
-                continue;
-            }
-
-            if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
-                continue;
-            }
-
             // Determine content type hint for this column.
             $column_name = null;
             if ($value_to_column_map !== null) {
@@ -245,6 +242,23 @@ class SqlStatementRewriter
                     $scanner->get_match_offset()
                 );
             }
+
+            $content_type = $column_name !== null
+                ? $this->get_content_type($value_to_column_map['table'], $column_name)
+                : null;
+            $encoded_payload_might_contain_known_shortcode_body =
+                $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+                && $this->url_rewriter->encoded_text_might_contain_known_shortcode_body(
+                    $scanner->get_encoded_payload()
+                );
+            if (
+                !$scanner->encoded_payload_could_contain_http_scheme()
+                && !$encoded_payload_might_contain_known_shortcode_body
+            ) {
+                continue;
+            }
+
+            $value = $scanner->get_value();
 
             $rewritten = $this->rewrite_value(
                 $value,

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -103,68 +103,16 @@ class StructuredDataUrlRewriter
     public function __construct(array $url_mapping)
     {
         $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping);
-        $this->shortcode_body_rewriters = array(
-            'vc_table'    => array($this, 'rewrite_wpbakery_table_body'),
-            'vc_raw_html' => array($this, 'rewrite_wpbakery_raw_code_body'),
-            'vc_raw_js'   => array($this, 'rewrite_wpbakery_raw_code_body'),
+        $wpbakery_url_rewriter = new WPBakeryUrlRewriter(
+            function (string $value): string {
+                return $this->rewrite($value, self::BLOCK_MARKUP);
+            },
+            function (string $value): string {
+                return $this->rewrite_urls($value, self::PLAIN_TEXT);
+            }
         );
-        $wpbakery_link_attribute_rewriter = array(
-            'rewrite'   => array($this, 'rewrite_wpbakery_link_attribute'),
-            'hides_url' => false,
-        );
-        $wpbakery_safe_attribute_rewriter = array(
-            'rewrite'   => array($this, 'rewrite_wpbakery_safe_attribute'),
-            'hides_url' => true,
-        );
-        $this->shortcode_attribute_rewriters = array(
-            'vc_btn'            => array(
-                'link' => $wpbakery_link_attribute_rewriter,
-                'url'  => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_button2'        => array(
-                'link' => $wpbakery_link_attribute_rewriter,
-                'url'  => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_cta_button2'    => array(
-                'link' => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_custom_heading' => array(
-                'link' => $wpbakery_link_attribute_rewriter,
-                'url'  => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_gallery'        => array(
-                'custom_links' => $wpbakery_safe_attribute_rewriter,
-                'custom_srcs'  => $wpbakery_safe_attribute_rewriter,
-            ),
-            'vc_gmaps'          => array(
-                'link' => $wpbakery_safe_attribute_rewriter,
-            ),
-            'vc_gitem_image'    => array(
-                'url' => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_gitem_zone'     => array(
-                'url' => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_gitem_zone_a'   => array(
-                'url' => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_gitem_zone_b'   => array(
-                'url' => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_icon'           => array(
-                'link' => $wpbakery_link_attribute_rewriter,
-                'url'  => $wpbakery_link_attribute_rewriter,
-            ),
-            'vc_images_carousel' => array(
-                'custom_links' => $wpbakery_safe_attribute_rewriter,
-            ),
-            'vc_posts_slider'   => array(
-                'custom_links' => $wpbakery_safe_attribute_rewriter,
-            ),
-            'vc_single_image'   => array(
-                'url' => $wpbakery_link_attribute_rewriter,
-            ),
-        );
+        $this->shortcode_body_rewriters = $wpbakery_url_rewriter->get_shortcode_body_rewriters();
+        $this->shortcode_attribute_rewriters = $wpbakery_url_rewriter->get_shortcode_attribute_rewriters();
         $encoded_shortcode_signals = array();
         $shortcode_tags_with_hidden_urls = array_fill_keys(
             array_keys($this->shortcode_body_rewriters),
@@ -570,144 +518,6 @@ class StructuredDataUrlRewriter
         }
 
         return ( $this->shortcode_body_rewriters[$shortcode_tag] )( $body );
-    }
-
-    /**
-     * Rewrite WPBakery Easy Tables cells without changing table delimiters.
-     *
-     * Easy Tables URL-encodes each cell while leaving `,` and `|` as table
-     * delimiters. Optional leading cell-style markers stay outside the encoded
-     * value and must be copied unchanged.
-     */
-    private function rewrite_wpbakery_table_body(string $body): string
-    {
-        $parts = preg_split('/([,|])/', $body, -1, PREG_SPLIT_DELIM_CAPTURE);
-        if ($parts === false) {
-            return $body;
-        }
-
-        foreach ($parts as $index => $cell) {
-            if ($cell === ',' || $cell === '|') {
-                continue;
-            }
-
-            $prefix_length = 0;
-            if (preg_match('/\A(?:\[[^\]\r\n]*\])*/', $cell, $matches) === 1) {
-                $prefix_length = strlen($matches[0]);
-            }
-            $encoded_content = substr($cell, $prefix_length);
-            if (preg_match('/%[0-9A-Fa-f]{2}/', $encoded_content) !== 1) {
-                continue;
-            }
-
-            $decoded_content = rawurldecode($encoded_content);
-            $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
-            if ($rewritten_content === $decoded_content) {
-                continue;
-            }
-
-            $parts[$index] = substr($cell, 0, $prefix_length)
-                . $this->encode_wpbakery_url_component($rewritten_content);
-        }
-
-        return implode('', $parts);
-    }
-
-    /**
-     * Rewrite either form of a WPBakery Raw HTML or Raw JS body.
-     *
-     * Both elements use textarea_raw_html, which stores Base64 content. Values
-     * saved by its editor control add URL encoding inside the Base64 layer. The
-     * rewritten body uses the same form.
-     */
-    private function rewrite_wpbakery_raw_code_body(string $body): string
-    {
-        $decoded_body = base64_decode($body, true);
-        if ($decoded_body === false || base64_encode($decoded_body) !== $body) {
-            return $body;
-        }
-
-        $uses_url_encoding = preg_match(
-            '/%(?:3c|3e|5b|5d)|https?%3a%2f%2f/i',
-            $decoded_body
-        ) === 1;
-        $decoded_content = $uses_url_encoding
-            ? rawurldecode($decoded_body)
-            : $decoded_body;
-        $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
-        if ($rewritten_content === $decoded_content) {
-            return $body;
-        }
-
-        if ($uses_url_encoding) {
-            $rewritten_content = $this->encode_wpbakery_url_component($rewritten_content);
-        }
-
-        return base64_encode($rewritten_content);
-    }
-
-    /**
-     * Rewrite a WPBakery textarea_safe or exploded_textarea_safe attribute.
-     *
-     * These controls store `#E-8_`, followed by Base64-encoded, URL-encoded
-     * content. The rewritten value keeps that wrapper and encoding order.
-     */
-    private function rewrite_wpbakery_safe_attribute(string $value): string
-    {
-        $prefix = '#E-8_';
-        if (strncmp($value, $prefix, strlen($prefix)) !== 0) {
-            return $value;
-        }
-
-        $encoded_content = substr($value, strlen($prefix));
-        $decoded_content = base64_decode($encoded_content, true);
-        if ($decoded_content === false || base64_encode($decoded_content) !== $encoded_content) {
-            return $value;
-        }
-
-        $decoded_content = rawurldecode($decoded_content);
-        $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
-        if ($rewritten_content === $decoded_content) {
-            return $value;
-        }
-
-        return $prefix . base64_encode($this->encode_wpbakery_url_component($rewritten_content));
-    }
-
-    /**
-     * Rewrite the URL field in a WPBakery vc_link attribute.
-     *
-     * The control stores URL-encoded fields separated by pipes, for example
-     * `url:https%3A%2F%2Fexample.com|title:Read|target:%20_blank|`.
-     */
-    private function rewrite_wpbakery_link_attribute(string $value): string
-    {
-        $fields = explode('|', $value);
-        foreach ($fields as $index => $field) {
-            if (strncmp($field, 'url:', 4) !== 0) {
-                continue;
-            }
-
-            $encoded_url = substr($field, 4);
-            $decoded_url = rawurldecode($encoded_url);
-            $rewritten_url = $this->rewrite_urls($decoded_url, self::PLAIN_TEXT);
-            if ($rewritten_url === $decoded_url) {
-                continue;
-            }
-
-            $fields[$index] = 'url:' . $this->encode_wpbakery_url_component($rewritten_url);
-        }
-
-        return implode('|', $fields);
-    }
-
-    private function encode_wpbakery_url_component(string $value): string
-    {
-        return str_replace(
-            array('%21', '%27', '%28', '%29', '%2A'),
-            array('!', "'", '(', ')', '*'),
-            rawurlencode($value)
-        );
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -79,8 +79,8 @@ class StructuredDataUrlRewriter
     /** @var array<string, array<string, array{rewrite: callable(string): string, hides_url: bool}>> */
     private array $shortcode_attribute_rewriters;
 
-    /** @var string[] Base64 fragments that signal a shortcode codec which may hide URLs. */
-    private array $encoded_shortcode_signals;
+    /** Base64 fragments which signal a shortcode codec that may hide URLs. */
+    private string $encoded_shortcode_signal_pattern;
 
     /**
      * Rewrites keyed by an entire value; hits only on an exact repeat.
@@ -165,7 +165,7 @@ class StructuredDataUrlRewriter
                 'url' => $wpbakery_link_attribute_rewriter,
             ),
         );
-        $this->encoded_shortcode_signals = array();
+        $encoded_shortcode_signals = array();
         $shortcode_tags_with_hidden_urls = array_fill_keys(
             array_keys($this->shortcode_body_rewriters),
             true
@@ -187,11 +187,14 @@ class StructuredDataUrlRewriter
                     continue;
                 }
 
-                $this->encoded_shortcode_signals[] = base64_encode(
+                $encoded_shortcode_signals[] = base64_encode(
                     substr($shortcode_prefix, $skip, $signal_length)
                 );
             }
         }
+        $this->encoded_shortcode_signal_pattern = '~(?:'
+            . implode('|', array_map('preg_quote', $encoded_shortcode_signals))
+            . ')~';
 
         // Extract unique source domains for the quick-reject check.
         $domains = [];
@@ -257,13 +260,13 @@ class StructuredDataUrlRewriter
         // domain, an encoding marker which may hide a source-domain byte, or a
         // registered shortcode codec which may hide a complete URL. This avoids
         // constructing the structured parsers for most values.
-        $block_markup_may_hide_shortcode_url = self::BLOCK_MARKUP === $content_type
-            && $this->value_might_contain_hidden_shortcode_url($value);
-        if (
-            !$block_markup_may_hide_shortcode_url
-            && !$this->maybe_contains_rewritable_urls($value)
-        ) {
-            return $value;
+        if (!$this->maybe_contains_rewritable_urls($value)) {
+            if (
+                self::BLOCK_MARKUP !== $content_type
+                || !$this->value_might_contain_hidden_shortcode_url($value)
+            ) {
+                return $value;
+            }
         }
 
         // Performance guard: avoid constructing the serialized-PHP parser for
@@ -417,6 +420,10 @@ class StructuredDataUrlRewriter
 
     public function value_might_contain_hidden_shortcode_url(string $value): bool
     {
+        if (strpos($value, '[') === false) {
+            return false;
+        }
+
         foreach ($this->shortcode_attribute_rewriters as $shortcode_tag => $attribute_rewriters) {
             foreach ($attribute_rewriters as $attribute_rewriter) {
                 if (
@@ -452,13 +459,7 @@ class StructuredDataUrlRewriter
      */
     public function encoded_text_might_contain_hidden_shortcode_url(string $encoded_text): bool
     {
-        foreach ($this->encoded_shortcode_signals as $signal) {
-            if (strpos($encoded_text, $signal) !== false) {
-                return true;
-            }
-        }
-
-        return false;
+        return preg_match($this->encoded_shortcode_signal_pattern, $encoded_text) === 1;
     }
 
     /**
@@ -940,6 +941,7 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                $may_contain_json_script = false !== stripos( $content, '<script' );
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
                     $resolve_relative_urls ? $base_url : null
@@ -982,7 +984,8 @@ class StructuredDataUrlRewriter
                     // A JSON media type makes the script body safe to parse as
                     // JSON. Other script bodies keep the cautious byte scan.
                     if (
-                        '#tag' === $p->get_token_type()
+                        $may_contain_json_script
+                        && '#tag' === $p->get_token_type()
                         && ! $p->is_tag_closer()
                         && 'SCRIPT' === $p->get_tag()
                     ) {
@@ -1195,6 +1198,7 @@ class StructuredDataUrlRewriter
         if ( $starts_with_html_opening_tag ) {
             // The format is inferred, so do not reinterpret `#`, `/about`, or
             // other relative values against the configured source URL.
+            $value = $this->rewrite_shortcode_markup( $value );
             return $this->rewrite_urls( $value, self::BLOCK_MARKUP, false );
         }
 

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -76,8 +76,11 @@ class StructuredDataUrlRewriter
     /** @var array<string, callable(string): string> Shortcode tag => encoded-body rewriter. */
     private array $shortcode_body_rewriters;
 
-    /** @var string[] Base64 fragments that signal a registered shortcode body. */
-    private array $encoded_shortcode_body_signals;
+    /** @var array<string, array<string, array{rewrite: callable(string): string, hides_url: bool}>> */
+    private array $shortcode_attribute_rewriters;
+
+    /** @var string[] Base64 fragments that signal a shortcode codec which may hide URLs. */
+    private array $encoded_shortcode_signals;
 
     /**
      * Rewrites keyed by an entire value; hits only on an exact repeat.
@@ -102,10 +105,79 @@ class StructuredDataUrlRewriter
         $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping);
         $this->shortcode_body_rewriters = array(
             'vc_table'    => array($this, 'rewrite_wpbakery_table_body'),
-            'vc_raw_html' => array($this, 'rewrite_wpbakery_raw_html_body'),
+            'vc_raw_html' => array($this, 'rewrite_wpbakery_raw_code_body'),
+            'vc_raw_js'   => array($this, 'rewrite_wpbakery_raw_code_body'),
         );
-        $this->encoded_shortcode_body_signals = array();
-        foreach (array_keys($this->shortcode_body_rewriters) as $shortcode_tag) {
+        $wpbakery_link_attribute_rewriter = array(
+            'rewrite'   => array($this, 'rewrite_wpbakery_link_attribute'),
+            'hides_url' => false,
+        );
+        $wpbakery_safe_attribute_rewriter = array(
+            'rewrite'   => array($this, 'rewrite_wpbakery_safe_attribute'),
+            'hides_url' => true,
+        );
+        $this->shortcode_attribute_rewriters = array(
+            'vc_btn'            => array(
+                'link' => $wpbakery_link_attribute_rewriter,
+                'url'  => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_button2'        => array(
+                'link' => $wpbakery_link_attribute_rewriter,
+                'url'  => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_cta_button2'    => array(
+                'link' => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_custom_heading' => array(
+                'link' => $wpbakery_link_attribute_rewriter,
+                'url'  => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_gallery'        => array(
+                'custom_links' => $wpbakery_safe_attribute_rewriter,
+                'custom_srcs'  => $wpbakery_safe_attribute_rewriter,
+            ),
+            'vc_gmaps'          => array(
+                'link' => $wpbakery_safe_attribute_rewriter,
+            ),
+            'vc_gitem_image'    => array(
+                'url' => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_gitem_zone'     => array(
+                'url' => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_gitem_zone_a'   => array(
+                'url' => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_gitem_zone_b'   => array(
+                'url' => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_icon'           => array(
+                'link' => $wpbakery_link_attribute_rewriter,
+                'url'  => $wpbakery_link_attribute_rewriter,
+            ),
+            'vc_images_carousel' => array(
+                'custom_links' => $wpbakery_safe_attribute_rewriter,
+            ),
+            'vc_posts_slider'   => array(
+                'custom_links' => $wpbakery_safe_attribute_rewriter,
+            ),
+            'vc_single_image'   => array(
+                'url' => $wpbakery_link_attribute_rewriter,
+            ),
+        );
+        $this->encoded_shortcode_signals = array();
+        $shortcode_tags_with_hidden_urls = array_fill_keys(
+            array_keys($this->shortcode_body_rewriters),
+            true
+        );
+        foreach ($this->shortcode_attribute_rewriters as $shortcode_tag => $attribute_rewriters) {
+            foreach ($attribute_rewriters as $attribute_rewriter) {
+                if ($attribute_rewriter['hides_url']) {
+                    $shortcode_tags_with_hidden_urls[$shortcode_tag] = true;
+                }
+            }
+        }
+        foreach (array_keys($shortcode_tags_with_hidden_urls) as $shortcode_tag) {
             $shortcode_prefix = '[' . $shortcode_tag;
             for ($alignment = 0; $alignment < 3; $alignment++) {
                 $skip = $alignment === 0 ? 0 : 3 - $alignment;
@@ -115,7 +187,7 @@ class StructuredDataUrlRewriter
                     continue;
                 }
 
-                $this->encoded_shortcode_body_signals[] = base64_encode(
+                $this->encoded_shortcode_signals[] = base64_encode(
                     substr($shortcode_prefix, $skip, $signal_length)
                 );
             }
@@ -182,9 +254,15 @@ class StructuredDataUrlRewriter
         }
 
         // Quick-reject values without an HTML URL attribute, a literal source
-        // domain, or an encoding marker which may hide a source-domain byte.
-        // This avoids constructing the structured parsers for most values.
-        if (!$this->maybe_contains_rewritable_urls($value)) {
+        // domain, an encoding marker which may hide a source-domain byte, or a
+        // registered shortcode codec which may hide a complete URL. This avoids
+        // constructing the structured parsers for most values.
+        $block_markup_may_hide_shortcode_url = self::BLOCK_MARKUP === $content_type
+            && $this->value_might_contain_hidden_shortcode_url($value);
+        if (
+            !$block_markup_may_hide_shortcode_url
+            && !$this->maybe_contains_rewritable_urls($value)
+        ) {
             return $value;
         }
 
@@ -310,10 +388,24 @@ class StructuredDataUrlRewriter
                     continue;
                 }
 
-                $rewritten_attribute_value = $this->rewrite_urls(
-                    $attribute_value,
-                    self::PLAIN_TEXT
-                );
+                $attribute_name = $shortcodes->get_attribute_name();
+                $shortcode_tag_key = strtolower($shortcode_tag);
+                $attribute_name_key = $attribute_name !== null
+                    ? strtolower($attribute_name)
+                    : null;
+                if (
+                    $attribute_name_key !== null
+                    && isset($this->shortcode_attribute_rewriters[$shortcode_tag_key][$attribute_name_key])
+                ) {
+                    $rewritten_attribute_value = (
+                        $this->shortcode_attribute_rewriters[$shortcode_tag_key][$attribute_name_key]['rewrite']
+                    )($attribute_value);
+                } else {
+                    $rewritten_attribute_value = $this->rewrite_urls(
+                        $attribute_value,
+                        self::PLAIN_TEXT
+                    );
+                }
                 if ($rewritten_attribute_value !== $attribute_value) {
                     $shortcodes->set_attribute_value($rewritten_attribute_value);
                 }
@@ -323,7 +415,23 @@ class StructuredDataUrlRewriter
         return $shortcodes->get_updated_text();
     }
 
-    public function value_might_contain_known_shortcode_body(string $value): bool
+    public function value_might_contain_hidden_shortcode_url(string $value): bool
+    {
+        foreach ($this->shortcode_attribute_rewriters as $shortcode_tag => $attribute_rewriters) {
+            foreach ($attribute_rewriters as $attribute_rewriter) {
+                if (
+                    $attribute_rewriter['hides_url']
+                    && stripos($value, '[' . $shortcode_tag) !== false
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return $this->value_might_contain_known_shortcode_body($value);
+    }
+
+    private function value_might_contain_known_shortcode_body(string $value): bool
     {
         foreach (array_keys($this->shortcode_body_rewriters) as $shortcode_tag) {
             if (stripos($value, '[' . $shortcode_tag) !== false) {
@@ -342,9 +450,9 @@ class StructuredDataUrlRewriter
      * the prefix inside the decoded value. A match may be incidental, but a
      * real registered prefix cannot be rejected before Base64 decoding.
      */
-    public function encoded_text_might_contain_known_shortcode_body(string $encoded_text): bool
+    public function encoded_text_might_contain_hidden_shortcode_url(string $encoded_text): bool
     {
-        foreach ($this->encoded_shortcode_body_signals as $signal) {
+        foreach ($this->encoded_shortcode_signals as $signal) {
             if (strpos($encoded_text, $signal) !== false) {
                 return true;
             }
@@ -460,7 +568,7 @@ class StructuredDataUrlRewriter
             return $body;
         }
 
-        return ($this->shortcode_body_rewriters[$shortcode_tag])($body);
+        return ( $this->shortcode_body_rewriters[$shortcode_tag] )( $body );
     }
 
     /**
@@ -505,12 +613,13 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Rewrite either form of a WPBakery Raw HTML body.
+     * Rewrite either form of a WPBakery Raw HTML or Raw JS body.
      *
-     * Raw HTML stores Base64 HTML. Values saved by its editor control add URL
-     * encoding inside the Base64 layer. The rewritten body uses the same form.
+     * Both elements use textarea_raw_html, which stores Base64 content. Values
+     * saved by its editor control add URL encoding inside the Base64 layer. The
+     * rewritten body uses the same form.
      */
-    private function rewrite_wpbakery_raw_html_body(string $body): string
+    private function rewrite_wpbakery_raw_code_body(string $body): string
     {
         $decoded_body = base64_decode($body, true);
         if ($decoded_body === false || base64_encode($decoded_body) !== $body) {
@@ -534,6 +643,61 @@ class StructuredDataUrlRewriter
         }
 
         return base64_encode($rewritten_content);
+    }
+
+    /**
+     * Rewrite a WPBakery textarea_safe or exploded_textarea_safe attribute.
+     *
+     * These controls store `#E-8_`, followed by Base64-encoded, URL-encoded
+     * content. The rewritten value keeps that wrapper and encoding order.
+     */
+    private function rewrite_wpbakery_safe_attribute(string $value): string
+    {
+        $prefix = '#E-8_';
+        if (strncmp($value, $prefix, strlen($prefix)) !== 0) {
+            return $value;
+        }
+
+        $encoded_content = substr($value, strlen($prefix));
+        $decoded_content = base64_decode($encoded_content, true);
+        if ($decoded_content === false || base64_encode($decoded_content) !== $encoded_content) {
+            return $value;
+        }
+
+        $decoded_content = rawurldecode($decoded_content);
+        $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
+        if ($rewritten_content === $decoded_content) {
+            return $value;
+        }
+
+        return $prefix . base64_encode($this->encode_wpbakery_url_component($rewritten_content));
+    }
+
+    /**
+     * Rewrite the URL field in a WPBakery vc_link attribute.
+     *
+     * The control stores URL-encoded fields separated by pipes, for example
+     * `url:https%3A%2F%2Fexample.com|title:Read|target:%20_blank|`.
+     */
+    private function rewrite_wpbakery_link_attribute(string $value): string
+    {
+        $fields = explode('|', $value);
+        foreach ($fields as $index => $field) {
+            if (strncmp($field, 'url:', 4) !== 0) {
+                continue;
+            }
+
+            $encoded_url = substr($field, 4);
+            $decoded_url = rawurldecode($encoded_url);
+            $rewritten_url = $this->rewrite_urls($decoded_url, self::PLAIN_TEXT);
+            if ($rewritten_url === $decoded_url) {
+                continue;
+            }
+
+            $fields[$index] = 'url:' . $this->encode_wpbakery_url_component($rewritten_url);
+        }
+
+        return implode('|', $fields);
     }
 
     private function encode_wpbakery_url_component(string $value): string
@@ -782,15 +946,18 @@ class StructuredDataUrlRewriter
                 );
                 while ( $p->next_token() ) {
                     $parsed_nested_block_attributes = false;
-                    $block_comment_may_contain_source_domain = false;
+                    $block_comment_may_hide_rewritable_url = false;
                     $block_comment_text = '';
                     if ( '#block-comment' === $p->get_token_type() ) {
                         $block_comment_text = $p->get_modifiable_text();
-                        $block_comment_may_contain_source_domain = $this->value_might_contain_source_domain( $block_comment_text );
+                        $block_comment_may_hide_rewritable_url =
+                            $this->value_might_contain_source_domain( $block_comment_text )
+                            || $this->value_might_contain_hidden_shortcode_url( $block_comment_text );
                     }
-                    if ( $block_comment_may_contain_source_domain ) {
-                        // The fast check includes supported encoding markers;
-                        // the parsed string leaves decide whether a URL exists.
+                    if ( $block_comment_may_hide_rewritable_url ) {
+                        // The fast check includes supported encoding markers
+                        // and registered shortcode signals. Parsed string
+                        // leaves still decide whether a URL exists.
                         $block_attributes = $p->get_block_attributes();
                         // A Unicode-escaped quote leaves an alphanumeric byte
                         // immediately before a raw URL. The cautious scanner
@@ -939,17 +1106,21 @@ class StructuredDataUrlRewriter
      * in HTML, CSS, JSON, shortcodes, and plain text. Parsing those values
      * again only changes their encoding and makes Divi imports slower.
      *
-     * Parsing is still needed when an escape or character reference may hide
-     * part of the host, or when serialized PHP length fields must be updated.
-     * A JSON value may contain serialized PHP at a deeper level, so its raw
-     * text is also checked for a serialization token. Non-ASCII values keep
-     * the structured path because the cautious raw-token pass supports ASCII
-     * and punycode domains, but not literal Unicode domains.
+     * Parsing is still needed when an escape, character reference, or registered
+     * shortcode codec may hide part or all of the URL, or when serialized PHP
+     * length fields must be updated. A JSON value may contain serialized PHP at
+     * a deeper level, so its raw text is also checked for a serialization token.
+     * Non-ASCII values keep the structured path because the cautious raw-token
+     * pass supports ASCII and punycode domains, but not literal Unicode domains.
      *
      * These are coarse signals, not proof of a content type. The format
      * hierarchy below still validates PHP serialization and JSON before use.
      */
     private function nested_block_string_needs_format_inference( string $value ): bool {
+        if ( $this->value_might_contain_hidden_shortcode_url( $value ) ) {
+            return true;
+        }
+
         if ( ! $this->maybe_contains_rewritable_urls( $value ) ) {
             return false;
         }
@@ -999,7 +1170,15 @@ class StructuredDataUrlRewriter
             return $this->rewrite_urls( $value, self::BLOCK_MARKUP, false );
         }
 
-        // 3. The coarse existing JSON gate checks only whether the first
+        // 3. A shortcode and a JSON array can both begin with `[`. Keep a
+        // valid JSON array for the JSON parser unless shortcode rewriting
+        // actually changes it.
+        $rewritten_shortcode_markup = $this->rewrite_shortcode_markup( $value );
+        if ( $rewritten_shortcode_markup !== $value ) {
+            return $this->rewrite( $rewritten_shortcode_markup, self::PLAIN_TEXT );
+        }
+
+        // 4. The coarse existing JSON gate checks only whether the first
         // non-whitespace byte is `{`, `[`, or `"`. JsonStringIterator then
         // validates the complete value before rewriting nested strings.
         $could_be_json_with_strings = $this->could_be_json_with_strings( $value );
@@ -1007,14 +1186,14 @@ class StructuredDataUrlRewriter
             return $this->rewrite( $value, self::PLAIN_TEXT );
         }
 
-        // 4. `url(` can occur in prose or code which is not CSS. Keep this
+        // 5. `url(` can occur in prose or code which is not CSS. Keep this
         // broad, naive hint after the complete PHP, HTML, and JSON shapes.
         $contains_css_url_function = false !== stripos( $value, 'url(' );
         if ( $contains_css_url_function ) {
             return $this->rewrite_urls( $value, self::BLOCK_MARKUP, false );
         }
 
-        // 5. Unknown strings receive only the cautious plain-text scan.
+        // 6. Unknown strings receive the cautious plain-text scan.
         return $this->rewrite( $value, self::PLAIN_TEXT );
     }
 

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -79,8 +79,8 @@ class StructuredDataUrlRewriter
     /** @var array<string, array<string, array{rewrite: callable(string): string, hides_url: bool}>> */
     private array $shortcode_attribute_rewriters;
 
-    /** Base64 fragments which signal a shortcode codec that may hide URLs. */
-    private string $encoded_shortcode_signal_pattern;
+    /** @var array<string, true> Shortcode tags whose registered codecs may hide URLs. */
+    private array $shortcode_tags_with_hidden_urls;
 
     /**
      * Rewrites keyed by an entire value; hits only on an exact repeat.
@@ -113,36 +113,17 @@ class StructuredDataUrlRewriter
         );
         $this->shortcode_body_rewriters = $wpbakery_url_rewriter->get_shortcode_body_rewriters();
         $this->shortcode_attribute_rewriters = $wpbakery_url_rewriter->get_shortcode_attribute_rewriters();
-        $encoded_shortcode_signals = array();
-        $shortcode_tags_with_hidden_urls = array_fill_keys(
+        $this->shortcode_tags_with_hidden_urls = array_fill_keys(
             array_keys($this->shortcode_body_rewriters),
             true
         );
         foreach ($this->shortcode_attribute_rewriters as $shortcode_tag => $attribute_rewriters) {
             foreach ($attribute_rewriters as $attribute_rewriter) {
                 if ($attribute_rewriter['hides_url']) {
-                    $shortcode_tags_with_hidden_urls[$shortcode_tag] = true;
+                    $this->shortcode_tags_with_hidden_urls[$shortcode_tag] = true;
                 }
             }
         }
-        foreach (array_keys($shortcode_tags_with_hidden_urls) as $shortcode_tag) {
-            $shortcode_prefix = '[' . $shortcode_tag;
-            for ($alignment = 0; $alignment < 3; $alignment++) {
-                $skip = $alignment === 0 ? 0 : 3 - $alignment;
-                $signal_length = strlen($shortcode_prefix) - $skip;
-                $signal_length -= $signal_length % 3;
-                if ($signal_length < 3) {
-                    continue;
-                }
-
-                $encoded_shortcode_signals[] = base64_encode(
-                    substr($shortcode_prefix, $skip, $signal_length)
-                );
-            }
-        }
-        $this->encoded_shortcode_signal_pattern = '~(?:'
-            . implode('|', array_map('preg_quote', $encoded_shortcode_signals))
-            . ')~';
 
         // Extract unique source domains for the quick-reject check.
         $domains = [];
@@ -372,18 +353,28 @@ class StructuredDataUrlRewriter
             return false;
         }
 
-        foreach ($this->shortcode_attribute_rewriters as $shortcode_tag => $attribute_rewriters) {
-            foreach ($attribute_rewriters as $attribute_rewriter) {
-                if (
-                    $attribute_rewriter['hides_url']
-                    && stripos($value, '[' . $shortcode_tag) !== false
-                ) {
-                    return true;
-                }
+        foreach ($this->shortcode_tags_with_hidden_urls as $shortcode_tag => $unused) {
+            if (stripos($value, '[' . $shortcode_tag) !== false) {
+                return true;
             }
         }
 
-        return $this->value_might_contain_known_shortcode_body($value);
+        return false;
+    }
+
+    /**
+     * Return decoded shortcode prefixes whose registered codecs may hide URLs.
+     *
+     * @return list<string>
+     */
+    public function get_shortcode_prefixes_that_may_hide_urls(): array
+    {
+        $prefixes = array();
+        foreach ($this->shortcode_tags_with_hidden_urls as $shortcode_tag => $unused) {
+            $prefixes[] = '[' . $shortcode_tag;
+        }
+
+        return $prefixes;
     }
 
     private function value_might_contain_known_shortcode_body(string $value): bool
@@ -395,19 +386,6 @@ class StructuredDataUrlRewriter
         }
 
         return false;
-    }
-
-    /**
-     * Return whether Base64 text may decode to a registered shortcode body.
-     *
-     * Each signal contains only complete three-byte groups from the shortcode
-     * prefix. This makes one signal stable for each possible byte alignment of
-     * the prefix inside the decoded value. A match may be incidental, but a
-     * real registered prefix cannot be rejected before Base64 decoding.
-     */
-    public function encoded_text_might_contain_hidden_shortcode_url(string $encoded_text): bool
-    {
-        return preg_match($this->encoded_shortcode_signal_pattern, $encoded_text) === 1;
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -76,6 +76,9 @@ class StructuredDataUrlRewriter
     /** @var array<string, callable(string): string> Shortcode tag => encoded-body rewriter. */
     private array $shortcode_body_rewriters;
 
+    /** @var string[] Base64 fragments that signal a registered shortcode body. */
+    private array $encoded_shortcode_body_signals;
+
     /**
      * Rewrites keyed by an entire value; hits only on an exact repeat.
      *
@@ -101,6 +104,22 @@ class StructuredDataUrlRewriter
             'vc_table'    => array($this, 'rewrite_wpbakery_table_body'),
             'vc_raw_html' => array($this, 'rewrite_wpbakery_raw_html_body'),
         );
+        $this->encoded_shortcode_body_signals = array();
+        foreach (array_keys($this->shortcode_body_rewriters) as $shortcode_tag) {
+            $shortcode_prefix = '[' . $shortcode_tag;
+            for ($alignment = 0; $alignment < 3; $alignment++) {
+                $skip = $alignment === 0 ? 0 : 3 - $alignment;
+                $signal_length = strlen($shortcode_prefix) - $skip;
+                $signal_length -= $signal_length % 3;
+                if ($signal_length < 3) {
+                    continue;
+                }
+
+                $this->encoded_shortcode_body_signals[] = base64_encode(
+                    substr($shortcode_prefix, $skip, $signal_length)
+                );
+            }
+        }
 
         // Extract unique source domains for the quick-reject check.
         $domains = [];
@@ -246,7 +265,7 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        $known_body_tokens = $this->maybe_contains_known_shortcode_body($value)
+        $known_body_tokens = $this->value_might_contain_known_shortcode_body($value)
             ? $this->find_known_shortcode_body_tokens($value)
             : array();
         $shortcodes = new ShortcodeProcessor($value);
@@ -304,10 +323,29 @@ class StructuredDataUrlRewriter
         return $shortcodes->get_updated_text();
     }
 
-    private function maybe_contains_known_shortcode_body(string $value): bool
+    public function value_might_contain_known_shortcode_body(string $value): bool
     {
         foreach (array_keys($this->shortcode_body_rewriters) as $shortcode_tag) {
             if (stripos($value, '[' . $shortcode_tag) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return whether Base64 text may decode to a registered shortcode body.
+     *
+     * Each signal contains only complete three-byte groups from the shortcode
+     * prefix. This makes one signal stable for each possible byte alignment of
+     * the prefix inside the decoded value. A match may be incidental, but a
+     * real registered prefix cannot be rejected before Base64 decoding.
+     */
+    public function encoded_text_might_contain_known_shortcode_body(string $encoded_text): bool
+    {
+        foreach ($this->encoded_shortcode_body_signals as $signal) {
+            if (strpos($encoded_text, $signal) !== false) {
                 return true;
             }
         }

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -979,6 +979,34 @@ class StructuredDataUrlRewriter
                         }
                     }
 
+                    // A JSON media type makes the script body safe to parse as
+                    // JSON. Other script bodies keep the cautious byte scan.
+                    if (
+                        '#tag' === $p->get_token_type()
+                        && ! $p->is_tag_closer()
+                        && 'SCRIPT' === $p->get_tag()
+                    ) {
+                        $script_type = $p->get_attribute('type');
+                        if (is_string($script_type)) {
+                            $script_media_type = strtolower(trim(explode(';', $script_type, 2)[0]));
+                            if (
+                                preg_match(
+                                    '/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
+                                    $script_media_type
+                                ) === 1
+                            ) {
+                                $script_body = $p->get_modifiable_text();
+                                $rewritten_script_body = $this->rewrite(
+                                    $script_body,
+                                    self::BLOCK_MARKUP
+                                );
+                                if ($rewritten_script_body !== $script_body) {
+                                    $p->set_modifiable_text($rewritten_script_body);
+                                }
+                            }
+                        }
+                    }
+
                     $token_type = $p->get_token_type() ?? '';
                     while ( $p->next_url_in_current_token() ) {
                         $raw_url = $p->get_raw_url();

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -1,6 +1,7 @@
 <?php
 
 use WordPress\DataLiberation\URL\WPURL;
+use WordPress\DataLiberation\Shortcode\ShortcodeProcessor;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
 /**
@@ -17,7 +18,9 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → StructuredBlockMarkupUrlProcessor (block_markup hint)
+ * 4. Shortcode markup → ShortcodeProcessor (block_markup hint), including
+ *    builder-specific body codecs selected by shortcode tag
+ * 5. Leaf text → StructuredBlockMarkupUrlProcessor (block_markup hint)
  *    or CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules (default)
  *
  * Top-level HTML is never auto-detected — the caller must explicitly pass
@@ -70,6 +73,9 @@ class StructuredDataUrlRewriter
     /** @var string Cache namespace for this rewriter's URL mapping. */
     private string $mapping_cache_key;
 
+    /** @var array<string, callable(string): string> Shortcode tag => encoded-body rewriter. */
+    private array $shortcode_body_rewriters;
+
     /**
      * Rewrites keyed by an entire value; hits only on an exact repeat.
      *
@@ -91,6 +97,10 @@ class StructuredDataUrlRewriter
     public function __construct(array $url_mapping)
     {
         $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping);
+        $this->shortcode_body_rewriters = array(
+            'vc_table'    => array($this, 'rewrite_wpbakery_table_body'),
+            'vc_raw_html' => array($this, 'rewrite_wpbakery_raw_html_body'),
+        );
 
         // Extract unique source domains for the quick-reject check.
         $domains = [];
@@ -210,7 +220,7 @@ class StructuredDataUrlRewriter
 
         $original_value = $value;
         if ($content_type === self::BLOCK_MARKUP) {
-            $value = $this->rewrite_wpbakery_encoded_shortcode_bodies($value);
+            $value = $this->rewrite_shortcode_markup($value);
         }
 
         $rewritten_value = $this->rewrite_urls($value, $content_type);
@@ -222,39 +232,206 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Rewrite the encoded bodies whose codecs are fixed by WPBakery.
+     * Rewrite shortcode attributes and bodies without parsing their bytes as HTML.
      *
-     * Easy Tables URL-encodes each cell while leaving `,` and `|` as table
-     * delimiters. Raw HTML stores either Base64 HTML or, for values saved by
-     * its editor control, Base64 URL-encoded HTML. Unknown shortcode bodies
-     * remain opaque.
+     * Attribute values receive the generic cautious URL-base replacement. Body
+     * decoding is selected separately from the shortcode tag, so an unknown
+     * builder's body remains opaque until its storage format is known.
+     * Rewriting attributes before HTML tokenization also keeps literal HTML in
+     * an attribute from being serialized as tags with different quote bytes.
      */
-    private function rewrite_wpbakery_encoded_shortcode_bodies(string $value): string
+    private function rewrite_shortcode_markup(string $value): string
     {
-        $opening_tag_tail = '(?:[^\]"\']+|"[^"]*"|\'[^\']*\')*\]';
-        foreach (array('vc_table', 'vc_raw_html') as $shortcode_name) {
-            $pattern = '~(?<!\[)(?<opener>\[' . $shortcode_name . '(?=[\s/\]])'
-                . $opening_tag_tail
-                . ')(?<body>.*?)(?<closer>\[/' . $shortcode_name . '\])(?!\])~s';
-            $rewritten_value = preg_replace_callback(
-                $pattern,
-                function (array $shortcode_match) use ($shortcode_name): string {
-                    $rewritten_body = $shortcode_name === 'vc_table'
-                        ? $this->rewrite_wpbakery_table_body($shortcode_match['body'])
-                        : $this->rewrite_wpbakery_raw_html_body($shortcode_match['body']);
+        if (strpos($value, '[') === false) {
+            return $value;
+        }
 
-                    return $shortcode_match['opener'] . $rewritten_body . $shortcode_match['closer'];
-                },
-                $value
-            );
-            if ($rewritten_value !== null) {
-                $value = $rewritten_value;
+        $known_body_tokens = $this->maybe_contains_known_shortcode_body($value)
+            ? $this->find_known_shortcode_body_tokens($value)
+            : array();
+        $shortcodes = new ShortcodeProcessor($value);
+
+        while ($shortcodes->next_token()) {
+            if ($shortcodes->get_token_type() === ShortcodeProcessor::TOKEN_TEXT) {
+                $token_start = $shortcodes->get_token_start();
+                if ($token_start === null || !isset($known_body_tokens[$token_start])) {
+                    continue;
+                }
+
+                $body = $shortcodes->get_modifiable_text();
+                if ($body === null) {
+                    continue;
+                }
+                $rewritten_body = $this->rewrite_known_shortcode_body(
+                    $known_body_tokens[$token_start],
+                    $body
+                );
+                if ($rewritten_body !== $body) {
+                    $shortcodes->set_modifiable_text($rewritten_body);
+                }
+                continue;
+            }
+
+            if ($shortcodes->is_escaped()) {
+                continue;
+            }
+
+            $shortcode_tag = $shortcodes->get_tag();
+            if ($shortcode_tag === null) {
+                continue;
+            }
+
+            if ($shortcodes->is_tag_closer()) {
+                continue;
+            }
+
+            while ($shortcodes->next_attribute()) {
+                $attribute_value = $shortcodes->get_attribute_value();
+                if ($attribute_value === null) {
+                    continue;
+                }
+
+                $rewritten_attribute_value = $this->rewrite_urls(
+                    $attribute_value,
+                    self::PLAIN_TEXT
+                );
+                if ($rewritten_attribute_value !== $attribute_value) {
+                    $shortcodes->set_attribute_value($rewritten_attribute_value);
+                }
             }
         }
 
-        return $value;
+        return $shortcodes->get_updated_text();
     }
 
+    private function maybe_contains_known_shortcode_body(string $value): bool
+    {
+        foreach (array_keys($this->shortcode_body_rewriters) as $shortcode_tag) {
+            if (stripos($value, '[' . $shortcode_tag) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find single text tokens enclosed by a matched known shortcode pair.
+     *
+     * A known encoded body containing nested shortcode tokens stays opaque.
+     * This keeps the body codec from receiving only part of its stored value.
+     *
+     * @return array<int, string> Text token byte offset => enclosing tag.
+     */
+    private function find_known_shortcode_body_tokens(string $value): array
+    {
+        $shortcodes = new ShortcodeProcessor($value);
+        $open_shortcodes = array();
+        $known_body_tokens = array();
+
+        while ($shortcodes->next_token()) {
+            if ($shortcodes->get_token_type() === ShortcodeProcessor::TOKEN_TEXT) {
+                if ($open_shortcodes === array()) {
+                    continue;
+                }
+
+                $index = count($open_shortcodes) - 1;
+                if (!$open_shortcodes[$index]['has_known_body_codec']) {
+                    continue;
+                }
+                if ($open_shortcodes[$index]['body_token_start'] !== null) {
+                    $open_shortcodes[$index]['body_is_complete'] = false;
+                    continue;
+                }
+
+                $open_shortcodes[$index]['body_token_start'] = $shortcodes->get_token_start();
+                continue;
+            }
+
+            if ($shortcodes->is_escaped()) {
+                if ($open_shortcodes !== array()) {
+                    $open_shortcodes[count($open_shortcodes) - 1]['body_is_complete'] = false;
+                }
+                continue;
+            }
+
+            $shortcode_tag = $shortcodes->get_tag();
+            if ($shortcode_tag === null) {
+                continue;
+            }
+
+            if ($shortcodes->is_tag_closer()) {
+                $matching_index = null;
+                for ($index = count($open_shortcodes) - 1; $index >= 0; $index--) {
+                    if ($open_shortcodes[$index]['tag'] !== $shortcode_tag) {
+                        continue;
+                    }
+
+                    $matching_index = $index;
+                    break;
+                }
+                if ($matching_index === null) {
+                    if ($open_shortcodes !== array()) {
+                        $open_shortcodes[count($open_shortcodes) - 1]['body_is_complete'] = false;
+                    }
+                    continue;
+                }
+
+                $closed_shortcode = $open_shortcodes[$matching_index];
+                array_splice($open_shortcodes, $matching_index);
+                if (
+                    $closed_shortcode['has_known_body_codec']
+                    && $closed_shortcode['body_is_complete']
+                    && $closed_shortcode['body_token_start'] !== null
+                ) {
+                    $known_body_tokens[$closed_shortcode['body_token_start']] = $shortcode_tag;
+                }
+                continue;
+            }
+
+            if ($open_shortcodes !== array()) {
+                $open_shortcodes[count($open_shortcodes) - 1]['body_is_complete'] = false;
+            }
+            if ($shortcodes->has_self_closing_flag()) {
+                continue;
+            }
+
+            $open_shortcodes[] = array(
+                'tag'                  => $shortcode_tag,
+                'has_known_body_codec' => $this->has_known_shortcode_body_codec($shortcode_tag),
+                'body_token_start'     => null,
+                'body_is_complete'     => true,
+            );
+        }
+
+        return $known_body_tokens;
+    }
+
+    private function has_known_shortcode_body_codec(string $shortcode_tag): bool
+    {
+        return isset($this->shortcode_body_rewriters[strtolower($shortcode_tag)]);
+    }
+
+    /**
+     * Rewrite a body only when its site builder defines the body's codec.
+     */
+    private function rewrite_known_shortcode_body(string $shortcode_tag, string $body): string
+    {
+        $shortcode_tag = strtolower($shortcode_tag);
+        if (!isset($this->shortcode_body_rewriters[$shortcode_tag])) {
+            return $body;
+        }
+
+        return ($this->shortcode_body_rewriters[$shortcode_tag])($body);
+    }
+
+    /**
+     * Rewrite WPBakery Easy Tables cells without changing table delimiters.
+     *
+     * Easy Tables URL-encodes each cell while leaving `,` and `|` as table
+     * delimiters. Optional leading cell-style markers stay outside the encoded
+     * value and must be copied unchanged.
+     */
     private function rewrite_wpbakery_table_body(string $body): string
     {
         $parts = preg_split('/([,|])/', $body, -1, PREG_SPLIT_DELIM_CAPTURE);
@@ -289,6 +466,12 @@ class StructuredDataUrlRewriter
         return implode('', $parts);
     }
 
+    /**
+     * Rewrite either form of a WPBakery Raw HTML body.
+     *
+     * Raw HTML stores Base64 HTML. Values saved by its editor control add URL
+     * encoding inside the Base64 layer. The rewritten body uses the same form.
+     */
     private function rewrite_wpbakery_raw_html_body(string $body): string
     {
         $decoded_body = base64_decode($body, true);
@@ -555,11 +738,6 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
-                $wpbakery_shortcode_openers = array();
-                $content = $this->mask_wpbakery_shortcode_openers(
-                    $content,
-                    $wpbakery_shortcode_openers
-                );
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
                     $resolve_relative_urls ? $base_url : null
@@ -647,7 +825,7 @@ class StructuredDataUrlRewriter
                     }
                 }
 
-                return strtr($p->get_updated_html(), $wpbakery_shortcode_openers);
+                return $p->get_updated_html();
 
             case self::PLAIN_TEXT:
                 if ( ! $this->maybe_contains_rewritable_urls( $content ) ) {
@@ -669,7 +847,6 @@ class StructuredDataUrlRewriter
                 return $content;
         }
     }
-
     /**
      * Rewrite every string in a block attribute array.
      *
@@ -802,41 +979,6 @@ class StructuredDataUrlRewriter
         // 5. Unknown strings receive only the cautious plain-text scan.
         return $this->rewrite( $value, self::PLAIN_TEXT );
     }
-
-    /**
-     * Hide WPBakery opening tags which contain literal HTML from the HTML
-     * tokenizer. Their URL bases are rewritten first while the original quote
-     * spelling is still available.
-     *
-     * @param array<string, string> $shortcode_openers Placeholder => opening tag.
-     */
-    private function mask_wpbakery_shortcode_openers(
-        string $content,
-        array &$shortcode_openers
-    ): string {
-        $placeholder_prefix = '__REPRINT_WPBAKERY_' . sha1($content) . '_';
-        while (strpos($content, $placeholder_prefix) !== false) {
-            $placeholder_prefix .= '_';
-        }
-        $pattern = '~(?<!\[)\[vc_[A-Za-z0-9_-]+(?=[\s/\]])'
-            . '(?:[^\]"\']+|"[^"]*"|\'[^\']*\')*\]~s';
-        $masked_content = preg_replace_callback(
-            $pattern,
-            function (array $shortcode_match) use (&$shortcode_openers, $placeholder_prefix): string {
-                $opener = $shortcode_match[0];
-                if (strpos($opener, '<') === false) {
-                    return $opener;
-                }
-
-                $placeholder = $placeholder_prefix . count($shortcode_openers) . '__';
-                $shortcode_openers[$placeholder] = $this->rewrite($opener, self::PLAIN_TEXT);
-                return $placeholder;
-            },
-            $content
-        );
-
-         return $masked_content ?? $content;
-     }
 
     /**
      * Store one entry, then evict oldest until the cache is within budget.

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -208,12 +208,120 @@ class StructuredDataUrlRewriter
         // Base64ValueScanner in SqlStatementRewriter — this block
         // was for base64-within-base64 nesting which is rare in practice.
 
+        $original_value = $value;
+        if ($content_type === self::BLOCK_MARKUP) {
+            $value = $this->rewrite_wpbakery_encoded_shortcode_bodies($value);
+        }
+
         $rewritten_value = $this->rewrite_urls($value, $content_type);
         if ($cache_key !== null) {
-            $this->set_cached_value_rewrite($cache_key, $content_type, $value, $rewritten_value);
+            $this->set_cached_value_rewrite($cache_key, $content_type, $original_value, $rewritten_value);
         }
 
         return $rewritten_value;
+    }
+
+    /**
+     * Rewrite the encoded bodies whose codecs are fixed by WPBakery.
+     *
+     * Easy Tables URL-encodes each cell while leaving `,` and `|` as table
+     * delimiters. Raw HTML stores either Base64 HTML or, for values saved by
+     * its editor control, Base64 URL-encoded HTML. Unknown shortcode bodies
+     * remain opaque.
+     */
+    private function rewrite_wpbakery_encoded_shortcode_bodies(string $value): string
+    {
+        $opening_tag_tail = '(?:[^\]"\']+|"[^"]*"|\'[^\']*\')*\]';
+        foreach (array('vc_table', 'vc_raw_html') as $shortcode_name) {
+            $pattern = '~(?<!\[)(?<opener>\[' . $shortcode_name . '(?=[\s/\]])'
+                . $opening_tag_tail
+                . ')(?<body>.*?)(?<closer>\[/' . $shortcode_name . '\])(?!\])~s';
+            $rewritten_value = preg_replace_callback(
+                $pattern,
+                function (array $shortcode_match) use ($shortcode_name): string {
+                    $rewritten_body = $shortcode_name === 'vc_table'
+                        ? $this->rewrite_wpbakery_table_body($shortcode_match['body'])
+                        : $this->rewrite_wpbakery_raw_html_body($shortcode_match['body']);
+
+                    return $shortcode_match['opener'] . $rewritten_body . $shortcode_match['closer'];
+                },
+                $value
+            );
+            if ($rewritten_value !== null) {
+                $value = $rewritten_value;
+            }
+        }
+
+        return $value;
+    }
+
+    private function rewrite_wpbakery_table_body(string $body): string
+    {
+        $parts = preg_split('/([,|])/', $body, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if ($parts === false) {
+            return $body;
+        }
+
+        foreach ($parts as $index => $cell) {
+            if ($cell === ',' || $cell === '|') {
+                continue;
+            }
+
+            $prefix_length = 0;
+            if (preg_match('/\A(?:\[[^\]\r\n]*\])*/', $cell, $matches) === 1) {
+                $prefix_length = strlen($matches[0]);
+            }
+            $encoded_content = substr($cell, $prefix_length);
+            if (preg_match('/%[0-9A-Fa-f]{2}/', $encoded_content) !== 1) {
+                continue;
+            }
+
+            $decoded_content = rawurldecode($encoded_content);
+            $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
+            if ($rewritten_content === $decoded_content) {
+                continue;
+            }
+
+            $parts[$index] = substr($cell, 0, $prefix_length)
+                . $this->encode_wpbakery_url_component($rewritten_content);
+        }
+
+        return implode('', $parts);
+    }
+
+    private function rewrite_wpbakery_raw_html_body(string $body): string
+    {
+        $decoded_body = base64_decode($body, true);
+        if ($decoded_body === false || base64_encode($decoded_body) !== $body) {
+            return $body;
+        }
+
+        $uses_url_encoding = preg_match(
+            '/%(?:3c|3e|5b|5d)|https?%3a%2f%2f/i',
+            $decoded_body
+        ) === 1;
+        $decoded_content = $uses_url_encoding
+            ? rawurldecode($decoded_body)
+            : $decoded_body;
+        $rewritten_content = $this->rewrite($decoded_content, self::BLOCK_MARKUP);
+        if ($rewritten_content === $decoded_content) {
+            return $body;
+        }
+
+        if ($uses_url_encoding) {
+            $rewritten_content = $this->encode_wpbakery_url_component($rewritten_content);
+        }
+
+        return base64_encode($rewritten_content);
+    }
+
+    private function encode_wpbakery_url_component(string $value): string
+    {
+        return str_replace(
+            array('%21', '%27', '%28', '%29', '%2A'),
+            array('!', "'", '(', ')', '*'),
+            rawurlencode($value)
+        );
     }
 
     /**
@@ -447,6 +555,11 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                $wpbakery_shortcode_openers = array();
+                $content = $this->mask_wpbakery_shortcode_openers(
+                    $content,
+                    $wpbakery_shortcode_openers
+                );
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
                     $resolve_relative_urls ? $base_url : null
@@ -534,7 +647,7 @@ class StructuredDataUrlRewriter
                     }
                 }
 
-                return $p->get_updated_html();
+                return strtr($p->get_updated_html(), $wpbakery_shortcode_openers);
 
             case self::PLAIN_TEXT:
                 if ( ! $this->maybe_contains_rewritable_urls( $content ) ) {
@@ -689,6 +802,41 @@ class StructuredDataUrlRewriter
         // 5. Unknown strings receive only the cautious plain-text scan.
         return $this->rewrite( $value, self::PLAIN_TEXT );
     }
+
+    /**
+     * Hide WPBakery opening tags which contain literal HTML from the HTML
+     * tokenizer. Their URL bases are rewritten first while the original quote
+     * spelling is still available.
+     *
+     * @param array<string, string> $shortcode_openers Placeholder => opening tag.
+     */
+    private function mask_wpbakery_shortcode_openers(
+        string $content,
+        array &$shortcode_openers
+    ): string {
+        $placeholder_prefix = '__REPRINT_WPBAKERY_' . sha1($content) . '_';
+        while (strpos($content, $placeholder_prefix) !== false) {
+            $placeholder_prefix .= '_';
+        }
+        $pattern = '~(?<!\[)\[vc_[A-Za-z0-9_-]+(?=[\s/\]])'
+            . '(?:[^\]"\']+|"[^"]*"|\'[^\']*\')*\]~s';
+        $masked_content = preg_replace_callback(
+            $pattern,
+            function (array $shortcode_match) use (&$shortcode_openers, $placeholder_prefix): string {
+                $opener = $shortcode_match[0];
+                if (strpos($opener, '<') === false) {
+                    return $opener;
+                }
+
+                $placeholder = $placeholder_prefix . count($shortcode_openers) . '__';
+                $shortcode_openers[$placeholder] = $this->rewrite($opener, self::PLAIN_TEXT);
+                return $placeholder;
+            },
+            $content
+        );
+
+         return $masked_content ?? $content;
+     }
 
     /**
      * Store one entry, then evict oldest until the cache is within budget.

--- a/packages/reprint-client/src/lib/url-rewrite/class-wpbakery-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-wpbakery-url-rewriter.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Supplies WPBakery shortcode codecs to the generic structured URL rewriter.
+ *
+ * WPBakery controls store their values in several private formats. This class
+ * contains those format rules. Shortcode traversal, parser order, and recursive
+ * format detection remain in StructuredDataUrlRewriter.
+ */
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- URL rewriter classes use unprefixed domain names.
+class WPBakeryUrlRewriter {
+	/** @var Closure(string): string */
+	private Closure $rewrite_block_markup;
+
+	/** @var Closure(string): string */
+	private Closure $rewrite_plain_text;
+
+	/**
+	 * @param callable(string): string $rewrite_block_markup Rewrite decoded HTML and block markup.
+	 * @param callable(string): string $rewrite_plain_text   Rewrite one decoded plain-text value.
+	 */
+	public function __construct( callable $rewrite_block_markup, callable $rewrite_plain_text ) {
+		$this->rewrite_block_markup = Closure::fromCallable( $rewrite_block_markup );
+		$this->rewrite_plain_text   = Closure::fromCallable( $rewrite_plain_text );
+	}
+
+	/**
+	 * Return body codecs keyed by shortcode tag.
+	 *
+	 * @return array<string, Closure(string): string>
+	 */
+	public function get_shortcode_body_rewriters(): array {
+		return array(
+			'vc_table'    => function ( string $body ): string {
+				return $this->rewrite_table_body( $body );
+			},
+			'vc_raw_html' => function ( string $body ): string {
+				return $this->rewrite_raw_code_body( $body );
+			},
+			'vc_raw_js'   => function ( string $body ): string {
+				return $this->rewrite_raw_code_body( $body );
+			},
+		);
+	}
+
+	/**
+	 * Return attribute codecs keyed by shortcode tag and attribute name.
+	 *
+	 * @return array<string, array<string, array{rewrite: Closure(string): string, hides_url: bool}>>
+	 */
+	public function get_shortcode_attribute_rewriters(): array {
+		$link_attribute_rewriter = array(
+			'rewrite'   => function ( string $value ): string {
+				return $this->rewrite_link_attribute( $value );
+			},
+			'hides_url' => false,
+		);
+		$safe_attribute_rewriter = array(
+			'rewrite'   => function ( string $value ): string {
+				return $this->rewrite_safe_attribute( $value );
+			},
+			'hides_url' => true,
+		);
+
+		return array(
+			'vc_btn'             => array(
+				'link' => $link_attribute_rewriter,
+				'url'  => $link_attribute_rewriter,
+			),
+			'vc_button2'         => array(
+				'link' => $link_attribute_rewriter,
+				'url'  => $link_attribute_rewriter,
+			),
+			'vc_cta_button2'     => array(
+				'link' => $link_attribute_rewriter,
+			),
+			'vc_custom_heading'  => array(
+				'link' => $link_attribute_rewriter,
+				'url'  => $link_attribute_rewriter,
+			),
+			'vc_gallery'         => array(
+				'custom_links' => $safe_attribute_rewriter,
+				'custom_srcs'  => $safe_attribute_rewriter,
+			),
+			'vc_gmaps'           => array(
+				'link' => $safe_attribute_rewriter,
+			),
+			'vc_gitem_image'     => array(
+				'url' => $link_attribute_rewriter,
+			),
+			'vc_gitem_zone'      => array(
+				'url' => $link_attribute_rewriter,
+			),
+			'vc_gitem_zone_a'    => array(
+				'url' => $link_attribute_rewriter,
+			),
+			'vc_gitem_zone_b'    => array(
+				'url' => $link_attribute_rewriter,
+			),
+			'vc_icon'            => array(
+				'link' => $link_attribute_rewriter,
+				'url'  => $link_attribute_rewriter,
+			),
+			'vc_images_carousel' => array(
+				'custom_links' => $safe_attribute_rewriter,
+			),
+			'vc_posts_slider'    => array(
+				'custom_links' => $safe_attribute_rewriter,
+			),
+			'vc_single_image'    => array(
+				'url' => $link_attribute_rewriter,
+			),
+		);
+	}
+
+	/**
+	 * Rewrite WPBakery Easy Tables cells without changing table delimiters.
+	 *
+	 * Easy Tables URL-encodes each cell while leaving `,` and `|` as table
+	 * delimiters. Optional leading cell-style markers stay outside the encoded
+	 * value and must be copied unchanged.
+	 */
+	private function rewrite_table_body( string $body ): string {
+		$parts = preg_split( '/([,|])/', $body, -1, PREG_SPLIT_DELIM_CAPTURE );
+		if ( false === $parts ) {
+			return $body;
+		}
+
+		foreach ( $parts as $index => $cell ) {
+			if ( ',' === $cell || '|' === $cell ) {
+				continue;
+			}
+
+			$prefix_length = 0;
+			if ( 1 === preg_match( '/\A(?:\[[^\]\r\n]*\])*/', $cell, $matches ) ) {
+				$prefix_length = strlen( $matches[0] );
+			}
+			$encoded_content = substr( $cell, $prefix_length );
+			if ( 1 !== preg_match( '/%[0-9A-Fa-f]{2}/', $encoded_content ) ) {
+				continue;
+			}
+
+			$decoded_content   = rawurldecode( $encoded_content );
+			$rewritten_content = ( $this->rewrite_block_markup )( $decoded_content );
+			if ( $rewritten_content === $decoded_content ) {
+				continue;
+			}
+
+			$parts[ $index ] = substr( $cell, 0, $prefix_length )
+				. $this->encode_url_component( $rewritten_content );
+		}
+
+		return implode( '', $parts );
+	}
+
+	/**
+	 * Rewrite either form of a WPBakery Raw HTML or Raw JS body.
+	 *
+	 * Both elements use textarea_raw_html, which stores Base64 content. Values
+	 * saved by its editor control add URL encoding inside the Base64 layer. The
+	 * rewritten body uses the same form.
+	 */
+	private function rewrite_raw_code_body( string $body ): string {
+		$decoded_body = base64_decode( $body, true );
+		if ( false === $decoded_body || base64_encode( $decoded_body ) !== $body ) {
+			return $body;
+		}
+
+		$uses_url_encoding = 1 === preg_match(
+			'/%(?:3c|3e|5b|5d)|https?%3a%2f%2f/i',
+			$decoded_body
+		);
+		$decoded_content   = $uses_url_encoding
+			? rawurldecode( $decoded_body )
+			: $decoded_body;
+		$rewritten_content = ( $this->rewrite_block_markup )( $decoded_content );
+		if ( $rewritten_content === $decoded_content ) {
+			return $body;
+		}
+
+		if ( $uses_url_encoding ) {
+			$rewritten_content = $this->encode_url_component( $rewritten_content );
+		}
+
+		return base64_encode( $rewritten_content );
+	}
+
+	/**
+	 * Rewrite a WPBakery textarea_safe or exploded_textarea_safe attribute.
+	 *
+	 * These controls store `#E-8_`, followed by Base64-encoded, URL-encoded
+	 * content. The rewritten value keeps that wrapper and encoding order.
+	 */
+	private function rewrite_safe_attribute( string $value ): string {
+		$prefix = '#E-8_';
+		if ( 0 !== strncmp( $value, $prefix, strlen( $prefix ) ) ) {
+			return $value;
+		}
+
+		$encoded_content = substr( $value, strlen( $prefix ) );
+		$decoded_content = base64_decode( $encoded_content, true );
+		if ( false === $decoded_content || base64_encode( $decoded_content ) !== $encoded_content ) {
+			return $value;
+		}
+
+		$decoded_content   = rawurldecode( $decoded_content );
+		$rewritten_content = ( $this->rewrite_block_markup )( $decoded_content );
+		if ( $rewritten_content === $decoded_content ) {
+			return $value;
+		}
+
+		return $prefix . base64_encode( $this->encode_url_component( $rewritten_content ) );
+	}
+
+	/**
+	 * Rewrite the URL field in a WPBakery vc_link attribute.
+	 *
+	 * The control stores URL-encoded fields separated by pipes, for example
+	 * `url:https%3A%2F%2Fexample.com|title:Read|target:%20_blank|`.
+	 */
+	private function rewrite_link_attribute( string $value ): string {
+		$fields = explode( '|', $value );
+		foreach ( $fields as $index => $field ) {
+			if ( 0 !== strncmp( $field, 'url:', 4 ) ) {
+				continue;
+			}
+
+			$encoded_url   = substr( $field, 4 );
+			$decoded_url   = rawurldecode( $encoded_url );
+			$rewritten_url = ( $this->rewrite_plain_text )( $decoded_url );
+			if ( $rewritten_url === $decoded_url ) {
+				continue;
+			}
+
+			$fields[ $index ] = 'url:' . $this->encode_url_component( $rewritten_url );
+		}
+
+		return implode( '|', $fields );
+	}
+
+	private function encode_url_component( string $value ): string {
+		return str_replace(
+			array( '%21', '%27', '%28', '%29', '%2A' ),
+			array( '!', "'", '(', ')', '*' ),
+			rawurlencode( $value )
+		);
+	}
+}

--- a/packages/reprint-client/src/lib/url-rewrite/load.php
+++ b/packages/reprint-client/src/lib/url-rewrite/load.php
@@ -25,6 +25,7 @@ if (!class_exists(\WordPress\DataLiberation\Shortcode\ShortcodeProcessor::class)
 
 // Scans structured block markup and uses the cautious processor for opaque tokens.
 require_once __DIR__ . '/class-structured-block-markup-url-processor.php';
+require_once __DIR__ . '/class-wpbakery-url-rewriter.php';
 
 // Depend on the iterators above
 require_once __DIR__ . '/class-structured-data-url-rewriter.php';

--- a/packages/reprint-client/src/lib/url-rewrite/load.php
+++ b/packages/reprint-client/src/lib/url-rewrite/load.php
@@ -18,6 +18,11 @@ require_once __DIR__ . '/class-sqlite-prepared-insert-builder.php';
 require_once __DIR__ . '/class-cautious-url-base-rewrite-mapping.php';
 require_once __DIR__ . '/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php';
 
+// Use the php-toolkit implementation when the installed version provides it.
+if (!class_exists(\WordPress\DataLiberation\Shortcode\ShortcodeProcessor::class)) {
+    require_once __DIR__ . '/class-shortcode-processor.php';
+}
+
 // Scans structured block markup and uses the cautious processor for opaque tokens.
 require_once __DIR__ . '/class-structured-block-markup-url-processor.php';
 

--- a/tests/UrlRewriting/ShortcodeProcessorTest.php
+++ b/tests/UrlRewriting/ShortcodeProcessorTest.php
@@ -65,4 +65,23 @@ class ShortcodeProcessorTest extends TestCase {
             $processor->get_updated_text()
         );
     }
+
+    public function testAttributeUpdateKeepsEscapedDelimiterBytes(): void
+    {
+        $input = '[builder data="{\"url\":\"https://old.example/file\",\"label\":\"it\'s here\"}"]';
+        $processor = new ShortcodeProcessor($input);
+
+        $this->assertTrue($processor->next_shortcode('builder'));
+        $this->assertTrue($processor->next_attribute());
+        $this->assertTrue(
+            $processor->set_attribute_value(
+                '{\"url\":\"https://new.example/file\",\"label\":\"it\'s here\"}'
+            )
+        );
+
+        $this->assertSame(
+            '[builder data="{\"url\":\"https://new.example/file\",\"label\":\"it\'s here\"}"]',
+            $processor->get_updated_text()
+        );
+    }
 }

--- a/tests/UrlRewriting/ShortcodeProcessorTest.php
+++ b/tests/UrlRewriting/ShortcodeProcessorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\Shortcode\ShortcodeProcessor;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.php';
+
+class ShortcodeProcessorTest extends TestCase {
+    public function testReportsNestedOpenersAndClosersIndependently(): void
+    {
+        $processor = new ShortcodeProcessor(
+            '[row level="1"][row level="2"]Inner[/row][/row]'
+        );
+        $tokens = [];
+
+        while ($processor->next_shortcode('row')) {
+            $tokens[] = [
+                $processor->is_tag_closer() ? '/row' : 'row',
+                $processor->get_attribute('level'),
+            ];
+        }
+
+        $this->assertSame(
+            [
+                ['row', '1'],
+                ['row', '2'],
+                ['/row', null],
+                ['/row', null],
+            ],
+            $tokens
+        );
+    }
+
+    public function testKeepsHtmlAndBracketsInsideAQuotedAttribute(): void
+    {
+        $processor = new ShortcodeProcessor(
+            '[builder text="<a href=\'https://old.example/file\'>Keep ] here</a>" size="large"]'
+        );
+
+        $this->assertTrue($processor->next_shortcode('builder'));
+        $this->assertSame(
+            '<a href=\'https://old.example/file\'>Keep ] here</a>',
+            $processor->get_attribute('text')
+        );
+        $this->assertSame('large', $processor->get_attribute('size'));
+    }
+
+    public function testAttributeUpdatePreservesUnrelatedSourceBytes(): void
+    {
+        $input = "Before [builder image='https://old.example/file.jpg' label=wide] After";
+        $processor = new ShortcodeProcessor($input);
+
+        $this->assertTrue($processor->next_shortcode('builder'));
+        while ($processor->next_attribute()) {
+            if ($processor->get_attribute_name() === 'image') {
+                $this->assertTrue(
+                    $processor->set_attribute_value('https://new.example/file.jpg')
+                );
+            }
+        }
+
+        $this->assertSame(
+            "Before [builder image='https://new.example/file.jpg' label=wide] After",
+            $processor->get_updated_text()
+        );
+    }
+}

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -332,13 +332,29 @@ class SqlStatementRewriterTest extends TestCase
                 '<a href="https&#58;&#47;&#47;old-site&#46;com&#47;visit-us&#47;">Visit</a>',
                 '<a href="https://new-site.com/visit-us/">Visit</a>',
             ],
+            'percent escapes in a URL path and query' => [
+                '<a href="https://old-site.com/files/My%20Manual.pdf?next=%2Fvisit-us%2F">Manual</a>',
+                '<a href="https://new-site.com/files/My%20Manual.pdf?next=%2Fvisit-us%2F">Manual</a>',
+            ],
             'entity-quoted JSON with JSON-escaped slashes in an attribute' => [
                 '<a href="/visit-us/" data-analytics="{&quot;dest&quot;:&quot;https:\/\/old-site.com\/weddings\/&quot;}">Visit</a>',
                 '<a href="/visit-us/" data-analytics="{&quot;dest&quot;:&quot;https:\/\/new-site.com\/weddings\/&quot;}">Visit</a>',
             ],
             'JSON slash escapes and escaped HTML in a script element' => [
                 '<script type="application/json">{"url":"https:\/\/old-site.com\/visit-us\/","html":"<a href=\"https:\/\/old-site.com\/about\/\">About<\/a>"}</script>',
-                '<script type="application/json">{"url":"https:\/\/new-site.com\/visit-us\/","html":"<a href=\"https:\/\/new-site.com\/about\/\">About<\/a>"}</script>',
+                '<script type="application/json">{"url":"https://new-site.com/visit-us/","html":"<a href=\"https://new-site.com/about/\">About</a>"}</script>',
+            ],
+            'JSON Unicode slash escapes in an application/json script element' => [
+                '<script type="application/json">{"url":"https:\u002F\u002Fold-site.com\u002Fvisit-us\u002F"}</script>',
+                '<script type="application/json">{"url":"https://new-site.com/visit-us/"}</script>',
+            ],
+            'JSON Unicode slash escapes in an application/ld+json script element' => [
+                '<script type="application/ld+json; charset=utf-8">'
+                    . '{"@context":"https:\/\/schema.org","url":"https:\u002F\u002Fold-site.com\u002Fvisit-us\u002F"}'
+                    . '</script>',
+                '<script type="application/ld+json; charset=utf-8">'
+                    . '{"@context":"https://schema.org","url":"https://new-site.com/visit-us/"}'
+                    . '</script>',
             ],
             'CSS escaped slashes, a protocol-relative URL, and entity quotes' => [
                 '<style>.hero{background:url(https\:\/\/old-site.com\/hero.jpg)} @import url(//old-site.com/theme.css);</style>'
@@ -400,11 +416,6 @@ class SqlStatementRewriterTest extends TestCase
                 '<script>var urlPattern = /https:\/\/old-site.com\/weddings-and-celebrations\/\//;</script>',
                 '<script>var urlPattern = /https:\/\/new-site.com\/weddings-and-celebrations\/\//;</script>',
                 'The cautious scanner skips a URL immediately after a JavaScript regex delimiter.',
-            ],
-            'JSON Unicode slash escapes' => [
-                '<script type="application/json">{"url":"https:\u002F\u002Fold-site.com\u002Fvisit-us\u002F"}</script>',
-                '<script type="application/json">{"url":"https:\u002F\u002Fnew-site.com\u002Fvisit-us\u002F"}</script>',
-                'The cautious scanner does not decode JSON Unicode escapes around a URL.',
             ],
             'double-encoded HTML character references' => [
                 '<a href="https&amp;#58;&amp;#47;&amp;#47;old-site&amp;#46;com&amp;#47;visit-us&amp;#47;">Visit</a>',

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -209,33 +209,54 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
-    public function testPostContentRewritesUrlHiddenInRegisteredShortcodeBody(): void
+    public function testPostContentRewritesUrlsThroughRegisteredWPBakeryCodecs(): void
     {
         $rewriter = $this->createRewriter();
         $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
         $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
-        for ($alignment = 0; $alignment < 3; $alignment++) {
-            $prefix = str_repeat('x', $alignment);
-            $content = $prefix . '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]';
-            $sql = sprintf(
-                "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
-                base64_encode($content)
-            );
+        $old_map = '<iframe src="https://old-site.com/map"></iframe>';
+        $new_map = '<iframe src="https://new-site.com/map"></iframe>';
+        $old_javascript = '<script>window.reprintUrl="https://old-site.com/app.js";</script>';
+        $new_javascript = '<script>window.reprintUrl="https://new-site.com/app.js";</script>';
+        $cases = [
+            'Raw HTML' => [
+                '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]',
+                '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
+            ],
+            'Raw JS' => [
+                '[vc_raw_js]' . base64_encode(rawurlencode($old_javascript)) . '[/vc_raw_js]',
+                '[vc_raw_js]' . base64_encode(rawurlencode($new_javascript)) . '[/vc_raw_js]',
+            ],
+            'Google Maps' => [
+                '[vc_gmaps link="#E-8_' . base64_encode(rawurlencode($old_map)) . '"]',
+                '[vc_gmaps link="#E-8_' . base64_encode(rawurlencode($new_map)) . '"]',
+            ],
+            'Button link' => [
+                '[vc_btn link="url:https%3A%2F%2Fold-site.com%2Fmanual.pdf|title:Manual|"]',
+                '[vc_btn link="url:https%3A%2F%2Fnew-site.com%2Fmanual.pdf|title:Manual|"]',
+            ],
+        ];
 
-            $result = $rewriter->rewrite($sql);
+        foreach ($cases as $case_name => [$content, $expected]) {
+            for ($alignment = 0; $alignment < 3; $alignment++) {
+                $prefix = str_repeat('x', $alignment);
+                $sql = sprintf(
+                    "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+                    base64_encode($prefix . $content)
+                );
 
-            $this->assertSame(
-                $prefix . '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
-                $this->collectValues($result)[0],
-                'Shortcode prefix at Base64 alignment ' . $alignment
-            );
+                $result = $rewriter->rewrite($sql);
 
-            $prepared = $rewriter->build_sqlite_prepared_insert($sql);
-            $this->assertNotNull($prepared);
-            $this->assertSame(
-                $prefix . '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
-                $prepared['params'][1]
-            );
+                $this->assertSame(
+                    $prefix . $expected,
+                    $this->collectValues($result)[0],
+                    $case_name . ' at Base64 alignment ' . $alignment
+                );
+
+                $prepared = $rewriter->build_sqlite_prepared_insert($sql);
+                $this->assertNotNull($prepared);
+                $this->assertSame($prefix . $expected, $prepared['params'][1]);
+            }
         }
     }
 

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -212,13 +213,27 @@ class SqlStatementRewriterTest extends TestCase
     public function testPostContentRewritesUrlsThroughRegisteredWPBakeryCodecs(): void
     {
         $rewriter = $this->createRewriter();
+        $encode_wpbakery = static function (string $value): string {
+            return strtr(
+                rawurlencode($value),
+                ['%21' => '!', '%27' => "'", '%28' => '(', '%29' => ')', '%2A' => '*']
+            );
+        };
         $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
         $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
         $old_map = '<iframe src="https://old-site.com/map"></iframe>';
         $new_map = '<iframe src="https://new-site.com/map"></iframe>';
         $old_javascript = '<script>window.reprintUrl="https://old-site.com/app.js";</script>';
         $new_javascript = '<script>window.reprintUrl="https://new-site.com/app.js";</script>';
+        $old_table_cell = '<a href="https&#58;&#47;&#47;old-site&#46;com&#47;manual.pdf"'
+            . ' data-meta="{&quot;src&quot;:&quot;https:\/\/old-site.com\/manual.pdf&quot;}">Manual</a>';
+        $new_table_cell = '<a href="https://new-site.com/manual.pdf"'
+            . ' data-meta="{&quot;src&quot;:&quot;https:\/\/new-site.com\/manual.pdf&quot;}">Manual</a>';
         $cases = [
+            'Easy Tables HTML character references and JSON escapes' => [
+                '[vc_table allow_html="1"][bg#fff]Download,' . $encode_wpbakery($old_table_cell) . '[/vc_table]',
+                '[vc_table allow_html="1"][bg#fff]Download,' . $encode_wpbakery($new_table_cell) . '[/vc_table]',
+            ],
             'Raw HTML' => [
                 '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]',
                 '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
@@ -258,6 +273,150 @@ class SqlStatementRewriterTest extends TestCase
                 $this->assertSame($prefix . $expected, $prepared['params'][1]);
             }
         }
+    }
+
+    #[DataProvider('wpbakeryRawHtmlStructuredMarkupProvider')]
+    public function testPostContentRewritesStructuredMarkupInsideWPBakeryRawHtml(
+        string $old_html,
+        string $expected_html
+    ): void
+    {
+        $rewriter = $this->createRewriter();
+        $encode_wpbakery = static function (string $value): string {
+            return strtr(
+                rawurlencode($value),
+                ['%21' => '!', '%27' => "'", '%28' => '(', '%29' => ')', '%2A' => '*']
+            );
+        };
+        $stored_bodies = [
+            'literal Base64 body' => [
+                base64_encode($old_html),
+                base64_encode($expected_html),
+            ],
+            'URL-encoded Base64 body' => [
+                base64_encode($encode_wpbakery($old_html)),
+                base64_encode($encode_wpbakery($expected_html)),
+            ],
+        ];
+
+        foreach ($stored_bodies as $storage_name => [$stored_body, $expected_stored_body]) {
+            $content = '[vc_raw_html]' . $stored_body . '[/vc_raw_html]';
+            $expected = '[vc_raw_html]' . $expected_stored_body . '[/vc_raw_html]';
+            for ($alignment = 0; $alignment < 3; $alignment++) {
+                $prefix = str_repeat('x', $alignment);
+                $sql = sprintf(
+                    "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+                    base64_encode($prefix . $content)
+                );
+
+                $this->assertSame(
+                    $prefix . $expected,
+                    $this->collectValues($rewriter->rewrite($sql))[0],
+                    $storage_name . ' at SQL Base64 alignment ' . $alignment
+                );
+
+                $prepared = $rewriter->build_sqlite_prepared_insert($sql);
+                $this->assertNotNull($prepared);
+                $this->assertSame($prefix . $expected, $prepared['params'][1]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string}>
+     */
+    public static function wpbakeryRawHtmlStructuredMarkupProvider(): array
+    {
+        return [
+            'numeric HTML character references in an href' => [
+                '<a href="https&#58;&#47;&#47;old-site&#46;com&#47;visit-us&#47;">Visit</a>',
+                '<a href="https://new-site.com/visit-us/">Visit</a>',
+            ],
+            'entity-quoted JSON with JSON-escaped slashes in an attribute' => [
+                '<a href="/visit-us/" data-analytics="{&quot;dest&quot;:&quot;https:\/\/old-site.com\/weddings\/&quot;}">Visit</a>',
+                '<a href="/visit-us/" data-analytics="{&quot;dest&quot;:&quot;https:\/\/new-site.com\/weddings\/&quot;}">Visit</a>',
+            ],
+            'JSON slash escapes and escaped HTML in a script element' => [
+                '<script type="application/json">{"url":"https:\/\/old-site.com\/visit-us\/","html":"<a href=\"https:\/\/old-site.com\/about\/\">About<\/a>"}</script>',
+                '<script type="application/json">{"url":"https:\/\/new-site.com\/visit-us\/","html":"<a href=\"https:\/\/new-site.com\/about\/\">About<\/a>"}</script>',
+            ],
+            'CSS escaped slashes, a protocol-relative URL, and entity quotes' => [
+                '<style>.hero{background:url(https\:\/\/old-site.com\/hero.jpg)} @import url(//old-site.com/theme.css);</style>'
+                    . '<div style="background:url(&quot;https://old-site.com/card.jpg&quot;)">Card</div>',
+                '<style>.hero{background:url(https\:\/\/new-site.com\/hero.jpg)} @import url(//new-site.com/theme.css);</style>'
+                    . '<div style="background:url(&quot;https://new-site.com/card.jpg&quot;)">Card</div>',
+            ],
+            'JavaScript strings, split pieces, and a URL constructor' => [
+                '<script>var links={'
+                    . 'canonical:"https:\/\/old-site.com\/",'
+                    . "about:'https:'+'//'+'old-site.com'+'/'+'about'+'/',"
+                    . 'menu:new URL("/menu/","https://old-site.com").href'
+                    . '};</script>',
+                '<script>var links={'
+                    . 'canonical:"https:\/\/new-site.com\/",'
+                    . "about:'https:'+'//'+'new-site.com'+'/'+'about'+'/',"
+                    . 'menu:new URL("/menu/","https://new-site.com").href'
+                    . '};</script>',
+            ],
+            'form action and bare URL in an HTML comment' => [
+                '<form action="https://old-site.com/menu/" method="get"></form>'
+                    . '<!-- source page: https://old-site.com/our-story/ -->',
+                '<form action="https://new-site.com/menu/" method="get"></form>'
+                    . '<!-- source page: https://new-site.com/our-story/ -->',
+            ],
+        ];
+    }
+
+    #[DataProvider('wpbakeryRawHtmlKnownFailureProvider')]
+    public function testKnownFailuresInsideWPBakeryRawHtml(
+        string $old_html,
+        string $expected_html,
+        string $reason
+    ): void
+    {
+        $rewriter = $this->createRewriter();
+        $content = '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]';
+        $expected = '[vc_raw_html]' . base64_encode($expected_html) . '[/vc_raw_html]';
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode($content)
+        );
+
+        $result = $this->collectValues($rewriter->rewrite($sql))[0];
+        if ($result !== $expected) {
+            $this->markTestIncomplete($reason);
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string, 2:string}>
+     */
+    public static function wpbakeryRawHtmlKnownFailureProvider(): array
+    {
+        return [
+            'JavaScript regex literal' => [
+                '<script>var urlPattern = /https:\/\/old-site.com\/weddings-and-celebrations\/\//;</script>',
+                '<script>var urlPattern = /https:\/\/new-site.com\/weddings-and-celebrations\/\//;</script>',
+                'The cautious scanner skips a URL immediately after a JavaScript regex delimiter.',
+            ],
+            'JSON Unicode slash escapes' => [
+                '<script type="application/json">{"url":"https:\u002F\u002Fold-site.com\u002Fvisit-us\u002F"}</script>',
+                '<script type="application/json">{"url":"https:\u002F\u002Fnew-site.com\u002Fvisit-us\u002F"}</script>',
+                'The cautious scanner does not decode JSON Unicode escapes around a URL.',
+            ],
+            'double-encoded HTML character references' => [
+                '<a href="https&amp;#58;&amp;#47;&amp;#47;old-site&amp;#46;com&amp;#47;visit-us&amp;#47;">Visit</a>',
+                '<a href="https&amp;#58;&amp;#47;&amp;#47;new-site&amp;#46;com&amp;#47;visit-us&amp;#47;">Visit</a>',
+                'The HTML processor decodes one character-reference layer, not two.',
+            ],
+            'percent-encoded URL inside otherwise literal HTML' => [
+                '<a href="https%3A%2F%2Fold-site.com%2Fvisit-us%2F">Visit</a>',
+                '<a href="https%3A%2F%2Fnew-site.com%2Fvisit-us%2F">Visit</a>',
+                'The WPBakery codec currently mistakes an encoded URL for an encoded whole body.',
+            ],
+        ];
     }
 
     public function testUnknownColumnUsesPlainTextUrlScanning(): void

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -209,6 +209,36 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
+    public function testPostContentRewritesUrlHiddenInRegisteredShortcodeBody(): void
+    {
+        $rewriter = $this->createRewriter();
+        $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
+        $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
+        for ($alignment = 0; $alignment < 3; $alignment++) {
+            $prefix = str_repeat('x', $alignment);
+            $content = $prefix . '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]';
+            $sql = sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+                base64_encode($content)
+            );
+
+            $result = $rewriter->rewrite($sql);
+
+            $this->assertSame(
+                $prefix . '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
+                $this->collectValues($result)[0],
+                'Shortcode prefix at Base64 alignment ' . $alignment
+            );
+
+            $prepared = $rewriter->build_sqlite_prepared_insert($sql);
+            $this->assertNotNull($prepared);
+            $this->assertSame(
+                $prefix . '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
+                $prepared['params'][1]
+            );
+        }
+    }
+
     public function testUnknownColumnUsesPlainTextUrlScanning(): void
     {
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -679,6 +679,31 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/from-css.jpg', $rewritten_code);
     }
 
+    #[DataProvider('nonJsonScriptTypeProvider')]
+    public function testDoesNotParseJsonLookingScriptBodiesWithoutAJsonMediaType(
+        string $opening_tag
+    ): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = $opening_tag
+            . '{"url":"https:\u002F\u002Fold-site.com\u002Fvisit-us\u002F"}'
+            . '</script>';
+
+        $this->assertSame($input, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    /**
+     * @return array<string, array{0:string}>
+     */
+    public static function nonJsonScriptTypeProvider(): array
+    {
+        return [
+            'missing type' => ['<script>'],
+            'JavaScript media type' => ['<script type="text/javascript">'],
+            'JSONP media type' => ['<script type="application/jsonp">'],
+        ];
+    }
+
     public function testDiviHtmlEntityHostRewritesWithoutLiteralSourceHostBytes(): void
     {
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1062,6 +1062,49 @@ class StructuredDataUrlRewriterTest extends TestCase
         ];
     }
 
+    #[DataProvider('wpbakeryEncodedShortcodeProvider')]
+    public function testRewritesUrlsInWPBakeryEncodedShortcodes(
+        string $input,
+        string $expected
+    ): void {
+        $rewriter = $this->createRewriter();
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string}>
+     */
+    public static function wpbakeryEncodedShortcodeProvider(): array
+    {
+        $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
+        $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
+
+        return [
+            'Easy Tables percent-encoded HTML cell' => [
+                '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
+                '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fnew-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
+            ],
+            'Raw HTML Base64 body' => [
+                '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]',
+                '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
+            ],
+            'Raw HTML URL-encoded Base64 body' => [
+                '[vc_raw_html]' . base64_encode(rawurlencode($old_html)) . '[/vc_raw_html]',
+                '[vc_raw_html]' . base64_encode(rawurlencode($new_html)) . '[/vc_raw_html]',
+            ],
+        ];
+    }
+
+    public function testRewritesLiteralHtmlInsideAWPBakeryShortcodeAttributeWithoutChangingItsQuotes(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[vc_custom_heading text="<a href=\'https://old-site.com/manual.pdf\'>Download</a>" font_container="tag:h2"]';
+        $expected = '[vc_custom_heading text="<a href=\'https://new-site.com/manual.pdf\'>Download</a>" font_container="tag:h2"]';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
     /**
      * @param array<string, string> $mapping
      */

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -705,6 +705,29 @@ class StructuredDataUrlRewriterTest extends TestCase
         );
     }
 
+    public function testWPBakeryEncodedShortcodeInsideNamespacedBlockAttribute(): void
+    {
+        $rewriter = $this->createRewriter();
+        $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
+        $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
+        $attributes = [
+            'module' => [
+                'content' => [
+                    'value' => '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]',
+                ],
+            ],
+        ];
+        $input = '<!-- wp:divi/code ' . json_encode($attributes) . ' /-->';
+
+        $result = $rewriter->rewrite($input, 'block_markup');
+
+        $rewritten_attributes = $this->getBlockAttributes($result, 'wp:divi/code');
+        $this->assertSame(
+            '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
+            $rewritten_attributes['module']['content']['value']
+        );
+    }
+
     /**
      * Extensions may put one structured string inside another. Re-enter the
      * existing JSON and serialized-PHP parsers at every level instead of
@@ -1079,8 +1102,25 @@ class StructuredDataUrlRewriterTest extends TestCase
     {
         $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
         $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
+        $old_json_html = '<script type="application/ld+json">{"url":"https://old-site.com/manual.pdf"}</script>';
+        $new_json_html = '<script type="application/ld+json">{"url":"https://new-site.com/manual.pdf"}</script>';
+        $old_json_with_html = '{"markup":"<a href=\"https://old-site.com/manual.pdf\">Manual<\/a>"}';
+        $new_json_with_html = '{"markup":"<a href=\"https://new-site.com/manual.pdf\">Manual</a>"}';
+        $old_javascript = '<script>fetch("https://old-site.com/api");</script>';
+        $new_javascript = '<script>fetch("https://new-site.com/api");</script>';
+        $old_map = '<iframe src="https://old-site.com/map"></iframe>';
+        $new_map = '<iframe src="https://new-site.com/map"></iframe>';
+        $old_link_list = 'https://old-site.com/first.jpg,https://old-site.com/second.jpg?size=large';
+        $new_link_list = 'https://new-site.com/first.jpg,https://new-site.com/second.jpg?size=large';
+        $encode_wpbakery = static function (string $value): string {
+            return str_replace(
+                ['%21', '%27', '%28', '%29', '%2A'],
+                ['!', "'", '(', ')', '*'],
+                rawurlencode($value)
+            );
+        };
 
-        return [
+        $cases = [
             'Easy Tables percent-encoded HTML cell' => [
                 '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
                 '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fnew-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
@@ -1097,7 +1137,55 @@ class StructuredDataUrlRewriterTest extends TestCase
                 '[vc_raw_html]' . base64_encode(rawurlencode($old_html)) . '[/vc_raw_html]',
                 '[vc_raw_html]' . base64_encode(rawurlencode($new_html)) . '[/vc_raw_html]',
             ],
+            'Raw HTML Base64 body containing JSON script data' => [
+                '[vc_raw_html]' . base64_encode(rawurlencode($old_json_html)) . '[/vc_raw_html]',
+                '[vc_raw_html]' . base64_encode(rawurlencode($new_json_html)) . '[/vc_raw_html]',
+            ],
+            'Raw HTML Base64 body containing JSON with HTML' => [
+                '[vc_raw_html]' . base64_encode(rawurlencode($old_json_with_html)) . '[/vc_raw_html]',
+                '[vc_raw_html]' . base64_encode(rawurlencode($new_json_with_html)) . '[/vc_raw_html]',
+            ],
+            'Raw JS URL-encoded Base64 body' => [
+                '[vc_raw_js]' . base64_encode($encode_wpbakery($old_javascript)) . '[/vc_raw_js]',
+                '[vc_raw_js]' . base64_encode($encode_wpbakery($new_javascript)) . '[/vc_raw_js]',
+            ],
+            'Google Maps safe iframe attribute' => [
+                '[vc_gmaps link="#E-8_' . base64_encode(rawurlencode($old_map)) . '"]',
+                '[vc_gmaps link="#E-8_' . base64_encode(rawurlencode($new_map)) . '"]',
+            ],
+            'Gallery safe external image list' => [
+                '[vc_gallery type="image_grid" source="external_link" custom_srcs="#E-8_' . base64_encode(rawurlencode($old_link_list)) . '" img_size="thumbnail"]',
+                '[vc_gallery type="image_grid" source="external_link" custom_srcs="#E-8_' . base64_encode(rawurlencode($new_link_list)) . '" img_size="thumbnail"]',
+            ],
+            'Gallery safe custom link list' => [
+                '[vc_gallery type="flexslider_slide" onclick="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($old_link_list)) . '"]',
+                '[vc_gallery type="flexslider_slide" onclick="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($new_link_list)) . '"]',
+            ],
+            'Image Carousel safe custom link list' => [
+                '[vc_images_carousel images="10,11" onclick="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($old_link_list)) . '" wrap="yes"]',
+                '[vc_images_carousel images="10,11" onclick="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($new_link_list)) . '" wrap="yes"]',
+            ],
+            'Posts Slider safe custom link list' => [
+                '[vc_posts_slider count="3" link="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($old_link_list)) . '" posttypes="post"]',
+                '[vc_posts_slider count="3" link="custom_link" custom_links="#E-8_' . base64_encode(rawurlencode($new_link_list)) . '" posttypes="post"]',
+            ],
         ];
+
+        foreach (['vc_btn', 'vc_button2', 'vc_cta_button2', 'vc_custom_heading', 'vc_icon'] as $shortcode_tag) {
+            $cases[$shortcode_tag . ' pipe-delimited link attribute'] = [
+                '[' . $shortcode_tag . ' link="url:https%3A%2F%2Fold-site.com%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+                '[' . $shortcode_tag . ' link="url:https%3A%2F%2Fnew-site.com%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+            ];
+        }
+
+        foreach (['vc_btn', 'vc_button2', 'vc_custom_heading', 'vc_gitem_image', 'vc_gitem_zone', 'vc_gitem_zone_a', 'vc_gitem_zone_b', 'vc_icon', 'vc_single_image'] as $shortcode_tag) {
+            $cases[$shortcode_tag . ' grid-item pipe-delimited URL attribute'] = [
+                '[' . $shortcode_tag . ' link="custom" url="url:https%3A%2F%2Fold-site.com%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+                '[' . $shortcode_tag . ' link="custom" url="url:https%3A%2F%2Fnew-site.com%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+            ];
+        }
+
+        return $cases;
     }
 
     public function testRewritesLiteralHtmlInsideAWPBakeryShortcodeAttributeWithoutChangingItsQuotes(): void

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -753,6 +753,29 @@ class StructuredDataUrlRewriterTest extends TestCase
         );
     }
 
+    public function testWPBakeryEncodedShortcodeInsideHtmlInNamespacedBlockAttribute(): void
+    {
+        $rewriter = $this->createRewriter();
+        $old_html = '<a href="https://old-site.com/manual.pdf">Manual</a>';
+        $new_html = '<a href="https://new-site.com/manual.pdf">Manual</a>';
+        $old_value = '<div>[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]</div>';
+        $new_value = '<div>[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]</div>';
+        $input = '<!-- wp:divi/code '
+            . json_encode([
+                'module' => [
+                    'content' => [
+                        'value' => $old_value,
+                    ],
+                ],
+            ])
+            . ' /-->';
+
+        $result = $rewriter->rewrite($input, 'block_markup');
+        $rewritten_attributes = $this->getBlockAttributes($result, 'wp:divi/code');
+
+        $this->assertSame($new_value, $rewritten_attributes['module']['content']['value']);
+    }
+
     /**
      * Extensions may put one structured string inside another. Re-enter the
      * existing JSON and serialized-PHP parsers at every level instead of
@@ -1231,6 +1254,15 @@ class StructuredDataUrlRewriterTest extends TestCase
         ]);
         $input = '<!-- wp:shortcode -->[builder_heading text="<a href=\'http://127.0.0.1:8108/manual.pdf\'>Download</a>" layout="wide"]<!-- /wp:shortcode -->';
         $expected = '<!-- wp:shortcode -->[builder_heading text="<a href=\'https://target.example.com/manual.pdf\'>Download</a>" layout="wide"]<!-- /wp:shortcode -->';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testRewritesJsonLikeShortcodeAttributeWithoutChangingEscapedQuotes(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[builder data="{\"url\":\"https://old-site.com/file\",\"label\":\"it\'s here\"}"]';
+        $expected = '[builder data="{\"url\":\"https://new-site.com/file\",\"label\":\"it\'s here\"}"]';
 
         $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1111,6 +1111,45 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }
 
+    public function testRewritesLiteralHtmlInsideAGenericShortcodeAttributeWithoutChangingItsQuotes(): void
+    {
+        $rewriter = $this->createRewriter([
+            'http://127.0.0.1:8108' => 'https://target.example.com',
+        ]);
+        $input = '<!-- wp:shortcode -->[builder_heading text="<a href=\'http://127.0.0.1:8108/manual.pdf\'>Download</a>" layout="wide"]<!-- /wp:shortcode -->';
+        $expected = '<!-- wp:shortcode -->[builder_heading text="<a href=\'https://target.example.com/manual.pdf\'>Download</a>" layout="wide"]<!-- /wp:shortcode -->';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testLeavesUnknownEncodedShortcodeBodiesOpaque(): void
+    {
+        $rewriter = $this->createRewriter();
+        $encodedHtml = '%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E';
+        $base64Html = base64_encode('<a href="https://old-site.com/manual.pdf">Link</a>');
+        $input = '[builder_table]' . $encodedHtml . '[/builder_table]'
+            . '[builder_raw_html]' . $base64Html . '[/builder_raw_html]';
+
+        $this->assertSame($input, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testLeavesAnUnclosedKnownEncodedShortcodeBodyOpaque(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[vc_table allow_html="1"]%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E';
+
+        $this->assertSame($input, $rewriter->rewrite($input, 'block_markup'));
+    }
+
+    public function testGenericShortcodeParserKeepsBracketsInsideAttributeValues(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '[builder_card label="Keep ] here" image="https://old-site.com/card.jpg"]';
+        $expected = '[builder_card label="Keep ] here" image="https://new-site.com/card.jpg"]';
+
+        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+    }
+
     /**
      * @param array<string, string> $mapping
      */

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1085,6 +1085,10 @@ class StructuredDataUrlRewriterTest extends TestCase
                 '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
                 '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fnew-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
             ],
+            'Easy Tables rows and cell styles stay intact' => [
+                '[vc_table allow_html="1"][bg#fff]Name,[bg#fff]%3Ca%20href%3D%22https%3A%2F%2Fold-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E|Other,%3Cstrong%3EKeep%3C%2Fstrong%3E[/vc_table]',
+                '[vc_table allow_html="1"][bg#fff]Name,[bg#fff]%3Ca%20href%3D%22https%3A%2F%2Fnew-site.com%2Fmanual.pdf%22%3ELink%3C%2Fa%3E|Other,%3Cstrong%3EKeep%3C%2Fstrong%3E[/vc_table]',
+            ],
             'Raw HTML Base64 body' => [
                 '[vc_raw_html]' . base64_encode($old_html) . '[/vc_raw_html]',
                 '[vc_raw_html]' . base64_encode($new_html) . '[/vc_raw_html]',
@@ -1098,9 +1102,11 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     public function testRewritesLiteralHtmlInsideAWPBakeryShortcodeAttributeWithoutChangingItsQuotes(): void
     {
-        $rewriter = $this->createRewriter();
-        $input = '[vc_custom_heading text="<a href=\'https://old-site.com/manual.pdf\'>Download</a>" font_container="tag:h2"]';
-        $expected = '[vc_custom_heading text="<a href=\'https://new-site.com/manual.pdf\'>Download</a>" font_container="tag:h2"]';
+        $rewriter = $this->createRewriter([
+            'http://127.0.0.1:8108' => 'https://target.example.com',
+        ]);
+        $input = '<!-- wp:shortcode -->[vc_custom_heading text="<a href=\'http://127.0.0.1:8108/manual.pdf\'>Download</a>" font_container="tag:h2"]<!-- /wp:shortcode -->';
+        $expected = '<!-- wp:shortcode -->[vc_custom_heading text="<a href=\'https://target.example.com/manual.pdf\'>Download</a>" font_container="tag:h2"]<!-- /wp:shortcode -->';
 
         $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
     }

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -28,6 +28,7 @@ describe('Import: URL Rewriting', () => {
     // readable string literals.
     const SOURCE_DOMAIN = new URL(getSiteUrl(site)).origin;
     const TARGET_DOMAIN = 'https://target.example.com';
+    const encodeWPBakeryValue = (value) => Buffer.from(encodeURIComponent(value)).toString('base64');
     // These shapes come from the WPBakery and Divi records in the site-builder
     // markup report. The URLs use this test site's origin so db-apply can map
     // them, but the surrounding shortcode grammar is kept intact. In
@@ -98,6 +99,27 @@ describe('Import: URL Rewriting', () => {
             expected: '[vc_raw_html]PGEgaHJlZj0iaHR0cHM6Ly90YXJnZXQuZXhhbXBsZS5jb20vbWFudWFsLnBkZiI+TWFudWFsPC9hPg==[/vc_raw_html]',
             rendered: '<a href="https://target.example.com/manual.pdf">Manual</a>',
         },
+        {
+            name: 'WPBakery raw JS with URL-encoded Base64 content',
+            slug: 'url-rewrite-wpbakery-base64-js',
+            input: `[vc_raw_js]${encodeWPBakeryValue('<script>window.reprintUrl="http://127.0.0.1:8108/app.js";</script>')}[/vc_raw_js]`,
+            expected: `[vc_raw_js]${encodeWPBakeryValue('<script>window.reprintUrl="https://target.example.com/app.js";</script>')}[/vc_raw_js]`,
+            rendered: '<script>window.reprintUrl="https://target.example.com/app.js";</script>',
+        },
+        {
+            name: 'WPBakery Google Maps safe iframe attribute',
+            slug: 'url-rewrite-wpbakery-safe-map',
+            input: `[vc_gmaps link="#E-8_${encodeWPBakeryValue('<iframe src="http://127.0.0.1:8108/map"></iframe>')}"]`,
+            expected: `[vc_gmaps link="#E-8_${encodeWPBakeryValue('<iframe src="https://target.example.com/map"></iframe>')}"]`,
+            rendered: '<iframe src="https://target.example.com/map"></iframe>',
+        },
+        {
+            name: 'WPBakery button with a pipe-delimited link attribute',
+            slug: 'url-rewrite-wpbakery-button-link',
+            input: '[vc_btn title="Manual" link="url:http%3A%2F%2F127.0.0.1%3A8108%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+            expected: '[vc_btn title="Manual" link="url:https%3A%2F%2Ftarget.example.com%2Fmanual.pdf|title:Read%20it|target:%20_blank|"]',
+            rendered: '<a data-e2e-shortcode="vc_btn" href="https://target.example.com/manual.pdf">Manual</a>',
+        },
     ];
 
     // These are useful failures, not descriptions of current behavior. A
@@ -152,6 +174,27 @@ function reprint_e2e_raw_html_shortcode($attributes, $content = null) {
     return rawurldecode((string) base64_decode((string) $content, true));
 }
 
+function reprint_e2e_safe_shortcode($attributes) {
+    $value = isset($attributes['link']) ? (string) $attributes['link'] : '';
+    if (0 !== strncmp($value, '#E-8_', 5)) {
+        return '';
+    }
+
+    return rawurldecode((string) base64_decode(substr($value, 5), true));
+}
+
+function reprint_e2e_button_shortcode($attributes) {
+    $link = isset($attributes['link']) ? (string) $attributes['link'] : '';
+    $url = '';
+    foreach (explode('|', $link) as $field) {
+        if (0 === strncmp($field, 'url:', 4)) {
+            $url = rawurldecode(substr($field, 4));
+        }
+    }
+
+    return '<a data-e2e-shortcode="vc_btn" href="' . esc_url($url) . '">' . esc_html((string) ($attributes['title'] ?? '')) . '</a>';
+}
+
 foreach (['vc_row', 'vc_column', 'vc_column_text', 'et_pb_section'] as $shortcode) {
     add_shortcode($shortcode, 'reprint_e2e_container_shortcode');
 }
@@ -160,6 +203,9 @@ foreach (['vc_video', 'dipl_image_card'] as $shortcode) {
 }
 add_shortcode('vc_table', 'reprint_e2e_table_shortcode');
 add_shortcode('vc_raw_html', 'reprint_e2e_raw_html_shortcode');
+add_shortcode('vc_raw_js', 'reprint_e2e_raw_html_shortcode');
+add_shortcode('vc_gmaps', 'reprint_e2e_safe_shortcode');
+add_shortcode('vc_btn', 'reprint_e2e_button_shortcode');
 register_block_type('reprint/e2e-shortcode', [
     'render_callback' => static function ($attributes) {
         return do_shortcode((string) ($attributes['shortcode'] ?? ''));

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -84,26 +84,26 @@ describe('Import: URL Rewriting', () => {
             expected: '[vc_column_text]<input type="hidden" value="{&quot;url&quot;:&quot;https:\\/\\/target.example.com\\/hero.jpg&quot;}">[/vc_column_text]',
             rendered: '<div data-e2e-shortcode="vc_column_text"><input type="hidden" value="{&quot;url&quot;:&quot;https:\\/\\/target.example.com\\/hero.jpg&quot;}"></div>',
         },
+        {
+            name: 'WPBakery table with percent-encoded HTML and URL',
+            slug: 'url-rewrite-wpbakery-percent-encoded-table',
+            input: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22http%3A%2F%2F127.0.0.1%3A8108%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
+            expected: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Ftarget.example.com%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
+            rendered: '<div data-e2e-shortcode="vc_table">Download,<a href="https://target.example.com/wp-content/uploads/manual.pdf">Link</a></div>',
+        },
+        {
+            name: 'WPBakery raw HTML with a Base64-encoded link',
+            slug: 'url-rewrite-wpbakery-base64-html',
+            input: '[vc_raw_html]PGEgaHJlZj0iaHR0cDovLzEyNy4wLjAuMTo4MTA4L21hbnVhbC5wZGYiPk1hbnVhbDwvYT4=[/vc_raw_html]',
+            expected: '[vc_raw_html]PGEgaHJlZj0iaHR0cHM6Ly90YXJnZXQuZXhhbXBsZS5jb20vbWFudWFsLnBkZiI+TWFudWFsPC9hPg==[/vc_raw_html]',
+            rendered: '<a href="https://target.example.com/manual.pdf">Manual</a>',
+        },
     ];
 
     // These are useful failures, not descriptions of current behavior. A
     // migration user would reasonably expect each URL to move, but the URL is
     // hidden behind an encoding layer the cautious processor does not decode.
     const SITE_BUILDER_EXPECTED_FAILURES = [
-        {
-            name: 'WPBakery table with percent-encoded HTML and URL',
-            slug: 'url-rewrite-wpbakery-percent-encoded-table',
-            input: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22http%3A%2F%2F127.0.0.1%3A8108%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
-            expected: '[vc_table allow_html="1"]Download,%3Ca%20href%3D%22http%3A%2F%2Ftarget.example.com%2Fwp-content%2Fuploads%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]',
-            rendered: '<div data-e2e-shortcode="vc_table">Download,<a href="http://target.example.com/wp-content/uploads/manual.pdf">Link</a></div>',
-        },
-        {
-            name: 'WPBakery raw HTML with a Base64-encoded link',
-            slug: 'url-rewrite-wpbakery-base64-html',
-            input: '[vc_raw_html]PGEgaHJlZj0iaHR0cDovLzEyNy4wLjAuMTo4MTA4L21hbnVhbC5wZGYiPk1hbnVhbDwvYT4=[/vc_raw_html]',
-            expected: '[vc_raw_html]PGEgaHJlZj0iaHR0cDovL3RhcmdldC5leGFtcGxlLmNvbS9tYW51YWwucGRmIj5NYW51YWw8L2E+[/vc_raw_html]',
-            rendered: '<a href="http://target.example.com/manual.pdf">Manual</a>',
-        },
         {
             name: 'percent-encoded redirect URL in a shortcode attribute',
             slug: 'url-rewrite-percent-encoded-query-url',
@@ -149,7 +149,7 @@ function reprint_e2e_table_shortcode($attributes, $content = null) {
 }
 
 function reprint_e2e_raw_html_shortcode($attributes, $content = null) {
-    return (string) base64_decode((string) $content, true);
+    return rawurldecode((string) base64_decode((string) $content, true));
 }
 
 foreach (['vc_row', 'vc_column', 'vc_column_text', 'et_pb_section'] as $shortcode) {


### PR DESCRIPTION
WPBakery pages now migrate URLs inside shortcode attributes and encoded payloads while preserving the surrounding shortcode syntax and WPBakery storage format.

## Why

WPBakery can hide markup behind more than one encoding layer. For example:

```text
[vc_table allow_html="1"]Download,%3Ca%20href%3D%22https%3A%2F%2Fold.example%2Fmanual.pdf%22%3ELink%3C%2Fa%3E[/vc_table]
```

The URL belongs to an HTML link, but the HTML is URL-encoded inside an Easy Tables cell. The block-markup processor cannot see that link. Passing the complete shortcode through an HTML serializer is also unsafe because shortcode attributes may themselves contain HTML, JSON, CSS, quotes, and brackets whose original bytes must stay intact.

## What changes

This gives the structured-data rewriter an explicit parsing order:

```text
serialized PHP, JSON, or Base64
    -> shortcode syntax
        -> generic shortcode attributes
        -> registered builder codecs
    -> HTML and block markup
```

Shortcode parsing runs first only for leaves already known to contain block markup. Generic attribute values use the existing cautious URL scanner, so URLs can move without reserializing the shortcode or changing its delimiters. The shortcode parser comes from [WordPress/php-toolkit#300](https://github.com/WordPress/php-toolkit/pull/300); Reprint supplies the class until a released toolkit dependency includes it.

Builder-specific formats use a tag-and-attribute registry. `StructuredDataUrlRewriter` handles generic shortcode traversal and dispatch. `WPBakeryUrlRewriter` supplies the WPBakery tag registry and storage codecs. Each codec decodes its value, sends the decoded value back through the structured rewriter, and then restores the original storage layers. The first registered WPBakery formats are:

- URL-encoded cells in `vc_table`, including row, column, and style delimiters;
- Base64 and Base64-plus-URL-encoded bodies in `vc_raw_html` and `vc_raw_js`;
- pipe-delimited `vc_link` fields used by buttons, headings, icons, images, and grid items;
- `#E-8_` Base64-plus-URL-encoded fields used by maps, galleries, carousels, and post sliders.

This recursive path covers combinations such as SQL Base64 -> shortcode -> WPBakery Base64 -> URL encoding -> HTML -> JSON, CSS, or JavaScript. JSON bodies in `<script>` elements are parsed as JSON when `type` is `application/json` or an `application/*+json` media type. Other script bodies keep the cautious byte scan.

A registered body codec runs only for a complete text body between a matching opening and closing shortcode. Unknown encoded-body formats and incomplete body spans stay opaque.

## Known limits

Three cases remain recorded as incomplete tests:

- a URL written as a JavaScript regular-expression literal;
- a URL hidden behind two layers of HTML character references;
- a percent-encoded URL inside an otherwise literal Raw HTML body, which the current WPBakery codec mistakes for a URL-encoded whole body.

## Verification

An import of the supplied WPBakery test site's database left 12 source-host references in the homepage content on trunk. This branch rewrote 11 and left only the JavaScript regular-expression case above.

The unit suite checks exact stored output across SQL Base64 alignments, shortcode quoting and brackets, table delimiters, both Raw HTML encodings, Raw JS, WPBakery attribute formats, JSON slash and Unicode escapes, HTML character references, CSS escapes, valid percent escapes in URL paths and queries, and malformed or unknown shortcode bodies. The E2E test checks both the stored shortcode and its rendered URL.

## Rewriter benchmark

Each page benchmark rewrites 10,000 distinct pages of about 17 KB. Input construction is outside the timer. Each number is the median of three fresh PHP processes.

| Page corpus | trunk | this branch | time change | peak memory, trunk -> branch |
| --- | ---: | ---: | ---: | ---: |
| Ordinary Gutenberg markup | 25.07 s | 25.43 s | +1.5% | 44 -> 46 MiB |
| Generic non-WPBakery shortcode | 21.42 s | 21.79 s | +1.7% | 42 -> 42 MiB |
| Complex WPBakery homepage | 58.45 s | 77.15 s | +32.0% | 42 -> 48 MiB |

Both non-WPBakery corpora rewrote all 10,000 direct source URLs. The WPBakery corpus contains 13 source references inside each decoded Raw HTML body: trunk rewrote none, while this branch rewrote 12. The remaining reference is the known JavaScript regular-expression case.

The SQL rewriter owns the Base64 fast-reject. It checks the four fragments that cover lowercase `http` and `https` at every byte alignment before looking for encoded builder markers derived from the structured rewriter's decoded shortcode prefixes. On a URL-free 15.5 MB `INSERT`, trunk returned in 15.7 ms and this branch returned in 31.4 ms, before SQL tokenization or Base64 decoding. Combining the 21 builder-marker searches into one pattern reduced the branch result from 77.1 ms.
