### PR TITLE
Use the adaptive tuner to handle http 413 errors

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -222,6 +222,7 @@ class ImportClient
     private const POTENTIALLY_TRANSIENT_HTTP_STATUS_CODES = [
         400, // Bad Request
         408, // Request Timeout
+        413, // Content Too Large (adaptive tuner will adjust)
         418, // Observed when an upstream bot filter replaced a Reprint response
         425, // Too Early
         429, // Too Many Requests
@@ -2503,6 +2504,23 @@ class ImportClient
     }
 
     /**
+     * Bound the file_fetch request body by what preflight reported.
+     */
+    private function apply_reported_request_body_limit(): void
+    {
+        if (!$this->tuner instanceof AdaptiveTuner) {
+            return;
+        }
+
+        $this->tuner->apply_reported_request_body_limit(
+            "file_fetch",
+            (int) (
+                (int) $this->get_state()->get('preflight.limits.max_request_bytes') * 0.8
+            ),
+        );
+    }
+
+    /**
      * Initialize adaptive tuning from CLI options and persisted state.
      */
     private function initialize_tuner(array $options): void
@@ -2514,6 +2532,7 @@ class ImportClient
         $config = array_merge($config, $cli_config);
 
         $this->tuner = new AdaptiveTuner($config, $state);
+        $this->apply_reported_request_body_limit();
         $this->get_state()->tuning->config = $this->tuner->get_config();
         $this->get_state()->tuning->state = $this->tuner->get_state();
 
@@ -2627,6 +2646,8 @@ class ImportClient
         }
 
         $this->fetch_runtime_files();
