### PR TITLE
Remove `autoload.files` altogether from Reprint server

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -358,7 +358,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-client",
-            "version": "dev-self-contained-reprint-server",
+            "version": "dev-feature/lazy-reprint-server-utils",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-client",
@@ -389,11 +389,11 @@
         },
         {
             "name": "wp-php-toolkit/reprint-server",
-            "version": "dev-fix/remove-pdo-polyfill",
+            "version": "dev-feature/lazy-reprint-server-utils",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-server",
-                "reference": "4c6c6ef2d34593de5c0dfe787e81260755fc7af5"
+                "reference": "5a50dbfd84c6d39fcddfd8bff37cc69f9bddbeca"
             },
             "require": {
                 "php": ">=7.2"
@@ -409,9 +409,6 @@
             "autoload": {
                 "classmap": [
                     "src/"
-                ],
-                "files": [
-                    "src/utils.php"
                 ]
             },
             "license": [

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -66,16 +66,7 @@ foreach ([
 ] as $autoloader) {
     if (file_exists($autoloader)) {
         require_once $autoloader;
-        break;
-    }
-}
-
-foreach ([
-    __DIR__ . '/../../reprint-server/src/utils.php',
-    __DIR__ . '/../../../vendor/wp-php-toolkit/reprint-server/src/utils.php',
-] as $utils_path) {
-    if (file_exists($utils_path)) {
-        require_once $utils_path;
+        require_once dirname($autoloader) . '/wp-php-toolkit/reprint-server/src/utils.php';
         break;
     }
 }

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -70,6 +70,8 @@ foreach ([
     }
 }
 
+require_once __DIR__ . '/../../reprint-server/src/utils.php';
+
 // Load vendored MySQL query stream (from sqlite-database-integration PR #264)
 require_once __DIR__ . '/lib/mysql-query-stream/load.php';
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -70,7 +70,15 @@ foreach ([
     }
 }
 
-require_once __DIR__ . '/../../reprint-server/src/utils.php';
+foreach ([
+    __DIR__ . '/../../reprint-server/src/utils.php',
+    __DIR__ . '/../../../vendor/wp-php-toolkit/reprint-server/src/utils.php',
+] as $utils_path) {
+    if (file_exists($utils_path)) {
+        require_once $utils_path;
+        break;
+    }
+}
 
 // Load vendored MySQL query stream (from sqlite-database-integration PR #264)
 require_once __DIR__ . '/lib/mysql-query-stream/load.php';

--- a/packages/reprint-server/README.md
+++ b/packages/reprint-server/README.md
@@ -13,19 +13,8 @@ installed side by side. Consumers should require
 Composer's classmap covers every class in `src/`, so classes resolve after
 requiring `vendor/autoload.php`.
 
-The namespaced helpers in `src/utils.php` are loaded lazily. A consumer that
-calls one directly must require the file after Composer's autoloader:
-
-```php
-require __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/vendor/wp-php-toolkit/reprint-server/src/utils.php';
-
-\WordPress\Reprint\Server\normalize_path('/srv/site/../site/wp-content');
-```
-
-This is a loading-contract change from releases that declared `utils.php` in
-Composer's `autoload.files`: code that previously called a helper after only
-requiring `vendor/autoload.php` must add the explicit `require_once` above.
+Reprint's entry points load their utility functions internally. `src/utils.php`
+is an internal implementation file and is not a public autoload entry point.
 
 `src/export.php` never autoloads, and that is deliberate. It declares functions
 rather than classes, so the classmap scan finds nothing in it to register. Keep

--- a/packages/reprint-server/README.md
+++ b/packages/reprint-server/README.md
@@ -10,9 +10,22 @@ installed side by side. Consumers should require
 
 ## Loading it
 
-The package autoloads normally. Composer's classmap covers every class in
-`src/`, and the `files` entry loads `src/utils.php`. Install it and the classes
-resolve — there is nothing to call.
+Composer's classmap covers every class in `src/`, so classes resolve after
+requiring `vendor/autoload.php`.
+
+The namespaced helpers in `src/utils.php` are loaded lazily. A consumer that
+calls one directly must require the file after Composer's autoloader:
+
+```php
+require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/wp-php-toolkit/reprint-server/src/utils.php';
+
+\WordPress\Reprint\Server\normalize_path('/srv/site/../site/wp-content');
+```
+
+This is a loading-contract change from releases that declared `utils.php` in
+Composer's `autoload.files`: code that previously called a helper after only
+requiring `vendor/autoload.php` must add the explicit `require_once` above.
 
 `src/export.php` never autoloads, and that is deliberate. It declares functions
 rather than classes, so the classmap scan finds nothing in it to register. Keep

--- a/packages/reprint-server/composer.json
+++ b/packages/reprint-server/composer.json
@@ -12,9 +12,6 @@
     "autoload": {
         "classmap": [
             "src/"
-        ],
-        "files": [
-            "src/utils.php"
         ]
     },
     "suggest": {

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\Reprint\Server;
 
+require_once __DIR__ . '/utils.php';
+
 use InvalidArgumentException;
 use LogicException;
 

--- a/packages/reprint-server/src/class-file-tree-producer.php
+++ b/packages/reprint-server/src/class-file-tree-producer.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\Reprint\Server;
 
+require_once __DIR__ . '/utils.php';
+
 use InvalidArgumentException;
 
 /**

--- a/packages/reprint-server/src/class-hmac-client.php
+++ b/packages/reprint-server/src/class-hmac-client.php
@@ -2,6 +2,8 @@
 
 use function WordPress\Reprint\Server\generate_random_bytes;
 
+require_once __DIR__ . '/utils.php';
+
 /**
  * HMAC Client for the Site Export API.
  *

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -4,6 +4,8 @@ use WordPress\Reprint\Server\ResourceBudget;
 
 use function WordPress\Reprint\Server\parse_size;
 
+require_once __DIR__ . '/utils.php';
+
 if (!class_exists('WordPress\\Reprint\\Server\\ResourceBudget', false)) {
     require_once __DIR__ . '/class-resource-budget.php';
 }

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -2,6 +2,7 @@
 
 namespace WordPress\Reprint\Server;
 
+require_once __DIR__ . '/utils.php';
 require_once __DIR__ . "/class-database-rows-reader.php";
 
 /**

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -10,6 +10,8 @@ use function WordPress\Reprint\Server\parse_size;
 use function WordPress\Reprint\Server\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Server\realpath_with_missing_tail;
 
+require_once __DIR__ . '/utils.php';
+
 /**
  * Exposes push-session operations through the exporter HTTP dispatcher.
  *

--- a/packages/reprint-server/src/class-push-session.php
+++ b/packages/reprint-server/src/class-push-session.php
@@ -10,6 +10,8 @@ use function WordPress\Reprint\Server\relative_path_under;
 use function WordPress\Reprint\Server\trim_right_slash;
 use function WordPress\Reprint\Server\wp_join_unix_paths;
 
+require_once __DIR__ . '/utils.php';
+
 if (!class_exists('Site_Export_Multipart_Processor', false)) {
     require_once __DIR__ . '/class-multipart-processor.php';
 }

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -22,6 +22,7 @@ use function WordPress\Reprint\Server\path_is_same_as_or_descendant_of;
 use function WordPress\Reprint\Server\trim_right_slash;
 use function WordPress\Reprint\Server\wp_join_unix_paths;
 
+require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/class-resource-budget.php';
 require_once __DIR__ . '/class-gzip-output-stream.php';
 require_once __DIR__ . '/class-file-index-processor.php';
@@ -396,15 +397,6 @@ function create_wpdb_pdo_adapter()
     return new WpdbDriverPDO($wpdb);
 }
 
-// Guard with existence checks: when loaded via Composer autoloader, both
-// files are already included from a path that may differ from __DIR__
-// (e.g. symlink vs realpath). With opcache.revalidate_path=0 (default),
-// require_once does not resolve symlinks, so the same physical file can
-// be loaded twice through different paths, causing "Cannot redeclare"
-// fatal errors.
-if (!function_exists('WordPress\\Reprint\\Server\\build_pdo_dsn')) {
-    require_once __DIR__ . "/utils.php";
-}
 if (!class_exists('Site_Export_HTTP_Server', false)) {
     require_once __DIR__ . "/class-http-server.php";
 }

--- a/packages/reprint-server/src/utils.php
+++ b/packages/reprint-server/src/utils.php
@@ -9,15 +9,13 @@
  * namespace, and more than one plugin on a WordPress.com site loads this
  * file.
  *
- * Composer's "files" autoload includes this file, so every host that installs
- * the package gets these symbols on every request. Keep this file limited to
- * guarded function declarations: do not add I/O, hooks, mutable global state,
- * or eager class definitions here. Changes to this eager-load surface require
- * security-sensitive review.
+ * Consumers require this file when they need its helpers. Keep this file
+ * limited to guarded function declarations: do not add I/O, hooks, mutable
+ * global state, or eager class definitions here.
  *
- * The two str_* polyfills at the top stay global on purpose: they
- * backfill functions unavailable before PHP 8.0, so callers reach them via
- * the global namespace without a use-statement.
+ * The two str_* polyfills stay global on purpose: they backfill functions
+ * unavailable before PHP 8.0, so callers reach them via the global namespace
+ * without a use-statement.
  */
 
 // Polyfill for PHP versions before 8.0, which lack str_starts_with().
@@ -53,11 +51,9 @@ use RuntimeException;
 // Per-function guards degrade to "whoever loaded first wins the functions it
 // has, this copy supplies the rest" instead.
 //
-// Composer's "files" autoload dedupes by file identifier, so a single installed
-// copy is included once however many plugins depend on it, and these guards do
-// nothing in the common case. They earn their keep when two identifiers exist:
-// a monorepo checkout that loads both packages/reprint-server/src/utils.php and
-// the vendor/ mirror of it, or a site still carrying reprint-exporter v0.1.47
+// The guards earn their keep when two copies are loaded: a monorepo checkout
+// that loads both packages/reprint-server/src/utils.php and the vendor/ mirror
+// of it, or a site still carrying reprint-exporter v0.1.47
 // under its old package name. That older copy declares its helpers in
 // WordPress\Reprint\Exporter, a namespace nothing here uses any more, so it
 // cannot reach these names at all — but the guards cost nothing and they

--- a/reprint-server-wp/composer.lock
+++ b/reprint-server-wp/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "wp-php-toolkit/reprint-server",
-            "version": "dev-fix/remove-pdo-polyfill",
+            "version": "dev-feature/lazy-reprint-server-utils",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-server",
-                "reference": "111b06d1c519dcdf5a401baee240400d59dba7f1"
+                "reference": "57cc3844bfe2644c9a6b500ed0044f4f8ecacdfa"
             },
             "require": {
                 "php": ">=7.2"
@@ -28,9 +28,6 @@
             "autoload": {
                 "classmap": [
                     "src/"
-                ],
-                "files": [
-                    "src/utils.php"
                 ]
             },
             "license": [

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -105,25 +105,29 @@ function _site_export_load_exporter_runtime(): ?string {
         [
             'autoload' => SITE_EXPORT_PLUGIN_DIR . 'vendor/autoload.php',
             'export' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/export.php',
+            'utils' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/utils.php',
         ],
         [
             'autoload' => $repo_root . '/vendor/autoload.php',
             'export' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/export.php',
+            'utils' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/utils.php',
         ],
     ];
 
     foreach ($candidates as $candidate) {
-        if (!file_exists($candidate['autoload']) || !file_exists($candidate['export'])) {
+        if (!file_exists($candidate['autoload']) || !file_exists($candidate['export']) || !file_exists($candidate['utils'])) {
             continue;
         }
 
         $autoload_path = realpath($candidate['autoload']);
         $export_path = realpath($candidate['export']);
-        if ($autoload_path === false || $export_path === false) {
+        $utils_path = realpath($candidate['utils']);
+        if ($autoload_path === false || $export_path === false || $utils_path === false) {
             continue;
         }
 
         require_once $autoload_path;
+        require_once $utils_path;
         $loaded_export_path = $export_path;
         return $export_path;
     }

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -85,6 +85,23 @@ function _site_export_push_is_supported(): bool {
     return PHP_VERSION_ID >= 70200;
 }
 
+/** Resolves dot segments in a slash-delimited path without touching the filesystem. */
+function _site_export_normalize_path(string $path): string {
+    $parts = explode('/', $path);
+    $resolved = [];
+    foreach ($parts as $part) {
+        if ($part === '' || $part === '.') {
+            continue;
+        }
+        if ($part === '..') {
+            array_pop($resolved);
+        } else {
+            $resolved[] = $part;
+        }
+    }
+    return '/' . implode('/', $resolved);
+}
+
 /**
  * Resolve and load the server package runtime.
  *
@@ -105,29 +122,25 @@ function _site_export_load_exporter_runtime(): ?string {
         [
             'autoload' => SITE_EXPORT_PLUGIN_DIR . 'vendor/autoload.php',
             'export' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/export.php',
-            'utils' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/reprint-server/src/utils.php',
         ],
         [
             'autoload' => $repo_root . '/vendor/autoload.php',
             'export' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/export.php',
-            'utils' => $repo_root . '/vendor/wp-php-toolkit/reprint-server/src/utils.php',
         ],
     ];
 
     foreach ($candidates as $candidate) {
-        if (!file_exists($candidate['autoload']) || !file_exists($candidate['export']) || !file_exists($candidate['utils'])) {
+        if (!file_exists($candidate['autoload']) || !file_exists($candidate['export'])) {
             continue;
         }
 
         $autoload_path = realpath($candidate['autoload']);
         $export_path = realpath($candidate['export']);
-        $utils_path = realpath($candidate['utils']);
-        if ($autoload_path === false || $export_path === false || $utils_path === false) {
+        if ($autoload_path === false || $export_path === false) {
             continue;
         }
 
         require_once $autoload_path;
-        require_once $utils_path;
         $loaded_export_path = $export_path;
         return $export_path;
     }
@@ -527,7 +540,7 @@ function _site_export_handle_api_request(array $options = []): void {
                 );
             }
             $docroot = $canonical_docroot === '/' ? '/' : rtrim($canonical_docroot, '/\\');
-            $lexical_docroot = \WordPress\Reprint\Server\normalize_path(str_replace('\\', '/', $configured_docroot));
+            $lexical_docroot = _site_export_normalize_path(str_replace('\\', '/', $configured_docroot));
             $reprint_directory = $options['reprint_directory'] ?? (
                 dirname($docroot) . '/.reprint-' . substr(hash('sha256', $docroot), 0, 12)
             );
@@ -544,7 +557,7 @@ function _site_export_handle_api_request(array $options = []): void {
                 // symlinked plugin into its outside target and omit protection.
                 $registered_plugin_file = str_replace('\\', '/', plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'));
                 $registered_plugin_directory = dirname($registered_plugin_file);
-                $logical_plugin_directory = \WordPress\Reprint\Server\normalize_path(
+                $logical_plugin_directory = _site_export_normalize_path(
                     str_replace('\\', '/', (string) WP_PLUGIN_DIR)
                     . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                 );
@@ -566,7 +579,7 @@ function _site_export_handle_api_request(array $options = []): void {
                     // path survives a final symlink to the outside target.
                     $canonical_wordpress_plugin_directory = realpath( (string) WP_PLUGIN_DIR );
                     if ($canonical_wordpress_plugin_directory !== false) {
-                        $logical_plugin_directory_from_canonical_parent = \WordPress\Reprint\Server\normalize_path(
+                        $logical_plugin_directory_from_canonical_parent = _site_export_normalize_path(
                             str_replace('\\', '/', $canonical_wordpress_plugin_directory)
                             . ( $registered_plugin_directory === '.' ? '' : '/' . $registered_plugin_directory )
                         );

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -76,9 +76,11 @@ final class ExportLibraryLoadTest extends TestCase {
         $autoload_path = $physical_plugin_directory . '/vendor/autoload.php';
         $linked_autoload_path = $linked_plugin_directory . '/vendor/autoload.php';
         $export_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/export.php';
+        $utils_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/utils.php';
         mkdir(dirname($export_path), 0755, true);
         file_put_contents($autoload_path, "<?php\n");
         file_put_contents($export_path, "<?php\n");
+        file_put_contents($utils_path, "<?php\n");
 
         if (!symlink($physical_plugin_directory, $linked_plugin_directory)) {
             $this->removePath($tmp_dir);

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -76,11 +76,9 @@ final class ExportLibraryLoadTest extends TestCase {
         $autoload_path = $physical_plugin_directory . '/vendor/autoload.php';
         $linked_autoload_path = $linked_plugin_directory . '/vendor/autoload.php';
         $export_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/export.php';
-        $utils_path = $physical_plugin_directory . '/vendor/wp-php-toolkit/reprint-server/src/utils.php';
         mkdir(dirname($export_path), 0755, true);
         file_put_contents($autoload_path, "<?php\n");
         file_put_contents($export_path, "<?php\n");
-        file_put_contents($utils_path, "<?php\n");
 
         if (!symlink($physical_plugin_directory, $linked_plugin_directory)) {
             $this->removePath($tmp_dir);

--- a/tests/ExportUtilsLoadingTest.php
+++ b/tests/ExportUtilsLoadingTest.php
@@ -52,8 +52,7 @@ final class ExportUtilsLoadingTest extends TestCase
         return $matches[1];
     }
 
-    // Reprint ships with Jetpack, so Composer executes these entries on every Jetpack request.
-    public function testComposerFilesAutoloadIsLimitedToTheUtilityFile(): void
+    public function testComposerDoesNotEagerLoadTheUtilityFile(): void
     {
         $composer_path = __DIR__ . '/../packages/reprint-server/composer.json';
         $composer_json = file_get_contents($composer_path);
@@ -63,10 +62,10 @@ final class ExportUtilsLoadingTest extends TestCase
         $this->assertIsArray($composer, 'reprint-server composer.json must contain valid JSON.');
 
         $this->assertSame(
-            ['src/utils.php'],
+            [],
             $composer['autoload']['files'] ?? [],
             'Composer executes every autoload.files entry on each consumer request. '
-            . 'Keep this eager-load surface limited to utils.php.'
+            . 'Utility consumers must require utils.php locally instead.'
         );
     }
 

--- a/tests/PushCommitTest.php
+++ b/tests/PushCommitTest.php
@@ -726,10 +726,12 @@ final class PushCommitTest extends TestCase {
         }
         $this->push_parts($push_session, $parts);
         $this->complete_work_deletes($push_session);
-        $push_session->commit(1);
+        $push_session->commit(1000);
 
         $commit_state_lock_path = $this->reprint_directory . '/.reprint/push/commit-state.lock';
         $deleted_docroot_path = $this->docroot . '/' . $deleted_path;
+        $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
+        file_put_contents($active_path, $push_session->get_push_session_id() . "\n");
         $ready_path = $this->root . '/release-lock-ready';
         $script = '$lock_path = base64_decode(' . json_encode(base64_encode($commit_state_lock_path), JSON_THROW_ON_ERROR) . ');'
             . '$deleted = base64_decode(' . json_encode(base64_encode($deleted_docroot_path), JSON_THROW_ON_ERROR) . ');'
@@ -746,6 +748,11 @@ final class PushCommitTest extends TestCase {
         foreach ($pipes as $pipe) {
             fclose($pipe);
         }
+        $deadline = microtime(true) + 10;
+        while (!is_file($ready_path) && microtime(true) < $deadline) {
+            usleep(100);
+        }
+        $this->assertFileExists($ready_path);
         try {
             $push_session->commit(1000);
             $this->fail('Commit reported success while another request held the commit-state lock.');
@@ -754,9 +761,7 @@ final class PushCommitTest extends TestCase {
         } finally {
             $this->assertSame(0, proc_close($process));
         }
-        $this->assertFileExists($ready_path);
         $this->assertSame('complete', $this->commit_state($push_session)['phase']);
-        $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
         $this->assertSame($push_session->get_push_session_id() . "\n", file_get_contents($active_path));
 
         file_put_contents($this->docroot . '/reachable-release-entry-0', 'changed after completion');
@@ -792,10 +797,12 @@ final class PushCommitTest extends TestCase {
         }
         $this->push_parts($push_session, $parts);
         $this->complete_work_deletes($push_session);
-        $push_session->commit(1);
+        $push_session->commit(1000);
 
         $commit_state_lock_path = $this->reprint_directory . '/.reprint/push/commit-state.lock';
         $deleted_docroot_path = $this->docroot . '/' . $deleted_path;
+        $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
+        file_put_contents($active_path, $push_session->get_push_session_id() . "\n");
         $completion_ready_path = $this->root . '/remove-completion-lock-ready';
         $completion_script = '$lock_path = base64_decode(' . json_encode(base64_encode($commit_state_lock_path), JSON_THROW_ON_ERROR) . ');'
             . '$deleted = base64_decode(' . json_encode(base64_encode($deleted_docroot_path), JSON_THROW_ON_ERROR) . ');'
@@ -812,6 +819,11 @@ final class PushCommitTest extends TestCase {
         foreach ($completion_pipes as $pipe) {
             fclose($pipe);
         }
+        $deadline = microtime(true) + 10;
+        while (!is_file($completion_ready_path) && microtime(true) < $deadline) {
+            usleep(100);
+        }
+        $this->assertFileExists($completion_ready_path);
         try {
             $push_session->commit(1000);
             $this->fail('Commit release was not blocked by valid commit-state lock contention.');
@@ -821,7 +833,6 @@ final class PushCommitTest extends TestCase {
             $this->assertSame(0, proc_close($completion_process));
         }
         $this->assertSame('complete', $this->commit_state($push_session)['phase']);
-        $active_path = $this->reprint_directory . '/.reprint/push/commit-state';
         $this->assertSame($push_session->get_push_session_id() . "\n", file_get_contents($active_path));
 
         $remove_ready_path = $this->root . '/remove-lock-ready';


### PR DESCRIPTION
As discussed in https://github.com/Automattic/jetpack/pull/51430#discussion_r3864891571, always autoloading `utils.php` creates unnecessary overhead and risk at Jetpack scale. Although the file contents are relatively harmless, it's better to be safe here.

This PR takes the cheaper approach and adds `require_once` statements for `utils.php` to the relevant files. We can do better and add a `Utils` class that's autoloaded via the classmap, but I chose the easy approach for this initial PR.