### PR TITLE
[PHP] Remove the include-caches pull override

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ The normal path options define that selection. This includes `--include`,
 the selection. `--on-fs-root-nonempty=preserve-local`
 also keeps pre-existing local paths which were not recorded by the first pull.
 
+File pulls always omit paths matched by the built-in default skip rules. These
+rules cover generated cache, upgrade, and Wordfence data under `wp-content`,
+version-control metadata, `node_modules`, IDE and package-manager caches,
+operating-system metadata, and editor scratch files. `--include`, `--exclude`,
+`--filter`, and `--remap` cannot override these omissions.
+
 Mirror mode requires `--state-dir` to be outside `--fs-root`, because the state
 files must not appear in the local tree being compared. The selected mode is
 saved when `files-pull` starts. To switch modes, first run the same command with

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ Mirror downloads the remote `style.css` and removes `debug.log` when both paths
 are inside the current pull selection.
 
 The normal path options define that selection. This includes `--include`,
-`--exclude`, `--filter`, `--include-caches`, and `--remap`. Mirror does not
-change paths outside the selection. `--on-fs-root-nonempty=preserve-local`
+`--exclude`, `--filter`, and `--remap`. Mirror does not change paths outside
+the selection. `--on-fs-root-nonempty=preserve-local`
 also keeps pre-existing local paths which were not recorded by the first pull.
 
 Mirror mode requires `--state-dir` to be outside `--fs-root`, because the state

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -348,19 +348,6 @@ class ImportClient
     /** @var array|null Cached result of get_export_directories(). */
     private $export_directories_cache = null;
 
-    /**
-     * @var bool When true, ask the server to ship the default-skipped
-     * generated content (wp-content/cache, .git, node_modules, etc.).
-     *
-     * The server's file-index endpoint filters these by default so a
-     * typical migration doesn't waste bytes on regeneratable junk. Set
-     * to true with --include-caches when the consumer genuinely needs
-     * those paths transferred (for example, debugging a caching plugin
-     * or migrating a site whose cache holds first-render-only artifacts
-     * with no source).
-     */
-    private $include_caches = false;
-
     /** @var string `mirror` or `catch-up`. */
     private $files_pull_mode = "catch-up";
 
