### PR TITLE
DOTCOM-18274: Rework Reprint Server plugin UI to use WordPress primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ Every command run by `ImportClient` accepts `--progress=auto|tty|jsonl` for that
 - reprint-server-wp/: Self-contained WordPress plugin distribution directory
   - index.php: WordPress plugin entry point — intercepts `?reprint-api` requests (and the legacy `?site-export-api` alias) during plugin load, requires lib.php
   - lib.php: Standalone library — constants, auth functions, and request handler. Can be required without index.php by projects that want to embed the export engine with their own URL routing and authentication (pass a custom `authenticate` callable in the `$options` array to `_site_export_handle_api_request()`)
-  - wordpress/: WordPress admin UI (site-export.php)
+  - wordpress/: Namespaced WordPress configuration adapter and native administrator UI (`configuration.php`, `reprint-server.php`)
 - docs/: Architecture documentation (read these for deep understanding) and project logos (docs/assets/)
 - tests/: PHPUnit test suite organized by component
 - tests/e2e/: End-to-end Docker-based integration tests

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -11509,7 +11509,7 @@ class ImportClient
                         "No --secret was provided. The remote site requires " .
                         "authentication.\n\n" .
                         "Pass --secret=YOUR_SECRET using the same secret " .
-                        "configured in the Reprint Server plugin on the remote site.",
+                        "configured under Tools > Reprint Server on the remote site.",
                 ];
             }
 
@@ -11533,8 +11533,7 @@ class ImportClient
                     'code' => 'AUTH_SECRET_MISMATCH',
                     'message' =>
                         "Wrong shared secret. The --secret value does not match " .
-                        "the one configured in the Reprint Server plugin settings " .
-                        "(wp-admin → Reprint Server).",
+                        "the one configured under Tools > Reprint Server in wp-admin.",
                 ];
             }
 
@@ -13490,11 +13489,11 @@ if (
         echo "  2. Go to Plugins → Add New Plugin → Upload Plugin\n";
         echo "  3. Upload reprint-exporter-wp.zip and activate Reprint Server\n";
         echo "\n";
-        echo "{$bold}Step 3: Configure the shared secret{$reset}\n";
+        echo "{$bold}Step 3: Configure the connection token{$reset}\n";
         echo "\n";
-        echo "  1. In wp-admin, go to Reprint Server (in the sidebar)\n";
-        echo "  2. Enter a shared secret and save\n";
-        echo "  3. Use the same secret with reprint:\n";
+        echo "  1. In wp-admin, go to Tools → Reprint Server\n";
+        echo "  2. Enter a connection token and save\n";
+        echo "  3. Pass the same token to reprint with --secret:\n";
         echo "\n";
         echo "     {$dim}php reprint.phar preflight https://your-site.com \\\n";
         echo "       --secret=YOUR_SECRET \\\n";

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -1174,7 +1174,7 @@ class ImportClient
 
         $this->initialize_tuner($options);
 
-        // Initialize HMAC authentication if a shared secret was provided.
+        // Initialize HMAC authentication if a connection token was provided.
         // When set, every outgoing HTTP request will include X-Auth-Signature,
         // X-Auth-Nonce, and X-Auth-Timestamp headers so the export API can verify
         // the caller without a SECRET_KEY in the URL.
@@ -1642,7 +1642,7 @@ class ImportClient
      * @param array $options {
      *     Parsed files-push options and context.
      *
-     *     @type string $secret             HMAC shared secret.
+     *     @type string $secret             HMAC connection token.
      *     @type bool   $force_http         Whether the operator allowed a plain-HTTP target.
      *     @type string $progress           Progress output mode: auto, tty, or jsonl.
      *     @type array  $files_push_context Optional context already validated by the CLI entry point.
@@ -2113,7 +2113,7 @@ class ImportClient
      * @param array $options {
      *     Parsed files-push options.
      *
-     *     @type string $secret     HMAC shared secret.
+     *     @type string $secret     HMAC connection token.
      *     @type bool   $force_http Whether the operator allowed a plain-HTTP target.
      * }
      * @phpstan-param array<string,mixed> $options
@@ -11508,8 +11508,8 @@ class ImportClient
                     'message' =>
                         "No --secret was provided. The remote site requires " .
                         "authentication.\n\n" .
-                        "Pass --secret=YOUR_SECRET using the same secret " .
-                        "configured under Tools > Reprint Server on the remote site.",
+                        "Pass --secret=YOUR_SECRET using the same connection " .
+                        "token configured under Tools > Reprint Server on the remote site.",
                 ];
             }
 
@@ -11532,7 +11532,7 @@ class ImportClient
                 return [
                     'code' => 'AUTH_SECRET_MISMATCH',
                     'message' =>
-                        "Wrong shared secret. The --secret value does not match " .
+                        "Wrong connection token. The --secret value does not match " .
                         "the one configured under Tools > Reprint Server in wp-admin.",
                 ];
             }