+
+        $this->apply_reported_request_body_limit();
     }
 
     /**
@@ -3036,7 +3057,7 @@ class ImportClient
             return;
         }
 
-        $decision = $this->tuner->record_error($endpoint, $error);
+        $decision = $this->tuner->tune_after_error($endpoint, $error);
         $log = [
             "TUNER ERROR",
             "endpoint={$endpoint}",
@@ -3066,7 +3087,7 @@ class ImportClient
             return;
         }
 
-        $decision = $this->tuner->record_result($endpoint, [
+        $decision = $this->tuner->tune_after_response($endpoint, [
             "wall_time" => $wall_time,
             "server_time" => $response_stats["server_time"] ?? null,
             "status" => $response_stats["status"] ?? null,
@@ -8099,6 +8120,27 @@ class ImportClient
     }
 
     /**
+     * Byte budget for the JSON path list uploaded to file_fetch.
+     */
+    private function fetch_request_body_budget(): int
+    {
+        $budget = $this->tuner instanceof AdaptiveTuner
+            ? $this->tuner->get_request_body_budget("file_fetch")
+            : null;
+
+        if ($budget !== null) {
+            return $budget;
+        }
+
+        // Fallback for if the adaptive tuner is disabled.
+        $max_request = $this->get_state()->get('preflight.limits.max_request_bytes');
+        return (int) max(
+            256 * 1024,
+            min(AdaptiveTuner::REQUEST_BODY_HARD_CAP_BYTES, (int) ($max_request * 0.8)),
+        );
+    }
+
+    /**
      * Download files from a prepared list.
      *
      * @param string $list_file Path to the JSONL fetch list to process.
@@ -8130,6 +8172,24 @@ class ImportClient
         $cursor = $fetch_state->cursor;
 
         $batch_entries = $fetch_state->batch_entries;
+
+        // Reset the batch if the request body budget has dropped below this batch's list size.
+        if (
+            $batch_file !== null
+            && file_exists($batch_file)
+            && filesize($batch_file) > $this->fetch_request_body_budget()
+        ) {
+            @unlink($batch_file);
+            $this->audit_log(
+                "FILE DELETE | {$batch_file} | larger than the request body budget",
+            );
+            $batch_file = null;
+
+            // Clear this batch's progress tracking, as it's going to be rebuilt & restarted.
+            $this->get_state()->current_file = null;
+            $this->get_state()->current_file_bytes = null;
+            $this->files_pulled = 0;
+        }
 
         if ($batch_file === null || !file_exists($batch_file)) {
             $batch = $this->prepare_fetch_batch($list_file, $batch_offset);
@@ -8195,9 +8255,9 @@ class ImportClient
      * Builds a JSON batch file listing the next set of paths to download.
      *
      * Reads from the fetch list (pull/fetch-list.jsonl) starting at
-     * $offset, accumulating paths into a JSON array until the batch approaches
-     * 80% of the server's max request size.  Always includes at least one path,
-     * even if it alone exceeds the limit.
+     * $offset, accumulating paths into a JSON array until the batch reaches the
+     * budget from fetch_request_body_budget().  Always includes at least one
+     * path, even if it alone exceeds the budget.
      *
      * The batch file is written to a temp file and intended to be uploaded as
      * the request body for the file_fetch endpoint.
@@ -8216,11 +8276,7 @@ class ImportClient
      */
     private function prepare_fetch_batch(string $list_file, int $offset): ?array
     {
-        // Cap the batch at 80% of the server's max request size so the
-        // multipart envelope and headers still fit.  Floor at 256 KB so
-        // tiny max_request values don't produce degenerate single-file batches.
-        $max_request = $this->get_state()->get('preflight.limits.max_request_bytes');
-        $limit = (int) max(256 * 1024, $max_request * 0.8);
+        $limit = $this->fetch_request_body_budget();
 
         // Open the fetch list and seek to where the previous batch left off.
         $handle = fopen($list_file, "r");
@@ -11264,6 +11320,17 @@ class ImportClient
     }
 
     /**
+     * Whether the request after this failure is the last one that will be tried.
+     */
+    private function is_final_resume_attempt(): bool
+    {
+        // The current failure hasn't been counted yet, so add an artificial 1 to the count.
+        $failures = $this->get_state()->consecutive_interrupted_responses + 1;
+
+        return self::MAX_CONSECUTIVE_INTERRUPTED_RESPONSES - $failures <= 1;
+    }
+
+    /**
      * Track consecutive temporary request failures and decide whether to resume.
      *
      * Compares the cursor before and after the request. A cursor advance means
@@ -11449,6 +11516,14 @@ class ImportClient
             $msg .= "\n\nRun `php reprint.phar install-server` for setup " .
                      "instructions.";
             return ['code' => 'NOT_FOUND', 'message' => $msg];
+        }
+
+        if ($http_code === 413) {
+            $msg = "The source rejected the request as too large (HTTP 413).";
+            if ($server_msg !== null) {
+                $msg .= "\n\nThe source reported: {$server_msg}";
+            }
+            return ['code' => 'REQUEST_TOO_LARGE', 'message' => $msg];
         }
 
         // An endpoint media-type rejection and a firewall greylist can both
@@ -11925,6 +12000,7 @@ class ImportClient
                     "http_code" => $http_code,
                     "timeout" => false,
                     "curl_errno" => 0,
+                    "final_attempt" => $this->is_final_resume_attempt(),
                 ]);
             }
 

--- a/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
+++ b/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
@@ -13,6 +13,13 @@ namespace Reprint\Importer\Tuning;
  */
 class AdaptiveTuner
 {
+    /**
+     * Ceiling for the request body size.
+     *
+     * Under nginx's 1 MiB default to leave room for envelope wrapping and other overhead.
+     */
+    public const REQUEST_BODY_HARD_CAP_BYTES = 800 * 1024;
+
     /** @var array<string, mixed> */
     private array $config;
 
@@ -36,6 +43,9 @@ class AdaptiveTuner
             "max_key" => "file_chunk_max",
             "start_key" => "file_chunk_start",
             "work_metric" => "bytes_processed",
+            "request_body_key" => "file_fetch_request_body_bytes",
+            "request_body_min_key" => "file_fetch_request_body_min",
+            "request_body_max_key" => "file_fetch_request_body_max",
         ],
         "file_index" => [
             "size_key" => "index_batch_size",
@@ -129,12 +139,12 @@ class AdaptiveTuner
     }
 
     /**
-     * Record a successful request and update endpoint sizing state.
+     * Record a completed response and update endpoint sizing state.
      *
      * @param array<string, mixed> $metrics
      * @return array<string, mixed>
      */
