### PR TITLE
Bound the url rewrite cache sizes

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -30,8 +30,13 @@ class StructuredDataUrlRewriter
 {
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
-    private const STRUCTURED_REWRITE_CACHE_MAX = 4096;
-    private const REWRITE_RESULT_CACHE_MAX = 4096;
+
+    /** There are diminishing hit rate returns when dealing with values larger than this. */
+    private const VALUE_REWRITE_CACHE_MAX_INPUT_BYTES = 64 * 1024;
+    private const VALUE_REWRITE_CACHE_MAX_TOTAL_BYTES = 32 * 1024 * 1024;
+
+    private const URL_REWRITE_CACHE_MAX_INPUT_BYTES = 2 * 1024;
+    private const URL_REWRITE_CACHE_MAX_TOTAL_BYTES = 4 * 1024 * 1024;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
@@ -64,21 +69,20 @@ class StructuredDataUrlRewriter
     /** @var string Cache namespace for this rewriter's URL mapping. */
     private string $mapping_cache_key;
 
-    /** @var array<string, array{content_type: string, input: string, output: string}> */
-    private array $structured_rewrite_cache = [];
+    /**
+     * Rewrites keyed by an entire value; hits only on an exact repeat.
+     *
+     * @var array{bytes: int, data: array<string, string>}
+     */
+    private array $value_rewrite_cache = ['bytes' => 0, 'data' => []];
 
-    /** @var string[] */
-    private array $structured_rewrite_cache_ring = [];
-
-    private int $structured_rewrite_cache_next = 0;
-
-    /** @var array<string, false|array{raw_url: string, parsed_url: mixed}> */
-    private array $rewrite_result_cache = [];
-
-    /** @var string[] */
-    private array $rewrite_result_cache_ring = [];
-
-    private int $rewrite_result_cache_next = 0;
+    /**
+     * Rewrites keyed by one URL found inside a value, including misses. An
+     * empty entry records a URL that matched no source base.
+     *
+     * @var array{bytes: int, data: array<string, string>}
+     */
+    private array $url_rewrite_cache = ['bytes' => 0, 'data' => []];
 
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
@@ -137,10 +141,14 @@ class StructuredDataUrlRewriter
             $content_type = self::PLAIN_TEXT;
         }
 
-        $structured_cache_key = sha1($content_type . "\0" . $value);
-        $cached = $this->get_cached_structured_rewrite($structured_cache_key, $content_type, $value);
-        if ($cached !== null) {
-            return $cached;
+        $cache_key = null;
+        if (strlen($value) <= self::VALUE_REWRITE_CACHE_MAX_INPUT_BYTES) {
+            $cache_key = sha1($content_type . "\0" . $value);
+
+            $cached = $this->get_cached_value_rewrite($cache_key, $content_type, $value);
+            if ($cached !== null) {
+                return $cached;
+            }
         }
 
         // Quick-reject: if the value doesn't contain href=", src=", or any
@@ -166,7 +174,9 @@ class StructuredDataUrlRewriter
                     }
                 }
                 $rewritten_value = $p->get_updated_serialization();
-                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+                if ($cache_key !== null) {
+                    $this->set_cached_value_rewrite($cache_key, $content_type, $value, $rewritten_value);
+                }
                 return $rewritten_value;
             }
         }
@@ -186,7 +196,9 @@ class StructuredDataUrlRewriter
                     }
                 }
                 $rewritten_value = $iter->get_result();
-                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+                if ($cache_key !== null) {
+                    $this->set_cached_value_rewrite($cache_key, $content_type, $value, $rewritten_value);
+                }
                 return $rewritten_value;
             }
         }
@@ -197,7 +209,10 @@ class StructuredDataUrlRewriter
         // was for base64-within-base64 nesting which is rare in practice.
 
         $rewritten_value = $this->rewrite_urls($value, $content_type);
-        $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+        if ($cache_key !== null) {
+            $this->set_cached_value_rewrite($cache_key, $content_type, $value, $rewritten_value);
+        }
+
         return $rewritten_value;
     }
 
