### PR TITLE
Fix mirror index collisions from intermediate symlinks

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3632,6 +3632,12 @@ class ImportClient
                 $remote_entry = $changed_path_diff->get_entry_in_new_index();
                 if ($remote_entry !== null) {
                     /** @var array{copy_source_path:string,type:string} $remote_entry */
+                    // Intermediate symlinks are neither fetched nor removed
+                    // here. recreate_intermediate_symlinks() owns them, and
+                    // deleting one would break the chain until it runs.
+                    if (!empty($remote_entry["intermediate"])) {
+                        continue;
+                    }
                     if (
                         !$this->is_selected_for_pulling(
                             $remote_entry["copy_source_path"],
@@ -7951,15 +7957,23 @@ class ImportClient
                             }
                         }
                     } elseif ($transition !== "unchanged") {
-                        $remote_path_type =
-                            $index_diff->get_path_type_in_new_index();
+                        // `$next_remote_entry` is the entry for
+                        // `$remote_absolute_path`, so its `type` and
+                        // `intermediate` fields describe that path.
+                        $next_remote_entry =
+                            $index_diff->get_entry_in_new_index();
+                        $remote_path_type = $next_remote_entry["type"] ?? null;
                         if ($remote_path_type === null) {
                             throw new LogicException(
                                 "Remote index path is absent from the next remote index: {$remote_absolute_path}"
                             );
                         }
+                        // Intermediate symlinks are recreated from the next
+                        // remote index once fetching finishes, never fetched as
+                        // symlink chunks. See recreate_intermediate_symlinks().
                         if (
-                            $this->is_selected_for_pulling(
+                            empty($next_remote_entry["intermediate"])
+                            && $this->is_selected_for_pulling(
                                 $remote_absolute_path,
                                 true,
                                 $remote_path_type

--- a/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
+++ b/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
@@ -116,6 +116,9 @@ final class MappedRemoteIndexBuilder
                         $remote_entry["path"],
                         $excluded_remote_absolute_path_prefixes
                     )
+                    // Recreated separately after fetching. See
+                    // ImportClient::recreate_intermediate_symlinks().
+                    && empty($remote_entry["intermediate"])
                 ) {
                     self::write_mapped_entry(
                         $mapped_index_handle,

--- a/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
+++ b/packages/reprint-client/src/lib/pull/class-mapped-remote-index-builder.php
@@ -116,9 +116,6 @@ final class MappedRemoteIndexBuilder
                         $remote_entry["path"],
                         $excluded_remote_absolute_path_prefixes
                     )
-                    // Recreated separately after fetching. See
-                    // ImportClient::recreate_intermediate_symlinks().
-                    && empty($remote_entry["intermediate"])
                 ) {
                     self::write_mapped_entry(
                         $mapped_index_handle,
@@ -169,8 +166,9 @@ final class MappedRemoteIndexBuilder
      *     @type int    $ctime            Always zero; clocks are not compared.
      *     @type int    $size             Remote size.
      *     @type string $copy_source_path Remote absolute path.
+     *     @type true   $intermediate     Present for intermediate symlinks only.
      * }
-     * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,copy_source_path:string}
+     * @phpstan-return array{path:string,type:'file'|'link'|'dir',ctime:int,size:int,copy_source_path:string,intermediate?:true}
      */
     public static function decode_index_line(string $line): array
     {
@@ -196,13 +194,17 @@ final class MappedRemoteIndexBuilder
         ) {
             throw new RuntimeException("Invalid mapped remote-index entry.");
         }
-        return [
+        $mapped_entry = [
             "path" => $local_relative_path,
             "type" => $type,
             "ctime" => 0,
             "size" => (int) ( $entry["size"] ?? 0 ),
             "copy_source_path" => $remote_absolute_path,
         ];
+        if (!empty($entry["intermediate"])) {
+            $mapped_entry["intermediate"] = true;
+        }
+        return $mapped_entry;
     }
 
     /** @param resource $mapped_index_handle */
@@ -223,7 +225,12 @@ final class MappedRemoteIndexBuilder
             );
         }
         if ($local_relative_path === "") {
-            if ($remote_entry["type"] !== "dir") {
+            // An intermediate symlink mapped onto the root stands for the root
+            // directory itself, which always exists.
+            if (
+                $remote_entry["type"] !== "dir"
+                && empty($remote_entry["intermediate"])
+            ) {
                 throw new RuntimeException(
                     "A remote path cannot replace the filesystem root: {$remote_absolute_path}."
                 );
@@ -234,13 +241,17 @@ final class MappedRemoteIndexBuilder
         $mapped_key = bin2hex($local_relative_path)
             . "/"
             . bin2hex($remote_absolute_path);
+        $mapped_record = [
+            "path" => base64_encode($mapped_key),
+            "ctime" => 0,
+            "size" => $remote_entry["size"],
+            "type" => $remote_entry["type"],
+        ];
+        if (!empty($remote_entry["intermediate"])) {
+            $mapped_record["intermediate"] = true;
+        }
         $line = json_encode(
-            [
-                "path" => base64_encode($mapped_key),
-                "ctime" => 0,
-                "size" => $remote_entry["size"],
-                "type" => $remote_entry["type"],
-            ],
+            $mapped_record,
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         ) . "\n";
         if (fwrite($mapped_index_handle, $line) !== strlen($line)) {
@@ -248,7 +259,14 @@ final class MappedRemoteIndexBuilder
         }
     }
 
-    /** Rejects remote paths which map to the same local path or below one. */
+    /**
+     * Rejects remote paths which map to the same local path or below one.
+     *
+     * Intermediate symlinks are the one exception to the second rule: their
+     * paths legitimately map to a parent of resolved content, so entries below
+     * one are permitted. They remain subject to the same-local-path rule, since
+     * two remote paths on one local path collide whatever their kind.
+     */
     private static function assert_no_path_collisions(
         string $mapped_remote_index_file
     ): void {
@@ -267,13 +285,15 @@ final class MappedRemoteIndexBuilder
             );
         }
         $preceding_local_path = null;
-        /** @var array{path:string,record_offset:int,previous_record_offset:int|null}|null $active_mapped_path */
+        /** @var array{path:string,intermediate:bool,record_offset:int,previous_record_offset:int|null}|null $active_mapped_path */
         $active_mapped_path = null;
         $collision_stack_byte_offset = 0;
         try {
             $line = fgets($mapped_index_handle);
             while ($line !== false) {
-                $local_path = self::decode_index_line($line)["path"];
+                $mapped_entry = self::decode_index_line($line);
+                $local_path = $mapped_entry["path"];
+                $path_is_intermediate = !empty($mapped_entry["intermediate"]);
                 if ($local_path === $preceding_local_path) {
                     throw new RuntimeException(
                         "Remote paths map to the same local path: {$local_path}."
@@ -282,10 +302,15 @@ final class MappedRemoteIndexBuilder
                 while ($active_mapped_path !== null) {
                     $mapped_path = $active_mapped_path["path"];
                     if (path_is_descendant_of($local_path, $mapped_path)) {
-                        throw new RuntimeException(
-                            "A remote path maps below another remote path: "
-                            . "{$local_path} is below {$mapped_path}."
-                        );
+                        if (!$active_mapped_path["intermediate"]) {
+                            throw new RuntimeException(
+                                "A remote path maps below another remote path: "
+                                . "{$local_path} is below {$mapped_path}."
+                            );
+                        }
+                        // Resolved content below an intermediate symlink. Keep
+                        // that symlink active for the entries which follow.
+                        break;
                     }
                     if (strcmp($local_path, $mapped_path . "/") <= 0) {
                         break;
@@ -317,6 +342,7 @@ final class MappedRemoteIndexBuilder
                     }
                     $active_mapped_path = [
                         "path" => $stack_path,
+                        "intermediate" => !empty($stack_record["intermediate"]),
                         "record_offset" => $previous_record_offset,
                         "previous_record_offset" =>
                             $stack_record["previous_record_offset"] ?? null,
@@ -325,6 +351,7 @@ final class MappedRemoteIndexBuilder
                 $stack_line = json_encode(
                     [
                         "path_b64" => base64_encode($local_path),
+                        "intermediate" => $path_is_intermediate,
                         "previous_record_offset" =>
                             $active_mapped_path["record_offset"] ?? null,
                     ],
@@ -341,6 +368,7 @@ final class MappedRemoteIndexBuilder
                 }
                 $active_mapped_path = [
                     "path" => $local_path,
+                    "intermediate" => $path_is_intermediate,
                     "record_offset" => $collision_stack_byte_offset,
                     "previous_record_offset" =>
                         $active_mapped_path["record_offset"] ?? null,

--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -25,12 +25,15 @@ use function WordPress\Reprint\Server\assert_valid_path;
  *         "type"  => "file",
  *     ]
  *
- * The `intermediate` marker is retained for consumers that must omit
- * path-component symlinks from content comparisons. Other raw-record fields,
- * such as `target`, are deliberately omitted. Callers which need a symlink
- * target read the raw symlink records instead. This reader also does not read
- * `local_index.jsonl`: that relative-path format has an optional `empty`
- * field and remains owned by PushPlan and the local-index merge helpers.
+ * The `intermediate` marker is retained for consumers that must treat
+ * intermediate symlinks apart from content. Only `remote-index.next.jsonl`
+ * carries it: the pull journal rebuilds the retained `remote-index.jsonl` from
+ * path, ctime, size, and type alone, so entries read from that file never
+ * report the marker. Other raw-record fields, such as `target`, are
+ * deliberately omitted. Callers which need a symlink target read the raw
+ * symlink records instead. This reader also does not read `local_index.jsonl`:
+ * that relative-path format has an optional `empty` field and remains owned by
+ * PushPlan and the local-index merge helpers.
  *
  * ## Lifecycle and resume
  *
@@ -148,7 +151,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
-     *     @type true   $intermediate Present for path-component symlinks only.
+     *     @type true   $intermediate Present for intermediate symlinks; next index only.
      * }
      * @throws RuntimeException When a non-blank line is not a decodable index
      *                          entry.
@@ -241,7 +244,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
-     *     @type true   $intermediate Present for path-component symlinks only.
+     *     @type true   $intermediate Present for intermediate symlinks; next index only.
      * }
      * @throws RuntimeException When the line or base64 path is malformed.
      * @throws InvalidArgumentException When the decoded path is not a valid

--- a/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
+++ b/packages/reprint-client/src/lib/pull/class-remote-index-reader.php
@@ -25,9 +25,10 @@ use function WordPress\Reprint\Server\assert_valid_path;
  *         "type"  => "file",
  *     ]
  *
- * Extra raw-record fields such as `target` and `intermediate` are deliberately
- * omitted from the returned entry. Callers which need those fields read the
- * raw symlink records instead. This reader also does not read
+ * The `intermediate` marker is retained for consumers that must omit
+ * path-component symlinks from content comparisons. Other raw-record fields,
+ * such as `target`, are deliberately omitted. Callers which need a symlink
+ * target read the raw symlink records instead. This reader also does not read
  * `local_index.jsonl`: that relative-path format has an optional `empty`
  * field and remains owned by PushPlan and the local-index merge helpers.
  *
@@ -147,6 +148,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
+     *     @type true   $intermediate Present for path-component symlinks only.
      * }
      * @throws RuntimeException When a non-blank line is not a decodable index
      *                          entry.
@@ -239,6 +241,7 @@ class RemoteIndexReader
      *     @type int    $ctime Change time reported by the exporter.
      *     @type int    $size  Size in bytes.
      *     @type string $type  `file`, `dir`, or `link`.
+     *     @type true   $intermediate Present for path-component symlinks only.
      * }
      * @throws RuntimeException When the line or base64 path is malformed.
      * @throws InvalidArgumentException When the decoded path is not a valid
@@ -260,11 +263,15 @@ class RemoteIndexReader
             throw new RuntimeException("Invalid index path (base64 decode failed)");
         }
         assert_valid_path($path, "index path");
-        return [
+        $entry = [
             "path" => $path,
             "ctime" => (int) ( $data["ctime"] ?? 0 ),
             "size" => (int) ( $data["size"] ?? 0 ),
             "type" => (string) ( $data["type"] ?? "file" ),
         ];
+        if (!empty($data["intermediate"])) {
+            $entry["intermediate"] = true;
+        }
+        return $entry;
     }
 }