-    public function record_result(string $endpoint, array $metrics): array
+    public function tune_after_response(string $endpoint, array $metrics): array
     {
         if (!$this->config["enabled"]) {
             return [
@@ -176,16 +186,23 @@ class AdaptiveTuner
     }
 
     /**
-     * Record a request-level error and trigger temporary backoff.
+     * Record a request-level error, adjust sizing, and trigger backoff.
      *
      * @param array<string, mixed> $error
      * @return array<string, mixed>
      */
-    public function record_error(string $endpoint, array $error): array
+    public function tune_after_error(string $endpoint, array $error): array
     {
         $http_code = (int) ($error["http_code"] ?? 0);
         $timeout = (bool) ($error["timeout"] ?? false);
         $curl_errno = (int) ($error["curl_errno"] ?? 0);
+
+        if ($http_code === 413 && isset(self::ENDPOINTS[$endpoint]["request_body_key"])) {
+            return $this->shrink_request_body(
+                $endpoint,
+                !empty($error["final_attempt"]),
+            );
+        }
 
         $should_backoff =
             $timeout ||
@@ -228,6 +245,82 @@ class AdaptiveTuner
     }
 
     /**
+     * Current request-body budget for an endpoint in bytes.
+     */
+    public function get_request_body_budget(string $endpoint): ?int
+    {
+        if (!$this->config["enabled"]) {
+            return null;
+        }
+
+        $key = self::ENDPOINTS[$endpoint]["request_body_key"] ?? null;
+
+        return $key === null ? null : (int) $this->state[$key];
+    }
+
+    /**
+     * Bound the request body by what the source reported it accepts.
+     */
+    public function apply_reported_request_body_limit(string $endpoint, int $bytes): void
+    {
+        $ep = self::ENDPOINTS[$endpoint] ?? null;
+        if (!isset($ep["request_body_key"]) || $bytes <= 0) {
+            return;
+        }
+
+        $this->config[$ep["request_body_max_key"]] = max(
+            (int) $this->config[$ep["request_body_min_key"]],
+            min(self::REQUEST_BODY_HARD_CAP_BYTES, $bytes),
+        );
+        $this->state[$ep["request_body_key"]] = $this->clamp_request_body(
+            $ep,
+            (int) $this->state[$ep["request_body_key"]],
+        );
+    }
+
+    /**
+     * Shrink the request-body budget after a size rejection.
+     *
+     * @return array<string, mixed>
+     */
+    private function shrink_request_body(string $endpoint, bool $final_attempt): array
+    {
+        $ep = self::ENDPOINTS[$endpoint];
+        $key = $ep["request_body_key"];
+
+        $decision = [
+            "decision" => "request_too_large",
+            "http_code" => 413,
+            "timeout" => false,
+            "curl_errno" => 0,
+            "error_backoff_remaining" => $this->state["error_backoff_remaining"],
+            "size_key" => $key,
+            "size_value" => null,
+        ];
+
+        $new_size = (int) round( (int) $this->state[$key] * (float) $this->config["error_decrease_factor"] );
+        if ( $final_attempt ) {
+            $new_size = (int) $this->config[$ep["request_body_min_key"]];
+        }
+
+        $this->state[$key] = $this->clamp_request_body($ep, $new_size);
+        $decision["size_value"] = $this->state[$key];
+
+        return $decision;
+    }
+
+    /**
+     * @param array<string, string> $endpoint
+     */
+    private function clamp_request_body(array $endpoint, int $size): int
+    {
+        return max(
+            (int) $this->config[$endpoint["request_body_min_key"]],
+            min((int) $this->config[$endpoint["request_body_max_key"]], $size),
+        );
+    }
+
+    /**
      * @param array<string, mixed> $config
      * @return array<string, mixed>
      */
@@ -251,6 +344,8 @@ class AdaptiveTuner
             "aimd_increase_index_entries" => 500,
             "aimd_increase_sql_fragments" => 100,
             "error_backoff_requests" => 3,
+            "file_fetch_request_body_min" => 256 * 1024,
+            "file_fetch_request_body_max" => self::REQUEST_BODY_HARD_CAP_BYTES,
             "file_chunk_start" => 5 * 1024 * 1024,
             "file_chunk_min" => 256 * 1024,
             "file_chunk_max" => 16 * 1024 * 1024,
@@ -287,6 +382,24 @@ class AdaptiveTuner
                 1,
                 min((int) $config[$endpoint["max_key"]], (int) $config[$endpoint["increase_key"]]),
             );
+
+            if (isset($endpoint["request_body_key"])) {
+                $config[$endpoint["request_body_min_key"]] = max(
+                    1,
+                    min(
+                        self::REQUEST_BODY_HARD_CAP_BYTES,
+                        (int) $config[$endpoint["request_body_min_key"]],
+                    ),
+                );
+
+                $config[$endpoint["request_body_max_key"]] = max(
+                    (int) $config[$endpoint["request_body_min_key"]],
+                    min(
+                        self::REQUEST_BODY_HARD_CAP_BYTES,
+                        (int) $config[$endpoint["request_body_max_key"]],
+                    ),
+                );
+            }
         }
 
         return $config;
@@ -319,6 +432,13 @@ class AdaptiveTuner
 
             $ema = $state[$endpoint["ema_key"]] ?? null;
             $state[$endpoint["ema_key"]] = ($ema !== null && (float) $ema > 0) ? (float) $ema : null;
+
+            if (isset($endpoint["request_body_key"])) {
+                $state[$endpoint["request_body_key"]] = $this->clamp_request_body(
+                    $endpoint,
+                    (int) ($state[$endpoint["request_body_key"]] ?? $config[$endpoint["request_body_max_key"]]),
+                );
+            }
         }
 
         $state["duty"] = $this->clamp((float) $state["duty"], $config["duty_min"], $config["duty_max"]);