@@ -296,13 +311,14 @@ class StructuredDataUrlRewriter
         }
     }
 
-    private function get_cached_structured_rewrite(string $cache_key, string $content_type, string $value): ?string
+    private function get_cached_value_rewrite(string $cache_key, string $content_type, string $value): ?string
     {
-        if (!array_key_exists($cache_key, $this->structured_rewrite_cache)) {
+        $cached_entry = $this->value_rewrite_cache['data'][$cache_key] ?? null;
+        if ($cached_entry === null) {
             return null;
         }
 
-        $entry = $this->structured_rewrite_cache[$cache_key];
+        $entry = unserialize($cached_entry);
         if ($entry['content_type'] !== $content_type || $entry['input'] !== $value) {
             return null;
         }
@@ -310,25 +326,20 @@ class StructuredDataUrlRewriter
         return $entry['output'];
     }
 
-    private function set_cached_structured_rewrite(string $cache_key, string $content_type, string $input, string $output): void
+    private function set_cached_value_rewrite(string $cache_key, string $content_type, string $input, string $output): void
     {
-        if (!array_key_exists($cache_key, $this->structured_rewrite_cache)) {
-            if (count($this->structured_rewrite_cache_ring) < self::STRUCTURED_REWRITE_CACHE_MAX) {
-                $this->structured_rewrite_cache_ring[] = $cache_key;
-            } else {
-                $evicted_key = $this->structured_rewrite_cache_ring[$this->structured_rewrite_cache_next];
-                unset($this->structured_rewrite_cache[$evicted_key]);
-                $this->structured_rewrite_cache_ring[$this->structured_rewrite_cache_next] = $cache_key;
-            }
-
-            $this->structured_rewrite_cache_next = ($this->structured_rewrite_cache_next + 1) % self::STRUCTURED_REWRITE_CACHE_MAX;
-        }
-
-        $this->structured_rewrite_cache[$cache_key] = [
+        $entry = serialize([
             'content_type' => $content_type,
-            'input'       => $input,
-            'output'      => $output,
-        ];
+            'input'        => $input,
+            'output'       => $output,
+        ]);
+
+        $this->store_in_bounded_cache(
+            $this->value_rewrite_cache,
+            $cache_key,
+            $entry,
+            self::VALUE_REWRITE_CACHE_MAX_TOTAL_BYTES
+        );
     }
 
     /**
@@ -364,11 +375,14 @@ class StructuredDataUrlRewriter
         return false;
     }
 
-    private function get_cached_rewrite_result(string $cache_key)
+    private function get_cached_url_rewrite(string $cache_key)
     {
-        return array_key_exists($cache_key, $this->rewrite_result_cache)
-            ? $this->rewrite_result_cache[$cache_key]
-            : null;
+        $cached_entry = $this->url_rewrite_cache['data'][$cache_key] ?? null;
+        if ($cached_entry === null) {
+            return null;
+        }
+
+        return $cached_entry === '' ? false : unserialize($cached_entry);
     }
 
     /**
@@ -380,21 +394,16 @@ class StructuredDataUrlRewriter
      * }
      * @phpstan-param false|array{raw_url: string, parsed_url: mixed} $value
      */
-    private function set_cached_rewrite_result(string $cache_key, $value): void
+    private function set_cached_url_rewrite(string $cache_key, $value): void
     {
-        if (!array_key_exists($cache_key, $this->rewrite_result_cache)) {
-            if (count($this->rewrite_result_cache_ring) < self::REWRITE_RESULT_CACHE_MAX) {
-                $this->rewrite_result_cache_ring[] = $cache_key;
-            } else {
-                $evicted_key = $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next];
-                unset($this->rewrite_result_cache[$evicted_key]);
-                $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next] = $cache_key;
-            }
+        $entry = $value === false ? '' : serialize($value);
 
-            $this->rewrite_result_cache_next = ($this->rewrite_result_cache_next + 1) % self::REWRITE_RESULT_CACHE_MAX;
-        }
-
-        $this->rewrite_result_cache[$cache_key] = $value;
+        $this->store_in_bounded_cache(
+            $this->url_rewrite_cache,
+            $cache_key,
+            $entry,
+            self::URL_REWRITE_CACHE_MAX_TOTAL_BYTES
+        );
     }
 
     /**
@@ -426,7 +435,7 @@ class StructuredDataUrlRewriter
      *
      * then it would be nice to re-encode that block markup also without the space character. This is similar
      * to how the tag processor avoids changing parts of the tag it doesn't need to change.
-     * 
+     *
      * TODO: Migrate these changes back into the php-toolkit repo
      */
     private function rewrite_urls( string $content, string $content_type ): string {
@@ -443,13 +452,18 @@ class StructuredDataUrlRewriter
                     $token_type = $p->get_token_type() ?? '';
                     while ( $p->next_url_in_current_token() ) {
                         $raw_url = $p->get_raw_url();
-                        $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
-                        $cached = $this->get_cached_rewrite_result($cache_key);
-                        if ($cached !== null) {
-                            if ($cached !== false) {
-                                $p->set_url($cached['raw_url'], $cached['parsed_url']);
+
+                        $url_cache_key = null;
+                        if (strlen($raw_url) <= self::URL_REWRITE_CACHE_MAX_INPUT_BYTES) {
+                            $url_cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+
+                            $cached = $this->get_cached_url_rewrite($url_cache_key);
+                            if ($cached !== null) {
+                                if ($cached !== false) {
+                                    $p->set_url($cached['raw_url'], $cached['parsed_url']);
+                                }
+                                continue;
                             }
-                            continue;
                         }
 
                         $parsed_url = $p->get_parsed_url();
@@ -477,7 +491,9 @@ class StructuredDataUrlRewriter
                             ];
                             $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
                         }
-                        $this->set_cached_rewrite_result($cache_key, $cache_value);
+                        if ($url_cache_key !== null) {
+                            $this->set_cached_url_rewrite($url_cache_key, $cache_value);
+                        }
                     }
                     $p->replace_url_bases_in_current_token( $this->cautious_url_base_rewrite_mapping );
                 }