--- a/tests/Import/FilesPullMirrorDiffTest.php
+++ b/tests/Import/FilesPullMirrorDiffTest.php
@@ -140,6 +140,52 @@ final class FilesPullMirrorDiffTest extends TestCase
         );
     }
 
+    public function testKeepsDriftedIntermediateSymlinksOutOfMirrorDeletions(): void
+    {
+        $client = $this->client();
+        $intermediate = $client->filesystem_root . '/srv/wordpress';
+        mkdir(dirname($intermediate), 0755, true);
+        $this->assertTrue(symlink('/wordpress', $intermediate));
+        $intermediateStat = lstat($intermediate);
+        $this->assertIsArray($intermediateStat);
+
+        // A drifted ctime puts the symlink in the changed local paths.
+        $this->writeIndex($this->path($client, 'local_index_file'), [[
+            'path' => 'srv/wordpress',
+            'ctime' => $intermediateStat['ctime'] - 1,
+            'size' => $intermediateStat['size'],
+            'type' => 'link',
+        ]]);
+        $this->writeMappedIndex($client, [
+            ['srv/wordpress', '/srv/wordpress', 'link', 0, true],
+        ]);
+        $this->writeFetchList($client, []);
+
+        ( new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_local_changes'
+        ) )->invoke($client);
+        ( new \ReflectionMethod(
+            \ImportClient::class,
+            'build_files_pull_mirror_fetch_list'
+        ) )->invoke($client);
+        $journal = ( new \ReflectionProperty(
+            \ImportClient::class,
+            'pull_index_journal'
+        ) )->getValue($client);
+        $journal->flush();
+
+        // recreate_intermediate_symlinks() owns this path: the mirror stage
+        // neither removes it nor refetches it as a symlink chunk.
+        $this->assertTrue(is_link($intermediate));
+        $this->assertSame([], $this->readFetchList($client));
+        $walPath = $this->path($client, 'pull_index_wal_path');
+        $this->assertSame(
+            [],
+            file_exists($walPath) ? $this->readJsonLines($walPath) : []
+        );
+    }
+
     private function client(): \ImportClient
     {
         return new \ImportClient(
@@ -160,19 +206,27 @@ final class FilesPullMirrorDiffTest extends TestCase
         fclose($handle);
     }
 
-    /** @param list<array{0:string,1:string,2:string,3:int}> $entries */
+    /** @param list<array{0:string,1:string,2:string,3:int,4?:bool}> $entries */
     private function writeMappedIndex(\ImportClient $client, array $entries): void
     {
         $lines = '';
-        foreach ($entries as [$localPath, $remotePath, $type, $size]) {
-            $lines .= json_encode([
+        foreach ($entries as $entry) {
+            [$localPath, $remotePath, $type, $size] = $entry;
+            $record = [
                 'path' => base64_encode(
                     bin2hex($localPath) . '/' . bin2hex($remotePath)
                 ),
                 'ctime' => 0,
                 'size' => $size,
                 'type' => $type,
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+            ];
+            if (!empty($entry[4])) {
+                $record['intermediate'] = true;
+            }
+            $lines .= json_encode(
+                $record,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
         }
         $path = $this->path($client, 'mapped_remote_index_file');
         file_put_contents($path, $lines);

--- a/tests/Import/MappedRemoteIndexBuilderTest.php
+++ b/tests/Import/MappedRemoteIndexBuilderTest.php
@@ -142,39 +142,28 @@ final class MappedRemoteIndexBuilderTest extends TestCase
             ],
         ]);
 
-        $lines = file(
-            $mappedIndex,
-            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
-        );
-        $this->assertIsArray($lines);
-        $this->assertCount(1, $lines);
-        $this->assertSame(
+        $this->assertMappedSourcePaths($mappedIndex, [
             '/remote/included/file.txt',
-            \MappedRemoteIndexBuilder::decode_index_line(
-                $lines[0]
-            )['copy_source_path']
-        );
+        ]);
     }
 
-    public function testOmitsIntermediateSymlinksBeforeCollisionValidation(): void
+    public function testRetainsIntermediateSymlinksAboveMappedContent(): void
     {
         $remoteIndex = $this->root . '/remote.jsonl';
         $mappedIndex = $this->root . '/mapped.jsonl';
-        file_put_contents($remoteIndex, implode("\n", [
-            json_encode([
-                'path' => base64_encode('/srv/wordpress'),
-                'ctime' => 1,
+        $this->writeRemoteIndex($remoteIndex, [
+            [
+                'path' => '/srv/wordpress',
                 'size' => 0,
                 'type' => 'link',
                 'intermediate' => true,
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
-            json_encode([
-                'path' => base64_encode('/wordpress/core/latest'),
-                'ctime' => 1,
+            ],
+            [
+                'path' => '/wordpress/core/latest',
                 'size' => 0,
                 'type' => 'link',
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
-        ]) . "\n");
+            ],
+        ]);
 
         \MappedRemoteIndexBuilder::build([
             'remote_index_file' => $remoteIndex,
@@ -189,33 +178,100 @@ final class MappedRemoteIndexBuilderTest extends TestCase
             ),
         ]);
 
+        $this->assertMappedSourcePaths($mappedIndex, [
+            '/srv/wordpress',
+            '/wordpress/core/latest',
+        ]);
+        $entries = array_map(
+            static function (string $line): array {
+                return \MappedRemoteIndexBuilder::decode_index_line($line);
+            },
+            file($mappedIndex, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
+        );
+        $this->assertTrue($entries[0]['intermediate']);
+        $this->assertArrayNotHasKey('intermediate', $entries[1]);
+    }
+
+    public function testRejectsIntermediateSymlinkSharingAMappedLocalPath(): void
+    {
+        $remoteIndex = $this->root . '/remote.jsonl';
+        $this->writeRemoteIndex($remoteIndex, [
+            [
+                'path' => '/srv/wordpress',
+                'size' => 0,
+                'type' => 'link',
+                'intermediate' => true,
+            ],
+            ['path' => '/wordpress'],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Remote paths map to the same local path: srv/wordpress.'
+        );
+        \MappedRemoteIndexBuilder::build([
+            'remote_index_file' => $remoteIndex,
+            'mapped_remote_index_file' => $this->root . '/mapped.jsonl',
+            'filesystem_root' => $this->root . '/files',
+            'path_mapper' => new \RemoteToLocalPathMapper(
+                $this->root . '/files',
+                ['/srv'],
+                [
+                    '/wordpress' => $this->root . '/files/srv/wordpress',
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * Writes a remote index from paths, or from field overrides keyed by path.
+     *
+     * @param list<string|array<string,mixed>> $remoteEntries
+     */
+    private function writeRemoteIndex(string $path, array $remoteEntries): void
+    {
+        $lines = '';
+        foreach ($remoteEntries as $remoteEntry) {
+            if (is_string($remoteEntry)) {
+                $remoteEntry = ['path' => $remoteEntry];
+            }
+            $record = array_merge([
+                'path' => '',
+                'ctime' => 1,
+                'size' => 1,
+                'type' => 'file',
+            ], $remoteEntry);
+            $record['path'] = base64_encode($record['path']);
+            $lines .= json_encode(
+                $record,
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ) . "\n";
+        }
+        file_put_contents($path, $lines);
+    }
+
+    /**
+     * Asserts the mapped index holds exactly these sources, in file order.
+     *
+     * @param list<string> $expectedRemotePaths
+     */
+    private function assertMappedSourcePaths(
+        string $mappedIndex,
+        array $expectedRemotePaths
+    ): void {
         $lines = file(
             $mappedIndex,
             FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
         );
         $this->assertIsArray($lines);
-        $this->assertCount(1, $lines);
-        $this->assertSame(
-            '/wordpress/core/latest',
-            \MappedRemoteIndexBuilder::decode_index_line(
-                $lines[0]
-            )['copy_source_path']
-        );
-    }
-
-    /** @param list<string> $remotePaths */
-    private function writeRemoteIndex(string $path, array $remotePaths): void
-    {
-        $lines = '';
-        foreach ($remotePaths as $remotePath) {
-            $lines .= json_encode([
-                'path' => base64_encode($remotePath),
-                'ctime' => 1,
-                'size' => 1,
-                'type' => 'file',
-            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-        }
-        file_put_contents($path, $lines);
+        $this->assertSame($expectedRemotePaths, array_map(
+            static function (string $line): string {
+                return \MappedRemoteIndexBuilder::decode_index_line(
+                    $line
+                )['copy_source_path'];
+            },
+            $lines
+        ));
     }
 
     private function remove(string $path): void

--- a/tests/Import/MappedRemoteIndexBuilderTest.php
+++ b/tests/Import/MappedRemoteIndexBuilderTest.php
@@ -156,6 +156,53 @@ final class MappedRemoteIndexBuilderTest extends TestCase
         );
     }
 
+    public function testOmitsIntermediateSymlinksBeforeCollisionValidation(): void
+    {
+        $remoteIndex = $this->root . '/remote.jsonl';
+        $mappedIndex = $this->root . '/mapped.jsonl';
+        file_put_contents($remoteIndex, implode("\n", [
+            json_encode([
+                'path' => base64_encode('/srv/wordpress'),
+                'ctime' => 1,
+                'size' => 0,
+                'type' => 'link',
+                'intermediate' => true,
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+            json_encode([
+                'path' => base64_encode('/wordpress/core/latest'),
+                'ctime' => 1,
+                'size' => 0,
+                'type' => 'link',
+            ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+        ]) . "\n");
+
+        \MappedRemoteIndexBuilder::build([
+            'remote_index_file' => $remoteIndex,
+            'mapped_remote_index_file' => $mappedIndex,
+            'filesystem_root' => $this->root . '/files',
+            'path_mapper' => new \RemoteToLocalPathMapper(
+                $this->root . '/files',
+                ['/srv'],
+                [
+                    '/wordpress' => $this->root . '/files/srv/wordpress',
+                ]
+            ),
+        ]);
+
+        $lines = file(
+            $mappedIndex,
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+        $this->assertIsArray($lines);
+        $this->assertCount(1, $lines);
+        $this->assertSame(
+            '/wordpress/core/latest',
+            \MappedRemoteIndexBuilder::decode_index_line(
+                $lines[0]
+            )['copy_source_path']
+        );
+    }
+
     /** @param list<string> $remotePaths */
     private function writeRemoteIndex(string $path, array $remotePaths): void
     {


### PR DESCRIPTION
Intermediate symlinks (symlinks discovered on the source while resolving the path of another symlink) can make `MappedRemoteIndexBuilder::assert_no_path_collisions()` throw when running `files-pull --mode=mirror`, depending on the source layout.

The issue boils down to how Reprint assumes indexes are sparse: they do not contain explicit directory entries, instead deriving directories from file and symlink paths. Intermediate symlinks are an exception to this rule because their paths can map to a parent of resolved content. They must remain in the remote index, however, so Reprint can faithfully recreate the source layout locally. Consider the following example:

```text
/release/r42/assets/logo.txt       (file)
/shortcuts/latest -> /release/r42  (symlink)
/site -> /shortcuts/latest/assets  (symlink)
```

While following `/site`, Reprint resolves and fetches `/release/r42/assets/logo.txt`. To recreate a working local `/site`, it must also recreate `/shortcuts/latest`. That is the intermediate symlink.

`RemoteIndexReader::decode_index_line()` currently drops the `intermediate` marker, so nothing downstream can tell these entries apart. This PR retains the marker and carries it into the mapped remote index through `MappedRemoteIndexBuilder::write_mapped_entry()` and `decode_index_line()`. Each reader of that index then handles them explicitly:

- `assert_no_path_collisions()` permits entries mapping below an intermediate symlink. It still rejects two remote paths mapping to one local path, whatever their kind.
- `build_files_pull_mirror_fetch_list()` leaves marked entries in place, neither deleting nor refetching them.
- `compare_remote_indexes_and_build_fetch_list()` skips marked entries, in both pull modes.

`build_files_pull_mirror_fetch_list()` and `compare_remote_indexes_and_build_fetch_list()` are the only callers of `append_to_fetch_list()`, so no intermediate symlink reaches a fetch list. `recreate_intermediate_symlinks()` remains the only place that creates them, running once the fetch completes.

`write_mapped_entry()` also skips an intermediate symlink that maps onto the filesystem root instead of failing the pull, matching the rule already used for directories. `RemoteIndexReader`'s docblock now records that only `remote-index.next.jsonl` carries the marker, since the pull journal rebuilds the retained `remote-index.jsonl` from path, ctime, size and type alone.