--- a/tests/Import/AdaptiveTunerTest.php
+++ b/tests/Import/AdaptiveTunerTest.php
@@ -35,7 +35,7 @@ class AdaptiveTunerTest extends TestCase
 
         $result = null;
         for ($i = 0; $i < $count; $i++) {
-            $result = $tuner->record_result($endpoint, [
+            $result = $tuner->tune_after_response($endpoint, [
                 "wall_time" => $serverTime + 0.1,
                 "server_time" => $serverTime,
                 "status" => "continue",
@@ -201,7 +201,7 @@ class AdaptiveTunerTest extends TestCase
         $sizeBefore = $tuner->get_state()["file_chunk_size"];
 
         // Now simulate much lower throughput (same time, way less work).
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "server_time" => 1.0,
             "wall_time" => 1.1,
             "status" => "continue",
@@ -226,7 +226,7 @@ class AdaptiveTunerTest extends TestCase
 
         // Trigger many decreases.
         for ($i = 0; $i < 10; $i++) {
-            $tuner->record_result("file_fetch", [
+            $tuner->tune_after_response("file_fetch", [
                 "server_time" => 1.0,
                 "wall_time" => 1.1,
                 "status" => "continue",
@@ -250,7 +250,7 @@ class AdaptiveTunerTest extends TestCase
             "file_chunk_min" => 100,
         ]);
 
-        $result = $tuner->record_error("file_fetch", [
+        $result = $tuner->tune_after_error("file_fetch", [
             "http_code" => 500,
             "timeout" => false,
         ]);
@@ -263,11 +263,11 @@ class AdaptiveTunerTest extends TestCase
     public function testErrorBackoffDecays(): void
     {
         $tuner = $this->makeTuner(["error_backoff_requests" => 3]);
-        $tuner->record_error("file_fetch", ["http_code" => 500]);
+        $tuner->tune_after_error("file_fetch", ["http_code" => 500]);
 
         $this->assertSame(3, $tuner->get_state()["error_backoff_remaining"]);
 
-        // Each record_result should decrement.
+        // Each tune_after_response should decrement.
         [$tuner, $r] = $this->runRequests($tuner, "file_fetch", 1, 1.0, 1000);
         $this->assertSame(2, $tuner->get_state()["error_backoff_remaining"]);
 
@@ -282,7 +282,7 @@ class AdaptiveTunerTest extends TestCase
         // Warmup first so we have EMA.
         [$tuner] = $this->runRequests($tuner, "file_fetch", 2, 1.0, 10000);
 
-        $tuner->record_error("file_fetch", ["http_code" => 503]);
+        $tuner->tune_after_error("file_fetch", ["http_code" => 503]);
         $sizeAfterError = $tuner->get_state()["file_chunk_size"];
 
         // Next successful request should hold steady, not increase.
@@ -294,17 +294,136 @@ class AdaptiveTunerTest extends TestCase
     public function testTimeoutTriggersBackoff(): void
     {
         $tuner = $this->makeTuner();
-        $result = $tuner->record_error("file_fetch", [
+        $result = $tuner->tune_after_error("file_fetch", [
             "http_code" => 0,
             "timeout" => true,
         ]);
         $this->assertSame("backoff", $result["decision"]);
     }
 
+    // ---------------------------------------------------------------
+    // Request body sizing (HTTP 413)
+    // ---------------------------------------------------------------
+
+    public function testRequestBodyShrinksTowardTheFloorAcrossTheAllowedAttempts(): void
+    {
+        // Observed in the wild: post_max_size=512M with upload_max_filesize=256M
+        // reports a 256 MiB maximum, which would otherwise build a 204 MB body.
+        $tuner = $this->makeTuner([
+            "file_fetch_request_body_max" => 204 * 1024 * 1024,
+        ]);
+        $this->assertSame(800 * 1024, $tuner->get_request_body_budget("file_fetch"));
+
+        $result = $tuner->tune_after_error("file_fetch", ["http_code" => 413]);
+        $this->assertSame("request_too_large", $result["decision"]);
+        $this->assertSame("file_fetch_request_body_bytes", $result["size_key"]);
+        $this->assertSame(400 * 1024, $result["size_value"]);
+
+        // The last attempt stops narrowing and takes the floor: overshooting
+        // ends the transfer, undershooting only costs throughput.
+        $result = $tuner->tune_after_error("file_fetch", [
+            "http_code" => 413,
+            "final_attempt" => true,
+        ]);
+        $this->assertSame(256 * 1024, $result["size_value"]);
+
+        // And never below it.
+        $tuner->tune_after_error("file_fetch", ["http_code" => 413]);
+        $this->assertSame(256 * 1024, $tuner->get_request_body_budget("file_fetch"));
+    }
+
+    public function testTheLastAttemptTakesTheFloorRatherThanHalvingAgain(): void
+    {
+        // The shipped floor is within 4x of the cap, so plain halving reaches it
+        // on the same attempt and hides the difference. A lower floor separates
+        // the two paths, which is what the branch exists for if the cap is ever
+        // raised again.
+        $config = [
+            "file_fetch_request_body_max" => 800 * 1024,
+            "file_fetch_request_body_min" => 64 * 1024,
+        ];
+
+        $halving = $this->makeTuner($config);
+        $halving->tune_after_error("file_fetch", ["http_code" => 413]);
+        $halving->tune_after_error("file_fetch", ["http_code" => 413]);
+        $this->assertSame(200 * 1024, $halving->get_request_body_budget("file_fetch"));
+
+        $final = $this->makeTuner($config);
+        $final->tune_after_error("file_fetch", ["http_code" => 413]);
+        $final->tune_after_error("file_fetch", [
+            "http_code" => 413,
+            "final_attempt" => true,
+        ]);
+        $this->assertSame(64 * 1024, $final->get_request_body_budget("file_fetch"));
+    }
+
+    public function testTheFloorWinsOverASmallerReportedMaximum(): void
+    {
+        // Predates the 413 handling: a host claiming it accepts less than one
+        // sensible batch would otherwise produce near-degenerate requests.
+        $tuner = $this->makeTuner(["file_fetch_request_body_max" => 52 * 1024]);
+
+        $this->assertSame(256 * 1024, $tuner->get_request_body_budget("file_fetch"));
+    }
+
+    public function testTooLargeLeavesResponseSizingAndBackoffAlone(): void
+    {
+        // 413 rejects the request body. chunk_size sizes the response and
+        // error_backoff paces later requests; neither caused the rejection.
+        $tuner = $this->makeTuner([
+            "file_chunk_start" => 5000,
+            "file_chunk_min" => 100,
+        ]);
+
+        $tuner->tune_after_error("file_fetch", ["http_code" => 413]);
+
+        $this->assertSame(5000, $tuner->get_state()["file_chunk_size"]);
+        $this->assertSame(0, $tuner->get_state()["error_backoff_remaining"]);
+    }
+
+    public function testATighterReportedLimitClampsABudgetCarriedForward(): void
+    {
+        // preflight runs after the first command has already stored a budget,
+        // and reports a smaller maximum than the one in that state.
+        $tuner = $this->makeTuner(["file_fetch_request_body_max" => 800 * 1024]);
+
+        $resumed = new AdaptiveTuner(
+            array_merge($tuner->get_config(), [
+                "file_fetch_request_body_max" => 600 * 1024,
+            ]),
+            $tuner->get_state(),
+        );
+
+        $this->assertSame(600 * 1024, $resumed->get_request_body_budget("file_fetch"));
+    }
+
+    public function testEndpointsWithoutARequestBodyFallBackToOrdinaryBackoff(): void
+    {
+        // file_index, sql_chunk and db_index are GETs — nothing to size, so a
+        // 413 there came from something else (an over-long URL, a firewall)
+        // and still deserves the pacing and shrink every other error gets.
+        $tuner = $this->makeTuner([
+            "index_batch_start" => 5000,
+            "index_batch_min" => 100,
+        ]);
+
+        $this->assertNull($tuner->get_request_body_budget("file_index"));
+        $this->assertNull($tuner->get_request_body_budget("sql_chunk"));
+        $this->assertNull(
+            $this->makeTuner(["enabled" => false])->get_request_body_budget("file_fetch")
+        );
+
+        $result = $tuner->tune_after_error("file_index", ["http_code" => 413]);
+
+        $this->assertSame("backoff", $result["decision"]);
+        $this->assertSame(3, $result["error_backoff_remaining"]);
+        $this->assertSame(2500, $tuner->get_state()["index_batch_size"]);
+    }
+
     public function testLowStatusCodeIgnored(): void
     {
         $tuner = $this->makeTuner();
-        $result = $tuner->record_error("file_fetch", [
+        $result = $tuner->tune_after_error("file_fetch", [
             "http_code" => 301,
             "timeout" => false,
         ]);
@@ -330,7 +449,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner(["duty" => 0.5]);
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "server_time" => 2.0,
             "wall_time" => 2.1,
             "status" => "complete",
@@ -356,7 +475,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner(["enabled" => false]);
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "server_time" => 2.0,
             "wall_time" => 2.1,
             "status" => "continue",
@@ -423,7 +542,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner();
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "server_time" => 1.0,
             "wall_time" => 1.1,
             "status" => "continue",
@@ -437,7 +556,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner();
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "server_time" => 1.0,
             "wall_time" => 1.1,
             "status" => "continue",
@@ -455,7 +574,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner(["use_server_time" => true]);
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "wall_time" => 1.0,
             "server_time" => 0,
             "status" => "continue",
@@ -469,7 +588,7 @@ class AdaptiveTunerTest extends TestCase
     {
         $tuner = $this->makeTuner(["use_server_time" => false]);
 
-        $result = $tuner->record_result("file_fetch", [
+        $result = $tuner->tune_after_response("file_fetch", [
             "wall_time" => 2.0,
             "server_time" => 0,
             "status" => "continue",

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -188,6 +188,30 @@ class DiagnoseHttpErrorTest extends TestCase
         $this->assertStringContainsString('install-server', $result['message']);
     }
 
+    // ── Request too large (413) ──────────────────────────────────
+
+    public function testNginx413ReadsAsATooLargeRequestAndIsRetried()
+    {
+        $nginx = "<html>\r\n" .
+            "<head><title>413 Request Entity Too Large</title></head>\r\n" .
+            "<body>\r\n" .
+            "<center><h1>413 Request Entity Too Large</h1></center>\r\n" .
+            "<hr><center>nginx</center>\r\n" .
+            "</body>\r\n</html>\r\n";
+
+        $result = $this->diagnose(413, $nginx);
+
+        $this->assertSame('REQUEST_TOO_LARGE', $result['code']);
+        $this->assertStringNotContainsString('not installed', $result['message']);
+        $this->assertStringNotContainsString('install-server', $result['message']);
+        $this->assertStringContainsString('413', $result['message']);
+
+        $this->assertTrue($this->isPotentiallyTransientHttpError(413, $nginx));
+        $this->assertFalse(
+            $this->isPotentiallyTransientHttpError(413, '{"code":413,"error":"too large"}')
+        );
+    }
+
     // ── Server errors (500+) ─────────────────────────────────────
 
     public function testServerError500WithMessage()

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\State\FetchListProgressState;
+use Reprint\Importer\StreamingContext;
+use Reprint\Importer\Tuning\AdaptiveTuner;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+/**
+ * The JSON path list uploaded to file_fetch is the only request body a pull
+ * sends, and a web server in front of the source can refuse it for being too
+ * large. Reprint sizes that body from limits PHP reports, which say nothing
+ * about what the server ahead of PHP will accept, so the size has to be able
+ * to come down and a batch already written at the old size has to be rebuilt.
+ */
+class FetchRequestBodySizingTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $pullStateDirectory;
+    private $filesystemRoot;
+    private $fetchListFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/fetch-body-sizing-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->pullStateDirectory =
+            $this->stateDir . '/remotes/' . md5('http://fake.url') . '/pull';
+        $this->filesystemRoot = $this->tempDir . '/fs-root';
+        mkdir($this->pullStateDirectory, 0755, true);
+        mkdir($this->filesystemRoot, 0755, true);
+
+        $this->fetchListFile = $this->pullStateDirectory . '/fetch-list.jsonl';
+        $lines = '';
+        for ($i = 0; $i < 4000; $i++) {
+            $path = sprintf('/var/www/web/wp-content/uploads/2026/01/file-%05d.jpg', $i);
+            $lines .= json_encode(['path' => base64_encode($path)]) . "\n";
+        }
+        file_put_contents($this->fetchListFile, $lines);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteRecursively($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function deleteRecursively(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->deleteRecursively($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Serve one canned HTTP response from a forked child.
+     *
+     * @return array{0: string, 1: int} Remote URL and the child's pid.
+     */
+    private function startJsonServer(string $response): array
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($listener, (string) $errstr);
+        $address = stream_socket_get_name($listener, false);
+
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+        if ($pid === 0) {
+            $connection = stream_socket_accept($listener, 5);
+            if ($connection !== false) {
+                stream_set_timeout($connection, 5);
+                $request = '';
+                while (strpos($request, "\r\n\r\n") === false) {
+                    $piece = fread($connection, 8192);
+                    if ($piece === false || $piece === '') {
+                        break;
+                    }
+                    $request .= $piece;
+                }
+                fwrite($connection, $response);
+                fclose($connection);
+            }
+            fclose($listener);
+            exit(0);
+        }
+        fclose($listener);
+
+        return ['http://' . $address . '/?site-export-api', $pid];
+    }
+
+    /**
+     * @return array{0: \ImportClient, 1: \ReflectionClass}
+     */
+    private function prepareClient(int $requestBodyBudget, array $fetchState = []): array
+    {
+        $client = new BatchCapturingClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->filesystemRoot,
+        );
+        \write_current_pull_state($client, [
+            'preflight' => ['data' => ['ok' => true], 'http_code' => 200],
+            'fetch' => array_merge(
+                (new FetchListProgressState())->to_array(),
+                $fetchState,
+            ),
+        ]);
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client),
+        );
+        $reflection->getProperty('is_tty')->setValue($client, false);
+        $reflection->getProperty('tuner')->setValue($client, new AdaptiveTuner([
+            'file_fetch_request_body_max' => $requestBodyBudget,
+            'file_fetch_request_body_min' => 1024,
+        ]));
+
+        return [$client, $reflection];
+    }
+
+    private function writeBatchFile(int $bytes): string
+    {
+        $path = $this->tempDir . '/batch-' . uniqid() . '.json';
+        file_put_contents($path, '[' . str_repeat('x', max(0, $bytes - 2)) . ']');
+
+        return $path;
+    }
+
+    public function testBatchIsBuiltWithinTheRequestBodyBudget(): void
+    {
+        [$client, $reflection] = $this->prepareClient(64 * 1024);
+
+        $batch = $reflection->getMethod('prepare_fetch_batch')
+            ->invoke($client, $this->fetchListFile, 0);
+
+        $this->assertNotNull($batch);
+        $this->assertGreaterThan(0, $batch['entries']);
+        $this->assertLessThanOrEqual(64 * 1024, filesize($batch['file']));
+        // The list is far longer than one budget's worth, so this has to be a
+        // partial batch rather than the whole thing squeaking under the limit.
+        $this->assertLessThan(filesize($this->fetchListFile), $batch['next_offset']);
+    }
+
+    public function testAnOversizedBatchIsRebuiltFromTheSamePlaceInTheList(): void
+    {
+        // A batch outlives many requests: the exporter streams what its
+        // per-request budget allows, returns a cursor, and the same body goes
+        // back up next time. After a 413 drops the budget, that batch has to be
+        // rebuilt — and rebuilding must not step over anything it had reached,
+        // which holds because fetch.offset only advances on batch completion.
+        $lines = file($this->fetchListFile);
+        $offsetOfLine100 = strlen(implode('', array_slice($lines, 0, 100)));
+        $expectedFirstPath = json_decode($lines[100], true)['path'];
+
+        $stale = $this->writeBatchFile(512 * 1024);
+        [$client, $reflection] = $this->prepareClient(64 * 1024, [
+            'offset' => $offsetOfLine100,
+            'batch_file' => $stale,
+            'batch_entries' => 3900,
+            'next_offset' => filesize($this->fetchListFile),
+            'cursor' => 'cursor-from-a-completed-part',
+        ]);
+        $state = $reflection->getMethod('get_state')->invoke($client);
+        $state->current_file = $this->filesystemRoot . '/partly-written.bin';
+        $state->current_file_bytes = 4096;
+
+        $reflection->getMethod('fetch_files_from_list')
+            ->invoke($client, $this->fetchListFile);
+
+        $this->assertFileDoesNotExist($stale);
+        $this->assertLessThanOrEqual(64 * 1024, $client->sentBatchBytes);
+        $this->assertSame($offsetOfLine100, $state->fetch->offset);
+
+        $rebuilt = json_decode(file_get_contents($client->sentBatchFile), true);
+        $this->assertSame($expectedFirstPath, $rebuilt[0]['path']);
+
+        // Left set, fetch_file_batch() reopens that path in append mode and
+        // resumes writing into it for a batch that no longer contains it.
+        $this->assertNull($client->currentFileAtSend);
+    }
+
+    public function testAShrunkBudgetSurvivesIntoTheNextInvocation(): void
+    {
+        // files-pull sends one request per process and the adapter loops on
+        // exit 2. A budget that did not outlive the process would resend the
+        // same oversized body every attempt and never recover.
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $loadState = $reflection->getMethod('load_state');
+        $initTuner = $reflection->getMethod('initialize_tuner');
+        $tunerProperty = $reflection->getProperty('tuner');
+
+        $first = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystemRoot);
+        \write_current_pull_state($first, [
+            'preflight' => [
+                // Under the hard cap, so this value is what has to reach the
+                // tuner — above it the clamp result is indistinguishable from
+                // the default and the seeding would go unverified.
+                'data' => ['limits' => ['max_request_bytes' => 655360]],
+                'http_code' => 200,
+            ],
+        ]);
+        $reflection->getProperty('state')->setValue($first, $loadState->invoke($first));
+        $initTuner->invoke($first, []);
+
+        // 640 KiB reported, x0.8, under the cap so it stands as-is.
+        $this->assertSame(
+            524288,
+            $tunerProperty->getValue($first)->get_request_body_budget('file_fetch'),
+        );
+
+        $reflection->getMethod('handle_tuner_error')->invoke($first, 'file_fetch', [
+            'http_code' => 413,
+            'timeout' => false,
+            'curl_errno' => 0,
+            'final_attempt' => false,
+        ]);
+        $first->save_state();
+
+        $second = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystemRoot);
+        $reflection->getProperty('state')->setValue($second, $loadState->invoke($second));
+        $initTuner->invoke($second, []);
+
+        $this->assertSame(
+            262144,
+            $tunerProperty->getValue($second)->get_request_body_budget('file_fetch'),
+        );
+    }
+
+    public function testRunningPreflightTightensTheBoundInTheSameRun(): void
+    {
+        // initialize_tuner() runs before run_preflight(), so until preflight
+        // reports, the bound comes from the fallback default. A source that
+        // accepts less than the cap has to take effect in the run that learns
+        // it: exceeding upload_max_filesize is rejected by PHP as a bad file
+        // part, not as a 413, so nothing downstream would recover from it.
+        $payload = json_encode([
+            'ok' => true,
+            'protocol_version' => 3,
+            // upload_max_filesize=512K caps the source below the hard ceiling.
+            'limits' => ['max_request_bytes' => 524288],
+        ]);
+        $response = "HTTP/1.1 200 OK\r\n"
+            . "Content-Type: application/json\r\n"
+            . "Content-Length: " . strlen($payload) . "\r\n"
+            . "Connection: close\r\n\r\n"
+            . $payload;
+
+        [$url, $pid] = $this->startJsonServer($response);
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $client = new \ImportClient($url, $this->stateDir, $this->filesystemRoot);
+        \write_current_pull_state($client, []);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client),
+        );
+        $reflection->getProperty('is_tty')->setValue($client, false);
+        $reflection->getMethod('initialize_tuner')->invoke($client, []);
+
+        $tunerProperty = $reflection->getProperty('tuner');
+        $this->assertSame(
+            800 * 1024,
+            $tunerProperty->getValue($client)->get_request_body_budget('file_fetch'),
+        );
+
+        $client->run_preflight();
+        pcntl_waitpid($pid, $status);
+
+        $this->assertSame(
+            419430,
+            $tunerProperty->getValue($client)->get_request_body_budget('file_fetch'),
+        );
+    }
+
+    public function testApplyingAReportedLimitKeepsWhatTheTunerAlreadyLearned(): void
+    {
+        // preflight lands after a rejection has already forced the budget down
+        // — on a resumed run, where the shrink came back from state. Raising it
+        // to the newly reported bound would resend the body that was refused.
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystemRoot);
+        \write_current_pull_state($client, [
+            'preflight' => [
+                'data' => ['limits' => ['max_request_bytes' => 8388608]],
+                'http_code' => 200,
+            ],
+        ]);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client),
+        );
+        $reflection->getMethod('initialize_tuner')->invoke($client, []);
+
+        $reflection->getMethod('handle_tuner_error')->invoke($client, 'file_fetch', [
+            'http_code' => 413,
+            'timeout' => false,
+            'curl_errno' => 0,
+            'final_attempt' => false,
+        ]);
+
+        $tuner = $reflection->getProperty('tuner')->getValue($client);
+        $this->assertSame(400 * 1024, $tuner->get_request_body_budget('file_fetch'));
+
+        $reflection->getMethod('apply_reported_request_body_limit')->invoke($client);
+
+        $this->assertSame(400 * 1024, $tuner->get_request_body_budget('file_fetch'));
+    }
+
+    public function testFinalAttemptIsReachedOneRequestBeforeTheLimit(): void
+    {
+        [$client, $reflection] = $this->prepareClient(64 * 1024);
+        $isFinal = $reflection->getMethod('is_final_resume_attempt');
+        $state = $reflection->getMethod('get_state')->invoke($client);
+
+        // MAX_CONSECUTIVE_INTERRUPTED_RESPONSES is 3, and the failure being
+        // handled has not been counted yet: at a stored count of 1 exactly one
+        // request remains, so that is the last chance to pick a working size.
+        $state->consecutive_interrupted_responses = 0;
+        $this->assertFalse($isFinal->invoke($client));
+
+        $state->consecutive_interrupted_responses = 1;
+        $this->assertTrue($isFinal->invoke($client));
+    }
+}
+
+/**
+ * Records the batch handed to file_fetch instead of sending it.
+ */
+class BatchCapturingClient extends \ImportClient
+{
+    public $sentBatchFile = null;
+    public $sentBatchBytes = null;
+    public $currentFileAtSend = false;
+
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        $file = $post_data['file_list']->getFilename();
+        $this->sentBatchFile = $file;
+        $this->sentBatchBytes = filesize($file);
+
+        // Sampled here rather than after the call: fetch_file_batch() clears
+        // its own file tracking once the request finishes with no open handle,
+        // which would mask whether the discarded batch cleared it.
+        $this->currentFileAtSend = (new \ReflectionClass(\ImportClient::class))
+            ->getMethod('get_state')
+            ->invoke($this)
+            ->current_file;
+    }
+}


### PR DESCRIPTION
A `files-pull` can fail with an HTTP 413 (request body too large), without us ever trying to scale it down.

With this PR, a `413` now diagnoses as `REQUEST_TOO_LARGE`, halves the tuner's request-body budget (800 KiB → 400 KiB → 256 KiB, taking the floor on the last attempt before the existing three-failure limit), and rebuilds the batch from
the same fetch-list offset so nothing is skipped.

The budget has a maximum of 80% of `max_request_bytes` (read from preflight) and is capped at 800 KiB regardless of what the host reports (we can see what PHP says, but not higher levels like nginx). This helps keeps things under the common 1mb nginx limit  with extra room for the multipart envelope. It costs basically no throughput: batch size doesn't set the pace, the number of requests needed to stream the files does and the batch is re-uploaded on every one of them.