@@ -500,8 +516,42 @@ class StructuredDataUrlRewriter
                 return $p->get_updated_text();
 
             default:
-                _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );
-                return '';
+                trigger_error('rewrite_urls() requires either block_markup or plain_text to be provided', E_USER_WARNING);
+                return $content;
         }
+    }
+
+    /**
+     * Store one entry, then evict oldest until the cache is within budget.
+     */
+    private function store_in_bounded_cache(array &$cache, string $key, string $value, int $max_bytes): void
+    {
+        if (isset($cache['data'][$key])) {
+            $cache['bytes'] -= $this->measure_cache_entry($key, $cache['data'][$key]);
+            unset($cache['data'][$key]);
+        }
+
+        $cache['data'][$key] = $value;
+        $cache['bytes'] += $this->measure_cache_entry($key, $value);
+
+        while ($cache['bytes'] > $max_bytes) {
+            $oldest_key = array_key_first($cache['data']);
+            if ($oldest_key === null) {
+                $cache['bytes'] = 0;
+                break;
+            }
+
+            $cache['bytes'] -= $this->measure_cache_entry($oldest_key, $cache['data'][$oldest_key]);
+            unset($cache['data'][$oldest_key]);
+        }
+    }
+
+    /**
+     * Total bytes one entry retains: The key, its value, and the average PHP storage overhead.
+     */
+    private function measure_cache_entry(string $key, string $value): int
+    {
+        $cache_storage_overhead_bytes = 512;
+        return strlen($key) + strlen($value) + $cache_storage_overhead_bytes;
     }
 }

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -785,4 +785,147 @@ class StructuredDataUrlRewriterTest extends TestCase
             $rewriter->value_might_contain_source_domain('<a href="https://other-site.com/page">Link</a>')
         );
     }