@@ -881,7 +868,6 @@ class ImportClient
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->progress->set_verbose_mode($this->verbose_mode);
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
-        $this->include_caches = $options["include_caches"] ?? false;
         $this->extra_directory = $options["extra_directory"] ?? null;
         if (isset($options["fs_root_nonempty_behavior"])) {
             $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
@@ -3549,7 +3535,6 @@ class ImportClient
             [$filesystem_root_record],
             $filesystem_root_record,
             false,
-            $this->include_caches,
             $plan_directory
         );
         try {
@@ -3698,12 +3683,9 @@ class ImportClient
                     $local_relative_path
                 );
                 if (
-                    (
-                        !$this->include_caches
-                        && $this->local_path_requires_include_caches(
-                            $local_absolute_path,
-                            $local_relative_path
-                        )
+                    $this->local_path_is_default_skipped(
+                        $local_absolute_path,
+                        $local_relative_path
                     )
                     || !$this->is_selected_for_pulling(
                         $local_absolute_path,
@@ -3751,15 +3733,14 @@ class ImportClient
     }
 
     /**
-     * Checks whether mirroring this local path requires --include-caches.
+     * Checks whether a local path is omitted from the remote index by default.
      *
-     * Unless --include-caches is set, the file index omits generated caches,
-     * version-control metadata, OS metadata, and editor scratch files. A remap
-     * may place one of those paths under a different local name, so this checks
-     * both the path relative to --fs-root and every matching remote path before
-     * allowing its removal.
+     * The file index omits generated caches, version-control metadata, OS
+     * metadata, and editor scratch files. A remap may place one of those paths
+     * under a different local name, so this checks both the path relative to
+     * --fs-root and every matching remote path before allowing its removal.
      */
-    private function local_path_requires_include_caches(
+    private function local_path_is_default_skipped(
         string $local_absolute_path,
         string $local_relative_path
     ): bool {
@@ -7693,11 +7674,6 @@ class ImportClient
         }
         if ($this->follow_symlinks) {
             $params["follow_symlinks"] = "1";
-        }
-        if ($this->include_caches) {
-            // Server defaults to skipping caches/VCS metadata/OS junk.
-            // Opt in to include them when the consumer explicitly asks.
-            $params["include_caches"] = "1";
         }
         // Always send directory[] to the server when we have export dirs.
         // Without this parameter, the server falls back to ABSPATH as the
@@ -12778,15 +12754,6 @@ if (
             'help_section' => 'global',
             'commands' => ['pull', 'pull-files', 'files-pull'],
             'aliases' => ['on-docroot-nonempty'],
-        ],
-        [
-            'name' => 'include-caches',
-            'type' => 'flag',
-            'target' => 'include_caches',
-            'flag_value' => true,
-            'help' => 'Include generated caches, VCS metadata, OS junk and editor scratch files (skipped by default)',
-            'help_section' => 'global',
-            'commands' => ['pull', 'pull-files', 'files-pull', 'files-index'],
         ],
         [
             'name' => 'adaptive',

--- a/packages/reprint-client/src/lib/push/class-push-plan.php
+++ b/packages/reprint-client/src/lib/push/class-push-plan.php
@@ -167,7 +167,6 @@ class PushPlan
             [$filesystem_root_record],
             $filesystem_root_record,
             false,
-            false,
             $plan->plan_directory
         );
         $plan->cursor = [
@@ -376,7 +375,6 @@ class PushPlan
         $this->file_index_processor = FileIndexProcessor::resume(
             [$filesystem_root_record],
             json_encode($cursor["file_index_cursor"], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
-            false,
             false,
             $this->plan_directory
         );

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -58,9 +58,6 @@ final class FileIndexProcessor {
     /** @var bool Whether directory symlinks may lead outside the allowed directories. */
     private $follow_symlinks;
 
-    /** @var bool Whether generated caches and development files are included. */
-    private $include_caches;
-
     /** @var string Canonical Reprint storage path omitted from the index, or an empty string. */
     private $storage_path;
 
@@ -104,7 +101,6 @@ final class FileIndexProcessor {
      * @param FileIndexRoot   $start_root  Root scheduled first. It may be an
      *                                      external directory reached by a followed link.
      * @param bool            $follow_symlinks Whether directory symlinks may lead outside the allowed directories.
-     * @param bool            $include_caches Whether generated caches and development files are included.
      * @param string          $storage_path Reprint storage path omitted from the index, or an empty string.
      * @return self New file-index processor.
      */
@@ -112,7 +108,6 @@ final class FileIndexProcessor {
         array $roots,
         array $start_root,
         bool $follow_symlinks,
-        bool $include_caches,
         string $storage_path
     ): self {
         $roots = self::validate_roots($roots);
@@ -192,7 +187,6 @@ final class FileIndexProcessor {
             $roots,
             $configured_directories,
             $follow_symlinks,
-            $include_caches,
             $storage_path,
             $directory_stack,
             $reported_index_directory,
@@ -207,7 +201,6 @@ final class FileIndexProcessor {
      * @param FileIndexRoot[] $roots   Structured roots scheduled for this index.
      * @param string          $cursor_json JSON cursor returned by the preceding request.
      * @param bool            $follow_symlinks Whether directory symlinks may lead outside the allowed directories.
-     * @param bool            $include_caches Whether generated caches and development files are included.
      * @param string          $storage_path Reprint storage path omitted from the index, or an empty string.
      * @return self Resumed file-index processor.
      */
@@ -215,7 +208,6 @@ final class FileIndexProcessor {
         array $roots,
         string $cursor_json,
         bool $follow_symlinks,
-        bool $include_caches,
         string $storage_path
     ): self {
         $roots = self::validate_roots($roots);
@@ -294,7 +286,6 @@ final class FileIndexProcessor {
             $roots,
             $configured_directories,
             $follow_symlinks,
-            $include_caches,
             $storage_path,
             $directory_stack,
             $index_directory,
@@ -369,7 +360,7 @@ final class FileIndexProcessor {
 
         // Apply omissions before lstat() and before a directory can enter the
         // stack. Omitted subtrees therefore cost no extra filesystem calls.
-        if (!$this->include_caches && self::path_is_default_skipped($path)) {
+        if (self::path_is_default_skipped($path)) {
             $this->step_status = self::STATUS_SKIPPED;
             return true;
         }
@@ -584,7 +575,6 @@ final class FileIndexProcessor {
      * @param array[]  $roots                Structured file-index roots.
      * @param string[] $configured_directories Canonical directories selected by the request.
      * @param bool     $follow_symlinks      Whether directory symlinks may leave the allowed directories.
-     * @param bool     $include_caches       Whether generated caches and development files are included.
      * @param string   $storage_path         Reprint storage path omitted from the index, or an empty string.
      * @param array[]  $directory_stack      Active directory stack.
      * @param string   $index_directory      Directory reported by the endpoint.
@@ -595,7 +585,6 @@ final class FileIndexProcessor {
         array $roots,
         array $configured_directories,
         bool $follow_symlinks,
-        bool $include_caches,
         string $storage_path,
         array $directory_stack,
         string $index_directory,
@@ -605,7 +594,6 @@ final class FileIndexProcessor {
         $this->roots = $roots;
         $this->configured_directories = $configured_directories;
         $this->follow_symlinks = $follow_symlinks;
-        $this->include_caches = $include_caches;
         $this->storage_path = self::canonical_storage_path($storage_path);
         $this->directory_stack = $directory_stack;
         $this->index_directory = $index_directory;
@@ -782,7 +770,7 @@ final class FileIndexProcessor {
 
         $path_root = $root["requested_path"];
 
-        if (!$this->include_caches && self::path_is_default_skipped($path_root)) {
+        if (self::path_is_default_skipped($path_root)) {
             $this->step_status = self::STATUS_SKIPPED;
             return;
         }

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -506,7 +506,7 @@ final class FileIndexProcessor {
      * Reports whether a path belongs to the established default skip set.
      *
      * @param string $path Filesystem path to classify.
-     * @return bool Whether the path should be omitted unless caches are included.
+     * @return bool Whether the path should be omitted.
      */
     public static function path_is_default_skipped(string $path): bool
     {

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -3484,7 +3484,7 @@ function path_head_looks_like_text(string $path): bool
  * Reports whether a path belongs to the established default file-index skip set.
  *
  * @param string $path Filesystem path to classify.
- * @return bool Whether the path is omitted unless caches are included.
+ * @return bool Whether the path is omitted.
  */
 function path_is_default_skipped(string $path): bool
 {

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2928,7 +2928,6 @@ function endpoint_file_index(
         100000
     );
     $follow_symlinks = !empty($config["follow_symlinks"]);
-    $include_caches = !empty($config["include_caches"]);
     $storage_path = isset($config["storage_path"]) && is_string($config["storage_path"])
         ? $config["storage_path"]
         : "";
@@ -2938,7 +2937,6 @@ function endpoint_file_index(
             $file_index_roots,
             $config["cursor"],
             $follow_symlinks,
-            $include_caches,
             $storage_path
         );
     } else {
@@ -2955,7 +2953,6 @@ function endpoint_file_index(
             $file_index_roots,
             $start_root,
             $follow_symlinks,
-            $include_caches,
             $storage_path
         );
     }

--- a/tests/FileIndexNamedRootTest.php
+++ b/tests/FileIndexNamedRootTest.php
@@ -128,7 +128,6 @@ final class FileIndexNamedRootTest extends TestCase
             $roots,
             $this->startRoot($roots, $start),
             true,
-            true,
             ''
         );
         $entries = [];
@@ -139,7 +138,7 @@ final class FileIndexNamedRootTest extends TestCase
             if ($resume) {
                 $cursor = json_encode($processor->get_cursor(), JSON_THROW_ON_ERROR);
                 $processor->close();
-                $processor = FileIndexProcessor::resume($roots, $cursor, true, true, '');
+                $processor = FileIndexProcessor::resume($roots, $cursor, true, '');
             }
         }
         $processor->close();

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -72,7 +72,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$docroot],
             $docroot,
             false,
-            true,
             ''
         );
         $this->assertTrue($processor->next_index_step());
@@ -102,7 +101,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$docroot],
             $docroot,
             false,
-            true,
             ''
         );
         $this->assertTrue($processor->next_index_step());
@@ -141,7 +139,6 @@ final class FileIndexProcessorTest extends TestCase {
             ['/'],
             $docroot,
             false,
-            true,
             ''
         );
 
@@ -163,7 +160,6 @@ final class FileIndexProcessorTest extends TestCase {
         $processor = $this->startProcessor(
             [$docroot],
             $docroot,
-            true,
             true,
             ''
         );
@@ -204,7 +200,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$docroot],
             $docroot,
             false,
-            true,
             ''
         );
         $this->assertTrue($processor->next_index_step());
@@ -222,7 +217,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$this->root($docroot)],
             $cursor,
             false,
-            true,
             ''
         );
         $this->assertFalse($resumed->next_index_step());
@@ -237,7 +231,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$docroot],
             $docroot,
             false,
-            true,
             ''
         );
         $processor->close();
@@ -316,7 +309,7 @@ final class FileIndexProcessorTest extends TestCase {
             'requested_path' => $brokenPath,
             'resolved_path' => null,
             'type' => 'symlink',
-        ], false, true, '');
+        ], false, '');
     }
 
     public function testStartRootMustBeConfiguredOrADirectory(): void
@@ -333,7 +326,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$this->root($docroot)],
             $this->root($unconfiguredPath),
             false,
-            false,
             ''
         );
     }
@@ -346,23 +338,10 @@ final class FileIndexProcessorTest extends TestCase {
         file_put_contents($docroot . '/wp-content/cache/keep.php', '<?php // keep');
         $cachedPath = (string) realpath($docroot . '/wp-content/cache/keep.php');
 
-        $result = $this->collectEntries([$cachedPath], $cachedPath, false);
+        $result = $this->collectEntries([$cachedPath], $cachedPath);
 
         $this->assertSame([], $result['entries']);
         $this->assertContains(FileIndexProcessor::STATUS_SKIPPED, $result['statuses']);
-    }
-
-    public function testFileRootInsideASkippedDirectoryIsIndexedWhenCachesAreIncluded(): void
-    {
-        $docroot = $this->tempDir . '/site';
-        mkdir($docroot . '/wp-content/cache', 0755, true);
-        file_put_contents($docroot . '/wp-content/cache/keep.php', '<?php // keep');
-        $cachedPath = (string) realpath($docroot . '/wp-content/cache/keep.php');
-
-        $result = $this->collectEntries([$cachedPath], $cachedPath, true);
-
-        $this->assertCount(1, $result['entries']);
-        $this->assertSame($cachedPath, $result['entries'][0]['path']);
     }
 
     public function testFileRootInsideTheStoragePathIsNeverIndexed(): void
@@ -373,7 +352,7 @@ final class FileIndexProcessorTest extends TestCase {
         $storagePath = (string) realpath($docroot . '/.reprint');
         $senderPath = $storagePath . '/sender.json';
 
-        $processor = $this->startProcessor([$senderPath], $senderPath, false, true, $storagePath);
+        $processor = $this->startProcessor([$senderPath], $senderPath, false, $storagePath);
         $entries = [];
         while ($processor->next_index_step()) {
             foreach ($processor->get_index_entries() as $entry) {
@@ -397,7 +376,7 @@ final class FileIndexProcessorTest extends TestCase {
         }
 
         $uninterrupted = $this->collectEntries($roots, $roots[0]);
-        $resumed = $this->collectEntries($roots, $roots[0], true, true);
+        $resumed = $this->collectEntries($roots, $roots[0], true);
 
         $this->assertSame($roots, array_column($uninterrupted['entries'], 'path'));
         $this->assertSame($roots, array_column($resumed['entries'], 'path'));
@@ -422,7 +401,7 @@ final class FileIndexProcessorTest extends TestCase {
         $roots = [$configPath, $nestedPath];
 
         $uninterrupted = $this->collectEntries($roots, $configPath);
-        $resumed = $this->collectEntries($roots, $configPath, true, true);
+        $resumed = $this->collectEntries($roots, $configPath, true);
 
         $this->assertSame(
             array_column($uninterrupted['entries'], 'path'),
@@ -440,7 +419,6 @@ final class FileIndexProcessorTest extends TestCase {
      *
      * @param string[] $roots                Configured roots, canonical.
      * @param string   $indexDirectory       Root where traversal begins.
-     * @param bool     $includeCaches        Whether generated caches are included.
      * @param bool     $resumeAfterEveryStep Whether to reopen from the cursor each step.
      * @return array {
      *     @type array[]  $entries  File-index entries.
@@ -450,7 +428,6 @@ final class FileIndexProcessorTest extends TestCase {
     private function collectEntries(
         array $roots,
         string $indexDirectory,
-        bool $includeCaches = true,
         bool $resumeAfterEveryStep = false
     ): array {
         $root_records = array_map([$this, 'root'], $roots);
@@ -458,7 +435,6 @@ final class FileIndexProcessorTest extends TestCase {
             $root_records,
             $this->root($indexDirectory),
             false,
-            $includeCaches,
             ''
         );
         $entries = [];
@@ -475,7 +451,6 @@ final class FileIndexProcessorTest extends TestCase {
                     $root_records,
                     $cursor,
                     false,
-                    $includeCaches,
                     ''
                 );
             }
@@ -492,7 +467,6 @@ final class FileIndexProcessorTest extends TestCase {
         array $roots,
         string $start,
         bool $followSymlinks,
-        bool $includeCaches,
         string $storagePath
     ): FileIndexProcessor {
         $rootRecords = array_map([$this, 'root'], $roots);
@@ -500,7 +474,6 @@ final class FileIndexProcessorTest extends TestCase {
             $rootRecords,
             $this->root($start),
             $followSymlinks,
-            $includeCaches,
             $storagePath
         );
     }
@@ -546,7 +519,6 @@ final class FileIndexProcessorTest extends TestCase {
             [$root],
             $root,
             false,
-            false,
             ''
         );
         $entries = [];
@@ -563,7 +535,6 @@ final class FileIndexProcessorTest extends TestCase {
                 $processor = FileIndexProcessor::resume(
                     [$root],
                     $cursor,
-                    false,
                     false,
                     ''
                 );

--- a/tests/FileIndexSkipDefaultsTest.php
+++ b/tests/FileIndexSkipDefaultsTest.php
@@ -20,9 +20,7 @@ use function WordPress\Reprint\Server\relative_path_under;
  *   2. endpoint_file_index() integration tests via subprocess: build a
  *      fixture tree that mixes real-WP-shaped junk and real content,
  *      run the endpoint, decode the multipart response, and assert
- *      which entries appear and which were filtered. A separate run
- *      with include_caches=1 confirms the override turns the filter
- *      off cleanly.
+ *      which entries appear and which were filtered.
  *
  * The unit tests are the safety net: silent over-skip would mean
  * silent data loss during migration, which is the worst failure mode.
@@ -170,7 +168,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
     public function testFileIndexFiltersDefaultJunk(): void
     {
         $siteDir = $this->buildFixtureSite();
-        $entries = $this->runFileIndexEntries($siteDir, /* include_caches */ false);
+        $entries = $this->runFileIndexEntries($siteDir);
 
         $rel = $this->relativePaths($entries, $siteDir);
 
@@ -199,21 +197,6 @@ final class FileIndexSkipDefaultsTest extends TestCase
         $this->assertNotContains('wp-content/themes/foo/.#style.css', $rel);
     }
 
-    public function testFileIndexIncludesEverythingWhenOverrideEnabled(): void
-    {
-        $siteDir = $this->buildFixtureSite();
-        $entries = $this->runFileIndexEntries($siteDir, /* include_caches */ true);
-        $rel = $this->relativePaths($entries, $siteDir);
-
-        // Override should ship the junk too.
-        $this->assertContains('wp-content/cache/page.html', $rel);
-        $this->assertContains('wp-content/upgrade/wp-7.0/file.php', $rel);
-        $this->assertContains('.git/HEAD', $rel);
-        $this->assertContains('wp-content/themes/foo/node_modules/react.js', $rel);
-        $this->assertContains('.DS_Store', $rel);
-        $this->assertContains('wp-content/themes/foo/style.css~', $rel);
-    }
-
     public function testFileIndexNeverListsReprintStorage(): void
     {
         $siteDir = $this->buildFixtureSite();
@@ -229,7 +212,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
         // Configured with a trailing slash on purpose: the endpoint must
         // normalize the setting before comparing it against entry paths.
         $rel = $this->relativePaths(
-            $this->runFileIndexEntries($siteDir, false, 5000, $storage . '/'),
+            $this->runFileIndexEntries($siteDir, 5000, $storage . '/'),
             $siteDir
         );
 
@@ -237,15 +220,6 @@ final class FileIndexSkipDefaultsTest extends TestCase
         $this->assertNotContains('wp-content/reprint-storage/state.json', $rel);
         $this->assertNotContains('wp-content/reprint-storage/files/wp-content/themes/foo/style.css', $rel);
         $this->assertContains('wp-content/reprint-storage-2/keep.txt', $rel, 'a shared name prefix must not widen the exclusion');
-
-        // include_caches=1 turns the junk filter off; it must not turn the
-        // storage exclusion off.
-        $withCaches = $this->relativePaths(
-            $this->runFileIndexEntries($siteDir, true, 5000, $storage),
-            $siteDir
-        );
-        $this->assertContains('wp-content/cache/page.html', $withCaches);
-        $this->assertNotContains('wp-content/reprint-storage/state.json', $withCaches);
     }
 
     public function testFileIndexKeepsOnlyPhysicalEmptyDirectories(): void
@@ -262,7 +236,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
         file_put_contents($siteDir . '/file.txt', 'file');
 
         $entries = $this->relativeEntries(
-            $this->runFileIndexEntries($siteDir, false, 5000, $storage),
+            $this->runFileIndexEntries($siteDir, 5000, $storage),
             $siteDir
         );
 
@@ -301,7 +275,7 @@ final class FileIndexSkipDefaultsTest extends TestCase
 
         try {
             $entries = $this->relativeEntries(
-                $this->runFileIndexEntries($siteDir, false),
+                $this->runFileIndexEntries($siteDir),
                 $siteDir
             );
             $this->assertSame('dir', $entries['unreadable']['type']);
@@ -322,8 +296,8 @@ final class FileIndexSkipDefaultsTest extends TestCase
         // in endpoint_file_index), so the "small" run picks the minimum
         // that still forces multiple batches given our fixture size.
         $siteDir = $this->buildFixtureSite();
-        $small = $this->runFileIndexEntries($siteDir, false, /* batch_size */ 100);
-        $large = $this->runFileIndexEntries($siteDir, false, /* batch_size */ 5000);
+        $small = $this->runFileIndexEntries($siteDir, /* batch_size */ 100);
+        $large = $this->runFileIndexEntries($siteDir, /* batch_size */ 5000);
 
         $this->assertSame(
             $this->relativePaths($large, $siteDir),
@@ -390,9 +364,9 @@ final class FileIndexSkipDefaultsTest extends TestCase
      * }
      * @phpstan-return list<array{path: string, type: string, empty?: bool}>
      */
-    private function runFileIndexEntries(string $siteDir, bool $includeCaches, int $batchSize = 5000, ?string $storagePath = null): array
+    private function runFileIndexEntries(string $siteDir, int $batchSize = 5000, ?string $storagePath = null): array
     {
-        $stdout = $this->runFileIndex($siteDir, $includeCaches, $batchSize, $storagePath);
+        $stdout = $this->runFileIndex($siteDir, $batchSize, $storagePath);
 
         // The response is `multipart/mixed; boundary="…"` containing one or
         // more `index_batch` JSON chunks. Parse out each batch and flatten.
@@ -474,14 +448,13 @@ final class FileIndexSkipDefaultsTest extends TestCase
         return $out;
     }
 
-    private function runFileIndex(string $siteDir, bool $includeCaches, int $batchSize, ?string $storagePath = null): string
+    private function runFileIndex(string $siteDir, int $batchSize, ?string $storagePath = null): string
     {
         $configPath = $this->tempDir . '/index-config.json';
         $config = [
             'directory' => $siteDir,
             'list_dir' => $siteDir,
             'batch_size' => $batchSize,
-            'include_caches' => $includeCaches,
         ];
         if ($storagePath !== null) {
             $config['storage_path'] = $storagePath;

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -634,15 +634,12 @@ final class FilesPullLocalIndexTest extends TestCase
         );
     }
 
-    public function testMirrorIncludesGeneratedCachePathsWhenRequested(): void
+    public function testMirrorPreservesGeneratedCachePaths(): void
     {
-        $remoteCache = 'wp-content/cache/remote.txt';
-        $this->writeRemoteOverrides([
-            'added_files' => [$remoteCache => 'remote cache'],
-        ]);
+        $cachePath = 'wp-content/cache/remote.txt';
         mkdir($this->localTree . '/wp-content/cache', 0700, true);
         file_put_contents(
-            $this->localTree . '/' . $remoteCache,
+            $this->localTree . '/' . $cachePath,
             'local cache edit'
         );
         file_put_contents(
@@ -650,18 +647,16 @@ final class FilesPullLocalIndexTest extends TestCase
             'local only cache'
         );
 
-        $mirror = $this->runFilesPull([
-            '--mode=mirror',
-            '--include-caches',
-        ]);
+        $mirror = $this->runFilesPull(['--mode=mirror']);
 
         $this->assertSame(0, $mirror['exit'], $mirror['output']);
         $this->assertSame(
-            'remote cache',
-            file_get_contents($this->localTree . '/' . $remoteCache)
+            'local cache edit',
+            file_get_contents($this->localTree . '/' . $cachePath)
         );
-        $this->assertFileDoesNotExist(
-            $this->localTree . '/wp-content/cache/local-only.txt'
+        $this->assertSame(
+            'local only cache',
+            file_get_contents($this->localTree . '/wp-content/cache/local-only.txt')
         );
     }
 

--- a/tests/e2e/tests/import-59-files-pull-mirror.test.js
+++ b/tests/e2e/tests/import-59-files-pull-mirror.test.js
@@ -575,7 +575,7 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         }
     });
 
-    it('includes caches and preserves unrecorded local paths when requested', () => {
+    it('preserves caches and unrecorded local paths', () => {
         const remoteCache = join(
             getSiteDir(site),
             'wp-content',
@@ -597,9 +597,7 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
             writeFileSync(join(localCacheDirectory, 'remote.txt'), 'local cache edit\n');
             writeFileSync(join(localCacheDirectory, 'local-only.txt'), 'local cache only\n');
 
-            const cacheResult = runFilesPull(cacheMirrorTempDir, 'mirror', {
-                extraArgs: ['--include-caches'],
-            });
+            const cacheResult = runFilesPull(cacheMirrorTempDir, 'mirror');
             assert.equal(
                 cacheResult.exitCode,
                 0,
@@ -607,9 +605,12 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
             );
             assert.equal(
                 readFileSync(join(localCacheDirectory, 'remote.txt'), 'utf-8'),
-                'remote cache\n',
+                'local cache edit\n',
             );
-            assert.ok(!existsSync(join(localCacheDirectory, 'local-only.txt')));
+            assert.equal(
+                readFileSync(join(localCacheDirectory, 'local-only.txt'), 'utf-8'),
+                'local cache only\n',
+            );
 
             const preservedLocalRoot = localSiteRoot(preservedMirrorTempDir);
             mkdirSync(join(preservedLocalRoot, 'test-data', 'local-only'), {


### PR DESCRIPTION
File pulls now always omit paths covered by the built-in cache, development metadata, OS metadata, and editor scratch rules. The `--include-caches` override is gone.

## Background

The option carried one choice through the CLI parser, HTTP request, file-index processor lifecycle, mirror deletion pass, and local-index updates. Extending the omission rules in #719 would carry that choice through more code.

No known integration uses the option. [Studio's Reprint pull](https://github.com/Automattic/studio/blob/trunk/apps/cli/commands/pull-reprint.ts) does not pass it. [wpcomsh](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/wpcomsh/feature-plugins/reprint-exporter-api.php) only exposes the server endpoint. A GitHub and SourceGraph search found no use.

The flag has shipped since v0.7.4. A script that still passes it now gets an unknown-option error. An old `include_caches` HTTP field is ignored with other unused endpoint fields.

## This change

Remove the CLI flag, HTTP request field, and processor boolean. The README now states that normal path options cannot override the built-in omissions. During an ordinary mirror, current local paths matched by the default rules remain outside the paths that mirror may remove.

A saved pull state created with the retired flag may treat a newly omitted path as a remote deletion on its first pull after this change. This PR does not add a state migration because the option is believed unused.

This PR is the base for #719.

## Testing

The focused file-index, mirror, local-index, and push-plan suites pass: 152 tests and 1,891 assertions, with one platform-specific test skipped. PHPStan, PHP compatibility checks, syntax checks, `git diff --check`, and changed-file PHPCS counts pass.
