### PR TITLE
Recover file pulls from HTTP 413 with adaptive tuning disabled

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8133,7 +8133,7 @@ class ImportClient
             return $budget;
         }
 
-        // Fallback for if the adaptive tuner is disabled.
+        // Fallback for callers that have not initialized the tuner.
         $max_request = $this->get_state()->get('preflight.limits.max_request_bytes');
         return (int) max(
             256 * 1024,

--- a/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
+++ b/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
@@ -246,13 +246,11 @@ class AdaptiveTuner
 
     /**
      * Current request-body budget for an endpoint in bytes.
+     *
+     * Size-rejection recovery remains active when performance tuning is disabled.
      */
     public function get_request_body_budget(string $endpoint): ?int
     {
-        if (!$this->config["enabled"]) {
-            return null;
-        }
-
         $key = self::ENDPOINTS[$endpoint]["request_body_key"] ?? null;
 
         return $key === null ? null : (int) $this->state[$key];

--- a/tests/Import/AdaptiveTunerTest.php
+++ b/tests/Import/AdaptiveTunerTest.php
@@ -409,7 +409,8 @@ class AdaptiveTunerTest extends TestCase
 
         $this->assertNull($tuner->get_request_body_budget("file_index"));
         $this->assertNull($tuner->get_request_body_budget("sql_chunk"));
-        $this->assertNull(
+        $this->assertSame(
+            800 * 1024,
             $this->makeTuner(["enabled" => false])->get_request_body_budget("file_fetch")
         );
 

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -104,7 +104,11 @@ class FetchRequestBodySizingTest extends TestCase
     /**
      * @return array{0: \ImportClient, 1: \ReflectionClass}
      */
-    private function prepareClient(int $requestBodyBudget, array $fetchState = []): array
+    private function prepareClient(
+        int $requestBodyBudget,
+        array $fetchState = [],
+        bool $adaptiveTuningEnabled = true
+    ): array
     {
         $client = new BatchCapturingClient(
             'http://fake.url',
@@ -126,6 +130,7 @@ class FetchRequestBodySizingTest extends TestCase
         );
         $reflection->getProperty('is_tty')->setValue($client, false);
         $reflection->getProperty('tuner')->setValue($client, new AdaptiveTuner([
+            'enabled' => $adaptiveTuningEnabled,
             'file_fetch_request_body_max' => $requestBodyBudget,
             'file_fetch_request_body_min' => 1024,
         ]));
@@ -194,7 +199,39 @@ class FetchRequestBodySizingTest extends TestCase
         $this->assertNull($client->currentFileAtSend);
     }
 
-    public function testAShrunkBudgetSurvivesIntoTheNextInvocation(): void
+    public function testA413RebuildsTheNextBatchWhenAdaptiveTuningIsDisabled(): void
+    {
+        $lines = file($this->fetchListFile);
+        $offsetOfLine100 = strlen(implode('', array_slice($lines, 0, 100)));
+        $expectedFirstPath = json_decode($lines[100], true)['path'];
+
+        $stale = $this->writeBatchFile(128 * 1024);
+        [$client, $reflection] = $this->prepareClient(128 * 1024, [
+            'offset' => $offsetOfLine100,
+            'batch_file' => $stale,
+            'batch_entries' => 3900,
+            'next_offset' => filesize($this->fetchListFile),
+            'cursor' => 'cursor-from-a-completed-part',
+        ], false);
+
+        $reflection->getMethod('handle_tuner_error')->invoke($client, 'file_fetch', [
+            'http_code' => 413,
+            'timeout' => false,
+            'curl_errno' => 0,
+            'final_attempt' => false,
+        ]);
+        $reflection->getMethod('fetch_files_from_list')
+            ->invoke($client, $this->fetchListFile);
+
+        $this->assertLessThanOrEqual(64 * 1024, $client->sentBatchBytes);
+        $state = $reflection->getMethod('get_state')->invoke($client);
+        $this->assertSame($offsetOfLine100, $state->fetch->offset);
+
+        $rebuilt = json_decode(file_get_contents($client->sentBatchFile), true);
+        $this->assertSame($expectedFirstPath, $rebuilt[0]['path']);
+    }
+
+    public function testAShrunkBudgetSurvivesIntoTheNextInvocationWhenAdaptiveTuningIsDisabled(): void
     {
         // files-pull sends one request per process and the adapter loops on
         // exit 2. A budget that did not outlive the process would resend the
@@ -215,7 +252,9 @@ class FetchRequestBodySizingTest extends TestCase
             ],
         ]);
         $reflection->getProperty('state')->setValue($first, $loadState->invoke($first));
-        $initTuner->invoke($first, []);
+        $initTuner->invoke($first, [
+            'tuning_config' => ['enabled' => false],
+        ]);
 
         // 640 KiB reported, x0.8, under the cap so it stands as-is.
         $this->assertSame(
@@ -233,7 +272,9 @@ class FetchRequestBodySizingTest extends TestCase
 
         $second = new \ImportClient('http://fake.url', $this->stateDir, $this->filesystemRoot);
         $reflection->getProperty('state')->setValue($second, $loadState->invoke($second));
-        $initTuner->invoke($second, []);
+        $initTuner->invoke($second, [
+            'tuning_config' => ['enabled' => false],
+        ]);
 
         $this->assertSame(
             262144,


### PR DESCRIPTION
Files pulled with `--no-adaptive` now reduce the `file_fetch` JSON path-list body after an HTTP 413.

The 413 response still halves the saved request-body budget. ImportClient now reads that budget when performance tuning is disabled, so the next process discards the old oversized batch and rebuilds it from the same fetch-list offset. The 800 KiB cap and preflight bound remain unchanged. Push request sizing remains unchanged.

## Testing

The importer suite covers batch rebuilding and saved-budget reuse across processes with adaptive tuning disabled.