+
+    // --- cache bounds ---
+
+    /** Reads a private member so the bound itself is asserted, not a proxy for it. */
+    private function readPrivate(StructuredDataUrlRewriter $rewriter, string $member)
+    {
+        $property = new ReflectionProperty($rewriter, $member);
+        $property->setAccessible(true);
+
+        return $property->getValue($rewriter);
+    }
+
+    public function testOversizedValuesSkipTheCacheButAreStillRewritten(): void
+    {
+        $rewriter = $this->createRewriter();
+
+        $unit = '<a href="https://old-site.com/page">Link</a>';
+        $oversized = str_repeat($unit, (int) ceil(70000 / strlen($unit)));
+        $this->assertGreaterThan(65536, strlen($oversized));
+
+        $result = $rewriter->rewrite($oversized);
+
+        $this->assertStringNotContainsString('old-site.com', $result);
+        $this->assertSame(
+            substr_count($oversized, 'old-site.com'),
+            substr_count($result, 'new-site.com')
+        );
+        $this->assertSame([], $this->readPrivate($rewriter, 'value_rewrite_cache')['data']);
+
+        // A repeat of the same oversized value must rewrite identically
+        // even though nothing was cached for it.
+        $this->assertSame($result, $rewriter->rewrite($oversized));
+    }
+
+    public function testBoundedCacheStaysWithinItsByteBudget(): void
+    {
+        $rewriter = $this->createRewriter();
+
+        $reflection = new ReflectionClass($rewriter);
+        $budget = $reflection->getConstant('URL_REWRITE_CACHE_MAX_TOTAL_BYTES');
+
+        // Enough distinct URLs to overflow the budget several times over, so
+        // eviction has to run. Driven through the URL cache because it shares
+        // store_in_bounded_cache() with the value cache but has a far smaller
+        // budget, keeping the test well inside PHP's default memory_limit.
+        $markup = '';
+        for ($i = 0; $i < 6000; $i++) {
+            $markup .= '<a href="https://old-site.com/page-' . $i . '">x</a>';
+        }
+
+        $rewriter->rewrite($markup, 'block_markup');
+
+        $cache = $this->readPrivate($rewriter, 'url_rewrite_cache');
+        $this->assertLessThanOrEqual($budget, $cache['bytes']);
+        $this->assertNotEmpty($cache['data']);
+        $this->assertLessThan(6000, count($cache['data']), 'Expected eviction to drop the oldest entries.');
+    }
+
+    public function testInlineDataUriIsNotCachedByTheUrlCache(): void
+    {
+        $rewriter = $this->createRewriter();
+
+        // An inline image is ordinary in post content, and its whole payload
+        // would otherwise become the cache key.
+        $data_uri = 'data:image/png;base64,' . base64_encode(str_repeat('p', 300000));
+        $markup = '<figure><img src="' . $data_uri . '"/>'
+            . '<a href="https://old-site.com/p">x</a></figure>';
+
+        $result = $rewriter->rewrite($markup, 'block_markup');
+
+        // The data: URI survives untouched and the real URL is still rewritten.
+        $this->assertStringContainsString($data_uri, $result);
+        $this->assertStringContainsString('https://new-site.com/p', $result);
+
+        $this->assertLessThan(
+            strlen($data_uri),
+            $this->readPrivate($rewriter, 'url_rewrite_cache')['bytes'],
+            'The data: URI payload must not be retained as a cache key.'
+        );
+    }
+
+    public function testRewritingTheSameValueTwiceDoesNotDoubleCountCacheBytes(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = '<a href="https://old-site.com/page">Link</a>';
+
+        $rewriter->rewrite($value);
+        $after_first = $this->readPrivate($rewriter, 'value_rewrite_cache')['bytes'];
+
+        $rewriter->rewrite($value);
+
+        $cache = $this->readPrivate($rewriter, 'value_rewrite_cache');
+        $this->assertSame($after_first, $cache['bytes']);
+        $this->assertCount(1, $cache['data']);
+    }
+
+    /**
+     * Each URL appears twice, so the second occurrence is served from the URL
+     * cache. A cached entry stores its parsed URL serialized, and a relative
+     * URL cannot be re-derived from its raw form alone — the processor's base
+     * is the source host — so this locks the round-trip for every shape.
+     */
+    public function testCachedUrlHitsRewriteIdenticallyForEveryUrlShape(): void
+    {
+        $shapes = [
+            'absolute'          => ['https://old-site.com/uploads/a.jpg', 'https://new-site.com/uploads/a.jpg'],
+            'relative path'     => ['/uploads/b.jpg', '/uploads/b.jpg'],
+            'protocol-relative' => ['//old-site.com/uploads/c.jpg', '/uploads/c.jpg'],
+            'relative no-slash' => ['uploads/d.jpg', '/uploads/d.jpg'],
+            'relative dotted'   => ['../uploads/e.jpg', '/uploads/e.jpg'],
+            'query embedded'    => ['/page?ref=https://old-site.com/x', '/page?ref=https://new-site.com/x'],
+        ];
+
+        $rewriter = $this->createRewriter();
+
+        foreach ($shapes as $label => [$input, $expected]) {
+            $markup = '<figure><img src="' . $input . '"/><img src="' . $input . '"/></figure>';
+            $result = $rewriter->rewrite($markup, 'block_markup');
+
+            $this->assertSame(
+                '<figure><img src="' . $expected . '"/><img src="' . $expected . '"/></figure>',
+                $result,
+                "Cached hit diverged from the first rewrite for: {$label}"
+            );
+        }
+    }
+
+    public function testUrlCacheRetainsNoObjects(): void
+    {
+        $rewriter = $this->createRewriter();
+        $rewriter->rewrite('<a href="https://old-site.com/page">x</a>', 'block_markup');
+
+        $cache = $this->readPrivate($rewriter, 'url_rewrite_cache');
+        $this->assertNotEmpty($cache['data']);
+
+        foreach ($cache['data'] as $entry) {
+            $parts = (array) $entry;
+
+            foreach ($parts as $part) {
+                $this->assertIsNotObject($part, 'The URL cache must hold no live object graph.');
+            }
+        }
+    }
 }