@@ -12773,7 +12773,7 @@ if (
             'type' => 'value',
             'target' => 'secret',
             'placeholder' => 'TOKEN',
-            'help' => 'HMAC shared secret for export API authentication',
+            'help' => 'HMAC connection token for export API authentication',
             'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'pull-db', 'files-pull', 'files-push', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],

--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -109,7 +109,7 @@ require_once '/path/to/reprint-server-wp/lib.php';
 
 // Route however you like — lib.php doesn't check URLs.
 if ($myRouter->matches('/export')) {
-    // Use default HMAC authentication (reads secret.php when present,
+    // Use default HMAC authentication (reads the connection token from secret.php when present,
     // otherwise falls back to the site option):
     handle_api_request();
 

--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -133,17 +133,18 @@ and its push-authorization revocation hooks may opt into that integration
 without loading the bundled administrator:
 
 ```php
+use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
+
 require_once '/path/to/reprint-server-wp/lib.php';
 require_once '/path/to/reprint-server-wp/wordpress/configuration.php';
 
-_site_export_register_wordpress_configuration();
+register_wordpress_configuration();
 ```
 
-The embedding plugin may render its own administrator surface with
-`_site_export_get_configuration_state()`, apply connection-token changes with
-`_site_export_change_connection_token()`, and apply push-access changes with
-`_site_export_change_push_access()`. It should not require
-`wordpress/site-export.php` unless it explicitly wants the bundled
+The embedding plugin may use the namespaced `get_configuration_state()`,
+`change_connection_token()`, and `change_push_access()` operations to render
+and process its own administrator surface. It should not require
+`wordpress/reprint-server.php` unless it explicitly wants the bundled
 **Tools > Reprint Server** page.
 
 `lib.php` defines these constants in `WordPress\Reprint\Server\Plugin`

--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -86,9 +86,17 @@ push is authorized again. Managed sites show the effective state as read-only
 in WordPress admin. Custom authentication does not bypass this authorization
 gate.
 
+The bundled settings page is available at **Tools > Reprint Server**. It uses
+the WordPress Settings API for the connection token and a separate authenticated
+administrator action for push access. The page is an adapter over the shared
+configuration functions; it does not own the token or push-authorization rules.
+
 ## Using as a library
 
-The export engine can be embedded in another PHP project without the WordPress plugin wrapper. Require `lib.php` instead of `index.php` — it defines constants and functions but does not handle any HTTP requests or check any URLs.
+The export engine can be embedded in another PHP project or WordPress plugin
+without the bundled plugin wrapper. Require `lib.php` instead of `index.php`.
+It defines constants and functions but does not handle requests, check URLs,
+register WordPress hooks, add administrator pages, or install activation hooks.
 
 ```php
 use function WordPress\Reprint\Server\Plugin\error;
@@ -119,6 +127,24 @@ if ($myRouter->matches('/export')) {
 `WordPress\Reprint\Server\Plugin\handle_api_request()` accepts the same options documented under
 Platform configuration. Direct `lib.php` embedders pass them as the function's
 array argument and do not use the WordPress filter.
+
+An embedding WordPress plugin which wants the option-backed connection token
+and its push-authorization revocation hooks may opt into that integration
+without loading the bundled administrator:
+
+```php
+require_once '/path/to/reprint-server-wp/lib.php';
+require_once '/path/to/reprint-server-wp/wordpress/configuration.php';
+
+_site_export_register_wordpress_configuration();
+```
+
+The embedding plugin may render its own administrator surface with
+`_site_export_get_configuration_state()`, apply connection-token changes with
+`_site_export_change_connection_token()`, and apply push-access changes with
+`_site_export_change_push_access()`. It should not require
+`wordpress/site-export.php` unless it explicitly wants the bundled
+**Tools > Reprint Server** page.
 
 `lib.php` defines these constants in `WordPress\Reprint\Server\Plugin`
 (using WordPress's `plugin_dir_path`):

--- a/reprint-server-wp/index.php
+++ b/reprint-server-wp/index.php
@@ -41,5 +41,7 @@ if (isset($_GET['reprint-api'])) {
     exit;
 }
 
-// Register the settings page.
+// Register the bundled WordPress configuration and settings page.
+require_once __DIR__ . '/wordpress/configuration.php';
+_site_export_register_wordpress_configuration();
 require_once __DIR__ . '/wordpress/site-export.php';

--- a/reprint-server-wp/index.php
+++ b/reprint-server-wp/index.php
@@ -43,5 +43,5 @@ if (isset($_GET['reprint-api'])) {
 
 // Register the bundled WordPress configuration and settings page.
 require_once __DIR__ . '/wordpress/configuration.php';
-_site_export_register_wordpress_configuration();
-require_once __DIR__ . '/wordpress/site-export.php';
+\WordPress\Reprint\Server\Plugin\register_wordpress_configuration();
+require_once __DIR__ . '/wordpress/reprint-server.php';

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -315,7 +315,7 @@ function update_push_authorization(bool $enabled): bool {
  * multipart boundaries internally so the client can't predict the exact
  * byte stream — but it CAN hash the logical content before encoding.
  *
- * Signature = HMAC-SHA256(nonce + timestamp + SHA256(body), secret)
+ * Signature = HMAC-SHA256(nonce + timestamp + SHA256(body), connection token)
  *
  * The client sends X-Auth-Content-Hash = SHA256(body).  The server
  * independently hashes what it received and checks both that the hash

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -100,7 +100,7 @@ function push_is_supported(): bool {
 }
 
 /** Resolves dot segments in a slash-delimited path without touching the filesystem. */
-function _site_export_normalize_path(string $path): string {
+function normalize_path(string $path): string {
     $parts = explode('/', $path);
     $resolved = [];
     foreach ($parts as $part) {
@@ -571,7 +571,7 @@ function handle_api_request(array $options = []): void {
                 );
             }
             $docroot = $canonical_docroot === '/' ? '/' : rtrim($canonical_docroot, '/\\');
-            $lexical_docroot = _site_export_normalize_path(str_replace('\\', '/', $configured_docroot));
+            $lexical_docroot = normalize_path(str_replace('\\', '/', $configured_docroot));
             $reprint_directory = $options['reprint_directory'] ?? (
                 dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
             );
@@ -588,7 +588,7 @@ function handle_api_request(array $options = []): void {
                 // symlinked plugin into its outside target and omit protection.
                 $registered_plugin_file = str_replace('\\', '/', plugin_basename(PLUGIN_DIR . 'index.php'));
                 $registered_plugin_directory = dirname($registered_plugin_file);
-                $logical_plugin_directory = _site_export_normalize_path(
+                $logical_plugin_directory = normalize_path(
                     str_replace('\\', '/', (string) WP_PLUGIN_DIR)
                     . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                 );
@@ -610,7 +610,7 @@ function handle_api_request(array $options = []): void {
                     // path survives a final symlink to the outside target.
                     $canonical_wordpress_plugin_directory = realpath( (string) WP_PLUGIN_DIR );
                     if ($canonical_wordpress_plugin_directory !== false) {
-                        $logical_plugin_directory_from_canonical_parent = _site_export_normalize_path(
+                        $logical_plugin_directory_from_canonical_parent = normalize_path(
                             str_replace('\\', '/', $canonical_wordpress_plugin_directory)
                             . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                         );

--- a/reprint-server-wp/wordpress/configuration.php
+++ b/reprint-server-wp/wordpress/configuration.php
@@ -16,13 +16,13 @@ function register_wordpress_configuration(): void {
     add_action('admin_init', __NAMESPACE__ . '\\register_connection_token_setting');
     add_action('rest_api_init', __NAMESPACE__ . '\\register_connection_token_setting');
     add_action(
-        'update_option_' . \SITE_EXPORT_SECRET_OPTION,
+        'update_option_' . CONNECTION_TOKEN_OPTION,
         __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_change',
         10,
         2
     );
     add_action(
-        'add_option_' . \SITE_EXPORT_SECRET_OPTION,
+        'add_option_' . CONNECTION_TOKEN_OPTION,
         __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_added',
         10,
         0
@@ -33,7 +33,7 @@ function register_wordpress_configuration(): void {
 function register_connection_token_setting(): void {
     register_setting(
         'reprint_server',
-        \SITE_EXPORT_SECRET_OPTION,
+        CONNECTION_TOKEN_OPTION,
         [
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',
@@ -50,21 +50,21 @@ function register_connection_token_setting(): void {
  * @param mixed $new_value New option value.
  */
 function revoke_push_authorization_after_connection_token_change($old_value, $new_value): void {
-    if (\_site_export_has_secret_file()) {
+    if (has_connection_token_file()) {
         return;
     }
 
     $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
     $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
     if ($old_connection_token !== $new_connection_token) {
-        \_site_export_update_push_authorization(false);
+        update_push_authorization(false);
     }
 }
 
 /** Revoke stale local push authorization when the connection-token option is added. */
 function revoke_push_authorization_after_connection_token_added(): void {
-    if (!\_site_export_has_secret_file()) {
-        \_site_export_update_push_authorization(false);
+    if (!has_connection_token_file()) {
+        update_push_authorization(false);
     }
 }
 
@@ -74,11 +74,11 @@ function revoke_push_authorization_after_connection_token_added(): void {
  * @return string One of saved, unchanged, or storage_failure.
  */
 function change_connection_token(string $connection_token): string {
-    if (\_site_export_get_option_secret() === $connection_token) {
+    if (get_option_connection_token() === $connection_token) {
         return 'unchanged';
     }
 
-    return \_site_export_update_shared_secret($connection_token) ? 'saved' : 'storage_failure';
+    return update_connection_token($connection_token) ? 'saved' : 'storage_failure';
 }
 
 /**
@@ -89,7 +89,7 @@ function change_connection_token(string $connection_token): string {
  *
  *     @type string    $stored_connection_token Option-backed connection token.
  *     @type bool      $is_configured Whether an effective connection token exists.
- *     @type bool      $has_secret_file Whether secret.php supplies the effective connection token.
+ *     @type bool      $has_connection_token_file Whether secret.php supplies the effective connection token.
  *     @type bool      $push_supported Whether this PHP runtime can serve push endpoints.
  *     @type bool|null $managed_push_enabled Hosting-provider push policy, or null when the site controls it.
  *     @type bool      $push_enabled Whether push is authorized for the current connection token.
@@ -97,23 +97,23 @@ function change_connection_token(string $connection_token): string {
  * @phpstan-return array{
  *     stored_connection_token:string,
  *     is_configured:bool,
- *     has_secret_file:bool,
+ *     has_connection_token_file:bool,
  *     push_supported:bool,
  *     managed_push_enabled:bool|null,
  *     push_enabled:bool
  * }
  */
 function get_configuration_state(): array {
-    $effective_connection_token = \_site_export_get_shared_secret();
-    $push_supported = \_site_export_push_is_supported();
+    $effective_connection_token = get_connection_token();
+    $push_supported = push_is_supported();
 
     return [
-        'stored_connection_token' => \_site_export_get_option_secret(),
+        'stored_connection_token' => get_option_connection_token(),
         'is_configured' => $effective_connection_token !== null && $effective_connection_token !== '',
-        'has_secret_file' => \_site_export_has_secret_file(),
+        'has_connection_token_file' => has_connection_token_file(),
         'push_supported' => $push_supported,
-        'managed_push_enabled' => \_site_export_get_managed_push_enabled(),
-        'push_enabled' => $push_supported && \_site_export_is_push_authorized(),
+        'managed_push_enabled' => get_managed_push_enabled(),
+        'push_enabled' => $push_supported && is_push_authorized(),
     ];
 }
 
@@ -124,15 +124,15 @@ function get_configuration_state(): array {
  *                not_configured, or storage_failure.
  */
 function change_push_access(bool $enabled): string {
-    if (!\_site_export_push_is_supported()) {
+    if (!push_is_supported()) {
         return 'unsupported';
     }
 
-    if (\_site_export_get_managed_push_enabled() !== null) {
+    if (get_managed_push_enabled() !== null) {
         return 'managed';
     }
 
-    $connection_token = \_site_export_get_shared_secret();
+    $connection_token = get_connection_token();
     if ($enabled && ( $connection_token === null || $connection_token === '' )) {
         return 'not_configured';
     }
@@ -140,10 +140,10 @@ function change_push_access(bool $enabled): string {
     $fingerprint = $enabled ? hash('sha256', $connection_token) : '';
     if (
         function_exists('get_option')
-        && get_option(\SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
+        && get_option(PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
     ) {
         return 'unchanged';
     }
 
-    return \_site_export_update_push_authorization($enabled) ? 'saved' : 'storage_failure';
+    return update_push_authorization($enabled) ? 'saved' : 'storage_failure';
 }

--- a/reprint-server-wp/wordpress/configuration.php
+++ b/reprint-server-wp/wordpress/configuration.php
@@ -1,0 +1,146 @@
+<?php
+/** UI-independent WordPress configuration integration for Reprint Server. */
+
+/** Register the option and hooks used by the option-backed configuration. */
+function _site_export_register_wordpress_configuration(): void {
+    static $registered = false;
+
+    if ($registered) {
+        return;
+    }
+    $registered = true;
+
+    add_action('admin_init', '_site_export_register_shared_secret_setting');
+    add_action('rest_api_init', '_site_export_register_shared_secret_setting');
+    add_action(
+        'update_option_' . SITE_EXPORT_SECRET_OPTION,
+        '_site_export_revoke_push_authorization_after_connection_token_change',
+        10,
+        2
+    );
+    add_action(
+        'add_option_' . SITE_EXPORT_SECRET_OPTION,
+        '_site_export_revoke_push_authorization_after_connection_token_added',
+        10,
+        0
+    );
+}
+
+/** Register the connection token for the Settings and REST APIs. */
+function _site_export_register_shared_secret_setting(): void {
+    register_setting(
+        'site_export',
+        SITE_EXPORT_SECRET_OPTION,
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+            'show_in_rest' => true,
+        ]
+    );
+}
+
+/**
+ * Revoke local push authorization when the effective connection token changes.
+ *
+ * @param mixed $old_value Previous option value.
+ * @param mixed $new_value New option value.
+ */
+function _site_export_revoke_push_authorization_after_connection_token_change($old_value, $new_value): void {
+    if (_site_export_has_secret_file()) {
+        return;
+    }
+
+    $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
+    $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
+    if ($old_connection_token !== $new_connection_token) {
+        _site_export_update_push_authorization(false);
+    }
+}
+
+/** Revoke stale local push authorization when the connection-token option is added. */
+function _site_export_revoke_push_authorization_after_connection_token_added(): void {
+    if (!_site_export_has_secret_file()) {
+        _site_export_update_push_authorization(false);
+    }
+}
+
+/**
+ * Applies an option-backed connection-token change.
+ *
+ * @return string One of saved, unchanged, or storage_failure.
+ */
+function _site_export_change_connection_token(string $connection_token): string {
+    if (_site_export_get_option_secret() === $connection_token) {
+        return 'unchanged';
+    }
+
+    return _site_export_update_shared_secret($connection_token) ? 'saved' : 'storage_failure';
+}
+
+/**
+ * Returns the configuration state used by WordPress integrations.
+ *
+ * @return array {
+ *     Current Reprint Server configuration state.
+ *
+ *     @type string    $stored_connection_token Option-backed connection token.
+ *     @type bool      $is_configured Whether an effective connection token exists.
+ *     @type bool      $has_secret_file Whether secret.php supplies the effective connection token.
+ *     @type bool      $push_supported Whether this PHP runtime can serve push endpoints.
+ *     @type bool|null $managed_push_enabled Hosting-provider push policy, or null when the site controls it.
+ *     @type bool      $push_enabled Whether push is authorized for the current connection token.
+ * }
+ * @phpstan-return array{
+ *     stored_connection_token:string,
+ *     is_configured:bool,
+ *     has_secret_file:bool,
+ *     push_supported:bool,
+ *     managed_push_enabled:bool|null,
+ *     push_enabled:bool
+ * }
+ */
+function _site_export_get_configuration_state(): array {
+    $effective_connection_token = _site_export_get_shared_secret();
+    $push_supported = _site_export_push_is_supported();
+
+    return [
+        'stored_connection_token' => _site_export_get_option_secret(),
+        'is_configured' => $effective_connection_token !== null && $effective_connection_token !== '',
+        'has_secret_file' => _site_export_has_secret_file(),
+        'push_supported' => $push_supported,
+        'managed_push_enabled' => _site_export_get_managed_push_enabled(),
+        'push_enabled' => $push_supported && _site_export_is_push_authorized(),
+    ];
+}
+
+/**
+ * Applies a site-controlled push-access change.
+ *
+ * @return string One of saved, unchanged, unsupported, managed,
+ *                not_configured, or storage_failure.
+ */
+function _site_export_change_push_access(bool $enabled): string {
+    if (!_site_export_push_is_supported()) {
+        return 'unsupported';
+    }
+
+    if (_site_export_get_managed_push_enabled() !== null) {
+        return 'managed';
+    }
+
+    $connection_token = _site_export_get_shared_secret();
+    if ($enabled && ( $connection_token === null || $connection_token === '' )) {
+        return 'not_configured';
+    }
+
+    $fingerprint = $enabled ? hash('sha256', $connection_token) : '';
+    if (
+        function_exists('get_option')
+        && get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
+    ) {
+        return 'unchanged';
+    }
+
+    return _site_export_update_push_authorization($enabled) ? 'saved' : 'storage_failure';
+}

--- a/reprint-server-wp/wordpress/configuration.php
+++ b/reprint-server-wp/wordpress/configuration.php
@@ -13,8 +13,8 @@ function register_wordpress_configuration(): void {
     }
     $registered = true;
 
-    add_action('admin_init', __NAMESPACE__ . '\\register_shared_secret_setting');
-    add_action('rest_api_init', __NAMESPACE__ . '\\register_shared_secret_setting');
+    add_action('admin_init', __NAMESPACE__ . '\\register_connection_token_setting');
+    add_action('rest_api_init', __NAMESPACE__ . '\\register_connection_token_setting');
     add_action(
         'update_option_' . \SITE_EXPORT_SECRET_OPTION,
         __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_change',
@@ -30,7 +30,7 @@ function register_wordpress_configuration(): void {
 }
 
 /** Register the connection token for the Settings and REST APIs. */
-function register_shared_secret_setting(): void {
+function register_connection_token_setting(): void {
     register_setting(
         'reprint_server',
         \SITE_EXPORT_SECRET_OPTION,

--- a/reprint-server-wp/wordpress/configuration.php
+++ b/reprint-server-wp/wordpress/configuration.php
@@ -1,8 +1,11 @@
 <?php
+
+namespace WordPress\Reprint\Server\Plugin;
+
 /** UI-independent WordPress configuration integration for Reprint Server. */
 
 /** Register the option and hooks used by the option-backed configuration. */
-function _site_export_register_wordpress_configuration(): void {
+function register_wordpress_configuration(): void {
     static $registered = false;
 
     if ($registered) {
@@ -10,27 +13,27 @@ function _site_export_register_wordpress_configuration(): void {
     }
     $registered = true;
 
-    add_action('admin_init', '_site_export_register_shared_secret_setting');
-    add_action('rest_api_init', '_site_export_register_shared_secret_setting');
+    add_action('admin_init', __NAMESPACE__ . '\\register_shared_secret_setting');
+    add_action('rest_api_init', __NAMESPACE__ . '\\register_shared_secret_setting');
     add_action(
-        'update_option_' . SITE_EXPORT_SECRET_OPTION,
-        '_site_export_revoke_push_authorization_after_connection_token_change',
+        'update_option_' . \SITE_EXPORT_SECRET_OPTION,
+        __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_change',
         10,
         2
     );
     add_action(
-        'add_option_' . SITE_EXPORT_SECRET_OPTION,
-        '_site_export_revoke_push_authorization_after_connection_token_added',
+        'add_option_' . \SITE_EXPORT_SECRET_OPTION,
+        __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_added',
         10,
         0
     );
 }
 
 /** Register the connection token for the Settings and REST APIs. */
-function _site_export_register_shared_secret_setting(): void {
+function register_shared_secret_setting(): void {
     register_setting(
-        'site_export',
-        SITE_EXPORT_SECRET_OPTION,
+        'reprint_server',
+        \SITE_EXPORT_SECRET_OPTION,
         [
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',
@@ -46,22 +49,22 @@ function _site_export_register_shared_secret_setting(): void {
  * @param mixed $old_value Previous option value.
  * @param mixed $new_value New option value.
  */
-function _site_export_revoke_push_authorization_after_connection_token_change($old_value, $new_value): void {
-    if (_site_export_has_secret_file()) {
+function revoke_push_authorization_after_connection_token_change($old_value, $new_value): void {
+    if (\_site_export_has_secret_file()) {
         return;
     }
 
     $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
     $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
     if ($old_connection_token !== $new_connection_token) {
-        _site_export_update_push_authorization(false);
+        \_site_export_update_push_authorization(false);
     }
 }
 
 /** Revoke stale local push authorization when the connection-token option is added. */
-function _site_export_revoke_push_authorization_after_connection_token_added(): void {
-    if (!_site_export_has_secret_file()) {
-        _site_export_update_push_authorization(false);
+function revoke_push_authorization_after_connection_token_added(): void {
+    if (!\_site_export_has_secret_file()) {
+        \_site_export_update_push_authorization(false);
     }
 }
 
@@ -70,12 +73,12 @@ function _site_export_revoke_push_authorization_after_connection_token_added(): 
  *
  * @return string One of saved, unchanged, or storage_failure.
  */
-function _site_export_change_connection_token(string $connection_token): string {
-    if (_site_export_get_option_secret() === $connection_token) {
+function change_connection_token(string $connection_token): string {
+    if (\_site_export_get_option_secret() === $connection_token) {
         return 'unchanged';
     }
 
-    return _site_export_update_shared_secret($connection_token) ? 'saved' : 'storage_failure';
+    return \_site_export_update_shared_secret($connection_token) ? 'saved' : 'storage_failure';
 }
 
 /**
@@ -100,17 +103,17 @@ function _site_export_change_connection_token(string $connection_token): string 
  *     push_enabled:bool
  * }
  */
-function _site_export_get_configuration_state(): array {
-    $effective_connection_token = _site_export_get_shared_secret();
-    $push_supported = _site_export_push_is_supported();
+function get_configuration_state(): array {
+    $effective_connection_token = \_site_export_get_shared_secret();
+    $push_supported = \_site_export_push_is_supported();
 
     return [
-        'stored_connection_token' => _site_export_get_option_secret(),
+        'stored_connection_token' => \_site_export_get_option_secret(),
         'is_configured' => $effective_connection_token !== null && $effective_connection_token !== '',
-        'has_secret_file' => _site_export_has_secret_file(),
+        'has_secret_file' => \_site_export_has_secret_file(),
         'push_supported' => $push_supported,
-        'managed_push_enabled' => _site_export_get_managed_push_enabled(),
-        'push_enabled' => $push_supported && _site_export_is_push_authorized(),
+        'managed_push_enabled' => \_site_export_get_managed_push_enabled(),
+        'push_enabled' => $push_supported && \_site_export_is_push_authorized(),
     ];
 }
 
@@ -120,16 +123,16 @@ function _site_export_get_configuration_state(): array {
  * @return string One of saved, unchanged, unsupported, managed,
  *                not_configured, or storage_failure.
  */
-function _site_export_change_push_access(bool $enabled): string {
-    if (!_site_export_push_is_supported()) {
+function change_push_access(bool $enabled): string {
+    if (!\_site_export_push_is_supported()) {
         return 'unsupported';
     }
 
-    if (_site_export_get_managed_push_enabled() !== null) {
+    if (\_site_export_get_managed_push_enabled() !== null) {
         return 'managed';
     }
 
-    $connection_token = _site_export_get_shared_secret();
+    $connection_token = \_site_export_get_shared_secret();
     if ($enabled && ( $connection_token === null || $connection_token === '' )) {
         return 'not_configured';
     }
@@ -137,10 +140,10 @@ function _site_export_change_push_access(bool $enabled): string {
     $fingerprint = $enabled ? hash('sha256', $connection_token) : '';
     if (
         function_exists('get_option')
-        && get_option(SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
+        && get_option(\SITE_EXPORT_PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
     ) {
         return 'unchanged';
     }
 
-    return _site_export_update_push_authorization($enabled) ? 'saved' : 'storage_failure';
+    return \_site_export_update_push_authorization($enabled) ? 'saved' : 'storage_failure';
 }

--- a/reprint-server-wp/wordpress/reprint-server.js
+++ b/reprint-server-wp/wordpress/reprint-server.js
@@ -1,7 +1,7 @@
 ( function() {
 	'use strict';
 
-	var token = document.getElementById( 'reprint_server_secret' );
+	var token = document.getElementById( 'reprint_server_connection_token' );
 	var toggle = document.querySelector( '.reprint-server-toggle-token' );
 	if ( token && toggle ) {
 		toggle.addEventListener( 'click', function() {

--- a/reprint-server-wp/wordpress/reprint-server.js
+++ b/reprint-server-wp/wordpress/reprint-server.js
@@ -1,8 +1,8 @@
 ( function() {
 	'use strict';
 
-	var token = document.getElementById( 'site_export_secret' );
-	var toggle = document.querySelector( '.site-export-toggle-token' );
+	var token = document.getElementById( 'reprint_server_secret' );
+	var toggle = document.querySelector( '.reprint-server-toggle-token' );
 	if ( token && toggle ) {
 		toggle.addEventListener( 'click', function() {
 			var showing = token.type === 'text';
@@ -15,8 +15,8 @@
 		} );
 	}
 
-	var remoteReprintApiUrl = document.getElementById( 'site-export-api-url' );
-	var copy = document.querySelector( '.site-export-copy-url' );
+	var remoteReprintApiUrl = document.getElementById( 'reprint-server-api-url' );
+	var copy = document.querySelector( '.reprint-server-copy-url' );
 	if ( remoteReprintApiUrl && copy ) {
 		copy.addEventListener( 'click', function() {
 			var copied;

--- a/reprint-server-wp/wordpress/reprint-server.php
+++ b/reprint-server-wp/wordpress/reprint-server.php
@@ -1,7 +1,10 @@
 <?php
+
+namespace WordPress\Reprint\Server\Plugin;
+
 /** Bundled WordPress administrator adapter for Reprint Server. */
 
-class Site_Export_Plugin {
+class SettingsPage {
 
     private static $instance = null;
 
@@ -18,10 +21,10 @@ class Site_Export_Plugin {
     private function __construct() {
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('admin_init', [$this, 'register_settings_fields']);
-        add_action('admin_post_site_export_save_push_access', [$this, 'handle_push_access_save']);
+        add_action('admin_post_reprint_server_save_push_access', [$this, 'handle_push_access_save']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
         add_filter(
-            'plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            'plugin_action_links_' . plugin_basename(\SITE_EXPORT_PLUGIN_DIR . 'index.php'),
             [$this, 'add_settings_link']
         );
     }
@@ -32,7 +35,7 @@ class Site_Export_Plugin {
             __('Reprint Server', 'reprint'),
             __('Reprint Server', 'reprint'),
             'manage_options',
-            'site-export',
+            'reprint-server',
             [$this, 'render_admin_page']
         );
     }
@@ -40,24 +43,24 @@ class Site_Export_Plugin {
     /** Register the connection-token section rendered by the Settings API. */
     public function register_settings_fields(): void {
         add_settings_section(
-            'site_export_connection',
+            'reprint_server_connection',
             __('Connection token', 'reprint'),
             [$this, 'render_connection_section'],
-            'site-export'
+            'reprint-server'
         );
         add_settings_field(
-            SITE_EXPORT_SECRET_OPTION,
+            \SITE_EXPORT_SECRET_OPTION,
             __('Connection token', 'reprint'),
             [$this, 'render_connection_token_field'],
-            'site-export',
-            'site_export_connection',
-            ['label_for' => SITE_EXPORT_SECRET_OPTION]
+            'reprint-server',
+            'reprint_server_connection',
+            ['label_for' => \SITE_EXPORT_SECRET_OPTION]
         );
     }
 
     /** Add the Settings link to the plugin row. */
     public function add_settings_link(array $links): array {
-        $url = admin_url('tools.php?page=site-export');
+        $url = admin_url('tools.php?page=reprint-server');
         array_unshift(
             $links,
             '<a href="' . esc_url($url) . '">' . esc_html__('Settings', 'reprint') . '</a>'
@@ -72,10 +75,10 @@ class Site_Export_Plugin {
         }
 
         wp_enqueue_script(
-            'site-export-admin',
-            plugins_url('wordpress/site-export.js', SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            'reprint-server-admin',
+            plugins_url('wordpress/reprint-server.js', \SITE_EXPORT_PLUGIN_DIR . 'index.php'),
             ['wp-a11y'],
-            SITE_EXPORT_VERSION,
+            \SITE_EXPORT_VERSION,
             true
         );
     }
@@ -90,17 +93,17 @@ class Site_Export_Plugin {
 
     /** Render the option-backed connection-token field. */
     public function render_connection_token_field(): void {
-        $configuration = _site_export_get_configuration_state();
+        $configuration = get_configuration_state();
         ?>
         <input type="password"
                class="regular-text code"
-               id="site_export_secret"
-               name="<?php echo esc_attr(SITE_EXPORT_SECRET_OPTION); ?>"
+               id="reprint_server_secret"
+               name="<?php echo esc_attr(\SITE_EXPORT_SECRET_OPTION); ?>"
                value="<?php echo esc_attr($configuration['stored_connection_token']); ?>"
                autocomplete="off" />
         <button type="button"
-                class="button site-export-toggle-token"
-                aria-controls="site_export_secret"
+                class="button reprint-server-toggle-token"
+                aria-controls="reprint_server_secret"
                 aria-pressed="false"
                 aria-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"
                 data-show-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"
@@ -116,13 +119,13 @@ class Site_Export_Plugin {
             wp_die(esc_html__('You are not allowed to manage Reprint Server.', 'reprint'));
         }
 
-        check_admin_referer('site_export_save_push_access');
-        $enabled = isset($_POST['site_export_push_enabled']);
-        $result = _site_export_change_push_access($enabled);
+        check_admin_referer('reprint_server_save_push_access');
+        $enabled = isset($_POST['reprint_server_push_enabled']);
+        $result = change_push_access($enabled);
         $redirect_url = add_query_arg(
-            'site_export_notice',
+            'reprint_server_notice',
             $result,
-            admin_url('tools.php?page=site-export')
+            admin_url('tools.php?page=reprint-server')
         );
         wp_safe_redirect($redirect_url);
         exit;
@@ -134,7 +137,7 @@ class Site_Export_Plugin {
             return;
         }
 
-        $configuration = _site_export_get_configuration_state();
+        $configuration = get_configuration_state();
         $remote_reprint_api_url = home_url('?reprint-api');
         ?>
         <div class="wrap">
@@ -166,8 +169,8 @@ class Site_Export_Plugin {
             <?php $this->render_configuration_status($configuration); ?>
 
             <form method="post" action="options.php">
-                <?php settings_fields('site_export'); ?>
-                <?php do_settings_sections('site-export'); ?>
+                <?php settings_fields('reprint_server'); ?>
+                <?php do_settings_sections('reprint-server'); ?>
                 <?php submit_button(); ?>
             </form>
 
@@ -196,11 +199,11 @@ class Site_Export_Plugin {
                 </p>
                 <input type="text"
                        class="regular-text code"
-                       id="site-export-api-url"
+                       id="reprint-server-api-url"
                        value="<?php echo esc_attr($remote_reprint_api_url); ?>"
                        readonly />
                 <button type="button"
-                        class="button site-export-copy-url"
+                        class="button reprint-server-copy-url"
                         data-copied-message="<?php echo esc_attr__('Remote Reprint API URL copied.', 'reprint'); ?>">
                     <?php echo esc_html__('Copy', 'reprint'); ?>
                 </button>
@@ -212,7 +215,7 @@ class Site_Export_Plugin {
     /**
      * Render current configuration status and notices which require attention.
      *
-     * @param array $configuration Configuration returned by _site_export_get_configuration_state().
+     * @param array $configuration Configuration returned by get_configuration_state().
      */
     private function render_configuration_status(array $configuration): void {
         if ($configuration['has_secret_file']) {
@@ -292,11 +295,11 @@ class Site_Export_Plugin {
 
         ?>
         <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-            <input type="hidden" name="action" value="site_export_save_push_access" />
-            <?php wp_nonce_field('site_export_save_push_access'); ?>
+            <input type="hidden" name="action" value="reprint_server_save_push_access" />
+            <?php wp_nonce_field('reprint_server_save_push_access'); ?>
             <label>
                 <input type="checkbox"
-                       name="site_export_push_enabled"
+                       name="reprint_server_push_enabled"
                        value="1"<?php checked($configuration['push_enabled']); ?> />
                 <?php echo esc_html__('Allow push to change files on this site', 'reprint'); ?>
             </label>
@@ -323,12 +326,12 @@ class Site_Export_Plugin {
         }
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The fixed query value selects a read-only notice.
-        if (!isset($_GET['site_export_notice']) || !is_string($_GET['site_export_notice'])) {
+        if (!isset($_GET['reprint_server_notice']) || !is_string($_GET['reprint_server_notice'])) {
             return;
         }
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The fixed query value selects a read-only notice.
-        $result = sanitize_key(wp_unslash($_GET['site_export_notice']));
+        $result = sanitize_key(wp_unslash($_GET['reprint_server_notice']));
         $notices = [
             'saved' => ['success', __('Push access updated.', 'reprint')],
             'unchanged' => ['success', __('Push access was already up to date.', 'reprint')],
@@ -349,26 +352,26 @@ class Site_Export_Plugin {
 }
 
 add_action('plugins_loaded', function() {
-    Site_Export_Plugin::get_instance();
+    SettingsPage::get_instance();
 });
 
-register_activation_hook(SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
+register_activation_hook(\SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
     if (!wp_doing_ajax() && is_admin()) {
-        set_transient('site_export_activated', 1, 30);
+        set_transient('reprint_server_activated', 1, 30);
     }
 
-    $gitignore = SITE_EXPORT_PLUGIN_DIR . '.gitignore';
+    $gitignore = \SITE_EXPORT_PLUGIN_DIR . '.gitignore';
     if (!file_exists($gitignore)) {
         file_put_contents($gitignore, "secret.php\n");
     }
 });
 
 add_action('admin_init', function() {
-    if (get_transient('site_export_activated')) {
-        delete_transient('site_export_activated');
+    if (get_transient('reprint_server_activated')) {
+        delete_transient('reprint_server_activated');
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This only suppresses activation redirects for bulk activation.
         if (!isset($_GET['activate-multi'])) {
-            wp_safe_redirect(admin_url('tools.php?page=site-export'));
+            wp_safe_redirect(admin_url('tools.php?page=reprint-server'));
             exit;
         }
     }

--- a/reprint-server-wp/wordpress/reprint-server.php
+++ b/reprint-server-wp/wordpress/reprint-server.php
@@ -97,13 +97,13 @@ class SettingsPage {
         ?>
         <input type="password"
                class="regular-text code"
-               id="reprint_server_secret"
+               id="reprint_server_connection_token"
                name="<?php echo esc_attr(\SITE_EXPORT_SECRET_OPTION); ?>"
                value="<?php echo esc_attr($configuration['stored_connection_token']); ?>"
                autocomplete="off" />
         <button type="button"
                 class="button reprint-server-toggle-token"
-                aria-controls="reprint_server_secret"
+                aria-controls="reprint_server_connection_token"
                 aria-pressed="false"
                 aria-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"
                 data-show-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"

--- a/reprint-server-wp/wordpress/reprint-server.php
+++ b/reprint-server-wp/wordpress/reprint-server.php
@@ -24,7 +24,7 @@ class SettingsPage {
         add_action('admin_post_reprint_server_save_push_access', [$this, 'handle_push_access_save']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
         add_filter(
-            'plugin_action_links_' . plugin_basename(\SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            'plugin_action_links_' . plugin_basename(PLUGIN_DIR . 'index.php'),
             [$this, 'add_settings_link']
         );
     }
@@ -49,12 +49,12 @@ class SettingsPage {
             'reprint-server'
         );
         add_settings_field(
-            \SITE_EXPORT_SECRET_OPTION,
+            CONNECTION_TOKEN_OPTION,
             __('Connection token', 'reprint'),
             [$this, 'render_connection_token_field'],
             'reprint-server',
             'reprint_server_connection',
-            ['label_for' => \SITE_EXPORT_SECRET_OPTION]
+            ['label_for' => CONNECTION_TOKEN_OPTION]
         );
     }
 
@@ -76,9 +76,9 @@ class SettingsPage {
 
         wp_enqueue_script(
             'reprint-server-admin',
-            plugins_url('wordpress/reprint-server.js', \SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            plugins_url('wordpress/reprint-server.js', PLUGIN_DIR . 'index.php'),
             ['wp-a11y'],
-            \SITE_EXPORT_VERSION,
+            VERSION,
             true
         );
     }
@@ -98,7 +98,7 @@ class SettingsPage {
         <input type="password"
                class="regular-text code"
                id="reprint_server_connection_token"
-               name="<?php echo esc_attr(\SITE_EXPORT_SECRET_OPTION); ?>"
+               name="<?php echo esc_attr(CONNECTION_TOKEN_OPTION); ?>"
                value="<?php echo esc_attr($configuration['stored_connection_token']); ?>"
                autocomplete="off" />
         <button type="button"
@@ -205,7 +205,7 @@ class SettingsPage {
      * @param array $configuration Configuration returned by get_configuration_state().
      */
     private function render_configuration_status(array $configuration): void {
-        if ($configuration['has_secret_file']) {
+        if ($configuration['has_connection_token_file']) {
             $message = '<strong><code>secret.php</code> '
                 . esc_html__('override is active.', 'reprint')
                 . '</strong> '
@@ -383,12 +383,12 @@ add_action('plugins_loaded', function() {
     SettingsPage::get_instance();
 });
 
-register_activation_hook(\SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
+register_activation_hook(PLUGIN_DIR . 'index.php', function() {
     if (!wp_doing_ajax() && is_admin()) {
         set_transient('reprint_server_activated', 1, 30);
     }
 
-    $gitignore = \SITE_EXPORT_PLUGIN_DIR . '.gitignore';
+    $gitignore = PLUGIN_DIR . '.gitignore';
     if (!file_exists($gitignore)) {
         file_put_contents($gitignore, "secret.php\n");
     }

--- a/reprint-server-wp/wordpress/reprint-server.php
+++ b/reprint-server-wp/wordpress/reprint-server.php
@@ -151,20 +151,7 @@ class SettingsPage {
             ?>
             </p>
 
-            <?php
-            ob_start();
-            settings_errors();
-            $settings_errors_markup = ob_get_clean();
-            if (is_string($settings_errors_markup)) {
-                // Core bolds each complete message and moves non-inline notices after load.
-                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- settings_errors() returns escaped core markup.
-                echo str_replace(
-                    ['settings-error is-dismissible', '<strong>', '</strong>'],
-                    ['settings-error is-dismissible inline', '', ''],
-                    $settings_errors_markup
-                );
-            }
-            ?>
+            <?php $this->render_settings_notices(); ?>
             <?php $this->render_push_access_notice(); ?>
             <?php $this->render_configuration_status($configuration); ?>
 
@@ -219,34 +206,33 @@ class SettingsPage {
      */
     private function render_configuration_status(array $configuration): void {
         if ($configuration['has_secret_file']) {
-            echo '<div class="notice notice-warning inline"><p><strong><code>secret.php</code> '
+            $message = '<strong><code>secret.php</code> '
                 . esc_html__('override is active.', 'reprint')
                 . '</strong> '
                 . esc_html__(
                     'This page and the REST API update only the site option. Remove secret.php to use the stored option value.',
                     'reprint'
-                )
-                . '</p></div>';
+                );
+            $this->render_notice('warning', $message);
         }
 
         if (!$configuration['is_configured']) {
-            echo '<div class="notice notice-warning inline"><p><strong>'
+            $message = '<strong>'
                 . esc_html__('Not configured yet.', 'reprint')
                 . '</strong> '
-                . esc_html__('Enter a connection token to get started.', 'reprint')
-                . '</p></div>';
+                . esc_html__('Enter a connection token to get started.', 'reprint');
+            $this->render_notice('warning', $message);
             return;
         }
 
-        echo '<div class="notice notice-info inline"><p>';
         if ($configuration['push_enabled']) {
-            echo '<strong>' . esc_html__('Connected for downloads and push.', 'reprint') . '</strong> '
+            $message = '<strong>' . esc_html__('Connected for downloads and push.', 'reprint') . '</strong> '
                 . esc_html__('The current connection token can change files on this site.', 'reprint');
         } else {
-            echo '<strong>' . esc_html__('Connected for downloads.', 'reprint') . '</strong> '
+            $message = '<strong>' . esc_html__('Connected for downloads.', 'reprint') . '</strong> '
                 . esc_html__('The connection token cannot change files on this site.', 'reprint');
         }
-        echo '</p></div>';
+        $this->render_notice('info', $message);
     }
 
     /** Render the push-access form or its read-only state. */
@@ -260,9 +246,7 @@ class SettingsPage {
                 ),
                 PHP_VERSION
             );
-            echo '<div class="notice notice-warning inline"><p>'
-                . esc_html($unsupported_message)
-                . '</p></div>';
+            $this->render_notice('warning', esc_html($unsupported_message));
             return;
         }
 
@@ -344,10 +328,54 @@ class SettingsPage {
             return;
         }
 
-        $notice_classes = 'notice notice-' . $notices[$result][0] . ' is-dismissible inline';
-        echo '<div class="' . esc_attr($notice_classes) . '"><p>'
-            . esc_html($notices[$result][1])
-            . '</p></div>';
+        $this->render_notice(
+            $notices[$result][0],
+            esc_html($notices[$result][1]),
+            true
+        );
+    }
+
+    /** Render Settings API results with stable native notice markup. */
+    private function render_settings_notices(): void {
+        foreach (get_settings_errors() as $notice) {
+            $type = $notice['type'] === 'updated' ? 'success' : $notice['type'];
+            $this->render_notice(
+                $type,
+                $notice['message'],
+                true,
+                'setting-error-' . $notice['code'],
+                true
+            );
+        }
+    }
+
+    /** Render one native inline administrator notice. */
+    private function render_notice(
+        string $type,
+        string $message,
+        bool $dismissible = false,
+        string $id = '',
+        bool $settings_error = false
+    ): void {
+        $allowed_types = ['error', 'success', 'warning', 'info'];
+        if (!in_array($type, $allowed_types, true)) {
+            $type = 'error';
+        }
+
+        $classes = 'notice notice-' . $type;
+        if ($settings_error) {
+            $classes .= ' settings-error';
+        }
+        if ($dismissible) {
+            $classes .= ' is-dismissible';
+        }
+        $classes .= ' inline';
+        ?>
+        <div<?php if ($id !== ''): ?> id="<?php echo esc_attr($id); ?>"<?php endif; ?>
+             class="<?php echo esc_attr($classes); ?>">
+            <p><?php echo wp_kses_post($message); ?></p>
+        </div>
+        <?php
     }
 }
 

--- a/reprint-server-wp/wordpress/site-export.js
+++ b/reprint-server-wp/wordpress/site-export.js
@@ -1,0 +1,37 @@
+( function() {
+	'use strict';
+
+	var token = document.getElementById( 'site_export_secret' );
+	var toggle = document.querySelector( '.site-export-toggle-token' );
+	if ( token && toggle ) {
+		toggle.addEventListener( 'click', function() {
+			var showing = token.type === 'text';
+			token.type = showing ? 'password' : 'text';
+			toggle.setAttribute( 'aria-pressed', showing ? 'false' : 'true' );
+			toggle.setAttribute(
+				'aria-label',
+				showing ? toggle.dataset.showLabel : toggle.dataset.hideLabel
+			);
+		} );
+	}
+
+	var remoteReprintApiUrl = document.getElementById( 'site-export-api-url' );
+	var copy = document.querySelector( '.site-export-copy-url' );
+	if ( remoteReprintApiUrl && copy ) {
+		copy.addEventListener( 'click', function() {
+			var copied;
+			if ( navigator.clipboard && navigator.clipboard.writeText ) {
+				copied = navigator.clipboard.writeText( remoteReprintApiUrl.value );
+			} else {
+				remoteReprintApiUrl.select();
+				copied = Promise.resolve( document.execCommand( 'copy' ) );
+			}
+
+			copied.then( function() {
+				if ( window.wp && wp.a11y ) {
+					wp.a11y.speak( copy.dataset.copiedMessage );
+				}
+			} );
+		} );
+	}
+}() );

--- a/reprint-server-wp/wordpress/site-export.php
+++ b/reprint-server-wp/wordpress/site-export.php
@@ -1,20 +1,12 @@
 <?php
-/**
- * Admin interface for Reprint Server plugin.
- *
- * This plugin provides a WordPress admin UI for configuring the export API.
- * The export API is triggered via `?reprint-api` (or the legacy
- * `?site-export-api` alias) during plugin load,
- * before WordPress finishes booting. It reads the secret from a site option,
- * with secret.php supported only as an override when present.
- *
- * Authentication uses HMAC signatures: the importing side generates a secret,
- * the user enters it here, and all requests must include a valid signature
- * computed from the nonce, timestamp, and request content hash.
- */
+/** Bundled WordPress administrator adapter for Reprint Server. */
+
 class Site_Export_Plugin {
 
     private static $instance = null;
+
+    /** @var string|false Page hook returned by add_management_page(). */
+    private $page_hook = false;
 
     public static function get_instance() {
         if (self::$instance === null) {
@@ -24,466 +16,343 @@ class Site_Export_Plugin {
     }
 
     private function __construct() {
-        add_action('init', [$this, 'register_settings']);
-        add_action(
-            'update_option_' . SITE_EXPORT_SECRET_OPTION,
-            [$this, 'revoke_push_authorization_after_connection_token_change'],
-            10,
-            2
-        );
-        add_action(
-            'add_option_' . SITE_EXPORT_SECRET_OPTION,
-            [$this, 'revoke_push_authorization_after_connection_token_added'],
-            10,
-            0
-        );
         add_action('admin_menu', [$this, 'add_admin_menu']);
-        add_action('admin_init', [$this, 'handle_settings_save']);
-        add_filter('plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'), [$this, 'add_settings_link']);
-        add_action('admin_bar_menu', [$this, 'add_admin_bar_node'], 100);
-    }
-
-    /** Register the option so core's /wp/v2/settings endpoint can update it. */
-    public function register_settings() {
-        register_setting(
-            'general',
-            SITE_EXPORT_SECRET_OPTION,
-            [
-                'type' => 'string',
-                'sanitize_callback' => 'sanitize_text_field',
-                'default' => '',
-                'show_in_rest' => true,
-            ]
+        add_action('admin_init', [$this, 'register_settings_fields']);
+        add_action('admin_post_site_export_save_push_access', [$this, 'handle_push_access_save']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+        add_filter(
+            'plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            [$this, 'add_settings_link']
         );
     }
 
-    /**
-     * Revoke local push authorization when the effective connection token changes.
-     *
-     * The secret.php override keeps the option from becoming the effective token.
-     *
-     * @param mixed $old_value Previous option value.
-     * @param mixed $new_value New option value.
-     */
-    public function revoke_push_authorization_after_connection_token_change($old_value, $new_value) {
-        if (_site_export_has_secret_file()) {
-            return;
-        }
-
-        $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
-        $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
-        if ($old_connection_token !== $new_connection_token) {
-            _site_export_update_push_authorization(false);
-        }
+    /** Add the bundled page beneath Tools. */
+    public function add_admin_menu(): void {
+        $this->page_hook = add_management_page(
+            __('Reprint Server', 'reprint'),
+            __('Reprint Server', 'reprint'),
+            'manage_options',
+            'site-export',
+            [$this, 'render_admin_page']
+        );
     }
 
-    /**
-     * Revoke stale local push authorization when the connection-token option is added.
-     *
-     * WordPress uses add_option() when update_option() receives a missing option,
-     * so that path does not emit the update hook above. A secret.php override
-     * still keeps the option from becoming the effective token.
-     *
-     */
-    public function revoke_push_authorization_after_connection_token_added() {
-        if (!_site_export_has_secret_file()) {
-            _site_export_update_push_authorization(false);
-        }
+    /** Register the connection-token section rendered by the Settings API. */
+    public function register_settings_fields(): void {
+        add_settings_section(
+            'site_export_connection',
+            __('Connection token', 'reprint'),
+            [$this, 'render_connection_section'],
+            'site-export'
+        );
+        add_settings_field(
+            SITE_EXPORT_SECRET_OPTION,
+            __('Connection token', 'reprint'),
+            [$this, 'render_connection_token_field'],
+            'site-export',
+            'site_export_connection',
+            ['label_for' => SITE_EXPORT_SECRET_OPTION]
+        );
     }
 
-    /**
-     * Add "Settings" link to the plugin row on the Plugins page.
-     */
+    /** Add the Settings link to the plugin row. */
     public function add_settings_link(array $links): array {
-        $url = admin_url('admin.php?page=site-export');
-        array_unshift($links, '<a href="' . esc_url($url) . '">Settings</a>');
+        $url = admin_url('tools.php?page=site-export');
+        array_unshift(
+            $links,
+            '<a href="' . esc_url($url) . '">' . esc_html__('Settings', 'reprint') . '</a>'
+        );
         return $links;
     }
 
-    /**
-     * Add top-level admin menu page.
-     */
-    public function add_admin_menu() {
-        add_menu_page(
-            'Reprint Server',
-            'Reprint Server',
-            'manage_options',
-            'site-export',
-            [$this, 'render_admin_page'],
-            'dashicons-cloud-upload'
+    /** Enqueue browser-only behavior on the bundled page. */
+    public function enqueue_assets(string $hook_suffix): void {
+        if ($this->page_hook === false || $hook_suffix !== $this->page_hook) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'site-export-admin',
+            plugins_url('wordpress/site-export.js', SITE_EXPORT_PLUGIN_DIR . 'index.php'),
+            ['wp-a11y'],
+            SITE_EXPORT_VERSION,
+            true
         );
     }
 
-    /**
-     * Add "Reprint Server" link to the admin bar.
-     */
-    public function add_admin_bar_node($wp_admin_bar) {
-        if (!current_user_can('manage_options')) {
-            return;
-        }
-
-        $wp_admin_bar->add_node([
-            'id'    => 'site-export',
-            'title' => 'Reprint Server',
-            'href'  => admin_url('admin.php?page=site-export'),
-            'meta'  => ['title' => 'Reprint Server'],
-        ]);
+    /** Explain where the connection token comes from. */
+    public function render_connection_section(): void {
+        echo '<p>' . esc_html__(
+            'Paste the connection token supplied by the tool which will connect to this site.',
+            'reprint'
+        ) . '</p>';
     }
 
-    /**
-     * Handle settings form submission.
-     */
-    public function handle_settings_save() {
-        $saving_connection_token = isset($_POST['site_export_save_settings']);
-        $saving_push_access = isset($_POST['site_export_save_push_access']);
-        if (!$saving_connection_token && !$saving_push_access) {
-            return;
-        }
-
-        if (!current_user_can('manage_options')) {
-            return;
-        }
-
-        check_admin_referer('site_export_settings');
-
-        if ($saving_connection_token) {
-            $secret = isset($_POST['site_export_secret'])
-                ? sanitize_text_field(wp_unslash($_POST['site_export_secret']))
-                : '';
-            $updated = _site_export_update_shared_secret($secret);
-            $saved = $updated || _site_export_get_option_secret() === $secret;
-
-            if (!$saved) {
-                add_settings_error('site_export', 'save_failed', 'Failed to save secret.', 'error');
-                return;
-            }
-
-            add_settings_error(
-                'site_export',
-                'save_success',
-                'Settings saved successfully.',
-                'success'
-            );
-            return;
-        }
-
-        if (!_site_export_push_is_supported()) {
-            add_settings_error(
-                'site_export',
-                'push_access_unsupported',
-                'Push access requires PHP 7.2 or newer. Downloads remain available.',
-                'error'
-            );
-            return;
-        }
-
-        if (_site_export_get_managed_push_enabled() !== null) {
-            add_settings_error(
-                'site_export',
-                'push_access_managed',
-                'Push access is managed by your hosting provider.',
-                'info'
-            );
-            return;
-        }
-
-        $push_enabled = isset($_POST['site_export_push_enabled']);
-        if (!_site_export_update_push_authorization($push_enabled)) {
-            add_settings_error('site_export', 'push_access_save_failed', 'Failed to save push access.', 'error');
-            return;
-        }
-
-        add_settings_error('site_export', 'push_access_saved', 'Push access updated.', 'success');
-    }
-
-    /**
-     * Render the admin page.
-     */
-    public function render_admin_page() {
-        if (!current_user_can('manage_options')) {
-            return;
-        }
-
-        $stored_secret = _site_export_get_option_secret();
-        $effective_secret = _site_export_get_shared_secret() ?? '';
-        $api_url = home_url('?reprint-api');
-        $is_configured = $effective_secret !== '';
-        $has_file_override = _site_export_has_secret_file();
-        $push_supported = _site_export_push_is_supported();
-        $managed_push_enabled = _site_export_get_managed_push_enabled();
-        $push_enabled = $push_supported && _site_export_is_push_authorized();
-
+    /** Render the option-backed connection-token field. */
+    public function render_connection_token_field(): void {
+        $configuration = _site_export_get_configuration_state();
         ?>
-        <style>
-            .site-export-wrap {
-                max-width: 680px;
-                margin: 40px auto 0;
-                font-size: 14px;
-            }
-            .site-export-wrap h1 {
-                font-size: 28px;
-                font-weight: 600;
-                margin-bottom: 4px;
-            }
-            .site-export-wrap .subtitle {
-                color: #646970;
-                font-size: 14px;
-                margin: 0 0 30px;
-            }
-            .site-export-card {
-                background: #fff;
-                border: 1px solid #ddd;
-                border-radius: 8px;
-                padding: 28px 32px;
-                margin-bottom: 24px;
-            }
-            .site-export-card h2 {
-                font-size: 16px;
-                font-weight: 600;
-                margin: 0 0 6px;
-                padding: 0;
-            }
-            .site-export-card .card-desc {
-                color: #646970;
-                margin: 0 0 20px;
-            }
-            .site-export-push-access {
-                padding: 20px 24px;
-            }
-            .site-export-push-access label {
-                display: flex;
-                gap: 8px;
-                align-items: flex-start;
-                font-weight: 600;
-            }
-            .site-export-push-access input[type="checkbox"] {
-                margin-top: 1px;
-            }
-            .site-export-push-disclosure {
-                color: #646970;
-                font-size: 13px;
-                margin: 10px 0 16px 24px;
-            }
-            .site-export-managed-copy {
-                color: #646970;
-                margin: 12px 0 0 24px;
-            }
-            .site-export-secret-field {
-                display: flex;
-                gap: 8px;
-                align-items: start;
-            }
-            .site-export-secret-field input[type="password"],
-            .site-export-secret-field input[type="text"] {
-                flex: 1;
-                font-family: monospace;
-                font-size: 14px;
-                padding: 8px 12px;
-                border-radius: 4px;
-            }
-            .site-export-secret-field .button {
-                flex-shrink: 0;
-                height: 38px;
-            }
-            .site-export-toggle-btn {
-                background: none;
-                border: 1px solid #8c8f94;
-                border-radius: 4px;
-                cursor: pointer;
-                padding: 6px 10px;
-                color: #50575e;
-                height: 38px;
-                display: inline-flex;
-                align-items: center;
-            }
-            .site-export-toggle-btn:hover {
-                border-color: #2271b1;
-                color: #2271b1;
-            }
-            .site-export-status {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                padding: 14px 18px;
-                border-radius: 6px;
-                margin-bottom: 20px;
-                font-size: 14px;
-            }
-            .site-export-status.is-ready {
-                background: #edfaef;
-                border: 1px solid #b8e6be;
-                color: #1e4620;
-            }
-            .site-export-status.is-pending {
-                background: #fef8ee;
-                border: 1px solid #f0d9a8;
-                color: #6e4e00;
-            }
-            .site-export-status .dashicons {
-                font-size: 20px;
-                width: 20px;
-                height: 20px;
-            }
-            .site-export-endpoint {
-                background: #f6f7f7;
-                border: 1px solid #ddd;
-                border-radius: 6px;
-                padding: 14px 18px;
-                display: flex;
-                align-items: center;
-                gap: 10px;
-            }
-            .site-export-endpoint code {
-                flex: 1;
-                font-size: 13px;
-                word-break: break-all;
-                background: none;
-                padding: 0;
-            }
-            .site-export-copy-btn {
-                background: none;
-                border: 1px solid #8c8f94;
-                border-radius: 4px;
-                cursor: pointer;
-                padding: 4px 10px;
-                color: #50575e;
-                font-size: 12px;
-                white-space: nowrap;
-            }
-            .site-export-copy-btn:hover {
-                border-color: #2271b1;
-                color: #2271b1;
-            }
-        </style>
+        <input type="password"
+               class="regular-text code"
+               id="site_export_secret"
+               name="<?php echo esc_attr(SITE_EXPORT_SECRET_OPTION); ?>"
+               value="<?php echo esc_attr($configuration['stored_connection_token']); ?>"
+               autocomplete="off" />
+        <button type="button"
+                class="button site-export-toggle-token"
+                aria-controls="site_export_secret"
+                aria-pressed="false"
+                aria-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"
+                data-show-label="<?php echo esc_attr__('Show connection token', 'reprint'); ?>"
+                data-hide-label="<?php echo esc_attr__('Hide connection token', 'reprint'); ?>">
+            <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+        </button>
+        <?php
+    }
 
-        <div class="site-export-wrap">
-            <h1>Reprint Server</h1>
-            <p class="subtitle">Allow an external tool to download your site's database and files.</p>
+    /** Apply one push-access change and redirect back to the bundled page. */
+    public function handle_push_access_save(): void {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('You are not allowed to manage Reprint Server.', 'reprint'));
+        }
 
-            <?php settings_errors('site_export'); ?>
+        check_admin_referer('site_export_save_push_access');
+        $enabled = isset($_POST['site_export_push_enabled']);
+        $result = _site_export_change_push_access($enabled);
+        $redirect_url = add_query_arg(
+            'site_export_notice',
+            $result,
+            admin_url('tools.php?page=site-export')
+        );
+        wp_safe_redirect($redirect_url);
+        exit;
+    }
 
-            <?php if ($has_file_override): ?>
-            <div class="site-export-status is-pending">
-                <span class="dashicons dashicons-lock"></span>
-                <span><strong><code>secret.php</code> override is active.</strong> This screen and the REST API update only the site option. Remove <code>secret.php</code> to use the stored option value.</span>
-            </div>
-            <?php endif; ?>
+    /** Render the bundled Tools page. */
+    public function render_admin_page(): void {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
 
-            <?php if ($is_configured): ?>
-            <div class="site-export-status is-ready">
-                <span class="dashicons dashicons-yes-alt"></span>
-                <?php if ($push_enabled): ?>
-                <span><strong>Connected for downloads and push.</strong> The current connection token can change files on this site.</span>
-                <?php else: ?>
-                <span><strong>Connected for downloads.</strong> The connection token cannot change files on this site.</span>
-                <?php endif; ?>
-            </div>
-            <?php else: ?>
-            <div class="site-export-status is-pending">
-                <span class="dashicons dashicons-warning"></span>
-                <span><strong>Not configured yet.</strong> Paste the connection token from your import tool below to get started.</span>
-            </div>
-            <?php endif; ?>
+        $configuration = _site_export_get_configuration_state();
+        $remote_reprint_api_url = home_url('?reprint-api');
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+            <p>
+            <?php
+            echo esc_html__(
+                'Allow an external tool to download your site\'s database and files.',
+                'reprint'
+            );
+            ?>
+            </p>
 
-            <div class="site-export-card">
-                <h2>Connection Token</h2>
-                <p class="card-desc">
-                    Your import tool will give you a token. Paste it here to authorize the connection.
+            <?php
+            ob_start();
+            settings_errors();
+            $settings_errors_markup = ob_get_clean();
+            if (is_string($settings_errors_markup)) {
+                // Core bolds each complete message and moves non-inline notices after load.
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- settings_errors() returns escaped core markup.
+                echo str_replace(
+                    ['settings-error is-dismissible', '<strong>', '</strong>'],
+                    ['settings-error is-dismissible inline', '', ''],
+                    $settings_errors_markup
+                );
+            }
+            ?>
+            <?php $this->render_push_access_notice(); ?>
+            <?php $this->render_configuration_status($configuration); ?>
+
+            <form method="post" action="options.php">
+                <?php settings_fields('site_export'); ?>
+                <?php do_settings_sections('site-export'); ?>
+                <?php submit_button(); ?>
+            </form>
+
+            <?php if ($configuration['is_configured']): ?>
+                <hr />
+                <h2><?php echo esc_html__('Push access', 'reprint'); ?></h2>
+                <p>
+                <?php
+                echo esc_html__(
+                    'You do not need push access when moving this site to another host.',
+                    'reprint'
+                );
+                ?>
                 </p>
+                <?php $this->render_push_access_form($configuration); ?>
 
-                <form method="post" action="">
-                    <?php wp_nonce_field('site_export_settings'); ?>
-
-                    <div class="site-export-secret-field">
-                        <input type="password"
-                               id="site_export_secret"
-                               name="site_export_secret"
-                               value="<?php echo esc_attr($stored_secret); ?>"
-                               placeholder="Paste your token here"
-                               autocomplete="off" />
-                        <button type="button" class="site-export-toggle-btn" onclick="siteExportToggleSecret()" title="Show / hide token">
-                            <span class="dashicons dashicons-visibility"></span>
-                        </button>
-                        <input type="submit"
-                               name="site_export_save_settings"
-                               class="button button-primary"
-                               value="Save" />
-                    </div>
-                </form>
-            </div>
-
-            <?php if ($is_configured): ?>
-            <div class="site-export-card site-export-push-access">
-                <h2>Push access</h2>
-                <p class="card-desc">You do not need push access when moving this site to another host.</p>
-
-                <?php if (!$push_supported): ?>
-                <p class="card-desc">Push access requires PHP 7.2 or newer. This site runs PHP <?php echo esc_html(PHP_VERSION); ?>. Downloads remain available.</p>
-                <?php elseif ($managed_push_enabled !== null): ?>
-                <label>
-                    <input type="checkbox" name="site_export_push_enabled" value="1"<?php echo $push_enabled ? ' checked' : ''; ?> disabled />
-                    <span>Allow push to change files on this site</span>
-                </label>
-                <p class="site-export-push-disclosure">While enabled, anyone with the connection token can upload, replace, and delete files in this site's document root, except excluded paths.</p>
-                <p class="site-export-managed-copy">Push access is managed by your hosting provider.</p>
-                <?php else: ?>
-                <form method="post" action="">
-                    <?php wp_nonce_field('site_export_settings'); ?>
-                    <label>
-                        <input type="checkbox" name="site_export_push_enabled" value="1"<?php echo $push_enabled ? ' checked' : ''; ?> />
-                        <span>Allow push to change files on this site</span>
-                    </label>
-                    <p class="site-export-push-disclosure">While enabled, anyone with the connection token can upload, replace, and delete files in this site's document root, except excluded paths.</p>
-                    <input type="submit"
-                           name="site_export_save_push_access"
-                           class="button button-secondary"
-                           value="Save push access" />
-                </form>
-                <?php endif; ?>
-            </div>
-            <?php endif; ?>
-
-            <?php if ($is_configured): ?>
-            <div class="site-export-card">
-                <h2>API Endpoint</h2>
-                <p class="card-desc">
-                    If your import tool asks for an endpoint URL, copy this:
+                <hr />
+                <h2><?php echo esc_html__('Remote Reprint API URL', 'reprint'); ?></h2>
+                <p>
+                <?php
+                echo esc_html__(
+                    'Use this URL when another tool asks for the remote Reprint API URL.',
+                    'reprint'
+                );
+                ?>
                 </p>
-                <div class="site-export-endpoint">
-                    <code id="site-export-api-url"><?php echo esc_html($api_url); ?></code>
-                    <button type="button" class="site-export-copy-btn" onclick="siteExportCopyUrl()">Copy</button>
-                </div>
-            </div>
+                <input type="text"
+                       class="regular-text code"
+                       id="site-export-api-url"
+                       value="<?php echo esc_attr($remote_reprint_api_url); ?>"
+                       readonly />
+                <button type="button"
+                        class="button site-export-copy-url"
+                        data-copied-message="<?php echo esc_attr__('Remote Reprint API URL copied.', 'reprint'); ?>">
+                    <?php echo esc_html__('Copy', 'reprint'); ?>
+                </button>
             <?php endif; ?>
         </div>
-
-        <script>
-        function siteExportToggleSecret() {
-            var input = document.getElementById('site_export_secret');
-            input.type = input.type === 'password' ? 'text' : 'password';
-        }
-        function siteExportCopyUrl() {
-            var url = document.getElementById('site-export-api-url').textContent.trim();
-            navigator.clipboard.writeText(url).then(function() {
-                var btn = document.querySelector('.site-export-copy-btn');
-                var original = btn.textContent;
-                btn.textContent = 'Copied!';
-                setTimeout(function() { btn.textContent = original; }, 1500);
-            });
-        }
-        </script>
         <?php
+    }
+
+    /**
+     * Render current configuration status and notices which require attention.
+     *
+     * @param array $configuration Configuration returned by _site_export_get_configuration_state().
+     */
+    private function render_configuration_status(array $configuration): void {
+        if ($configuration['has_secret_file']) {
+            echo '<div class="notice notice-warning inline"><p><strong><code>secret.php</code> '
+                . esc_html__('override is active.', 'reprint')
+                . '</strong> '
+                . esc_html__(
+                    'This page and the REST API update only the site option. Remove secret.php to use the stored option value.',
+                    'reprint'
+                )
+                . '</p></div>';
+        }
+
+        if (!$configuration['is_configured']) {
+            echo '<div class="notice notice-warning inline"><p><strong>'
+                . esc_html__('Not configured yet.', 'reprint')
+                . '</strong> '
+                . esc_html__('Enter a connection token to get started.', 'reprint')
+                . '</p></div>';
+            return;
+        }
+
+        echo '<div class="notice notice-info inline"><p>';
+        if ($configuration['push_enabled']) {
+            echo '<strong>' . esc_html__('Connected for downloads and push.', 'reprint') . '</strong> '
+                . esc_html__('The current connection token can change files on this site.', 'reprint');
+        } else {
+            echo '<strong>' . esc_html__('Connected for downloads.', 'reprint') . '</strong> '
+                . esc_html__('The connection token cannot change files on this site.', 'reprint');
+        }
+        echo '</p></div>';
+    }
+
+    /** Render the push-access form or its read-only state. */
+    private function render_push_access_form(array $configuration): void {
+        if (!$configuration['push_supported']) {
+            $unsupported_message = sprintf(
+                /* translators: %s: Current PHP version. */
+                __(
+                'Push access requires PHP 7.2 or newer. This site runs PHP %s. Downloads remain available.',
+                'reprint'
+                ),
+                PHP_VERSION
+            );
+            echo '<div class="notice notice-warning inline"><p>'
+                . esc_html($unsupported_message)
+                . '</p></div>';
+            return;
+        }
+
+        if ($configuration['managed_push_enabled'] !== null) {
+            ?>
+            <label>
+                <input type="checkbox"
+                       value="1"<?php checked($configuration['push_enabled']); ?><?php disabled(true); ?> />
+                <?php echo esc_html__('Allow push to change files on this site', 'reprint'); ?>
+            </label>
+            <p class="description">
+            <?php
+            echo esc_html__(
+                'While enabled, anyone with the connection token can upload, replace, and delete files in this site\'s document root, except excluded paths.',
+                'reprint'
+            );
+            ?>
+            </p>
+            <p class="description">
+            <?php
+            echo esc_html__(
+                'Push access is managed by your hosting provider.',
+                'reprint'
+            );
+            ?>
+            </p>
+            <?php
+            return;
+        }
+
+        ?>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+            <input type="hidden" name="action" value="site_export_save_push_access" />
+            <?php wp_nonce_field('site_export_save_push_access'); ?>
+            <label>
+                <input type="checkbox"
+                       name="site_export_push_enabled"
+                       value="1"<?php checked($configuration['push_enabled']); ?> />
+                <?php echo esc_html__('Allow push to change files on this site', 'reprint'); ?>
+            </label>
+            <p class="description">
+            <?php
+            echo esc_html__(
+                'While enabled, anyone with the connection token can upload, replace, and delete files in this site\'s document root, except excluded paths.',
+                'reprint'
+            );
+            ?>
+            </p>
+            <p class="submit">
+                <?php submit_button(__('Save push access', 'reprint'), 'secondary', 'submit', false); ?>
+            </p>
+        </form>
+        <?php
+    }
+
+    /** Render a fixed native notice for the admin-post result. */
+    private function render_push_access_notice(): void {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- A newer Settings API result supersedes the stale push result.
+        if (isset($_GET['settings-updated'])) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The fixed query value selects a read-only notice.
+        if (!isset($_GET['site_export_notice']) || !is_string($_GET['site_export_notice'])) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The fixed query value selects a read-only notice.
+        $result = sanitize_key(wp_unslash($_GET['site_export_notice']));
+        $notices = [
+            'saved' => ['success', __('Push access updated.', 'reprint')],
+            'unchanged' => ['success', __('Push access was already up to date.', 'reprint')],
+            'unsupported' => ['error', __('Push access requires PHP 7.2 or newer. Downloads remain available.', 'reprint')],
+            'managed' => ['info', __('Push access is managed by your hosting provider.', 'reprint')],
+            'not_configured' => ['error', __('Configure a connection token before enabling push access.', 'reprint')],
+            'storage_failure' => ['error', __('Failed to save push access.', 'reprint')],
+        ];
+        if (!isset($notices[$result])) {
+            return;
+        }
+
+        $notice_classes = 'notice notice-' . $notices[$result][0] . ' is-dismissible inline';
+        echo '<div class="' . esc_attr($notice_classes) . '"><p>'
+            . esc_html($notices[$result][1])
+            . '</p></div>';
     }
 }
 
-// Initialize
 add_action('plugins_loaded', function() {
     Site_Export_Plugin::get_instance();
 });
 
-// On activation: set a transient so we can redirect on the next admin page load.
 register_activation_hook(SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
-    // Only redirect when activated through the admin UI (not via WP-CLI or bulk).
     if (!wp_doing_ajax() && is_admin()) {
         set_transient('site_export_activated', 1, 30);
     }
@@ -494,12 +363,12 @@ register_activation_hook(SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
     }
 });
 
-// Redirect to settings page after activation.
 add_action('admin_init', function() {
     if (get_transient('site_export_activated')) {
         delete_transient('site_export_activated');
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This only suppresses activation redirects for bulk activation.
         if (!isset($_GET['activate-multi'])) {
-            wp_safe_redirect(admin_url('admin.php?page=site-export'));
+            wp_safe_redirect(admin_url('tools.php?page=site-export'));
             exit;
         }
     }

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -241,7 +241,9 @@ final class ExportLibraryLoadTest extends TestCase {
             'hooks' => $registered_hooks,
             'handler' => function_exists('_site_export_handle_api_request'),
             'canonical_handler' => function_exists('WordPress\\Reprint\\Server\\Plugin\\handle_api_request'),
-            'configuration' => function_exists('_site_export_get_configuration_state'),
+            'configuration' => function_exists(
+                'WordPress\\Reprint\\Server\\Plugin\\get_configuration_state'
+            ),
         ]);
         PHP;
 

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -213,6 +213,48 @@ final class ExportLibraryLoadTest extends TestCase {
         );
     }
 
+    public function testPluginLibraryDefinesEmbeddingFacadeWithoutRegisteringWordPressHooks(): void
+    {
+        $lib_path = realpath(__DIR__ . '/../reprint-server-wp/lib.php');
+        $this->assertNotFalse($lib_path, 'lib.php must exist');
+        $configuration_path = realpath(__DIR__ . '/../reprint-server-wp/wordpress/configuration.php');
+        $this->assertNotFalse($configuration_path, 'configuration.php must exist');
+
+        $php_code = <<<'PHP'
+        <?php
+        define('ABSPATH', __DIR__ . '/');
+        $registered_hooks = [];
+        function plugin_dir_path($file) {
+            return dirname($file) . '/';
+        }
+        function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+            global $registered_hooks;
+            $registered_hooks[] = $hook_name;
+        }
+        PHP;
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Builds isolated test source.
+        $php_code .= "\nrequire " . var_export($lib_path, true) . ";\n";
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Builds isolated test source.
+        $php_code .= "require " . var_export($configuration_path, true) . ";\n";
+        $php_code .= <<<'PHP'
+        echo json_encode([
+            'hooks' => $registered_hooks,
+            'handler' => function_exists('_site_export_handle_api_request'),
+            'canonical_handler' => function_exists('WordPress\\Reprint\\Server\\Plugin\\handle_api_request'),
+            'configuration' => function_exists('_site_export_get_configuration_state'),
+        ]);
+        PHP;
+
+        $result = $this->runPhpCode($php_code);
+
+        $this->assertSame(0, $result['status'], $result['output']);
+        $state = json_decode(trim($result['output']), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame([], $state['hooks']);
+        $this->assertTrue($state['handler']);
+        $this->assertTrue($state['canonical_handler']);
+        $this->assertTrue($state['configuration']);
+    }
+
     /**
      * @return array {
      *     Export runner result.

--- a/tests/Import/CompatibilityEntryPointsTest.php
+++ b/tests/Import/CompatibilityEntryPointsTest.php
@@ -50,6 +50,9 @@ class CompatibilityEntryPointsTest extends TestCase
         $this->assertSame($canonical_output, $alias_output);
         $this->assertSame($canonical_exit, $alias_exit);
         $this->assertStringContainsString('reprint-exporter-wp.zip', $canonical_output);
+        $this->assertStringContainsString('Configure the connection token', $canonical_output);
+        $this->assertStringContainsString('Tools → Reprint Server', $canonical_output);
+        $this->assertStringNotContainsString('Reprint Server (in the sidebar)', $canonical_output);
     }
 
     public function testMainHelpPresentsInstallServerWithoutTheLegacyAlias(): void

--- a/tests/ReprintServerCompatTest.php
+++ b/tests/ReprintServerCompatTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Backwards compatibility for the released Site Export names.
+ *
+ * Every test here exists only because compat.php exists: the released
+ * SITE_EXPORT_* constants, the released _site_export_*() functions, the
+ * legacy option migration, and the legacy push-policy environment variable.
+ * Nothing in the canonical suite depends on any of these names.
+ *
+ * TODO: Delete this file together with reprint-server-wp/compat.php after
+ * September 2026, as it should no longer be relevant by then.
+ */
+
+use WordPress\Reprint\Server\Plugin\SettingsPage;
+
+use const WordPress\Reprint\Server\Plugin\CONNECTION_TOKEN_OPTION;
+use const WordPress\Reprint\Server\Plugin\PUSH_AUTHORIZATION_OPTION;
+
+require_once __DIR__ . '/lib/ReprintServerPluginTestCase.php';
+
+final class ReprintServerCompatTest extends ReprintServerPluginTestCase
+{
+    /** @var string|false */
+    private $original_legacy_push_enabled_environment;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->original_legacy_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
+        putenv('SITE_EXPORT_PUSH_ENABLED');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->original_legacy_push_enabled_environment === false) {
+            putenv('SITE_EXPORT_PUSH_ENABLED');
+        } else {
+            putenv('SITE_EXPORT_PUSH_ENABLED=' . $this->original_legacy_push_enabled_environment);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testMigrationCreatesNoOptionsWhenNoLegacyOptionExists(): void
+    {
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame([], $GLOBALS['reprint_server_test_options']);
+    }
+
+    public function testMigrationKeepsPushAuthorizationGrantedUnderTheLegacyOptionNames(): void
+    {
+        // The plugin migrates before the settings page registers its
+        // listeners. Registering them first models a project which embeds
+        // lib.php later in the request, where the listener revoking
+        // authorization for the appearing connection token runs during the
+        // migration.
+        \WordPress\Reprint\Server\Plugin\SettingsPage::get_instance();
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
+            hash('sha256', 'legacy-token');
+
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame(
+            hash('sha256', 'legacy-token'),
+            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+        );
+        $this->assertArrayNotHasKey(
+            'site_export_push_authorized_token_fingerprint',
+            $GLOBALS['reprint_server_test_options']
+        );
+        $this->assertTrue(_site_export_is_push_authorized());
+    }
+
+    public function testCanonicalPluginSymbolsArePrimaryAndReleasedCompatibilityNamesRemainAvailable(): void
+    {
+        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\VERSION'));
+        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'));
+        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'));
+        $this->assertSame(
+            'reprint_server_connection_token',
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION')
+        );
+        $this->assertSame(
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'),
+            SITE_EXPORT_SECRET_OPTION
+        );
+        $this->assertSame(
+            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'),
+            REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE
+        );
+        $this->assertFalse(defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'));
+        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\handle_api_request'));
+        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_connection_token'));
+        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\update_connection_token'));
+        $this->assertFalse(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_shared_secret'));
+        $this->assertTrue(function_exists('_site_export_handle_api_request'));
+        $this->assertTrue(function_exists('_site_export_get_shared_secret'));
+        $this->assertFalse(class_exists('Site_Export_Plugin'));
+        $this->assertTrue(class_exists('WordPress\\Reprint\\Server\\Plugin\\SettingsPage'));
+    }
+
+    public function testLegacyOptionsMigrateWithoutChangingTheirValues(): void
+    {
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
+            'legacy-fingerprint';
+
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame(
+            'legacy-token',
+            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
+        );
+        $this->assertSame(
+            'legacy-fingerprint',
+            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
+        );
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
+        $this->assertArrayNotHasKey(
+            'site_export_push_authorized_token_fingerprint',
+            $GLOBALS['reprint_server_test_options']
+        );
+        $this->assertSame('legacy-token', _site_export_get_shared_secret());
+    }
+
+    public function testCanonicalOptionsTakePrecedenceDuringLegacyMigration(): void
+    {
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['reprint_server_connection_token'] = 'canonical-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
+            'legacy-fingerprint';
+        $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint'] =
+            'canonical-fingerprint';
+
+        reprint_server_compat_migrate_legacy_options();
+
+        $this->assertSame(
+            'canonical-token',
+            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
+        );
+        $this->assertSame(
+            'canonical-fingerprint',
+            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
+        );
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
+        $this->assertArrayNotHasKey(
+            'site_export_push_authorized_token_fingerprint',
+            $GLOBALS['reprint_server_test_options']
+        );
+    }
+
+    public function testCanonicalManagedEnvironmentTakesPrecedenceOverLegacyEnvironment(): void
+    {
+        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
+
+        $this->assertFalse(_site_export_get_managed_push_enabled());
+    }
+
+    /**
+     * Every released constant must keep resolving to its canonical value.
+     *
+     * Driven off compat.php's own map so a new entry there cannot be added
+     * without being covered here.
+     */
+    public function testEveryReleasedConstantMirrorsItsCanonicalCounterpart(): void
+    {
+        $constant_map = reprint_server_compat_constants();
+        $this->assertNotEmpty($constant_map);
+
+        foreach ($constant_map as $released_name => $canonical_name) {
+            $this->assertTrue(
+                defined($canonical_name),
+                "Canonical constant {$canonical_name} must be defined"
+            );
+            $this->assertTrue(
+                defined($released_name),
+                "Released constant {$released_name} must remain defined"
+            );
+            $this->assertSame(
+                constant($canonical_name),
+                constant($released_name),
+                "{$released_name} must mirror {$canonical_name}"
+            );
+        }
+    }
+
+    /**
+     * Every released function must still exist and delegate to the canonical
+     * runtime API rather than carrying its own copy of the behaviour.
+     */
+    public function testEveryReleasedFunctionDelegatesToTheCanonicalRuntimeApi(): void
+    {
+        $released_functions = [
+            '_site_export_error',
+            '_site_export_push_error',
+            '_site_export_is_push_endpoint',
+            '_site_export_push_is_supported',
+            '_site_export_load_exporter_runtime',
+            '_site_export_has_secret_file',
+            '_site_export_get_file_secret',
+            '_site_export_get_option_secret',
+            '_site_export_get_shared_secret',
+            '_site_export_update_shared_secret',
+            '_site_export_get_managed_push_enabled',
+            '_site_export_is_push_authorized',
+            '_site_export_get_push_authorization_error',
+            '_site_export_update_push_authorization',
+            '_site_export_verify_hmac',
+            '_site_export_default_authenticate',
+            '_site_export_handle_api_request',
+        ];
+
+        foreach ($released_functions as $released_function) {
+            $this->assertTrue(
+                function_exists($released_function),
+                "Released function {$released_function}() must remain available"
+            );
+        }
+
+        // Spot-check that the wrappers read and write the same state as the
+        // canonical API, rather than merely existing.
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'released-token';
+        $this->assertSame('released-token', _site_export_get_shared_secret());
+        $this->assertSame('released-token', _site_export_get_option_secret());
+
+        $this->assertTrue(_site_export_update_shared_secret('rotated-token'));
+        $this->assertSame(
+            'rotated-token',
+            $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION]
+        );
+
+        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertTrue(_site_export_update_push_authorization(true));
+        $this->assertTrue(_site_export_is_push_authorized());
+        $this->assertSame(
+            hash('sha256', 'rotated-token'),
+            $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
+        );
+    }
+
+    /**
+     * A platform which still defines SITE_EXPORT_* from a must-use plugin keeps
+     * its values: the canonical constants are adopted from the released ones.
+     *
+     * Runs in a subprocess because constants cannot be redefined in-process,
+     * and the canonical suite deliberately seeds only the canonical names.
+     */
+    public function testPlatformDefinedLegacyConstantsAreAdoptedAsCanonical(): void
+    {
+        $lib_path = realpath(__DIR__ . '/../reprint-server-wp/lib.php');
+        $this->assertNotFalse($lib_path, 'lib.php must exist');
+        $plugin_directory = dirname($lib_path) . '/';
+
+        $php_code = '<?php' . "\n"
+            . 'define(\'ABSPATH\', __DIR__ . \'/\');' . "\n"
+            . 'define(\'SITE_EXPORT_PLUGIN_DIR\', '
+            . var_export($plugin_directory, true) . ');' . "\n"
+            . 'define(\'SITE_EXPORT_SECRET_FILE\', \'/platform/token.php\');' . "\n"
+            . 'define(\'SITE_EXPORT_SECRET_OPTION\', \'platform_token_option\');' . "\n"
+            . 'define(\'SITE_EXPORT_TIMESTAMP_TOLERANCE\', 42);' . "\n"
+            . 'function plugin_dir_path($file) { return dirname($file) . \'/\'; }' . "\n"
+            . 'require ' . var_export($lib_path, true) . ';' . "\n"
+            . 'echo json_encode(['. "\n"
+            . '    \'token_file\' => constant(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\CONNECTION_TOKEN_FILE\'),' . "\n"
+            . '    \'token_option\' => constant(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\CONNECTION_TOKEN_OPTION\'),' . "\n"
+            . '    \'tolerance\' => constant(\'WordPress\\\\Reprint\\\\Server\\\\Plugin\\\\TIMESTAMP_TOLERANCE\'),' . "\n"
+            . '], JSON_THROW_ON_ERROR);' . "\n";
+
+        $result = $this->runPhpCode($php_code);
+
+        $this->assertSame(0, $result['status'], $result['output']);
+        $adopted = json_decode(trim($result['output']), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('/platform/token.php', $adopted['token_file']);
+        $this->assertSame('platform_token_option', $adopted['token_option']);
+        $this->assertSame(42, $adopted['tolerance']);
+    }
+
+    /**
+     * @return array{status:int,output:string}
+     */
+    private function runPhpCode(string $php_code): array
+    {
+        $tmp_dir = sys_get_temp_dir() . '/reprint-server-compat-test-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            file_put_contents($tmp_dir . '/run.php', $php_code);
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+            $process = proc_open([PHP_BINARY, $tmp_dir . '/run.php'], $descriptors, $pipes, $tmp_dir);
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $output = (string) stream_get_contents($pipes[1]);
+            $output .= (string) stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            return ['status' => proc_close($process), 'output' => $output];
+        } finally {
+            @unlink($tmp_dir . '/run.php');
+            @rmdir($tmp_dir);
+        }
+    }
+}

--- a/tests/ReprintServerPluginTest.php
+++ b/tests/ReprintServerPluginTest.php
@@ -2,635 +2,56 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+/**
+ * Bundled WordPress plugin behaviour, exercised through the canonical
+ * Reprint Server runtime API only.
+ *
+ * Backwards compatibility for the released SITE_EXPORT_* constants and
+ * _site_export_*() functions lives in ReprintServerCompatTest, which is
+ * deleted together with compat.php.
+ */
+
 use WordPress\Reprint\Server\Plugin\SettingsPage;
 
 use function WordPress\Reprint\Server\Plugin\change_connection_token;
 use function WordPress\Reprint\Server\Plugin\change_push_access;
 use function WordPress\Reprint\Server\Plugin\get_configuration_state;
+use function WordPress\Reprint\Server\Plugin\get_connection_token;
+use function WordPress\Reprint\Server\Plugin\get_managed_push_enabled;
+use function WordPress\Reprint\Server\Plugin\get_push_authorization_error;
+use function WordPress\Reprint\Server\Plugin\is_push_authorized;
 use function WordPress\Reprint\Server\Plugin\register_connection_token_setting;
-use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
+use function WordPress\Reprint\Server\Plugin\update_connection_token;
+use function WordPress\Reprint\Server\Plugin\update_push_authorization;
+use function WordPress\Reprint\Server\Plugin\verify_hmac;
 
-if (!defined('ABSPATH')) {
-    define('ABSPATH', __DIR__ . '/');
-}
+use const WordPress\Reprint\Server\Plugin\CONNECTION_TOKEN_OPTION;
+use const WordPress\Reprint\Server\Plugin\PUSH_AUTHORIZATION_OPTION;
 
-$reprint_server_test_plugin_dir = sys_get_temp_dir() . '/reprint-server-plugin-test-' . getmypid() . '/';
-if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
-    define('SITE_EXPORT_PLUGIN_DIR', $reprint_server_test_plugin_dir);
-}
-if (!defined('SITE_EXPORT_SECRET_FILE')) {
-    define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
-}
+require_once __DIR__ . '/lib/ReprintServerPluginTestCase.php';
 
-$GLOBALS['reprint_server_test_options'] = [];
-$GLOBALS['reprint_server_registered_settings'] = [];
-$GLOBALS['reprint_server_settings_errors'] = [];
-$GLOBALS['reprint_server_settings_error_requests'] = [];
-$GLOBALS['reprint_server_test_actions'] = [];
-$GLOBALS['reprint_server_test_menu'] = null;
-$GLOBALS['reprint_server_test_sections'] = [];
-$GLOBALS['reprint_server_test_fields'] = [];
-$GLOBALS['reprint_server_test_scripts'] = [];
-$GLOBALS['reprint_server_fail_option_updates'] = [];
-
-// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,Generic.CodeAnalysis.UnusedFunctionParameter.Found,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound,WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress test stubs.
-if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path(string $file): string {
-        return SITE_EXPORT_PLUGIN_DIR;
-    }
-}
-
-if (!function_exists('get_option')) {
-    function get_option(string $name, $default = false) {
-        if (array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
-            return $GLOBALS['reprint_server_test_options'][$name];
-        }
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Generic WordPress option test stub.
-        return apply_filters('default_option_' . $name, $default, $name, true);
-    }
-}
-
-if (!function_exists('update_option')) {
-    function update_option(string $name, $value, $autoload = null): bool {
-        if (in_array($name, $GLOBALS['reprint_server_fail_option_updates'], true)) {
-            return false;
-        }
-
-        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
-            $GLOBALS['reprint_server_test_options'][$name] = $value;
-            foreach ($GLOBALS['reprint_server_test_actions']['add_option_' . $name] ?? [] as $action) {
-                $args = array_slice([$name, $value], 0, $action['accepted_args']);
-                call_user_func_array($action['callback'], $args);
-            }
-            return true;
-        }
-
-        $old_value = get_option($name);
-        $GLOBALS['reprint_server_test_options'][$name] = $value;
-
-        if ($old_value !== $value) {
-            foreach ($GLOBALS['reprint_server_test_actions']['update_option_' . $name] ?? [] as $action) {
-                $args = array_slice([$old_value, $value, $name], 0, $action['accepted_args']);
-                call_user_func_array($action['callback'], $args);
-            }
-        }
-
-        return true;
-    }
-}
-
-if (!function_exists('delete_option')) {
-    function delete_option(string $name): bool {
-        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
-            return false;
-        }
-
-        unset($GLOBALS['reprint_server_test_options'][$name]);
-        return true;
-    }
-}
-
-if (!function_exists('register_setting')) {
-    function register_setting(string $group, string $name, array $args = []): void {
-        $GLOBALS['reprint_server_registered_settings'][$name] = [
-            'group' => $group,
-            'args' => $args,
-        ];
-    }
-}
-
-if (!function_exists('add_settings_section')) {
-    function add_settings_section(string $id, string $title, $callback, string $page): void {
-        $GLOBALS['reprint_server_test_sections'][$page][$id] = [
-            'title' => $title,
-            'callback' => $callback,
-        ];
-    }
-}
-
-if (!function_exists('add_settings_field')) {
-    function add_settings_field(
-        string $id,
-        string $title,
-        $callback,
-        string $page,
-        string $section,
-        array $args = []
-    ): void {
-        $GLOBALS['reprint_server_test_fields'][$page][$section][$id] = [
-            'title' => $title,
-            'callback' => $callback,
-            'args' => $args,
-        ];
-    }
-}
-
-if (!function_exists('add_action')) {
-    function add_action(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
-        $GLOBALS['reprint_server_test_actions'][$hook_name][] = [
-            'callback' => $callback,
-            'priority' => $priority,
-            'accepted_args' => $accepted_args,
-        ];
-    }
-}
-
-if (!function_exists('add_filter')) {
-    function add_filter(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
-        $GLOBALS['reprint_test_filters'][$hook_name][] = [
-            'callback' => $callback,
-            'priority' => $priority,
-            'accepted_args' => $accepted_args,
-        ];
-    }
-}
-
-if (!function_exists('do_action')) {
-    function do_action(string $hook_name, ...$args): void {
-        $actions = $GLOBALS['reprint_server_test_actions'][$hook_name] ?? [];
-        usort($actions, static function (array $left, array $right): int {
-            return $left['priority'] <=> $right['priority'];
-        });
-        foreach ($actions as $action) {
-            call_user_func_array(
-                $action['callback'],
-                array_slice($args, 0, $action['accepted_args'])
-            );
-        }
-    }
-}
-
-if (!function_exists('plugin_basename')) {
-    function plugin_basename(string $file): string {
-        return basename($file);
-    }
-}
-
-if (!function_exists('add_management_page')) {
-    function add_management_page($page_title, $menu_title, $capability, $menu_slug, $callback): string {
-        $GLOBALS['reprint_server_test_menu'] = [
-            'page_title' => $page_title,
-            'menu_title' => $menu_title,
-            'capability' => $capability,
-            'menu_slug' => $menu_slug,
-            'callback' => $callback,
-        ];
-        return 'tools_page_' . $menu_slug;
-    }
-}
-
-if (!function_exists('register_activation_hook')) {
-    function register_activation_hook(...$args): void {}
-}
-
-if (!function_exists('wp_doing_ajax')) {
-    function wp_doing_ajax(): bool {
-        return false;
-    }
-}
-
-if (!function_exists('is_admin')) {
-    function is_admin(): bool {
-        return true;
-    }
-}
-
-if (!function_exists('set_transient')) {
-    function set_transient(...$args): void {}
-}
-
-if (!function_exists('get_transient')) {
-    function get_transient(...$args): bool {
-        return false;
-    }
-}
-
-if (!function_exists('delete_transient')) {
-    function delete_transient(...$args): void {}
-}
-
-if (!function_exists('wp_safe_redirect')) {
-    function wp_safe_redirect(...$args): void {}
-}
-
-if (!function_exists('__')) {
-    function __(string $text, string $domain = 'default'): string {
-        return $text;
-    }
-}
-
-if (!function_exists('esc_html__')) {
-    function esc_html__(string $text, string $domain = 'default'): string {
-        return esc_html($text);
-    }
-}
-
-if (!function_exists('esc_attr__')) {
-    function esc_attr__(string $text, string $domain = 'default'): string {
-        return esc_attr($text);
-    }
-}
-
-if (!function_exists('current_user_can')) {
-    function current_user_can(string $capability): bool {
-        return $capability === 'manage_options';
-    }
-}
-
-if (!function_exists('check_admin_referer')) {
-    function check_admin_referer(string $action): void {}
-}
-
-if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($value): string {
-        return trim( (string) $value );
-    }
-}
-
-if (!function_exists('wp_unslash')) {
-    function wp_unslash($value) {
-        return $value;
-    }
-}
-
-if (!function_exists('add_settings_error')) {
-    function add_settings_error(string $setting, string $code, string $message, string $type): void {
-        $GLOBALS['reprint_server_settings_errors'][] = [
-            'setting' => $setting,
-            'code' => $code,
-            'message' => $message,
-            'type' => $type,
-        ];
-    }
-}
-
-if (!function_exists('get_settings_errors')) {
-    function get_settings_errors(string $setting = '', bool $sanitize = false): array {
-        $GLOBALS['reprint_server_settings_error_requests'][] = $setting;
-        if ($setting === '') {
-            return $GLOBALS['reprint_server_settings_errors'];
-        }
-
-        return array_values(
-            array_filter(
-                $GLOBALS['reprint_server_settings_errors'],
-                static function(array $notice) use ($setting): bool {
-                    return $notice['setting'] === $setting;
-                }
-            )
-        );
-    }
-}
-
-if (!function_exists('settings_fields')) {
-    function settings_fields(string $group): void {
-        echo '<input type="hidden" name="option_page" value="' . esc_attr($group) . '" />';
-    }
-}
-
-if (!function_exists('do_settings_sections')) {
-    function do_settings_sections(string $page): void {
-        foreach ($GLOBALS['reprint_server_test_sections'][$page] ?? [] as $section_id => $section) {
-            echo '<h2>' . esc_html($section['title']) . '</h2>';
-            call_user_func($section['callback']);
-            echo '<table class="form-table">';
-            foreach ($GLOBALS['reprint_server_test_fields'][$page][$section_id] ?? [] as $field) {
-                echo '<tr><th>' . esc_html($field['title']) . '</th><td>';
-                call_user_func($field['callback'], $field['args']);
-                echo '</td></tr>';
-            }
-            echo '</table>';
-        }
-    }
-}
-
-if (!function_exists('submit_button')) {
-    function submit_button(
-        string $text = 'Save Changes',
-        string $type = 'primary',
-        string $name = 'submit',
-        bool $wrap = true
-    ): void {
-        $button = '<input type="submit" name="' . esc_attr($name) . '" class="button button-'
-            . esc_attr($type) . '" value="' . esc_attr($text) . '" />';
-        echo $wrap ? '<p class="submit">' . $button . '</p>' : $button;
-    }
-}
-
-if (!function_exists('home_url')) {
-    function home_url(string $path = ''): string {
-        return 'https://example.test/' . ltrim($path, '/');
-    }
-}
-
-if (!function_exists('admin_url')) {
-    function admin_url(string $path = ''): string {
-        return 'https://example.test/wp-admin/' . ltrim($path, '/');
-    }
-}
-
-if (!function_exists('get_admin_page_title')) {
-    function get_admin_page_title(): string {
-        return 'Reprint Server';
-    }
-}
-
-if (!function_exists('checked')) {
-    function checked($checked, $current = true, bool $display = true): string {
-        $result = $checked == $current ? ' checked="checked"' : '';
-        if ($display) {
-            echo $result;
-        }
-        return $result;
-    }
-}
-
-if (!function_exists('disabled')) {
-    function disabled($disabled, $current = true, bool $display = true): string {
-        $result = $disabled == $current ? ' disabled="disabled"' : '';
-        if ($display) {
-            echo $result;
-        }
-        return $result;
-    }
-}
-
-if (!function_exists('plugins_url')) {
-    function plugins_url(string $path = '', string $plugin = ''): string {
-        return 'https://example.test/wp-content/plugins/reprint-server/' . ltrim($path, '/');
-    }
-}
-
-if (!function_exists('wp_enqueue_script')) {
-    function wp_enqueue_script($handle, $src, $dependencies, $version, $in_footer): void {
-        $GLOBALS['reprint_server_test_scripts'][$handle] = compact(
-            'src',
-            'dependencies',
-            'version',
-            'in_footer'
-        );
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key(string $key): string {
-        return preg_replace('/[^a-z0-9_\-]/', '', strtolower($key)) ?? '';
-    }
-}
-
-if (!function_exists('wp_nonce_field')) {
-    function wp_nonce_field(string $action): void {
-        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr($action) . '" />';
-    }
-}
-
-if (!function_exists('esc_attr')) {
-    function esc_attr(string $value): string {
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-    }
-}
-
-if (!function_exists('esc_html')) {
-    function esc_html(string $value): string {
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-    }
-}
-
-if (!function_exists('wp_kses_post')) {
-    function wp_kses_post(string $value): string {
-        return $value;
-    }
-}
-
-if (!function_exists('esc_url')) {
-    function esc_url(string $value): string {
-        return esc_attr($value);
-    }
-}
-// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
-
-require_once __DIR__ . '/../reprint-server-wp/lib.php';
-require_once __DIR__ . '/../reprint-server-wp/wordpress/configuration.php';
-register_wordpress_configuration();
-require_once __DIR__ . '/../reprint-server-wp/wordpress/reprint-server.php';
-
-final class ReprintServerPluginTest extends TestCase
+final class ReprintServerPluginTest extends ReprintServerPluginTestCase
 {
-    /** @var array<string, mixed> */
-    private $original_server = [];
-
-    /** @var array<string, mixed> */
-    private $original_files = [];
-
-    /** @var array<string, mixed> */
-    private $original_post = [];
-
-    /** @var array<string, mixed> */
-    private $original_get = [];
-
-    /** @var string|false */
-    private $original_push_enabled_environment;
-
-    /** @var string|false */
-    private $original_reprint_server_push_enabled_environment;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if (!is_dir(SITE_EXPORT_PLUGIN_DIR)) {
-            mkdir(SITE_EXPORT_PLUGIN_DIR, 0755, true);
-        }
-
-        $this->original_server = $_SERVER;
-        $this->original_files = $_FILES;
-        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
-        $this->original_post = $_POST;
-        $this->original_get = $_GET;
-        $this->original_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
-        $this->original_reprint_server_push_enabled_environment = getenv('REPRINT_SERVER_PUSH_ENABLED');
-
-        $GLOBALS['reprint_server_test_options'] = [];
-        $GLOBALS['reprint_server_registered_settings'] = [];
-        $GLOBALS['reprint_server_settings_errors'] = [];
-        $GLOBALS['reprint_server_settings_error_requests'] = [];
-        $GLOBALS['reprint_server_test_menu'] = null;
-        $GLOBALS['reprint_server_test_sections'] = [];
-        $GLOBALS['reprint_server_test_fields'] = [];
-        $GLOBALS['reprint_server_test_scripts'] = [];
-        $GLOBALS['reprint_server_fail_option_updates'] = [];
-        $_SERVER = [];
-        $_FILES = [];
-        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
-        $_POST = [];
-        $_GET = [];
-        putenv('SITE_EXPORT_PUSH_ENABLED');
-        putenv('REPRINT_SERVER_PUSH_ENABLED');
-
-        if (file_exists(SITE_EXPORT_SECRET_FILE)) {
-            unlink(SITE_EXPORT_SECRET_FILE);
-        }
-    }
-
-    protected function tearDown(): void
-    {
-        if (file_exists(SITE_EXPORT_SECRET_FILE)) {
-            unlink(SITE_EXPORT_SECRET_FILE);
-        }
-
-        if (is_dir(SITE_EXPORT_PLUGIN_DIR)) {
-            rmdir(SITE_EXPORT_PLUGIN_DIR);
-        }
-
-        $_SERVER = $this->original_server;
-        $_FILES = $this->original_files;
-        $_POST = $this->original_post;
-        $_GET = $this->original_get;
-        if ($this->original_push_enabled_environment === false) {
-            putenv('SITE_EXPORT_PUSH_ENABLED');
-        } else {
-            putenv('SITE_EXPORT_PUSH_ENABLED=' . $this->original_push_enabled_environment);
-        }
-        if ($this->original_reprint_server_push_enabled_environment === false) {
-            putenv('REPRINT_SERVER_PUSH_ENABLED');
-        } else {
-            putenv('REPRINT_SERVER_PUSH_ENABLED=' . $this->original_reprint_server_push_enabled_environment);
-        }
-
-        parent::tearDown();
-    }
-
     public function testConnectionTokenFallsBackToOptionWhenSecretFileMissing(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'option-token';
 
-        $this->assertSame('option-token', _site_export_get_shared_secret());
-    }
-
-    public function testMigrationCreatesNoOptionsWhenNoLegacyOptionExists(): void
-    {
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame([], $GLOBALS['reprint_server_test_options']);
-    }
-
-    public function testMigrationKeepsPushAuthorizationGrantedUnderTheLegacyOptionNames(): void
-    {
-        // The plugin migrates before the settings page registers its
-        // listeners. Registering them first models a project which embeds
-        // lib.php later in the request, where the listener revoking
-        // authorization for the appearing connection token runs during the
-        // migration.
-        \WordPress\Reprint\Server\Plugin\SettingsPage::get_instance();
-        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
-            hash('sha256', 'legacy-token');
-
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame(
-            hash('sha256', 'legacy-token'),
-            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
-        );
-        $this->assertArrayNotHasKey(
-            'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['reprint_server_test_options']
-        );
-        $this->assertTrue(_site_export_is_push_authorized());
-    }
-
-    public function testCanonicalPluginSymbolsArePrimaryAndReleasedCompatibilityNamesRemainAvailable(): void
-    {
-        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\VERSION'));
-        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'));
-        $this->assertTrue(defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'));
-        $this->assertSame(
-            'reprint_server_connection_token',
-            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION')
-        );
-        $this->assertSame(
-            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_OPTION'),
-            SITE_EXPORT_SECRET_OPTION
-        );
-        $this->assertSame(
-            constant('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE'),
-            SITE_EXPORT_SECRET_FILE
-        );
-        $this->assertFalse(defined('WordPress\\Reprint\\Server\\Plugin\\SECRET_OPTION'));
-        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\handle_api_request'));
-        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_connection_token'));
-        $this->assertTrue(function_exists('WordPress\\Reprint\\Server\\Plugin\\update_connection_token'));
-        $this->assertFalse(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_shared_secret'));
-        $this->assertTrue(function_exists('_site_export_handle_api_request'));
-        $this->assertTrue(function_exists('_site_export_get_shared_secret'));
-        $this->assertFalse(class_exists('Site_Export_Plugin'));
-        $this->assertTrue(class_exists('WordPress\\Reprint\\Server\\Plugin\\SettingsPage'));
-    }
-
-    public function testLegacyOptionsMigrateWithoutChangingTheirValues(): void
-    {
-        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
-            'legacy-fingerprint';
-
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame(
-            'legacy-token',
-            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
-        );
-        $this->assertSame(
-            'legacy-fingerprint',
-            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
-        );
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
-        $this->assertArrayNotHasKey(
-            'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['reprint_server_test_options']
-        );
-        $this->assertSame('legacy-token', _site_export_get_shared_secret());
-    }
-
-    public function testCanonicalOptionsTakePrecedenceDuringLegacyMigration(): void
-    {
-        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['reprint_server_test_options']['reprint_server_connection_token'] = 'canonical-token';
-        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
-            'legacy-fingerprint';
-        $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint'] =
-            'canonical-fingerprint';
-
-        reprint_server_compat_migrate_legacy_options();
-
-        $this->assertSame(
-            'canonical-token',
-            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
-        );
-        $this->assertSame(
-            'canonical-fingerprint',
-            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
-        );
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
-        $this->assertArrayNotHasKey(
-            'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['reprint_server_test_options']
-        );
+        $this->assertSame('option-token', get_connection_token());
     }
 
     public function testSecretFileConnectionTokenOverridesSiteOptionWhenPresent(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token';
-        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'option-token';
+        file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'file-token';\n");
 
-        $this->assertSame('file-token', _site_export_get_shared_secret());
+        $this->assertSame('file-token', get_connection_token());
     }
 
     public function testUpdatingConnectionTokenOnlyTouchesTheSiteOption(): void
     {
-        $this->assertTrue(_site_export_update_shared_secret('new-token'));
-        $this->assertSame('new-token', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION]);
-        $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
+        $this->assertTrue(update_connection_token('new-token'));
+        $this->assertSame('new-token', $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION]);
+        $this->assertFileDoesNotExist(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE);
     }
 
     public function testConnectionTokenOperationReturnsExplicitOutcomes(): void
@@ -638,7 +59,7 @@ final class ReprintServerPluginTest extends TestCase
         $this->assertSame('saved', change_connection_token('new-token'));
         $this->assertSame('unchanged', change_connection_token('new-token'));
 
-        $GLOBALS['reprint_server_fail_option_updates'][] = SITE_EXPORT_SECRET_OPTION;
+        $GLOBALS['reprint_server_fail_option_updates'][] = CONNECTION_TOKEN_OPTION;
         $this->assertSame('storage_failure', change_connection_token('other-token'));
     }
 
@@ -646,7 +67,7 @@ final class ReprintServerPluginTest extends TestCase
     {
         register_connection_token_setting();
 
-        $setting = $GLOBALS['reprint_server_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
+        $setting = $GLOBALS['reprint_server_registered_settings'][CONNECTION_TOKEN_OPTION] ?? null;
         $this->assertNotNull($setting);
         $this->assertSame('reprint_server', $setting['group']);
         $this->assertTrue($setting['args']['show_in_rest']);
@@ -657,8 +78,8 @@ final class ReprintServerPluginTest extends TestCase
     public function testConfigurationIntegrationRegistersOutsideTheAdministratorAdapter(): void
     {
         $rest_hooks = $GLOBALS['reprint_server_test_actions']['rest_api_init'] ?? [];
-        $update_hooks = $GLOBALS['reprint_server_test_actions']['update_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
-        $add_hooks = $GLOBALS['reprint_server_test_actions']['add_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
+        $update_hooks = $GLOBALS['reprint_server_test_actions']['update_option_' . CONNECTION_TOKEN_OPTION] ?? [];
+        $add_hooks = $GLOBALS['reprint_server_test_actions']['add_option_' . CONNECTION_TOKEN_OPTION] ?? [];
 
         $this->assertNotEmpty($rest_hooks);
         $this->assertSame(
@@ -690,43 +111,35 @@ final class ReprintServerPluginTest extends TestCase
         $_SERVER['HTTP_X_AUTH_TIMESTAMP'] = $timestamp;
         $_SERVER['HTTP_X_AUTH_CONTENT_HASH'] = $content_hash;
 
-        $this->assertNull(_site_export_verify_hmac($connection_token));
+        $this->assertNull(verify_hmac($connection_token));
     }
 
     public function testPushAuthorizationMatchesOnlyTheCurrentConnectionToken(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $this->assertFalse(_site_export_is_push_authorized());
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $this->assertFalse(is_push_authorized());
 
-        $this->assertTrue(_site_export_update_push_authorization(true));
-        $this->assertTrue(_site_export_is_push_authorized());
+        $this->assertTrue(update_push_authorization(true));
+        $this->assertTrue(is_push_authorized());
         $this->assertSame(
             hash('sha256', 'current-token'),
-            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
         );
 
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'rotated-token';
-        $this->assertFalse(_site_export_is_push_authorized());
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'rotated-token';
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testManagedEnvironmentOverridesLocalPushAuthorization(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
 
-        putenv('SITE_EXPORT_PUSH_ENABLED=true');
-        $this->assertTrue(_site_export_is_push_authorized());
+        putenv('REPRINT_SERVER_PUSH_ENABLED=true');
+        $this->assertTrue(is_push_authorized());
 
-        $this->assertTrue(_site_export_update_push_authorization(true));
-        putenv('SITE_EXPORT_PUSH_ENABLED=false');
-        $this->assertFalse(_site_export_is_push_authorized());
-    }
-
-    public function testCanonicalManagedEnvironmentTakesPrecedenceOverLegacyEnvironment(): void
-    {
-        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        $this->assertTrue(update_push_authorization(true));
         putenv('REPRINT_SERVER_PUSH_ENABLED=false');
-
-        $this->assertFalse(_site_export_get_managed_push_enabled());
+        $this->assertFalse(is_push_authorized());
     }
 
     /**
@@ -738,7 +151,7 @@ final class ReprintServerPluginTest extends TestCase
         define('REPRINT_SERVER_PUSH_ENABLED', false);
         putenv('REPRINT_SERVER_PUSH_ENABLED=true');
 
-        $this->assertFalse(_site_export_get_managed_push_enabled());
+        $this->assertFalse(get_managed_push_enabled());
     }
 
     /**
@@ -751,117 +164,117 @@ final class ReprintServerPluginTest extends TestCase
         define('REPRINT_SERVER_PUSH_ENABLED', false);
         putenv('REPRINT_SERVER_PUSH_ENABLED=false');
 
-        $this->assertTrue(_site_export_get_managed_push_enabled());
+        $this->assertTrue(get_managed_push_enabled());
     }
 
     public function testPresentEmptyManagedEnvironmentFailsClosed(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $this->assertTrue(update_push_authorization(true));
 
-        putenv('SITE_EXPORT_PUSH_ENABLED=');
+        putenv('REPRINT_SERVER_PUSH_ENABLED=');
 
-        $this->assertFalse(_site_export_get_managed_push_enabled());
-        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertFalse(get_managed_push_enabled());
+        $this->assertFalse(is_push_authorized());
         $this->assertSame(
             'Push access is disabled by the hosting provider through REPRINT_SERVER_PUSH_ENABLED.',
-            _site_export_get_push_authorization_error()
+            get_push_authorization_error()
         );
     }
 
     public function testSettingsApiTokenRotationRevokesPriorConsent(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $this->assertTrue(update_push_authorization(true));
 
-        update_option(SITE_EXPORT_SECRET_OPTION, 'rotated-token');
+        update_option(CONNECTION_TOKEN_OPTION, 'rotated-token');
 
-        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
-        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testRestSettingsConnectionTokenRotationPermanentlyRevokesPushAuthorization(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'token-a';
+        $this->assertTrue(update_push_authorization(true));
 
-        update_option(SITE_EXPORT_SECRET_OPTION, 'token-b');
-        update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
+        update_option(CONNECTION_TOKEN_OPTION, 'token-b');
+        update_option(CONNECTION_TOKEN_OPTION, 'token-a');
 
-        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
-        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testAddingAFormerSecretFileConnectionTokenCannotRestorePushAuthorization(): void
     {
-        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'token-a';\n");
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'token-a';\n");
+        $this->assertTrue(update_push_authorization(true));
 
-        unlink(SITE_EXPORT_SECRET_FILE);
-        $this->assertFalse(_site_export_is_push_authorized());
-        update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
+        unlink(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE);
+        $this->assertFalse(is_push_authorized());
+        update_option(CONNECTION_TOKEN_OPTION, 'token-a');
 
-        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
-        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]);
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testRestSettingsOptionChangePreservesAuthorizationForSecretFileConnectionToken(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
-        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'option-token-a';
+        file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'file-token';\n");
+        $this->assertTrue(update_push_authorization(true));
 
-        update_option(SITE_EXPORT_SECRET_OPTION, 'option-token-b');
+        update_option(CONNECTION_TOKEN_OPTION, 'option-token-b');
 
         $this->assertSame(
             hash('sha256', 'file-token'),
-            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
         );
-        $this->assertTrue(_site_export_is_push_authorized());
+        $this->assertTrue(is_push_authorized());
     }
 
     public function testPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
 
         $this->assertSame('saved', change_push_access(true));
         $this->assertSame(
             hash('sha256', 'current-token'),
-            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
         );
-        $this->assertTrue(_site_export_is_push_authorized());
+        $this->assertTrue(is_push_authorized());
     }
 
     public function testPushAccessOperationReturnsExplicitOutcomes(): void
     {
         $this->assertSame('not_configured', change_push_access(true));
 
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
         $this->assertSame('saved', change_push_access(true));
         $this->assertSame('unchanged', change_push_access(true));
 
-        putenv('SITE_EXPORT_PUSH_ENABLED=false');
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
         $this->assertSame('managed', change_push_access(false));
     }
 
     public function testPushAccessOperationReportsStorageFailure(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $GLOBALS['reprint_server_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_fail_option_updates'][] = PUSH_AUTHORIZATION_OPTION;
 
         $this->assertSame('storage_failure', change_push_access(true));
-        $this->assertFalse(_site_export_is_push_authorized());
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testConfigurationStateDescribesTheEffectiveConnection(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
 
         $configuration = get_configuration_state();
 
         $this->assertSame('current-token', $configuration['stored_connection_token']);
         $this->assertTrue($configuration['is_configured']);
-        $this->assertFalse($configuration['has_secret_file']);
+        $this->assertFalse($configuration['has_connection_token_file']);
         $this->assertTrue($configuration['push_supported']);
         $this->assertNull($configuration['managed_push_enabled']);
         $this->assertFalse($configuration['push_enabled']);
@@ -940,14 +353,14 @@ final class ReprintServerPluginTest extends TestCase
         $this->assertStringContainsString('<strong>Not configured yet.</strong>', $html);
         $this->assertStringContainsString('Enter a connection token to get started.', $html);
         $this->assertStringContainsString('id="reprint_server_connection_token"', $html);
-        $this->assertStringContainsString('name="' . SITE_EXPORT_SECRET_OPTION . '"', $html);
+        $this->assertStringContainsString('name="' . CONNECTION_TOKEN_OPTION . '"', $html);
         $this->assertStringNotContainsString('<h2>Push access</h2>', $html);
         $this->assertStringNotContainsString('id="reprint-server-api-url"', $html);
     }
 
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
 
         $html = $this->renderAdminPage();
 
@@ -1012,8 +425,8 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testOptedInAdminCopyShowsCurrentConnectionTokenCanPush(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $this->assertTrue(_site_export_update_push_authorization(true));
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $this->assertTrue(update_push_authorization(true));
 
         $html = $this->renderAdminPage();
 
@@ -1026,8 +439,8 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        putenv('SITE_EXPORT_PUSH_ENABLED=true');
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        putenv('REPRINT_SERVER_PUSH_ENABLED=true');
 
         $html = $this->renderAdminPage();
 
@@ -1038,8 +451,8 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testManagedDisabledAdminCopyIsReadOnlyAndUnchecked(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        putenv('SITE_EXPORT_PUSH_ENABLED=false');
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
 
         $html = $this->renderAdminPage();
 
@@ -1051,8 +464,8 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testSecretFileOverrideShowsStoredOptionAndWarning(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'stored-token';
-        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'stored-token';
+        file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'file-token';\n");
 
         $html = $this->renderAdminPage();
 
@@ -1066,7 +479,7 @@ final class ReprintServerPluginTest extends TestCase
         $configuration = [
             'stored_connection_token' => 'current-token',
             'is_configured' => true,
-            'has_secret_file' => false,
+            'has_connection_token_file' => false,
             'push_supported' => false,
             'managed_push_enabled' => null,
             'push_enabled' => false,
@@ -1084,7 +497,7 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testAdministratorMapsEveryPushAccessResultToANativeNotice(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
         $expected_notices = [
             'saved' => ['notice-success', 'Push access updated.'],
             'unchanged' => ['notice-success', 'Push access was already up to date.'],
@@ -1110,7 +523,7 @@ final class ReprintServerPluginTest extends TestCase
 
     public function testSettingsSaveSupersedesAStalePushAccessNotice(): void
     {
-        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
         $GLOBALS['reprint_server_settings_errors'][] = [
             'setting' => 'general',
             'code' => 'settings_updated',
@@ -1125,13 +538,5 @@ final class ReprintServerPluginTest extends TestCase
         $this->assertStringContainsString('Settings saved.', $html);
         $this->assertStringNotContainsString('<strong>Settings saved.</strong>', $html);
         $this->assertStringNotContainsString('Push access updated.', $html);
-    }
-
-    private function renderAdminPage(): string
-    {
-        SettingsPage::get_instance()->register_settings_fields();
-        ob_start();
-        SettingsPage::get_instance()->render_admin_page();
-        return (string) ob_get_clean();
     }
 }

--- a/tests/ReprintServerPluginTest.php
+++ b/tests/ReprintServerPluginTest.php
@@ -15,24 +15,24 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/');
 }
 
-$site_export_test_plugin_dir = sys_get_temp_dir() . '/site-export-secret-test-' . getmypid() . '/';
+$reprint_server_test_plugin_dir = sys_get_temp_dir() . '/reprint-server-plugin-test-' . getmypid() . '/';
 if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
-    define('SITE_EXPORT_PLUGIN_DIR', $site_export_test_plugin_dir);
+    define('SITE_EXPORT_PLUGIN_DIR', $reprint_server_test_plugin_dir);
 }
 if (!defined('SITE_EXPORT_SECRET_FILE')) {
     define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
 }
 
-$GLOBALS['site_export_test_options'] = [];
-$GLOBALS['site_export_registered_settings'] = [];
-$GLOBALS['site_export_settings_errors'] = [];
-$GLOBALS['site_export_settings_error_requests'] = [];
-$GLOBALS['site_export_test_actions'] = [];
-$GLOBALS['site_export_test_menu'] = null;
-$GLOBALS['site_export_test_sections'] = [];
-$GLOBALS['site_export_test_fields'] = [];
-$GLOBALS['site_export_test_scripts'] = [];
-$GLOBALS['site_export_fail_option_updates'] = [];
+$GLOBALS['reprint_server_test_options'] = [];
+$GLOBALS['reprint_server_registered_settings'] = [];
+$GLOBALS['reprint_server_settings_errors'] = [];
+$GLOBALS['reprint_server_settings_error_requests'] = [];
+$GLOBALS['reprint_server_test_actions'] = [];
+$GLOBALS['reprint_server_test_menu'] = null;
+$GLOBALS['reprint_server_test_sections'] = [];
+$GLOBALS['reprint_server_test_fields'] = [];
+$GLOBALS['reprint_server_test_scripts'] = [];
+$GLOBALS['reprint_server_fail_option_updates'] = [];
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,Generic.CodeAnalysis.UnusedFunctionParameter.Found,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound,WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress test stubs.
 if (!function_exists('plugin_dir_path')) {
@@ -43,8 +43,8 @@ if (!function_exists('plugin_dir_path')) {
 
 if (!function_exists('get_option')) {
     function get_option(string $name, $default = false) {
-        if (array_key_exists($name, $GLOBALS['site_export_test_options'])) {
-            return $GLOBALS['site_export_test_options'][$name];
+        if (array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
+            return $GLOBALS['reprint_server_test_options'][$name];
         }
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Generic WordPress option test stub.
         return apply_filters('default_option_' . $name, $default, $name, true);
@@ -53,13 +53,13 @@ if (!function_exists('get_option')) {
 
 if (!function_exists('update_option')) {
     function update_option(string $name, $value, $autoload = null): bool {
-        if (in_array($name, $GLOBALS['site_export_fail_option_updates'], true)) {
+        if (in_array($name, $GLOBALS['reprint_server_fail_option_updates'], true)) {
             return false;
         }
 
-        if (!array_key_exists($name, $GLOBALS['site_export_test_options'])) {
-            $GLOBALS['site_export_test_options'][$name] = $value;
-            foreach ($GLOBALS['site_export_test_actions']['add_option_' . $name] ?? [] as $action) {
+        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
+            $GLOBALS['reprint_server_test_options'][$name] = $value;
+            foreach ($GLOBALS['reprint_server_test_actions']['add_option_' . $name] ?? [] as $action) {
                 $args = array_slice([$name, $value], 0, $action['accepted_args']);
                 call_user_func_array($action['callback'], $args);
             }
@@ -67,10 +67,10 @@ if (!function_exists('update_option')) {
         }
 
         $old_value = get_option($name);
-        $GLOBALS['site_export_test_options'][$name] = $value;
+        $GLOBALS['reprint_server_test_options'][$name] = $value;
 
         if ($old_value !== $value) {
-            foreach ($GLOBALS['site_export_test_actions']['update_option_' . $name] ?? [] as $action) {
+            foreach ($GLOBALS['reprint_server_test_actions']['update_option_' . $name] ?? [] as $action) {
                 $args = array_slice([$old_value, $value, $name], 0, $action['accepted_args']);
                 call_user_func_array($action['callback'], $args);
             }
@@ -82,18 +82,18 @@ if (!function_exists('update_option')) {
 
 if (!function_exists('delete_option')) {
     function delete_option(string $name): bool {
-        if (!array_key_exists($name, $GLOBALS['site_export_test_options'])) {
+        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
             return false;
         }
 
-        unset($GLOBALS['site_export_test_options'][$name]);
+        unset($GLOBALS['reprint_server_test_options'][$name]);
         return true;
     }
 }
 
 if (!function_exists('register_setting')) {
     function register_setting(string $group, string $name, array $args = []): void {
-        $GLOBALS['site_export_registered_settings'][$name] = [
+        $GLOBALS['reprint_server_registered_settings'][$name] = [
             'group' => $group,
             'args' => $args,
         ];
@@ -102,7 +102,7 @@ if (!function_exists('register_setting')) {
 
 if (!function_exists('add_settings_section')) {
     function add_settings_section(string $id, string $title, $callback, string $page): void {
-        $GLOBALS['site_export_test_sections'][$page][$id] = [
+        $GLOBALS['reprint_server_test_sections'][$page][$id] = [
             'title' => $title,
             'callback' => $callback,
         ];
@@ -118,7 +118,7 @@ if (!function_exists('add_settings_field')) {
         string $section,
         array $args = []
     ): void {
-        $GLOBALS['site_export_test_fields'][$page][$section][$id] = [
+        $GLOBALS['reprint_server_test_fields'][$page][$section][$id] = [
             'title' => $title,
             'callback' => $callback,
             'args' => $args,
@@ -128,7 +128,7 @@ if (!function_exists('add_settings_field')) {
 
 if (!function_exists('add_action')) {
     function add_action(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
-        $GLOBALS['site_export_test_actions'][$hook_name][] = [
+        $GLOBALS['reprint_server_test_actions'][$hook_name][] = [
             'callback' => $callback,
             'priority' => $priority,
             'accepted_args' => $accepted_args,
@@ -148,7 +148,7 @@ if (!function_exists('add_filter')) {
 
 if (!function_exists('do_action')) {
     function do_action(string $hook_name, ...$args): void {
-        $actions = $GLOBALS['site_export_test_actions'][$hook_name] ?? [];
+        $actions = $GLOBALS['reprint_server_test_actions'][$hook_name] ?? [];
         usort($actions, static function (array $left, array $right): int {
             return $left['priority'] <=> $right['priority'];
         });
@@ -169,7 +169,7 @@ if (!function_exists('plugin_basename')) {
 
 if (!function_exists('add_management_page')) {
     function add_management_page($page_title, $menu_title, $capability, $menu_slug, $callback): string {
-        $GLOBALS['site_export_test_menu'] = [
+        $GLOBALS['reprint_server_test_menu'] = [
             'page_title' => $page_title,
             'menu_title' => $menu_title,
             'capability' => $capability,
@@ -256,7 +256,7 @@ if (!function_exists('wp_unslash')) {
 
 if (!function_exists('add_settings_error')) {
     function add_settings_error(string $setting, string $code, string $message, string $type): void {
-        $GLOBALS['site_export_settings_errors'][] = [
+        $GLOBALS['reprint_server_settings_errors'][] = [
             'setting' => $setting,
             'code' => $code,
             'message' => $message,
@@ -267,14 +267,14 @@ if (!function_exists('add_settings_error')) {
 
 if (!function_exists('get_settings_errors')) {
     function get_settings_errors(string $setting = '', bool $sanitize = false): array {
-        $GLOBALS['site_export_settings_error_requests'][] = $setting;
+        $GLOBALS['reprint_server_settings_error_requests'][] = $setting;
         if ($setting === '') {
-            return $GLOBALS['site_export_settings_errors'];
+            return $GLOBALS['reprint_server_settings_errors'];
         }
 
         return array_values(
             array_filter(
-                $GLOBALS['site_export_settings_errors'],
+                $GLOBALS['reprint_server_settings_errors'],
                 static function(array $notice) use ($setting): bool {
                     return $notice['setting'] === $setting;
                 }
@@ -291,11 +291,11 @@ if (!function_exists('settings_fields')) {
 
 if (!function_exists('do_settings_sections')) {
     function do_settings_sections(string $page): void {
-        foreach ($GLOBALS['site_export_test_sections'][$page] ?? [] as $section_id => $section) {
+        foreach ($GLOBALS['reprint_server_test_sections'][$page] ?? [] as $section_id => $section) {
             echo '<h2>' . esc_html($section['title']) . '</h2>';
             call_user_func($section['callback']);
             echo '<table class="form-table">';
-            foreach ($GLOBALS['site_export_test_fields'][$page][$section_id] ?? [] as $field) {
+            foreach ($GLOBALS['reprint_server_test_fields'][$page][$section_id] ?? [] as $field) {
                 echo '<tr><th>' . esc_html($field['title']) . '</th><td>';
                 call_user_func($field['callback'], $field['args']);
                 echo '</td></tr>';
@@ -358,13 +358,13 @@ if (!function_exists('disabled')) {
 
 if (!function_exists('plugins_url')) {
     function plugins_url(string $path = '', string $plugin = ''): string {
-        return 'https://example.test/wp-content/plugins/site-export/' . ltrim($path, '/');
+        return 'https://example.test/wp-content/plugins/reprint-server/' . ltrim($path, '/');
     }
 }
 
 if (!function_exists('wp_enqueue_script')) {
     function wp_enqueue_script($handle, $src, $dependencies, $version, $in_footer): void {
-        $GLOBALS['site_export_test_scripts'][$handle] = compact(
+        $GLOBALS['reprint_server_test_scripts'][$handle] = compact(
             'src',
             'dependencies',
             'version',
@@ -415,7 +415,7 @@ require_once __DIR__ . '/../reprint-server-wp/wordpress/configuration.php';
 register_wordpress_configuration();
 require_once __DIR__ . '/../reprint-server-wp/wordpress/reprint-server.php';
 
-final class SiteExportSecretTest extends TestCase
+final class ReprintServerPluginTest extends TestCase
 {
     /** @var array<string, mixed> */
     private $original_server = [];
@@ -451,15 +451,15 @@ final class SiteExportSecretTest extends TestCase
         $this->original_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
         $this->original_reprint_server_push_enabled_environment = getenv('REPRINT_SERVER_PUSH_ENABLED');
 
-        $GLOBALS['site_export_test_options'] = [];
-        $GLOBALS['site_export_registered_settings'] = [];
-        $GLOBALS['site_export_settings_errors'] = [];
-        $GLOBALS['site_export_settings_error_requests'] = [];
-        $GLOBALS['site_export_test_menu'] = null;
-        $GLOBALS['site_export_test_sections'] = [];
-        $GLOBALS['site_export_test_fields'] = [];
-        $GLOBALS['site_export_test_scripts'] = [];
-        $GLOBALS['site_export_fail_option_updates'] = [];
+        $GLOBALS['reprint_server_test_options'] = [];
+        $GLOBALS['reprint_server_registered_settings'] = [];
+        $GLOBALS['reprint_server_settings_errors'] = [];
+        $GLOBALS['reprint_server_settings_error_requests'] = [];
+        $GLOBALS['reprint_server_test_menu'] = null;
+        $GLOBALS['reprint_server_test_sections'] = [];
+        $GLOBALS['reprint_server_test_fields'] = [];
+        $GLOBALS['reprint_server_test_scripts'] = [];
+        $GLOBALS['reprint_server_fail_option_updates'] = [];
         $_SERVER = [];
         $_FILES = [];
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
@@ -503,16 +503,16 @@ final class SiteExportSecretTest extends TestCase
 
     public function testConnectionTokenFallsBackToOptionWhenSecretFileMissing(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token';
 
-        $this->assertSame('option-secret', _site_export_get_shared_secret());
+        $this->assertSame('option-token', _site_export_get_shared_secret());
     }
 
     public function testMigrationCreatesNoOptionsWhenNoLegacyOptionExists(): void
     {
         reprint_server_compat_migrate_legacy_options();
 
-        $this->assertSame([], $GLOBALS['site_export_test_options']);
+        $this->assertSame([], $GLOBALS['reprint_server_test_options']);
     }
 
     public function testMigrationKeepsPushAuthorizationGrantedUnderTheLegacyOptionNames(): void
@@ -523,19 +523,19 @@ final class SiteExportSecretTest extends TestCase
         // authorization for the appearing connection token runs during the
         // migration.
         \WordPress\Reprint\Server\Plugin\SettingsPage::get_instance();
-        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
             hash('sha256', 'legacy-token');
 
         reprint_server_compat_migrate_legacy_options();
 
         $this->assertSame(
             hash('sha256', 'legacy-token'),
-            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
         );
         $this->assertArrayNotHasKey(
             'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['site_export_test_options']
+            $GLOBALS['reprint_server_test_options']
         );
         $this->assertTrue(_site_export_is_push_authorized());
     }
@@ -570,66 +570,66 @@ final class SiteExportSecretTest extends TestCase
 
     public function testLegacyOptionsMigrateWithoutChangingTheirValues(): void
     {
-        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
             'legacy-fingerprint';
 
         reprint_server_compat_migrate_legacy_options();
 
         $this->assertSame(
             'legacy-token',
-            $GLOBALS['site_export_test_options']['reprint_server_connection_token']
+            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
         );
         $this->assertSame(
             'legacy-fingerprint',
-            $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
+            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
         );
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
         $this->assertArrayNotHasKey(
             'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['site_export_test_options']
+            $GLOBALS['reprint_server_test_options']
         );
         $this->assertSame('legacy-token', _site_export_get_shared_secret());
     }
 
     public function testCanonicalOptionsTakePrecedenceDuringLegacyMigration(): void
     {
-        $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
-        $GLOBALS['site_export_test_options']['reprint_server_connection_token'] = 'canonical-token';
-        $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
+        $GLOBALS['reprint_server_test_options']['site_export_secret'] = 'legacy-token';
+        $GLOBALS['reprint_server_test_options']['reprint_server_connection_token'] = 'canonical-token';
+        $GLOBALS['reprint_server_test_options']['site_export_push_authorized_token_fingerprint'] =
             'legacy-fingerprint';
-        $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint'] =
+        $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint'] =
             'canonical-fingerprint';
 
         reprint_server_compat_migrate_legacy_options();
 
         $this->assertSame(
             'canonical-token',
-            $GLOBALS['site_export_test_options']['reprint_server_connection_token']
+            $GLOBALS['reprint_server_test_options']['reprint_server_connection_token']
         );
         $this->assertSame(
             'canonical-fingerprint',
-            $GLOBALS['site_export_test_options']['reprint_server_push_authorized_token_fingerprint']
+            $GLOBALS['reprint_server_test_options']['reprint_server_push_authorized_token_fingerprint']
         );
-        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['site_export_test_options']);
+        $this->assertArrayNotHasKey('site_export_secret', $GLOBALS['reprint_server_test_options']);
         $this->assertArrayNotHasKey(
             'site_export_push_authorized_token_fingerprint',
-            $GLOBALS['site_export_test_options']
+            $GLOBALS['reprint_server_test_options']
         );
     }
 
     public function testSecretFileConnectionTokenOverridesSiteOptionWhenPresent(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
-        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-secret';\n");
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token';
+        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
 
-        $this->assertSame('file-secret', _site_export_get_shared_secret());
+        $this->assertSame('file-token', _site_export_get_shared_secret());
     }
 
     public function testUpdatingConnectionTokenOnlyTouchesTheSiteOption(): void
     {
-        $this->assertTrue(_site_export_update_shared_secret('new-secret'));
-        $this->assertSame('new-secret', $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION]);
+        $this->assertTrue(_site_export_update_shared_secret('new-token'));
+        $this->assertSame('new-token', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION]);
         $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
     }
 
@@ -638,7 +638,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertSame('saved', change_connection_token('new-token'));
         $this->assertSame('unchanged', change_connection_token('new-token'));
 
-        $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_SECRET_OPTION;
+        $GLOBALS['reprint_server_fail_option_updates'][] = SITE_EXPORT_SECRET_OPTION;
         $this->assertSame('storage_failure', change_connection_token('other-token'));
     }
 
@@ -646,7 +646,7 @@ final class SiteExportSecretTest extends TestCase
     {
         register_connection_token_setting();
 
-        $setting = $GLOBALS['site_export_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
+        $setting = $GLOBALS['reprint_server_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
         $this->assertNotNull($setting);
         $this->assertSame('reprint_server', $setting['group']);
         $this->assertTrue($setting['args']['show_in_rest']);
@@ -656,9 +656,9 @@ final class SiteExportSecretTest extends TestCase
 
     public function testConfigurationIntegrationRegistersOutsideTheAdministratorAdapter(): void
     {
-        $rest_hooks = $GLOBALS['site_export_test_actions']['rest_api_init'] ?? [];
-        $update_hooks = $GLOBALS['site_export_test_actions']['update_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
-        $add_hooks = $GLOBALS['site_export_test_actions']['add_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
+        $rest_hooks = $GLOBALS['reprint_server_test_actions']['rest_api_init'] ?? [];
+        $update_hooks = $GLOBALS['reprint_server_test_actions']['update_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
+        $add_hooks = $GLOBALS['reprint_server_test_actions']['add_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
 
         $this->assertNotEmpty($rest_hooks);
         $this->assertSame(
@@ -679,9 +679,9 @@ final class SiteExportSecretTest extends TestCase
 
     public function testPluginHmacVerifierDelegatesToPackageServer(): void
     {
-        $secret = 'delegated-secret';
+        $connection_token = 'delegated-token';
         $nonce = '0123456789abcdef0123456789abcdef';
-        $client = new Site_Export_HMAC_Client($secret);
+        $client = new Site_Export_HMAC_Client($connection_token);
         $timestamp = $client->get_timestamp();
         $content_hash = hash('sha256', '');
 
@@ -690,28 +690,28 @@ final class SiteExportSecretTest extends TestCase
         $_SERVER['HTTP_X_AUTH_TIMESTAMP'] = $timestamp;
         $_SERVER['HTTP_X_AUTH_CONTENT_HASH'] = $content_hash;
 
-        $this->assertNull(_site_export_verify_hmac($secret));
+        $this->assertNull(_site_export_verify_hmac($connection_token));
     }
 
     public function testPushAuthorizationMatchesOnlyTheCurrentConnectionToken(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertFalse(_site_export_is_push_authorized());
 
         $this->assertTrue(_site_export_update_push_authorization(true));
         $this->assertTrue(_site_export_is_push_authorized());
         $this->assertSame(
             hash('sha256', 'current-token'),
-            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
         );
 
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'rotated-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'rotated-token';
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
     public function testManagedEnvironmentOverridesLocalPushAuthorization(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
         putenv('SITE_EXPORT_PUSH_ENABLED=true');
         $this->assertTrue(_site_export_is_push_authorized());
@@ -756,7 +756,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testPresentEmptyManagedEnvironmentFailsClosed(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertTrue(_site_export_update_push_authorization(true));
 
         putenv('SITE_EXPORT_PUSH_ENABLED=');
@@ -771,24 +771,24 @@ final class SiteExportSecretTest extends TestCase
 
     public function testSettingsApiTokenRotationRevokesPriorConsent(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertTrue(_site_export_update_push_authorization(true));
 
         update_option(SITE_EXPORT_SECRET_OPTION, 'rotated-token');
 
-        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
     public function testRestSettingsConnectionTokenRotationPermanentlyRevokesPushAuthorization(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
         $this->assertTrue(_site_export_update_push_authorization(true));
 
         update_option(SITE_EXPORT_SECRET_OPTION, 'token-b');
         update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
 
-        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
@@ -801,13 +801,13 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(_site_export_is_push_authorized());
         update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
 
-        $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
+        $this->assertSame('', $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
     public function testRestSettingsOptionChangePreservesAuthorizationForSecretFileConnectionToken(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
         $this->assertTrue(_site_export_update_push_authorization(true));
 
@@ -815,19 +815,19 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertSame(
             hash('sha256', 'file-token'),
-            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
         );
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
     public function testPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
         $this->assertSame('saved', change_push_access(true));
         $this->assertSame(
             hash('sha256', 'current-token'),
-            $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
+            $GLOBALS['reprint_server_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
         );
         $this->assertTrue(_site_export_is_push_authorized());
     }
@@ -836,7 +836,7 @@ final class SiteExportSecretTest extends TestCase
     {
         $this->assertSame('not_configured', change_push_access(true));
 
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertSame('saved', change_push_access(true));
         $this->assertSame('unchanged', change_push_access(true));
 
@@ -846,8 +846,8 @@ final class SiteExportSecretTest extends TestCase
 
     public function testPushAccessOperationReportsStorageFailure(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
 
         $this->assertSame('storage_failure', change_push_access(true));
         $this->assertFalse(_site_export_is_push_authorized());
@@ -855,7 +855,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testConfigurationStateDescribesTheEffectiveConnection(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
         $configuration = get_configuration_state();
 
@@ -872,8 +872,8 @@ final class SiteExportSecretTest extends TestCase
         $plugin = SettingsPage::get_instance();
         $plugin->add_admin_menu();
 
-        $this->assertSame('reprint-server', $GLOBALS['site_export_test_menu']['menu_slug']);
-        $this->assertSame('manage_options', $GLOBALS['site_export_test_menu']['capability']);
+        $this->assertSame('reprint-server', $GLOBALS['reprint_server_test_menu']['menu_slug']);
+        $this->assertSame('manage_options', $GLOBALS['reprint_server_test_menu']['capability']);
         $this->assertSame(
             'WordPress\\Reprint\\Server\\Plugin\\SettingsPage',
             SettingsPage::class
@@ -883,18 +883,18 @@ final class SiteExportSecretTest extends TestCase
         $links = $plugin->add_settings_link([]);
         $this->assertStringContainsString('tools.php?page=reprint-server', $links[0]);
 
-        $admin_post_hooks = $GLOBALS['site_export_test_actions']['admin_post_reprint_server_save_push_access'] ?? [];
+        $admin_post_hooks = $GLOBALS['reprint_server_test_actions']['admin_post_reprint_server_save_push_access'] ?? [];
         $this->assertNotEmpty($admin_post_hooks);
         $this->assertSame([$plugin, 'handle_push_access_save'], $admin_post_hooks[0]['callback']);
-        $this->assertEmpty($GLOBALS['site_export_test_actions']['admin_bar_menu'] ?? []);
+        $this->assertEmpty($GLOBALS['reprint_server_test_actions']['admin_bar_menu'] ?? []);
 
         $plugin->enqueue_assets('tools_page_other');
-        $this->assertSame([], $GLOBALS['site_export_test_scripts']);
+        $this->assertSame([], $GLOBALS['reprint_server_test_scripts']);
 
         $plugin->enqueue_assets('tools_page_reprint-server');
         $this->assertSame(
             ['wp-a11y'],
-            $GLOBALS['site_export_test_scripts']['reprint-server-admin']['dependencies']
+            $GLOBALS['reprint_server_test_scripts']['reprint-server-admin']['dependencies']
         );
     }
 
@@ -947,7 +947,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
         $html = $this->renderAdminPage();
 
@@ -962,7 +962,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringContainsString('name="option_page" value="reprint_server"', $html);
         $this->assertStringContainsString('action="https://example.test/wp-admin/admin-post.php"', $html);
         $this->assertSame(2, substr_count($html, '<p class="submit">'));
-        $this->assertSame([''], $GLOBALS['site_export_settings_error_requests']);
+        $this->assertSame([''], $GLOBALS['reprint_server_settings_error_requests']);
         $this->assertStringNotContainsString('checked="checked"', $html);
         $this->assertStringNotContainsString('<style>', $html);
         $this->assertStringNotContainsString('<script>', $html);
@@ -970,7 +970,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testCoreSettingsNoticeIsInlineAtItsRenderedPosition(): void
     {
-        $GLOBALS['site_export_settings_errors'][] = [
+        $GLOBALS['reprint_server_settings_errors'][] = [
             'setting' => 'general',
             'code' => 'settings_updated',
             'message' => 'Settings saved.',
@@ -994,7 +994,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testCoreSettingsNoticeFallsBackToErrorForAnUnknownType(): void
     {
-        $GLOBALS['site_export_settings_errors'][] = [
+        $GLOBALS['reprint_server_settings_errors'][] = [
             'setting' => 'general',
             'code' => 'unexpected_type',
             'message' => 'Something needs attention.',
@@ -1012,7 +1012,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testOptedInAdminCopyShowsCurrentConnectionTokenCanPush(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertTrue(_site_export_update_push_authorization(true));
 
         $html = $this->renderAdminPage();
@@ -1026,7 +1026,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         putenv('SITE_EXPORT_PUSH_ENABLED=true');
 
         $html = $this->renderAdminPage();
@@ -1038,7 +1038,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testManagedDisabledAdminCopyIsReadOnlyAndUnchecked(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         putenv('SITE_EXPORT_PUSH_ENABLED=false');
 
         $html = $this->renderAdminPage();
@@ -1051,7 +1051,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testSecretFileOverrideShowsStoredOptionAndWarning(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'stored-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'stored-token';
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
 
         $html = $this->renderAdminPage();
@@ -1084,7 +1084,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testAdministratorMapsEveryPushAccessResultToANativeNotice(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $expected_notices = [
             'saved' => ['notice-success', 'Push access updated.'],
             'unchanged' => ['notice-success', 'Push access was already up to date.'],
@@ -1110,8 +1110,8 @@ final class SiteExportSecretTest extends TestCase
 
     public function testSettingsSaveSupersedesAStalePushAccessNotice(): void
     {
-        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $GLOBALS['site_export_settings_errors'][] = [
+        $GLOBALS['reprint_server_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_settings_errors'][] = [
             'setting' => 'general',
             'code' => 'settings_updated',
             'message' => 'Settings saved.',

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -19,8 +19,16 @@ if (!defined('SITE_EXPORT_SECRET_FILE')) {
 $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
 $GLOBALS['site_export_settings_errors'] = [];
+$GLOBALS['site_export_settings_error_requests'] = [];
+$GLOBALS['site_export_settings_errors_markup'] = '';
 $GLOBALS['site_export_test_actions'] = [];
+$GLOBALS['site_export_test_menu'] = null;
+$GLOBALS['site_export_test_sections'] = [];
+$GLOBALS['site_export_test_fields'] = [];
+$GLOBALS['site_export_test_scripts'] = [];
+$GLOBALS['site_export_fail_option_updates'] = [];
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,Generic.CodeAnalysis.UnusedFunctionParameter.Found,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound,WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress test stubs.
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(string $file): string {
         return SITE_EXPORT_PLUGIN_DIR;
@@ -39,6 +47,10 @@ if (!function_exists('get_option')) {
 
 if (!function_exists('update_option')) {
     function update_option(string $name, $value, $autoload = null): bool {
+        if (in_array($name, $GLOBALS['site_export_fail_option_updates'], true)) {
+            return false;
+        }
+
         if (!array_key_exists($name, $GLOBALS['site_export_test_options'])) {
             $GLOBALS['site_export_test_options'][$name] = $value;
             foreach ($GLOBALS['site_export_test_actions']['add_option_' . $name] ?? [] as $action) {
@@ -77,6 +89,32 @@ if (!function_exists('register_setting')) {
     function register_setting(string $group, string $name, array $args = []): void {
         $GLOBALS['site_export_registered_settings'][$name] = [
             'group' => $group,
+            'args' => $args,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_section')) {
+    function add_settings_section(string $id, string $title, $callback, string $page): void {
+        $GLOBALS['site_export_test_sections'][$page][$id] = [
+            'title' => $title,
+            'callback' => $callback,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_field')) {
+    function add_settings_field(
+        string $id,
+        string $title,
+        $callback,
+        string $page,
+        string $section,
+        array $args = []
+    ): void {
+        $GLOBALS['site_export_test_fields'][$page][$section][$id] = [
+            'title' => $title,
+            'callback' => $callback,
             'args' => $args,
         ];
     }
@@ -123,6 +161,19 @@ if (!function_exists('plugin_basename')) {
     }
 }
 
+if (!function_exists('add_management_page')) {
+    function add_management_page($page_title, $menu_title, $capability, $menu_slug, $callback): string {
+        $GLOBALS['site_export_test_menu'] = [
+            'page_title' => $page_title,
+            'menu_title' => $menu_title,
+            'capability' => $capability,
+            'menu_slug' => $menu_slug,
+            'callback' => $callback,
+        ];
+        return 'tools_page_' . $menu_slug;
+    }
+}
+
 if (!function_exists('register_activation_hook')) {
     function register_activation_hook(...$args): void {}
 }
@@ -157,7 +208,24 @@ if (!function_exists('wp_safe_redirect')) {
     function wp_safe_redirect(...$args): void {}
 }
 
-// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WordPress test stubs.
+if (!function_exists('__')) {
+    function __(string $text, string $domain = 'default'): string {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__(string $text, string $domain = 'default'): string {
+        return esc_html($text);
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__(string $text, string $domain = 'default'): string {
+        return esc_attr($text);
+    }
+}
+
 if (!function_exists('current_user_can')) {
     function current_user_can(string $capability): bool {
         return $capability === 'manage_options';
@@ -192,12 +260,105 @@ if (!function_exists('add_settings_error')) {
 }
 
 if (!function_exists('settings_errors')) {
-    function settings_errors(string $setting): void {}
+    function settings_errors(string $setting = ''): void {
+        $GLOBALS['site_export_settings_error_requests'][] = $setting;
+        echo $GLOBALS['site_export_settings_errors_markup'];
+    }
+}
+
+if (!function_exists('settings_fields')) {
+    function settings_fields(string $group): void {
+        echo '<input type="hidden" name="option_page" value="' . esc_attr($group) . '" />';
+    }
+}
+
+if (!function_exists('do_settings_sections')) {
+    function do_settings_sections(string $page): void {
+        foreach ($GLOBALS['site_export_test_sections'][$page] ?? [] as $section_id => $section) {
+            echo '<h2>' . esc_html($section['title']) . '</h2>';
+            call_user_func($section['callback']);
+            echo '<table class="form-table">';
+            foreach ($GLOBALS['site_export_test_fields'][$page][$section_id] ?? [] as $field) {
+                echo '<tr><th>' . esc_html($field['title']) . '</th><td>';
+                call_user_func($field['callback'], $field['args']);
+                echo '</td></tr>';
+            }
+            echo '</table>';
+        }
+    }
+}
+
+if (!function_exists('submit_button')) {
+    function submit_button(
+        string $text = 'Save Changes',
+        string $type = 'primary',
+        string $name = 'submit',
+        bool $wrap = true
+    ): void {
+        $button = '<input type="submit" name="' . esc_attr($name) . '" class="button button-'
+            . esc_attr($type) . '" value="' . esc_attr($text) . '" />';
+        echo $wrap ? '<p class="submit">' . $button . '</p>' : $button;
+    }
 }
 
 if (!function_exists('home_url')) {
     function home_url(string $path = ''): string {
         return 'https://example.test/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url(string $path = ''): string {
+        return 'https://example.test/wp-admin/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('get_admin_page_title')) {
+    function get_admin_page_title(): string {
+        return 'Reprint Server';
+    }
+}
+
+if (!function_exists('checked')) {
+    function checked($checked, $current = true, bool $display = true): string {
+        $result = $checked == $current ? ' checked="checked"' : '';
+        if ($display) {
+            echo $result;
+        }
+        return $result;
+    }
+}
+
+if (!function_exists('disabled')) {
+    function disabled($disabled, $current = true, bool $display = true): string {
+        $result = $disabled == $current ? ' disabled="disabled"' : '';
+        if ($display) {
+            echo $result;
+        }
+        return $result;
+    }
+}
+
+if (!function_exists('plugins_url')) {
+    function plugins_url(string $path = '', string $plugin = ''): string {
+        return 'https://example.test/wp-content/plugins/site-export/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script($handle, $src, $dependencies, $version, $in_footer): void {
+        $GLOBALS['site_export_test_scripts'][$handle] = compact(
+            'src',
+            'dependencies',
+            'version',
+            'in_footer'
+        );
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key(string $key): string {
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower($key)) ?? '';
     }
 }
 
@@ -218,9 +379,17 @@ if (!function_exists('esc_html')) {
         return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
     }
 }
+
+if (!function_exists('esc_url')) {
+    function esc_url(string $value): string {
+        return esc_attr($value);
+    }
+}
 // phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 
 require_once __DIR__ . '/../reprint-server-wp/lib.php';
+require_once __DIR__ . '/../reprint-server-wp/wordpress/configuration.php';
+_site_export_register_wordpress_configuration();
 require_once __DIR__ . '/../reprint-server-wp/wordpress/site-export.php';
 
 final class SiteExportSecretTest extends TestCase
@@ -233,6 +402,9 @@ final class SiteExportSecretTest extends TestCase
 
     /** @var array<string, mixed> */
     private $original_post = [];
+
+    /** @var array<string, mixed> */
+    private $original_get = [];
 
     /** @var string|false */
     private $original_push_enabled_environment;
@@ -252,16 +424,25 @@ final class SiteExportSecretTest extends TestCase
         $this->original_files = $_FILES;
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
         $this->original_post = $_POST;
+        $this->original_get = $_GET;
         $this->original_push_enabled_environment = getenv('SITE_EXPORT_PUSH_ENABLED');
         $this->original_reprint_server_push_enabled_environment = getenv('REPRINT_SERVER_PUSH_ENABLED');
 
         $GLOBALS['site_export_test_options'] = [];
         $GLOBALS['site_export_registered_settings'] = [];
         $GLOBALS['site_export_settings_errors'] = [];
+        $GLOBALS['site_export_settings_error_requests'] = [];
+        $GLOBALS['site_export_settings_errors_markup'] = '';
+        $GLOBALS['site_export_test_menu'] = null;
+        $GLOBALS['site_export_test_sections'] = [];
+        $GLOBALS['site_export_test_fields'] = [];
+        $GLOBALS['site_export_test_scripts'] = [];
+        $GLOBALS['site_export_fail_option_updates'] = [];
         $_SERVER = [];
         $_FILES = [];
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
         $_POST = [];
+        $_GET = [];
         putenv('SITE_EXPORT_PUSH_ENABLED');
         putenv('REPRINT_SERVER_PUSH_ENABLED');
 
@@ -283,6 +464,7 @@ final class SiteExportSecretTest extends TestCase
         $_SERVER = $this->original_server;
         $_FILES = $this->original_files;
         $_POST = $this->original_post;
+        $_GET = $this->original_get;
         if ($this->original_push_enabled_environment === false) {
             putenv('SITE_EXPORT_PUSH_ENABLED');
         } else {
@@ -429,16 +611,45 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
     }
 
+    public function testSharedConnectionTokenOperationReturnsExplicitOutcomes(): void
+    {
+        $this->assertSame('saved', _site_export_change_connection_token('new-token'));
+        $this->assertSame('unchanged', _site_export_change_connection_token('new-token'));
+
+        $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_SECRET_OPTION;
+        $this->assertSame('storage_failure', _site_export_change_connection_token('other-token'));
+    }
+
     public function testPluginRegistersConnectionTokenOptionForCoreSettingsRestEndpoint(): void
     {
-        Site_Export_Plugin::get_instance()->register_settings();
+        _site_export_register_shared_secret_setting();
 
         $setting = $GLOBALS['site_export_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
         $this->assertNotNull($setting);
-        $this->assertSame('general', $setting['group']);
+        $this->assertSame('site_export', $setting['group']);
         $this->assertTrue($setting['args']['show_in_rest']);
         $this->assertSame('string', $setting['args']['type']);
         $this->assertSame('', $setting['args']['default']);
+    }
+
+    public function testConfigurationIntegrationRegistersOutsideTheAdministratorAdapter(): void
+    {
+        $rest_hooks = $GLOBALS['site_export_test_actions']['rest_api_init'] ?? [];
+        $update_hooks = $GLOBALS['site_export_test_actions']['update_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
+        $add_hooks = $GLOBALS['site_export_test_actions']['add_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
+
+        $this->assertNotEmpty($rest_hooks);
+        $this->assertSame('_site_export_register_shared_secret_setting', $rest_hooks[0]['callback']);
+        $this->assertNotEmpty($update_hooks);
+        $this->assertSame(
+            '_site_export_revoke_push_authorization_after_connection_token_change',
+            $update_hooks[0]['callback']
+        );
+        $this->assertNotEmpty($add_hooks);
+        $this->assertSame(
+            '_site_export_revoke_push_authorization_after_connection_token_added',
+            $add_hooks[0]['callback']
+        );
     }
 
     public function testPluginHmacVerifierDelegatesToPackageServer(): void
@@ -533,16 +744,12 @@ final class SiteExportSecretTest extends TestCase
         );
     }
 
-    public function testSavingRotatedConnectionTokenRevokesPriorConsent(): void
+    public function testSettingsApiTokenRotationRevokesPriorConsent(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $this->assertTrue(_site_export_update_push_authorization(true));
 
-        $_POST = [
-            'site_export_save_settings' => '1',
-            'site_export_secret' => 'rotated-token',
-        ];
-        Site_Export_Plugin::get_instance()->handle_settings_save();
+        update_option(SITE_EXPORT_SECRET_OPTION, 'rotated-token');
 
         $this->assertSame('', $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]);
         $this->assertFalse(_site_export_is_push_authorized());
@@ -552,7 +759,6 @@ final class SiteExportSecretTest extends TestCase
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'token-a';
         $this->assertTrue(_site_export_update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
 
         update_option(SITE_EXPORT_SECRET_OPTION, 'token-b');
         update_option(SITE_EXPORT_SECRET_OPTION, 'token-a');
@@ -565,7 +771,6 @@ final class SiteExportSecretTest extends TestCase
     {
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'token-a';\n");
         $this->assertTrue(_site_export_update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
 
         unlink(SITE_EXPORT_SECRET_FILE);
         $this->assertFalse(_site_export_is_push_authorized());
@@ -580,7 +785,6 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-token-a';
         file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
         $this->assertTrue(_site_export_update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
 
         update_option(SITE_EXPORT_SECRET_OPTION, 'option-token-b');
 
@@ -591,21 +795,88 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
-    public function testPushAccessFormAuthorizesTheCurrentConnectionToken(): void
+    public function testSharedPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $_POST = [
-            'site_export_save_push_access' => '1',
-            'site_export_push_enabled' => '1',
-        ];
 
-        Site_Export_Plugin::get_instance()->handle_settings_save();
-
+        $this->assertSame('saved', _site_export_change_push_access(true));
         $this->assertSame(
             hash('sha256', 'current-token'),
             $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
         );
         $this->assertTrue(_site_export_is_push_authorized());
+    }
+
+    public function testSharedPushAccessOperationReturnsExplicitOutcomes(): void
+    {
+        $this->assertSame('not_configured', _site_export_change_push_access(true));
+
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $this->assertSame('saved', _site_export_change_push_access(true));
+        $this->assertSame('unchanged', _site_export_change_push_access(true));
+
+        putenv('SITE_EXPORT_PUSH_ENABLED=false');
+        $this->assertSame('managed', _site_export_change_push_access(false));
+    }
+
+    public function testSharedPushAccessOperationReportsStorageFailure(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
+
+        $this->assertSame('storage_failure', _site_export_change_push_access(true));
+        $this->assertFalse(_site_export_is_push_authorized());
+    }
+
+    public function testConfigurationStateDescribesTheEffectiveConnection(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+
+        $configuration = _site_export_get_configuration_state();
+
+        $this->assertSame('current-token', $configuration['stored_connection_token']);
+        $this->assertTrue($configuration['is_configured']);
+        $this->assertFalse($configuration['has_secret_file']);
+        $this->assertTrue($configuration['push_supported']);
+        $this->assertNull($configuration['managed_push_enabled']);
+        $this->assertFalse($configuration['push_enabled']);
+    }
+
+    public function testBundledAdministratorRegistersUnderTools(): void
+    {
+        $plugin = Site_Export_Plugin::get_instance();
+        $plugin->add_admin_menu();
+
+        $this->assertSame('site-export', $GLOBALS['site_export_test_menu']['menu_slug']);
+        $this->assertSame('manage_options', $GLOBALS['site_export_test_menu']['capability']);
+
+        $links = $plugin->add_settings_link([]);
+        $this->assertStringContainsString('tools.php?page=site-export', $links[0]);
+
+        $admin_post_hooks = $GLOBALS['site_export_test_actions']['admin_post_site_export_save_push_access'] ?? [];
+        $this->assertNotEmpty($admin_post_hooks);
+        $this->assertSame([$plugin, 'handle_push_access_save'], $admin_post_hooks[0]['callback']);
+        $this->assertEmpty($GLOBALS['site_export_test_actions']['admin_bar_menu'] ?? []);
+
+        $plugin->enqueue_assets('tools_page_other');
+        $this->assertSame([], $GLOBALS['site_export_test_scripts']);
+
+        $plugin->enqueue_assets('tools_page_site-export');
+        $this->assertSame(
+            ['wp-a11y'],
+            $GLOBALS['site_export_test_scripts']['site-export-admin']['dependencies']
+        );
+    }
+
+    public function testUnconfiguredAdminShowsOnlyConnectionTokenSetup(): void
+    {
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('<strong>Not configured yet.</strong>', $html);
+        $this->assertStringContainsString('Enter a connection token to get started.', $html);
+        $this->assertStringContainsString('name="' . SITE_EXPORT_SECRET_OPTION . '"', $html);
+        $this->assertStringNotContainsString('<h2>Push access</h2>', $html);
+        $this->assertStringNotContainsString('id="site-export-api-url"', $html);
     }
 
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
@@ -614,12 +885,41 @@ final class SiteExportSecretTest extends TestCase
 
         $html = $this->renderAdminPage();
 
+        $this->assertStringContainsString('notice notice-info inline', $html);
         $this->assertStringContainsString('<strong>Connected for downloads.</strong>', $html);
         $this->assertStringContainsString('The connection token cannot change files on this site.', $html);
+        $this->assertStringNotContainsString('notice notice-success inline', $html);
         $this->assertStringContainsString('You do not need push access when moving this site to another host.', $html);
         $this->assertStringContainsString('Allow push to change files on this site', $html);
         $this->assertStringContainsString('except excluded paths.', $html);
-        $this->assertStringNotContainsString('name="site_export_push_enabled" value="1" checked', $html);
+        $this->assertStringContainsString('<form method="post" action="options.php">', $html);
+        $this->assertStringContainsString('name="option_page" value="site_export"', $html);
+        $this->assertStringContainsString('action="https://example.test/wp-admin/admin-post.php"', $html);
+        $this->assertSame(2, substr_count($html, '<p class="submit">'));
+        $this->assertSame([''], $GLOBALS['site_export_settings_error_requests']);
+        $this->assertStringNotContainsString('checked="checked"', $html);
+        $this->assertStringNotContainsString('<style>', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testCoreSettingsNoticeIsInlineAtItsRenderedPosition(): void
+    {
+        $GLOBALS['site_export_settings_errors_markup'] =
+            '<div class="notice notice-success settings-error is-dismissible"><p><strong>'
+            . 'Settings saved.</strong></p></div>';
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString(
+            'notice notice-success settings-error is-dismissible inline',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'notice notice-success settings-error is-dismissible"',
+            $html
+        );
+        $this->assertStringContainsString('<p>Settings saved.</p>', $html);
+        $this->assertStringNotContainsString('<strong>Settings saved.</strong>', $html);
     }
 
     public function testOptedInAdminCopyShowsCurrentConnectionTokenCanPush(): void
@@ -630,7 +930,10 @@ final class SiteExportSecretTest extends TestCase
         $html = $this->renderAdminPage();
 
         $this->assertStringContainsString('<strong>Connected for downloads and push.</strong>', $html);
-        $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked', $html);
+        $this->assertStringContainsString('notice notice-info inline', $html);
+        $this->assertStringNotContainsString('notice notice-success inline', $html);
+        $this->assertStringContainsString('name="site_export_push_enabled"', $html);
+        $this->assertStringContainsString('checked="checked"', $html);
     }
 
     public function testManagedAdminCopyIsReadOnlyAndShowsEffectiveState(): void
@@ -641,12 +944,101 @@ final class SiteExportSecretTest extends TestCase
         $html = $this->renderAdminPage();
 
         $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
-        $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked disabled', $html);
-        $this->assertStringNotContainsString('name="site_export_save_push_access"', $html);
+        $this->assertStringContainsString('checked="checked" disabled="disabled"', $html);
+        $this->assertStringNotContainsString('action="site_export_save_push_access"', $html);
+    }
+
+    public function testManagedDisabledAdminCopyIsReadOnlyAndUnchecked(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        putenv('SITE_EXPORT_PUSH_ENABLED=false');
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
+        $this->assertStringContainsString('value="1" disabled="disabled"', $html);
+        $this->assertStringNotContainsString('checked="checked"', $html);
+        $this->assertStringNotContainsString('action="site_export_save_push_access"', $html);
+    }
+
+    public function testSecretFileOverrideShowsStoredOptionAndWarning(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'stored-token';
+        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-token';\n");
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('<code>secret.php</code> override is active.', $html);
+        $this->assertStringContainsString('value="stored-token"', $html);
+        $this->assertStringContainsString('Remove secret.php to use the stored option value.', $html);
+    }
+
+    public function testUnsupportedPushStateUsesANativeNoticeWithoutAForm(): void
+    {
+        $configuration = [
+            'stored_connection_token' => 'current-token',
+            'is_configured' => true,
+            'has_secret_file' => false,
+            'push_supported' => false,
+            'managed_push_enabled' => null,
+            'push_enabled' => false,
+        ];
+        $method = new ReflectionMethod(Site_Export_Plugin::class, 'render_push_access_form');
+
+        ob_start();
+        $method->invoke(Site_Export_Plugin::get_instance(), $configuration);
+        $html = (string) ob_get_clean();
+
+        $this->assertStringContainsString('notice notice-warning inline', $html);
+        $this->assertStringContainsString('Push access requires PHP 7.2 or newer.', $html);
+        $this->assertStringNotContainsString('<form', $html);
+    }
+
+    public function testAdministratorMapsEveryPushAccessResultToANativeNotice(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $expected_notices = [
+            'saved' => ['notice-success', 'Push access updated.'],
+            'unchanged' => ['notice-success', 'Push access was already up to date.'],
+            'unsupported' => ['notice-error', 'Push access requires PHP 7.2 or newer.'],
+            'managed' => ['notice-info', 'Push access is managed by your hosting provider.'],
+            'not_configured' => ['notice-error', 'Configure a connection token before enabling push access.'],
+            'storage_failure' => ['notice-error', 'Failed to save push access.'],
+        ];
+
+        foreach ($expected_notices as $result => [$notice_class, $message]) {
+            $_GET['site_export_notice'] = $result;
+            $html = $this->renderAdminPage();
+
+            $this->assertStringContainsString($notice_class, $html, $result);
+            $this->assertStringContainsString($message, $html, $result);
+            $this->assertStringContainsString(
+                $notice_class . ' is-dismissible inline',
+                $html,
+                $result
+            );
+        }
+    }
+
+    public function testSettingsSaveSupersedesAStalePushAccessNotice(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
+        $GLOBALS['site_export_settings_errors_markup'] =
+            '<div class="notice notice-success settings-error is-dismissible"><p><strong>'
+            . 'Settings saved.</strong></p></div>';
+        $_GET['settings-updated'] = 'true';
+        $_GET['site_export_notice'] = 'saved';
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString('Settings saved.', $html);
+        $this->assertStringNotContainsString('<strong>Settings saved.</strong>', $html);
+        $this->assertStringNotContainsString('Push access updated.', $html);
     }
 
     private function renderAdminPage(): string
     {
+        Site_Export_Plugin::get_instance()->register_settings_fields();
         ob_start();
         Site_Export_Plugin::get_instance()->render_admin_page();
         return (string) ob_get_clean();

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -3,6 +3,13 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use WordPress\Reprint\Server\Plugin\SettingsPage;
+
+use function WordPress\Reprint\Server\Plugin\change_connection_token;
+use function WordPress\Reprint\Server\Plugin\change_push_access;
+use function WordPress\Reprint\Server\Plugin\get_configuration_state;
+use function WordPress\Reprint\Server\Plugin\register_shared_secret_setting;
+use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
 
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/');
@@ -389,8 +396,8 @@ if (!function_exists('esc_url')) {
 
 require_once __DIR__ . '/../reprint-server-wp/lib.php';
 require_once __DIR__ . '/../reprint-server-wp/wordpress/configuration.php';
-_site_export_register_wordpress_configuration();
-require_once __DIR__ . '/../reprint-server-wp/wordpress/site-export.php';
+register_wordpress_configuration();
+require_once __DIR__ . '/../reprint-server-wp/wordpress/reprint-server.php';
 
 final class SiteExportSecretTest extends TestCase
 {
@@ -500,7 +507,7 @@ final class SiteExportSecretTest extends TestCase
         // lib.php later in the request, where the listener revoking
         // authorization for the appearing connection token runs during the
         // migration.
-        Site_Export_Plugin::get_instance();
+        \WordPress\Reprint\Server\Plugin\SettingsPage::get_instance();
         $GLOBALS['site_export_test_options']['site_export_secret'] = 'legacy-token';
         $GLOBALS['site_export_test_options']['site_export_push_authorized_token_fingerprint'] =
             hash('sha256', 'legacy-token');
@@ -542,8 +549,8 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFalse(function_exists('WordPress\\Reprint\\Server\\Plugin\\get_shared_secret'));
         $this->assertTrue(function_exists('_site_export_handle_api_request'));
         $this->assertTrue(function_exists('_site_export_get_shared_secret'));
-        $this->assertTrue(class_exists('Site_Export_Plugin'));
-        $this->assertFalse(class_exists('WordPress\\Reprint\\Server\\Plugin\\SettingsPage'));
+        $this->assertFalse(class_exists('Site_Export_Plugin'));
+        $this->assertTrue(class_exists('WordPress\\Reprint\\Server\\Plugin\\SettingsPage'));
     }
 
     public function testLegacyOptionsMigrateWithoutChangingTheirValues(): void
@@ -613,20 +620,20 @@ final class SiteExportSecretTest extends TestCase
 
     public function testSharedConnectionTokenOperationReturnsExplicitOutcomes(): void
     {
-        $this->assertSame('saved', _site_export_change_connection_token('new-token'));
-        $this->assertSame('unchanged', _site_export_change_connection_token('new-token'));
+        $this->assertSame('saved', change_connection_token('new-token'));
+        $this->assertSame('unchanged', change_connection_token('new-token'));
 
         $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_SECRET_OPTION;
-        $this->assertSame('storage_failure', _site_export_change_connection_token('other-token'));
+        $this->assertSame('storage_failure', change_connection_token('other-token'));
     }
 
     public function testPluginRegistersConnectionTokenOptionForCoreSettingsRestEndpoint(): void
     {
-        _site_export_register_shared_secret_setting();
+        register_shared_secret_setting();
 
         $setting = $GLOBALS['site_export_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
         $this->assertNotNull($setting);
-        $this->assertSame('site_export', $setting['group']);
+        $this->assertSame('reprint_server', $setting['group']);
         $this->assertTrue($setting['args']['show_in_rest']);
         $this->assertSame('string', $setting['args']['type']);
         $this->assertSame('', $setting['args']['default']);
@@ -639,15 +646,18 @@ final class SiteExportSecretTest extends TestCase
         $add_hooks = $GLOBALS['site_export_test_actions']['add_option_' . SITE_EXPORT_SECRET_OPTION] ?? [];
 
         $this->assertNotEmpty($rest_hooks);
-        $this->assertSame('_site_export_register_shared_secret_setting', $rest_hooks[0]['callback']);
+        $this->assertSame(
+            'WordPress\\Reprint\\Server\\Plugin\\register_shared_secret_setting',
+            $rest_hooks[0]['callback']
+        );
         $this->assertNotEmpty($update_hooks);
         $this->assertSame(
-            '_site_export_revoke_push_authorization_after_connection_token_change',
+            'WordPress\\Reprint\\Server\\Plugin\\revoke_push_authorization_after_connection_token_change',
             $update_hooks[0]['callback']
         );
         $this->assertNotEmpty($add_hooks);
         $this->assertSame(
-            '_site_export_revoke_push_authorization_after_connection_token_added',
+            'WordPress\\Reprint\\Server\\Plugin\\revoke_push_authorization_after_connection_token_added',
             $add_hooks[0]['callback']
         );
     }
@@ -799,7 +809,7 @@ final class SiteExportSecretTest extends TestCase
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
-        $this->assertSame('saved', _site_export_change_push_access(true));
+        $this->assertSame('saved', change_push_access(true));
         $this->assertSame(
             hash('sha256', 'current-token'),
             $GLOBALS['site_export_test_options'][SITE_EXPORT_PUSH_AUTHORIZATION_OPTION]
@@ -809,14 +819,14 @@ final class SiteExportSecretTest extends TestCase
 
     public function testSharedPushAccessOperationReturnsExplicitOutcomes(): void
     {
-        $this->assertSame('not_configured', _site_export_change_push_access(true));
+        $this->assertSame('not_configured', change_push_access(true));
 
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $this->assertSame('saved', _site_export_change_push_access(true));
-        $this->assertSame('unchanged', _site_export_change_push_access(true));
+        $this->assertSame('saved', change_push_access(true));
+        $this->assertSame('unchanged', change_push_access(true));
 
         putenv('SITE_EXPORT_PUSH_ENABLED=false');
-        $this->assertSame('managed', _site_export_change_push_access(false));
+        $this->assertSame('managed', change_push_access(false));
     }
 
     public function testSharedPushAccessOperationReportsStorageFailure(): void
@@ -824,7 +834,7 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
 
-        $this->assertSame('storage_failure', _site_export_change_push_access(true));
+        $this->assertSame('storage_failure', change_push_access(true));
         $this->assertFalse(_site_export_is_push_authorized());
     }
 
@@ -832,7 +842,7 @@ final class SiteExportSecretTest extends TestCase
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
-        $configuration = _site_export_get_configuration_state();
+        $configuration = get_configuration_state();
 
         $this->assertSame('current-token', $configuration['stored_connection_token']);
         $this->assertTrue($configuration['is_configured']);
@@ -844,16 +854,21 @@ final class SiteExportSecretTest extends TestCase
 
     public function testBundledAdministratorRegistersUnderTools(): void
     {
-        $plugin = Site_Export_Plugin::get_instance();
+        $plugin = SettingsPage::get_instance();
         $plugin->add_admin_menu();
 
-        $this->assertSame('site-export', $GLOBALS['site_export_test_menu']['menu_slug']);
+        $this->assertSame('reprint-server', $GLOBALS['site_export_test_menu']['menu_slug']);
         $this->assertSame('manage_options', $GLOBALS['site_export_test_menu']['capability']);
+        $this->assertSame(
+            'WordPress\\Reprint\\Server\\Plugin\\SettingsPage',
+            SettingsPage::class
+        );
+        $this->assertFalse(class_exists('Site_Export_Plugin', false));
 
         $links = $plugin->add_settings_link([]);
-        $this->assertStringContainsString('tools.php?page=site-export', $links[0]);
+        $this->assertStringContainsString('tools.php?page=reprint-server', $links[0]);
 
-        $admin_post_hooks = $GLOBALS['site_export_test_actions']['admin_post_site_export_save_push_access'] ?? [];
+        $admin_post_hooks = $GLOBALS['site_export_test_actions']['admin_post_reprint_server_save_push_access'] ?? [];
         $this->assertNotEmpty($admin_post_hooks);
         $this->assertSame([$plugin, 'handle_push_access_save'], $admin_post_hooks[0]['callback']);
         $this->assertEmpty($GLOBALS['site_export_test_actions']['admin_bar_menu'] ?? []);
@@ -861,11 +876,42 @@ final class SiteExportSecretTest extends TestCase
         $plugin->enqueue_assets('tools_page_other');
         $this->assertSame([], $GLOBALS['site_export_test_scripts']);
 
-        $plugin->enqueue_assets('tools_page_site-export');
+        $plugin->enqueue_assets('tools_page_reprint-server');
         $this->assertSame(
             ['wp-a11y'],
-            $GLOBALS['site_export_test_scripts']['site-export-admin']['dependencies']
+            $GLOBALS['site_export_test_scripts']['reprint-server-admin']['dependencies']
         );
+    }
+
+    public function testNewWordPressAdapterDeclaresOnlyCurrentNamespacedSymbols(): void
+    {
+        $configuration_source = file_get_contents(
+            __DIR__ . '/../reprint-server-wp/wordpress/configuration.php'
+        );
+        $administrator_source = file_get_contents(
+            __DIR__ . '/../reprint-server-wp/wordpress/reprint-server.php'
+        );
+        $administrator_script = file_get_contents(
+            __DIR__ . '/../reprint-server-wp/wordpress/reprint-server.js'
+        );
+        $this->assertIsString($configuration_source);
+        $this->assertIsString($administrator_source);
+        $this->assertIsString($administrator_script);
+        $this->assertStringContainsString(
+            'namespace WordPress\\Reprint\\Server\\Plugin;',
+            $configuration_source
+        );
+        $this->assertDoesNotMatchRegularExpression('/function\\s+_site_export/', $configuration_source);
+        $this->assertStringContainsString(
+            'namespace WordPress\\Reprint\\Server\\Plugin;',
+            $administrator_source
+        );
+        $this->assertStringContainsString('class SettingsPage', $administrator_source);
+        $this->assertStringNotContainsString('class Site_Export', $administrator_source);
+        $this->assertStringNotContainsString('site-export', $administrator_source);
+        $this->assertStringNotContainsString('site_export', $administrator_source);
+        $this->assertStringNotContainsString('site-export', $administrator_script);
+        $this->assertStringNotContainsString('site_export', $administrator_script);
     }
 
     public function testUnconfiguredAdminShowsOnlyConnectionTokenSetup(): void
@@ -876,7 +922,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringContainsString('Enter a connection token to get started.', $html);
         $this->assertStringContainsString('name="' . SITE_EXPORT_SECRET_OPTION . '"', $html);
         $this->assertStringNotContainsString('<h2>Push access</h2>', $html);
-        $this->assertStringNotContainsString('id="site-export-api-url"', $html);
+        $this->assertStringNotContainsString('id="reprint-server-api-url"', $html);
     }
 
     public function testDownloadOnlyAdminCopyAndPushAccessForm(): void
@@ -893,7 +939,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringContainsString('Allow push to change files on this site', $html);
         $this->assertStringContainsString('except excluded paths.', $html);
         $this->assertStringContainsString('<form method="post" action="options.php">', $html);
-        $this->assertStringContainsString('name="option_page" value="site_export"', $html);
+        $this->assertStringContainsString('name="option_page" value="reprint_server"', $html);
         $this->assertStringContainsString('action="https://example.test/wp-admin/admin-post.php"', $html);
         $this->assertSame(2, substr_count($html, '<p class="submit">'));
         $this->assertSame([''], $GLOBALS['site_export_settings_error_requests']);
@@ -932,7 +978,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringContainsString('<strong>Connected for downloads and push.</strong>', $html);
         $this->assertStringContainsString('notice notice-info inline', $html);
         $this->assertStringNotContainsString('notice notice-success inline', $html);
-        $this->assertStringContainsString('name="site_export_push_enabled"', $html);
+        $this->assertStringContainsString('name="reprint_server_push_enabled"', $html);
         $this->assertStringContainsString('checked="checked"', $html);
     }
 
@@ -945,7 +991,7 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
         $this->assertStringContainsString('checked="checked" disabled="disabled"', $html);
-        $this->assertStringNotContainsString('action="site_export_save_push_access"', $html);
+        $this->assertStringNotContainsString('action="reprint_server_save_push_access"', $html);
     }
 
     public function testManagedDisabledAdminCopyIsReadOnlyAndUnchecked(): void
@@ -958,7 +1004,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
         $this->assertStringContainsString('value="1" disabled="disabled"', $html);
         $this->assertStringNotContainsString('checked="checked"', $html);
-        $this->assertStringNotContainsString('action="site_export_save_push_access"', $html);
+        $this->assertStringNotContainsString('action="reprint_server_save_push_access"', $html);
     }
 
     public function testSecretFileOverrideShowsStoredOptionAndWarning(): void
@@ -983,10 +1029,10 @@ final class SiteExportSecretTest extends TestCase
             'managed_push_enabled' => null,
             'push_enabled' => false,
         ];
-        $method = new ReflectionMethod(Site_Export_Plugin::class, 'render_push_access_form');
+        $method = new ReflectionMethod(SettingsPage::class, 'render_push_access_form');
 
         ob_start();
-        $method->invoke(Site_Export_Plugin::get_instance(), $configuration);
+        $method->invoke(SettingsPage::get_instance(), $configuration);
         $html = (string) ob_get_clean();
 
         $this->assertStringContainsString('notice notice-warning inline', $html);
@@ -1007,7 +1053,7 @@ final class SiteExportSecretTest extends TestCase
         ];
 
         foreach ($expected_notices as $result => [$notice_class, $message]) {
-            $_GET['site_export_notice'] = $result;
+            $_GET['reprint_server_notice'] = $result;
             $html = $this->renderAdminPage();
 
             $this->assertStringContainsString($notice_class, $html, $result);
@@ -1027,7 +1073,7 @@ final class SiteExportSecretTest extends TestCase
             '<div class="notice notice-success settings-error is-dismissible"><p><strong>'
             . 'Settings saved.</strong></p></div>';
         $_GET['settings-updated'] = 'true';
-        $_GET['site_export_notice'] = 'saved';
+        $_GET['reprint_server_notice'] = 'saved';
 
         $html = $this->renderAdminPage();
 
@@ -1038,9 +1084,9 @@ final class SiteExportSecretTest extends TestCase
 
     private function renderAdminPage(): string
     {
-        Site_Export_Plugin::get_instance()->register_settings_fields();
+        SettingsPage::get_instance()->register_settings_fields();
         ob_start();
-        Site_Export_Plugin::get_instance()->render_admin_page();
+        SettingsPage::get_instance()->render_admin_page();
         return (string) ob_get_clean();
     }
 }

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -8,7 +8,7 @@ use WordPress\Reprint\Server\Plugin\SettingsPage;
 use function WordPress\Reprint\Server\Plugin\change_connection_token;
 use function WordPress\Reprint\Server\Plugin\change_push_access;
 use function WordPress\Reprint\Server\Plugin\get_configuration_state;
-use function WordPress\Reprint\Server\Plugin\register_shared_secret_setting;
+use function WordPress\Reprint\Server\Plugin\register_connection_token_setting;
 use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
 
 if (!defined('ABSPATH')) {
@@ -618,7 +618,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
     }
 
-    public function testSharedConnectionTokenOperationReturnsExplicitOutcomes(): void
+    public function testConnectionTokenOperationReturnsExplicitOutcomes(): void
     {
         $this->assertSame('saved', change_connection_token('new-token'));
         $this->assertSame('unchanged', change_connection_token('new-token'));
@@ -629,7 +629,7 @@ final class SiteExportSecretTest extends TestCase
 
     public function testPluginRegistersConnectionTokenOptionForCoreSettingsRestEndpoint(): void
     {
-        register_shared_secret_setting();
+        register_connection_token_setting();
 
         $setting = $GLOBALS['site_export_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
         $this->assertNotNull($setting);
@@ -647,7 +647,7 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertNotEmpty($rest_hooks);
         $this->assertSame(
-            'WordPress\\Reprint\\Server\\Plugin\\register_shared_secret_setting',
+            'WordPress\\Reprint\\Server\\Plugin\\register_connection_token_setting',
             $rest_hooks[0]['callback']
         );
         $this->assertNotEmpty($update_hooks);
@@ -805,7 +805,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
-    public function testSharedPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
+    public function testPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
 
@@ -817,7 +817,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertTrue(_site_export_is_push_authorized());
     }
 
-    public function testSharedPushAccessOperationReturnsExplicitOutcomes(): void
+    public function testPushAccessOperationReturnsExplicitOutcomes(): void
     {
         $this->assertSame('not_configured', change_push_access(true));
 
@@ -829,7 +829,7 @@ final class SiteExportSecretTest extends TestCase
         $this->assertSame('managed', change_push_access(false));
     }
 
-    public function testSharedPushAccessOperationReportsStorageFailure(): void
+    public function testPushAccessOperationReportsStorageFailure(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
         $GLOBALS['site_export_fail_option_updates'][] = SITE_EXPORT_PUSH_AUTHORIZATION_OPTION;
@@ -920,6 +920,7 @@ final class SiteExportSecretTest extends TestCase
 
         $this->assertStringContainsString('<strong>Not configured yet.</strong>', $html);
         $this->assertStringContainsString('Enter a connection token to get started.', $html);
+        $this->assertStringContainsString('id="reprint_server_connection_token"', $html);
         $this->assertStringContainsString('name="' . SITE_EXPORT_SECRET_OPTION . '"', $html);
         $this->assertStringNotContainsString('<h2>Push access</h2>', $html);
         $this->assertStringNotContainsString('id="reprint-server-api-url"', $html);

--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -27,7 +27,6 @@ $GLOBALS['site_export_test_options'] = [];
 $GLOBALS['site_export_registered_settings'] = [];
 $GLOBALS['site_export_settings_errors'] = [];
 $GLOBALS['site_export_settings_error_requests'] = [];
-$GLOBALS['site_export_settings_errors_markup'] = '';
 $GLOBALS['site_export_test_actions'] = [];
 $GLOBALS['site_export_test_menu'] = null;
 $GLOBALS['site_export_test_sections'] = [];
@@ -266,10 +265,21 @@ if (!function_exists('add_settings_error')) {
     }
 }
 
-if (!function_exists('settings_errors')) {
-    function settings_errors(string $setting = ''): void {
+if (!function_exists('get_settings_errors')) {
+    function get_settings_errors(string $setting = '', bool $sanitize = false): array {
         $GLOBALS['site_export_settings_error_requests'][] = $setting;
-        echo $GLOBALS['site_export_settings_errors_markup'];
+        if ($setting === '') {
+            return $GLOBALS['site_export_settings_errors'];
+        }
+
+        return array_values(
+            array_filter(
+                $GLOBALS['site_export_settings_errors'],
+                static function(array $notice) use ($setting): bool {
+                    return $notice['setting'] === $setting;
+                }
+            )
+        );
     }
 }
 
@@ -387,6 +397,12 @@ if (!function_exists('esc_html')) {
     }
 }
 
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post(string $value): string {
+        return $value;
+    }
+}
+
 if (!function_exists('esc_url')) {
     function esc_url(string $value): string {
         return esc_attr($value);
@@ -439,7 +455,6 @@ final class SiteExportSecretTest extends TestCase
         $GLOBALS['site_export_registered_settings'] = [];
         $GLOBALS['site_export_settings_errors'] = [];
         $GLOBALS['site_export_settings_error_requests'] = [];
-        $GLOBALS['site_export_settings_errors_markup'] = '';
         $GLOBALS['site_export_test_menu'] = null;
         $GLOBALS['site_export_test_sections'] = [];
         $GLOBALS['site_export_test_fields'] = [];
@@ -908,6 +923,10 @@ final class SiteExportSecretTest extends TestCase
         );
         $this->assertStringContainsString('class SettingsPage', $administrator_source);
         $this->assertStringNotContainsString('class Site_Export', $administrator_source);
+        $this->assertStringContainsString('get_settings_errors()', $administrator_source);
+        $this->assertDoesNotMatchRegularExpression('/(?<!get_)settings_errors\s*\(/', $administrator_source);
+        $this->assertStringNotContainsString('ob_start()', $administrator_source);
+        $this->assertStringNotContainsString('str_replace(', $administrator_source);
         $this->assertStringNotContainsString('site-export', $administrator_source);
         $this->assertStringNotContainsString('site_export', $administrator_source);
         $this->assertStringNotContainsString('site-export', $administrator_script);
@@ -951,12 +970,16 @@ final class SiteExportSecretTest extends TestCase
 
     public function testCoreSettingsNoticeIsInlineAtItsRenderedPosition(): void
     {
-        $GLOBALS['site_export_settings_errors_markup'] =
-            '<div class="notice notice-success settings-error is-dismissible"><p><strong>'
-            . 'Settings saved.</strong></p></div>';
+        $GLOBALS['site_export_settings_errors'][] = [
+            'setting' => 'general',
+            'code' => 'settings_updated',
+            'message' => 'Settings saved.',
+            'type' => 'updated',
+        ];
 
         $html = $this->renderAdminPage();
 
+        $this->assertStringContainsString('id="setting-error-settings_updated"', $html);
         $this->assertStringContainsString(
             'notice notice-success settings-error is-dismissible inline',
             $html
@@ -967,6 +990,24 @@ final class SiteExportSecretTest extends TestCase
         );
         $this->assertStringContainsString('<p>Settings saved.</p>', $html);
         $this->assertStringNotContainsString('<strong>Settings saved.</strong>', $html);
+    }
+
+    public function testCoreSettingsNoticeFallsBackToErrorForAnUnknownType(): void
+    {
+        $GLOBALS['site_export_settings_errors'][] = [
+            'setting' => 'general',
+            'code' => 'unexpected_type',
+            'message' => 'Something needs attention.',
+            'type' => 'unexpected',
+        ];
+
+        $html = $this->renderAdminPage();
+
+        $this->assertStringContainsString(
+            'notice notice-error settings-error is-dismissible inline',
+            $html
+        );
+        $this->assertStringContainsString('<p>Something needs attention.</p>', $html);
     }
 
     public function testOptedInAdminCopyShowsCurrentConnectionTokenCanPush(): void
@@ -1070,9 +1111,12 @@ final class SiteExportSecretTest extends TestCase
     public function testSettingsSaveSupersedesAStalePushAccessNotice(): void
     {
         $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'current-token';
-        $GLOBALS['site_export_settings_errors_markup'] =
-            '<div class="notice notice-success settings-error is-dismissible"><p><strong>'
-            . 'Settings saved.</strong></p></div>';
+        $GLOBALS['site_export_settings_errors'][] = [
+            'setting' => 'general',
+            'code' => 'settings_updated',
+            'message' => 'Settings saved.',
+            'type' => 'updated',
+        ];
         $_GET['settings-updated'] = 'true';
         $_GET['reprint_server_notice'] = 'saved';
 

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -268,7 +268,7 @@ export async function ensureSite(name, options = {}) {
         wpCoreInstall(siteDir, siteUrl, name);
         log('wp core install done');
 
-        // Activate the site-export plugin so WordPress loads index.php on requests.
+        // Activate the Reprint Server plugin so WordPress loads index.php on requests.
         wpPluginActivate(siteDir, 'site-export');
 
         // Run customDb hook to add extra tables on top of real WP

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -123,7 +123,7 @@ async function ensureSqliteSite(site, pluginVersion) {
             );
             rmSync(join(siteDir, '.maintenance'), { force: true });
 
-            // Activate the site-export plugin.
+            // Activate the Reprint Server plugin.
             execSync(
                 `php /tmp/wp-cli.phar plugin activate site-export` +
                 ` --path=${JSON.stringify(siteDir)}` +

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -242,7 +242,7 @@ describe('Import: SiteGround plugin stripping', () => {
             const flatDir = join(tempDir, 'flattened');
             assert.ok(
                 existsSync(join(flatDir, 'wp-content', 'plugins', 'site-export')),
-                'site-export plugin should still exist after apply-runtime',
+                'Reprint Server plugin should still exist after apply-runtime',
             );
         });
     });

--- a/tests/e2e/tests/import-47-plugin-auth.test.js
+++ b/tests/e2e/tests/import-47-plugin-auth.test.js
@@ -1,7 +1,7 @@
 /**
- * Test 47: WordPress plugin authentication
+ * Test 47: Reprint Server plugin authentication
  *
- * Installs the site-export plugin in a stock WordPress site — no custom
+ * Installs the Reprint Server plugin in a stock WordPress site — no custom
  * setup, no afterCreate hooks — and verifies the default authentication
  * behaviour via HTTP.
  *
@@ -18,7 +18,7 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: WordPress plugin authentication', () => {
+describe('Import: Reprint Server plugin authentication', () => {
     const site = 'plugin-auth';
 
     beforeAll(async () => {
@@ -39,24 +39,24 @@ describe('Import: WordPress plugin authentication', () => {
             'Response must include an error message');
     });
 
-    it('rejects requests signed with the wrong secret', async () => {
+    it('rejects requests signed with the wrong connection token', async () => {
         const url = new URL(getSiteUrl(site));
         url.searchParams.set('endpoint', 'preflight');
         url.searchParams.set('directory', getSiteDir(site));
 
-        const wrongClient = createHmacClient('not-the-right-secret');
+        const clientWithWrongConnectionToken = createHmacClient('not-the-right-connection-token');
         const response = await fetch(url.toString(), {
-            headers: wrongClient.getAuthHeaders(''),
+            headers: clientWithWrongConnectionToken.getAuthHeaders(''),
         });
         assert.equal(response.status, 403,
-            'Request signed with wrong secret must be rejected with 403');
+            'Request signed with the wrong connection token must be rejected with 403');
 
         const body = await response.json();
         assert.ok(body.error,
             'Response must include an error message');
     });
 
-    it('accepts requests signed with the correct secret', async () => {
+    it('accepts requests signed with the correct connection token', async () => {
         const response = await apiRequest(site, 'preflight', {
             directory: getSiteDir(site),
         });

--- a/tests/lib/ReprintServerPluginTestCase.php
+++ b/tests/lib/ReprintServerPluginTestCase.php
@@ -1,0 +1,520 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared harness for the bundled WordPress plugin tests.
+ *
+ * Boots the plugin against the canonical Reprint Server runtime API only, so
+ * the suite keeps working unchanged when compat.php is deleted. Backwards
+ * compatibility is covered separately by ReprintServerCompatTest.
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Reprint\Server\Plugin\SettingsPage;
+
+use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+// Test-owned paths, named independently of the plugin's own constants so the
+// tests never reach for a compat.php alias.
+if (!defined('REPRINT_SERVER_TEST_PLUGIN_DIR')) {
+    define(
+        'REPRINT_SERVER_TEST_PLUGIN_DIR',
+        sys_get_temp_dir() . '/reprint-server-plugin-test-' . getmypid() . '/'
+    );
+}
+if (!defined('REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE')) {
+    define('REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE', REPRINT_SERVER_TEST_PLUGIN_DIR . 'secret.php');
+}
+
+// Seed the canonical namespaced constants lib.php would otherwise derive, so
+// the plugin boots without compat.php adopting any SITE_EXPORT_* name.
+if (!defined('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR')) {
+    define('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR', REPRINT_SERVER_TEST_PLUGIN_DIR);
+}
+if (!defined('WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE')) {
+    define(
+        'WordPress\\Reprint\\Server\\Plugin\\CONNECTION_TOKEN_FILE',
+        REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE
+    );
+}
+
+$GLOBALS['reprint_server_test_options'] = [];
+$GLOBALS['reprint_server_registered_settings'] = [];
+$GLOBALS['reprint_server_settings_errors'] = [];
+$GLOBALS['reprint_server_settings_error_requests'] = [];
+$GLOBALS['reprint_server_test_actions'] = [];
+$GLOBALS['reprint_server_test_menu'] = null;
+$GLOBALS['reprint_server_test_sections'] = [];
+$GLOBALS['reprint_server_test_fields'] = [];
+$GLOBALS['reprint_server_test_scripts'] = [];
+$GLOBALS['reprint_server_fail_option_updates'] = [];
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,Generic.CodeAnalysis.UnusedFunctionParameter.Found,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound,WordPress.Security.EscapeOutput.OutputNotEscaped -- WordPress test stubs.
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path(string $file): string {
+        return REPRINT_SERVER_TEST_PLUGIN_DIR;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option(string $name, $default = false) {
+        if (array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
+            return $GLOBALS['reprint_server_test_options'][$name];
+        }
+        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Generic WordPress option test stub.
+        return apply_filters('default_option_' . $name, $default, $name, true);
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option(string $name, $value, $autoload = null): bool {
+        if (in_array($name, $GLOBALS['reprint_server_fail_option_updates'], true)) {
+            return false;
+        }
+
+        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
+            $GLOBALS['reprint_server_test_options'][$name] = $value;
+            foreach ($GLOBALS['reprint_server_test_actions']['add_option_' . $name] ?? [] as $action) {
+                $args = array_slice([$name, $value], 0, $action['accepted_args']);
+                call_user_func_array($action['callback'], $args);
+            }
+            return true;
+        }
+
+        $old_value = get_option($name);
+        $GLOBALS['reprint_server_test_options'][$name] = $value;
+
+        if ($old_value !== $value) {
+            foreach ($GLOBALS['reprint_server_test_actions']['update_option_' . $name] ?? [] as $action) {
+                $args = array_slice([$old_value, $value, $name], 0, $action['accepted_args']);
+                call_user_func_array($action['callback'], $args);
+            }
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option(string $name): bool {
+        if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
+            return false;
+        }
+
+        unset($GLOBALS['reprint_server_test_options'][$name]);
+        return true;
+    }
+}
+
+if (!function_exists('register_setting')) {
+    function register_setting(string $group, string $name, array $args = []): void {
+        $GLOBALS['reprint_server_registered_settings'][$name] = [
+            'group' => $group,
+            'args' => $args,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_section')) {
+    function add_settings_section(string $id, string $title, $callback, string $page): void {
+        $GLOBALS['reprint_server_test_sections'][$page][$id] = [
+            'title' => $title,
+            'callback' => $callback,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_field')) {
+    function add_settings_field(
+        string $id,
+        string $title,
+        $callback,
+        string $page,
+        string $section,
+        array $args = []
+    ): void {
+        $GLOBALS['reprint_server_test_fields'][$page][$section][$id] = [
+            'title' => $title,
+            'callback' => $callback,
+            'args' => $args,
+        ];
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
+        $GLOBALS['reprint_server_test_actions'][$hook_name][] = [
+            'callback' => $callback,
+            'priority' => $priority,
+            'accepted_args' => $accepted_args,
+        ];
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter(string $hook_name, $callback, int $priority = 10, int $accepted_args = 1): void {
+        $GLOBALS['reprint_test_filters'][$hook_name][] = [
+            'callback' => $callback,
+            'priority' => $priority,
+            'accepted_args' => $accepted_args,
+        ];
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action(string $hook_name, ...$args): void {
+        $actions = $GLOBALS['reprint_server_test_actions'][$hook_name] ?? [];
+        usort($actions, static function (array $left, array $right): int {
+            return $left['priority'] <=> $right['priority'];
+        });
+        foreach ($actions as $action) {
+            call_user_func_array(
+                $action['callback'],
+                array_slice($args, 0, $action['accepted_args'])
+            );
+        }
+    }
+}
+
+if (!function_exists('plugin_basename')) {
+    function plugin_basename(string $file): string {
+        return basename($file);
+    }
+}
+
+if (!function_exists('add_management_page')) {
+    function add_management_page($page_title, $menu_title, $capability, $menu_slug, $callback): string {
+        $GLOBALS['reprint_server_test_menu'] = [
+            'page_title' => $page_title,
+            'menu_title' => $menu_title,
+            'capability' => $capability,
+            'menu_slug' => $menu_slug,
+            'callback' => $callback,
+        ];
+        return 'tools_page_' . $menu_slug;
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook(...$args): void {}
+}
+
+if (!function_exists('wp_doing_ajax')) {
+    function wp_doing_ajax(): bool {
+        return false;
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin(): bool {
+        return true;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient(...$args): void {}
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient(...$args): bool {
+        return false;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient(...$args): void {}
+}
+
+if (!function_exists('wp_safe_redirect')) {
+    function wp_safe_redirect(...$args): void {}
+}
+
+if (!function_exists('__')) {
+    function __(string $text, string $domain = 'default'): string {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__(string $text, string $domain = 'default'): string {
+        return esc_html($text);
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__(string $text, string $domain = 'default'): string {
+        return esc_attr($text);
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can(string $capability): bool {
+        return $capability === 'manage_options';
+    }
+}
+
+if (!function_exists('check_admin_referer')) {
+    function check_admin_referer(string $action): void {}
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value): string {
+        return trim( (string) $value );
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        return $value;
+    }
+}
+
+if (!function_exists('add_settings_error')) {
+    function add_settings_error(string $setting, string $code, string $message, string $type): void {
+        $GLOBALS['reprint_server_settings_errors'][] = [
+            'setting' => $setting,
+            'code' => $code,
+            'message' => $message,
+            'type' => $type,
+        ];
+    }
+}
+
+if (!function_exists('get_settings_errors')) {
+    function get_settings_errors(string $setting = '', bool $sanitize = false): array {
+        $GLOBALS['reprint_server_settings_error_requests'][] = $setting;
+        if ($setting === '') {
+            return $GLOBALS['reprint_server_settings_errors'];
+        }
+
+        return array_values(
+            array_filter(
+                $GLOBALS['reprint_server_settings_errors'],
+                static function(array $notice) use ($setting): bool {
+                    return $notice['setting'] === $setting;
+                }
+            )
+        );
+    }
+}
+
+if (!function_exists('settings_fields')) {
+    function settings_fields(string $group): void {
+        echo '<input type="hidden" name="option_page" value="' . esc_attr($group) . '" />';
+    }
+}
+
+if (!function_exists('do_settings_sections')) {
+    function do_settings_sections(string $page): void {
+        foreach ($GLOBALS['reprint_server_test_sections'][$page] ?? [] as $section_id => $section) {
+            echo '<h2>' . esc_html($section['title']) . '</h2>';
+            call_user_func($section['callback']);
+            echo '<table class="form-table">';
+            foreach ($GLOBALS['reprint_server_test_fields'][$page][$section_id] ?? [] as $field) {
+                echo '<tr><th>' . esc_html($field['title']) . '</th><td>';
+                call_user_func($field['callback'], $field['args']);
+                echo '</td></tr>';
+            }
+            echo '</table>';
+        }
+    }
+}
+
+if (!function_exists('submit_button')) {
+    function submit_button(
+        string $text = 'Save Changes',
+        string $type = 'primary',
+        string $name = 'submit',
+        bool $wrap = true
+    ): void {
+        $button = '<input type="submit" name="' . esc_attr($name) . '" class="button button-'
+            . esc_attr($type) . '" value="' . esc_attr($text) . '" />';
+        echo $wrap ? '<p class="submit">' . $button . '</p>' : $button;
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url(string $path = ''): string {
+        return 'https://example.test/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url(string $path = ''): string {
+        return 'https://example.test/wp-admin/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('get_admin_page_title')) {
+    function get_admin_page_title(): string {
+        return 'Reprint Server';
+    }
+}
+
+if (!function_exists('checked')) {
+    function checked($checked, $current = true, bool $display = true): string {
+        $result = $checked == $current ? ' checked="checked"' : '';
+        if ($display) {
+            echo $result;
+        }
+        return $result;
+    }
+}
+
+if (!function_exists('disabled')) {
+    function disabled($disabled, $current = true, bool $display = true): string {
+        $result = $disabled == $current ? ' disabled="disabled"' : '';
+        if ($display) {
+            echo $result;
+        }
+        return $result;
+    }
+}
+
+if (!function_exists('plugins_url')) {
+    function plugins_url(string $path = '', string $plugin = ''): string {
+        return 'https://example.test/wp-content/plugins/reprint-server/' . ltrim($path, '/');
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script($handle, $src, $dependencies, $version, $in_footer): void {
+        $GLOBALS['reprint_server_test_scripts'][$handle] = compact(
+            'src',
+            'dependencies',
+            'version',
+            'in_footer'
+        );
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key(string $key): string {
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower($key)) ?? '';
+    }
+}
+
+if (!function_exists('wp_nonce_field')) {
+    function wp_nonce_field(string $action): void {
+        echo '<input type="hidden" name="_wpnonce" value="' . esc_attr($action) . '" />';
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr(string $value): string {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html(string $value): string {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post(string $value): string {
+        return $value;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url(string $value): string {
+        return esc_attr($value);
+    }
+}
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+
+require_once __DIR__ . '/../../reprint-server-wp/lib.php';
+require_once __DIR__ . '/../../reprint-server-wp/wordpress/configuration.php';
+register_wordpress_configuration();
+require_once __DIR__ . '/../../reprint-server-wp/wordpress/reprint-server.php';
+abstract class ReprintServerPluginTestCase extends TestCase
+{
+    /** @var array<string, mixed> */
+    protected $original_server = [];
+
+    /** @var array<string, mixed> */
+    protected $original_files = [];
+
+    /** @var array<string, mixed> */
+    protected $original_post = [];
+
+    /** @var array<string, mixed> */
+    protected $original_get = [];
+
+    /** @var string|false */
+    protected $original_reprint_server_push_enabled_environment;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!is_dir(REPRINT_SERVER_TEST_PLUGIN_DIR)) {
+            mkdir(REPRINT_SERVER_TEST_PLUGIN_DIR, 0755, true);
+        }
+
+        $this->original_server = $_SERVER;
+        $this->original_files = $_FILES;
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
+        $this->original_post = $_POST;
+        $this->original_get = $_GET;
+        $this->original_reprint_server_push_enabled_environment = getenv('REPRINT_SERVER_PUSH_ENABLED');
+
+        $GLOBALS['reprint_server_test_options'] = [];
+        $GLOBALS['reprint_server_registered_settings'] = [];
+        $GLOBALS['reprint_server_settings_errors'] = [];
+        $GLOBALS['reprint_server_settings_error_requests'] = [];
+        $GLOBALS['reprint_server_test_menu'] = null;
+        $GLOBALS['reprint_server_test_sections'] = [];
+        $GLOBALS['reprint_server_test_fields'] = [];
+        $GLOBALS['reprint_server_test_scripts'] = [];
+        $GLOBALS['reprint_server_fail_option_updates'] = [];
+        $_SERVER = [];
+        $_FILES = [];
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.
+        $_POST = [];
+        $_GET = [];
+        putenv('REPRINT_SERVER_PUSH_ENABLED');
+
+        if (file_exists(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE)) {
+            unlink(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE)) {
+            unlink(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE);
+        }
+
+        if (is_dir(REPRINT_SERVER_TEST_PLUGIN_DIR)) {
+            rmdir(REPRINT_SERVER_TEST_PLUGIN_DIR);
+        }
+
+        $_SERVER = $this->original_server;
+        $_FILES = $this->original_files;
+        $_POST = $this->original_post;
+        $_GET = $this->original_get;
+        if ($this->original_reprint_server_push_enabled_environment === false) {
+            putenv('REPRINT_SERVER_PUSH_ENABLED');
+        } else {
+            putenv('REPRINT_SERVER_PUSH_ENABLED=' . $this->original_reprint_server_push_enabled_environment);
+        }
+
+        parent::tearDown();
+    }
+
+    protected function renderAdminPage(): string
+    {
+        SettingsPage::get_instance()->register_settings_fields();
+        ob_start();
+        SettingsPage::get_instance()->render_admin_page();
+        return (string) ob_get_clean();
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -39,6 +39,7 @@
             <file>MultipartProcessorTest.php</file>
             <file>PushEndpointsTest.php</file>
             <file>ReprintServerPluginTest.php</file>
+            <file>ReprintServerCompatTest.php</file>
             <file>PushSessionTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -38,7 +38,7 @@
             <file>HmacServerTest.php</file>
             <file>MultipartProcessorTest.php</file>
             <file>PushEndpointsTest.php</file>
-            <file>SiteExportSecretTest.php</file>
+            <file>ReprintServerPluginTest.php</file>
             <file>PushSessionTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">


### PR DESCRIPTION
Rewrite the WordPress plugin to use WordPress primitives and make sure the latest terminology is used ("Reprint Server" and "connection token" vs "exporter" and "shared secret").

<img width="1051" height="797" alt="Screenshot 2026-08-26 at 14 07 18" src="https://github.com/user-attachments/assets/b6d76f37-bbb0-4fc8-9fbf-5999786e7442" />
