### PR TITLE
Simple safeguards around `autoload.files` in Reprint server

### DIFF
--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -10,7 +10,10 @@
  * file.
  *
  * Composer's "files" autoload includes this file, so every host that installs
- * the package gets these symbols on every request.
+ * the package gets these symbols on every request. Keep this file limited to
+ * guarded function declarations: do not add I/O, hooks, mutable global state,
+ * or eager class definitions here. Changes to this eager-load surface require
+ * security-sensitive review.
  *
  * The two str_* polyfills at the top stay global on purpose: they
  * backfill functions unavailable before PHP 8.0, so callers reach them via

--- a/tests/ExportUtilsLoadingTest.php
+++ b/tests/ExportUtilsLoadingTest.php
@@ -52,6 +52,24 @@ final class ExportUtilsLoadingTest extends TestCase
         return $matches[1];
     }
 
+    // Reprint ships with Jetpack, so Composer executes these entries on every Jetpack request.
+    public function testComposerFilesAutoloadIsLimitedToTheUtilityFile(): void
+    {
+        $composer_path = __DIR__ . '/../packages/reprint-server/composer.json';
+        $composer_json = file_get_contents($composer_path);
+        $this->assertNotFalse($composer_json, 'reprint-server composer.json must be readable.');
+
+        $composer = json_decode($composer_json, true);
+        $this->assertIsArray($composer, 'reprint-server composer.json must contain valid JSON.');
+
+        $this->assertSame(
+            ['src/utils.php'],
+            $composer['autoload']['files'] ?? [],
+            'Composer executes every autoload.files entry on each consumer request. '
+            . 'Keep this eager-load surface limited to utils.php.'
+        );
+    }
+
     public function testEveryHelperCarriesItsOwnFunctionExistsGuard(): void
     {
         $lines = file(self::utilsPath(), FILE_IGNORE_NEW_LINES);


### PR DESCRIPTION
In anticipation of shipping the Reprint server with Jetpack, I landed https://github.com/WordPress/reprint/pull/704 and reduced the `autoload.files` array for the Reprint server component to just `utils.php`. This is good because adding the Reprint server to Jetpack should have as little impact as possible on a regular request on a random Jetpack site, and the `PDO*` polyfills were potentially high-impact.

`utils.php` is much safer: the only real risk is the `str_starts_with` and `str_contains` polyfills, and since they are accurate implementations, the risk is very low.

The ideal long-term architecture would be to have no `autoload.files` array at all for the Reprint server, but that's a larger refactor, and I figured it would be worthwhile to discuss with Adam before landing. This PR adds some rudimentary safeguards in the meantime:

- A more extensive comment in `utils.php` about the sensitive nature of that file. 
- A test to ensure `autoload.files` in Reprint server's `composer.json` contains only `utils.php`