--- a/tests/phpstan/phpstan-baseline.neon
+++ b/tests/phpstan/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: ../../packages/reprint-server/src/export.php
 
 		-
-			message: "#^Function _doing_it_wrong not found\\.$#"
-			count: 1
-			path: ../../packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
-
-		-
 			message: "#^Class PDO\\\\SQLite not found\\.$#"
 			count: 1
 			path: ../../packages/reprint-client/src/lib/import/functions.php


### PR DESCRIPTION
> Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 1081344 bytes) in reprint-v0.10.0.phar/packages/reprint-client/src/lib/url-rewrite/class-base64-value-scanner.php on line 180

The url rewrite caches are currently bounded by the number of entries (4096), not by the byte size. And one in particular can easily grow overly large.

- `value_rewrite_cache`: Keyed by a hash and only hits on an exact repeat of a whole value. The key is a constant 40 bytes; while the entry can grow quite large, since it stores both the original value and its rewritten form. Having 4096 slots each holding two copies of a large `wp_posts.post_content` can be hundreds of MB.
- `url_rewrite_cache`: The key concatenates the raw URL, so an inline `data:` URI could be rather large.

## Solution

1. Both caches have an entry guard, limiting how large the key + value can be before entering into the cache. There's a diminishing return once the content gets large, as an exact match becomes much more unlikely whilst the storage cost increases substantially.
2. Both caches have a max bytes budget, evicting previous cache entries w/ FIFO to make space for new entries.

Also dropped a `_doing_it_wrong()` call, which is an undefined function on the client side, so that branch would
have been a fatal. And changed that fallback branch to return the original content, not an empty string.

### Verification

I replayed a real 1GB production dump:

| | before | after |
|---|---|---|
| peak memory | 1090 MB | **226.9 MB** |
| rewritten SQL | — | **byte-identical** (same SHA256) |
| value cache hits | 28,282 | 28,048 |
| value cache hit rate | 33.3% | 33.6% |
| URL cache hit rate | 99.2% | 99.2% |

The 234 fewer value-cache hits are the 64 KB guard skipping 1,508 large-value lookups that were
only converting at ~7% (about ~2s of re-rewriting on a ~100s run).