### PR TITLE
Run files-pull requests while PHP memory has headroom

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3151,7 +3151,7 @@ class ImportClient
     public function run_files_pull(): void
     {
         do {
-            $this->run_files_pull_once();
+            $this->run_files_pull_until_complete_or_partial_response();
         } while (
             $this->get_state()->active_resumable_command->completion_state === "partial"
             && !$this->shutdown_requested
@@ -3159,8 +3159,8 @@ class ImportClient
         );
     }
 
-    /** Runs files-pull until it completes or receives a partial response. */
-    private function run_files_pull_once(): void
+    /** Runs files-pull until it completes or receives a partial source response. */
+    private function run_files_pull_until_complete_or_partial_response(): void
     {
         $sender_state_path = wp_join_unix_paths(
             dirname($this->pull_state_directory),

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -3144,9 +3144,23 @@ class ImportClient
      * - Prior completed files-pull → delta mode (re-index, diff, fetch changes)
      * - In-progress files-pull → resume from saved state
      *
-     * Both modes share the same pipeline: index → diff → fetch.
+     * Both modes share the same pipeline: index → diff → fetch. Partial
+     * source responses continue in this process while PHP has memory headroom.
+     * Otherwise the saved partial state leaves exit code 2 for the next process.
      */
     public function run_files_pull(): void
+    {
+        do {
+            $this->run_files_pull_once();
+        } while (
+            $this->get_state()->active_resumable_command->completion_state === "partial"
+            && !$this->shutdown_requested
+            && $this->has_memory_for_another_files_pull_request()
+        );
+    }
+
+    /** Runs files-pull until it completes or receives a partial response. */
+    private function run_files_pull_once(): void
     {
         $sender_state_path = wp_join_unix_paths(
             dirname($this->pull_state_directory),
@@ -3501,6 +3515,22 @@ class ImportClient
         ], true);
 
         $this->report_volatile_files();
+    }
+
+    /**
+     * The next request starts only while at least one fifth of PHP's memory
+     * limit remains available. An unlimited PHP memory limit has no local
+     * memory boundary.
+     */
+    private function has_memory_for_another_files_pull_request(): bool
+    {
+        $memory_limit_value = trim( (string) ini_get('memory_limit') );
+        $memory_limit_bytes = $memory_limit_value === '' || $memory_limit_value === '-1'
+            ? -1
+            : parse_size($memory_limit_value);
+
+        return $memory_limit_bytes === -1
+            || memory_get_usage(true) < $memory_limit_bytes * 0.8;
     }
 
     /** Saves the local-before to local-now changes before remote work begins. */

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -233,9 +233,9 @@ class FetchRequestBodySizingTest extends TestCase
 
     public function testAShrunkBudgetSurvivesIntoTheNextInvocationWhenAdaptiveTuningIsDisabled(): void
     {
-        // files-pull sends one request per process and the adapter loops on
-        // exit 2. A budget that did not outlive the process would resend the
-        // same oversized body every attempt and never recover.
+        // files-pull can make several requests before it exits. A budget that
+        // did not survive a partial response would resend the same oversized
+        // body on the next request and never recover.
         $reflection = new \ReflectionClass(\ImportClient::class);
         $loadState = $reflection->getMethod('load_state');
         $initTuner = $reflection->getMethod('initialize_tuner');

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -166,6 +166,24 @@ class FilesPullStateTest extends TestCase
         $this->assertEquals("files-pull", $state["active_resumable_command"]["command_name"]);
     }
 
+    public function testFilesPullRequiresMemoryHeadroomForTheNextRequest()
+    {
+        [$client, $reflection] = $this->prepareClient();
+        $method = $reflection->getMethod('has_memory_for_another_files_pull_request');
+        $previous_memory_limit = ini_get('memory_limit');
+        $allocated_bytes = memory_get_usage(true);
+
+        try {
+            ini_set('memory_limit', sprintf('%d', $allocated_bytes + 1024 * 1024));
+            $this->assertFalse($method->invoke($client));
+
+            ini_set('memory_limit', '-1');
+            $this->assertTrue($method->invoke($client));
+        } finally {
+            ini_set('memory_limit', $previous_memory_limit);
+        }
+    }
+
     /**
      * After --abort, the state should not be "complete".
      */

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -146,6 +146,9 @@
     "only-symlinked-directory-root": {
       "port": 8139
     },
+    "files-pull-internal-loop": {
+      "port": 8140
+    },
     "mysql-session-settings-resume": {
       "port": 8126
     },

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -1,8 +1,8 @@
 /**
  * Test 20: Request Cutoff and Resume via import.php
  * Uses test hooks to simulate PHP crashing mid-stream by calling exit()
- * after a few file index batches. Verifies the importer can resume
- * and eventually reach completion.
+ * after a few file index batches. Verifies files-pull continues from its
+ * saved partial state and reaches completion in the same local process.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -53,7 +53,7 @@ describe('Import: Request Cutoff', () => {
         cleanupTempDir(tempDir);
     });
 
-    it('first importer run exits partial after cutoff', () => {
+    it('one importer run recovers after cutoff', () => {
         const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
         const result = runImporter(url, tempDir, 'files-pull', {
             secret: getSiteSecret(site),
@@ -62,21 +62,16 @@ describe('Import: Request Cutoff', () => {
         });
         assert.equal(
             result.exitCode,
-            2,
-            `Expected exit 2 after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+            0,
+            `Expected one process to recover after the interrupted file index response\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
         );
 
         const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assert.equal(
             state.active_resumable_command.completion_state,
-            'partial',
-            'Expected files-pull to retain a partial checkpoint',
-        );
-        assert.equal(
-            state.active_resumable_command.current_stage,
-            'index',
-            'Expected files-pull to remain in the index stage',
+            'complete',
+            'Expected files-pull to complete after the internal retry',
         );
     });
 
@@ -86,26 +81,15 @@ describe('Import: Request Cutoff', () => {
         assert.ok(state.scan_count >= 5, `Expected scan_count >= 5, got ${state.scan_count}`);
     });
 
-    it('importer resumes and completes after removing cutoff hook', () => {
-        // Remove the crashing hook so subsequent requests succeed
+    it('all file hashes match source after same-process recovery', () => {
         removeTestHooks(site);
 
-        const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-        // Run the importer again — it should resume from saved state
-        const result = runImporter(url, tempDir, 'files-pull', {
-            secret: getSiteSecret(site),
-            extraArgs: ['--max-exec=10'],
-        });
-        assert.equal(result.exitCode, 0, `Expected exit 0 on resume\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
-
-        const stateFile = join(pullStateDirectory(tempDir, url), 'state.json');
-        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected complete status, got ${state.active_resumable_command.completion_state}`);
-    });
-
-    it('all file hashes match source after resume', () => {
+        // The source hook itself was present while files-pull indexed the
+        // source. It is test setup rather than site content.
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
-        assertTreesMatch(getSiteDir(site), importedRoot);
+        assertTreesMatch(getSiteDir(site), importedRoot, {
+            exclude: ['wp-content/plugins/site-export/test-hooks.php'],
+        });
     });
 
     it('audit log shows the crash and recovery', () => {

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -16,8 +16,8 @@
  *
  * The source exits before it writes the boundary which would confirm the
  * first part. The importer must leave its cursor at the preceding boundary,
- * replay the unconfirmed bytes, and replace rather than append them. After
- * removing the hook, files-pull resumes and completes. Final assertion:
+ * replay the unconfirmed bytes, and replace rather than append them. The
+ * same files-pull process then resumes and completes. Final assertion:
  * SHA-256 of the imported file equals the source.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -31,7 +31,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     writeTestHooks, removeTestHooks,
     clearHookState,
-    fsRootDir, pullStateDirectory,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -92,7 +92,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('first run crashes mid-file on the second body chunk', () => {
+    it('one files-pull process recovers after the second body chunk cutoff', () => {
         // Hook exits when we hit a non-first chunk of the specific file
         // we care about. Two non-obvious bits:
         //
@@ -102,7 +102,7 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
         //   2. Self-disabling via a marker file. removeTestHooks() deletes
         //      the hook PHP source, but PHP-FPM workers keep the function
         //      in memory across requests — so a worker that already loaded
-        //      the hook would still call it on the resume run and crash
+        //      the hook would still call it on the next source request and crash
         //      again. The marker check makes the function a no-op once
         //      it has fired.
         const marker = `${'/srv/e2e-sites'}/.e2e-hook-fired-${site}`;
@@ -124,53 +124,12 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
             ],
             autoResume: false,
         });
-        assert.equal(result.exitCode, 2,
-            `Expected first run to retain partial progress after the interrupted response\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
-    });
-
-    it('partial file is on disk and smaller than source', () => {
-        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
-        const localPath = join(importedRoot, fileRel);
-        assert.ok(existsSync(localPath),
-            'Expected the partially-downloaded file to exist on disk; the streaming change should have flushed the first chunk before the crash');
-        const partialSize = statSync(localPath).size;
-        assert.ok(partialSize > 0 && partialSize < fileSize,
-            `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
-    });
-
-    it('state does not checkpoint the unconfirmed file part', () => {
-        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
-        const localPath = join(importedRoot, fileRel);
-        const serializedLocalPath = `base64:${Buffer.from(localPath).toString('base64')}`;
-        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
-        assert.ok(existsSync(stateFile), 'Expected import state file to exist');
-        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.notEqual(
-            state.current_file,
-            serializedLocalPath,
-            'Expected the unconfirmed file part to remain outside the checkpoint',
-        );
-    });
-
-    it('resume completes after removing the hook', () => {
-        removeTestHooks(site);
-
-        const result = runImporter(importUrl(), tempDir, 'files-pull', {
-            secret: getSiteSecret(site),
-            extraArgs: [
-                '--file-chunk-start=262144',
-                '--file-chunk-max=262144',
-            ],
-        });
         assert.equal(result.exitCode, 0,
-            `Expected resume to complete\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
-
-        const stateFile = join(pullStateDirectory(tempDir, importUrl()), 'state.json');
-        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.active_resumable_command.completion_state, 'complete', `Expected status=complete after resume, got ${state.active_resumable_command.completion_state}`);
+            `Expected the same process to recover after the interrupted response\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        assert.ok(existsSync(marker), 'Expected the source cutoff hook to fire');
     });
 
-    it('resumed file matches source byte-for-byte (no gap, no duplication)', () => {
+    it('recovered file matches source byte-for-byte (no gap, no duplication)', () => {
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const localPath = join(importedRoot, fileRel);
         const localSize = statSync(localPath).size;

--- a/tests/e2e/tests/import-59-files-pull-mirror.test.js
+++ b/tests/e2e/tests/import-59-files-pull-mirror.test.js
@@ -31,6 +31,7 @@ import {
     getSiteSecret,
     getSiteUrl,
     pullStateDirectory,
+    readHookState,
     removeTestHooks,
     runImporter,
     writeHookState,
@@ -346,7 +347,7 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         assert.ok(!existsSync(localOnlyPath));
     });
 
-    it('resumes an interrupted mirror and restores the current remote tree', () => {
+    it('recovers from an interrupted mirror and restores the current remote tree', () => {
         resetCompletedFilesPull(mirrorTempDir);
         changeLocalTree(localSiteRoot(mirrorTempDir));
 
@@ -364,31 +365,33 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         ].join('\n'));
         writeHookState(site, { scan_count: 0 });
 
-        const interrupted = runFilesPull(mirrorTempDir, 'mirror', {
+        const recovered = runFilesPull(mirrorTempDir, 'mirror', {
             autoResume: false,
         });
         assert.equal(
-            interrupted.exitCode,
-            2,
-            `Expected an interrupted mirror pull\nstderr: ${interrupted.stderr}\nstdout: ${interrupted.stdout}`,
+            recovered.exitCode,
+            0,
+            `Expected one process to recover from the interrupted mirror pull\nstderr: ${recovered.stderr}\nstdout: ${recovered.stdout}`,
+        );
+        assert.ok(
+            readHookState(site).scan_count >= 5,
+            'Expected the source cutoff hook to fire',
         );
 
-        const interruptedState = JSON.parse(readFileSync(
+        const recoveredState = JSON.parse(readFileSync(
             join(pullStateDirectory(mirrorTempDir, importUrl()), 'state.json'),
             'utf-8',
         ));
-        assert.equal(interruptedState.active_resumable_command.current_stage, 'index');
-        assert.equal(interruptedState.active_resumable_command.completion_state, 'partial');
-
         removeTestHooks(site);
-        const resumed = runFilesPull(mirrorTempDir, 'mirror');
         assert.equal(
-            resumed.exitCode,
-            0,
-            `Mirror resume failed\nstderr: ${resumed.stderr}\nstdout: ${resumed.stdout}`,
+            recoveredState.active_resumable_command.completion_state,
+            'complete',
+            'Expected the mirror pull to complete after the internal retry',
         );
 
-        assertTreesMatch(getSiteDir(site), localSiteRoot(mirrorTempDir));
+        assertTreesMatch(getSiteDir(site), localSiteRoot(mirrorTempDir), {
+            exclude: ['wp-content/plugins/site-export/test-hooks.php'],
+        });
         assert.ok(
             !existsSync(join(localSiteRoot(mirrorTempDir), 'test-data', 'local-only')),
             'Mirror should remove the local-only directory',

--- a/tests/e2e/tests/import-65-files-pull-internal-loop.test.js
+++ b/tests/e2e/tests/import-65-files-pull-internal-loop.test.js
@@ -1,0 +1,94 @@
+/**
+ * Test 65: files-pull continues after partial source responses.
+ *
+ * The source pauses before every index batch. With a one-second source
+ * execution budget, that forces several partial index responses. A single
+ * files-pull process must continue them while local PHP memory has room.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    writeTestHooks, removeTestHooks,
+    readHookState, clearHookState, pullStateDirectory,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: files-pull internal loop', { timeout: 120000 }, () => {
+    const site = 'files-pull-internal-loop';
+    const hookState = `/srv/e2e-sites/.e2e-hook-state-${site}`;
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            files: 'none',
+            afterCreate: async (siteDir) => {
+                const manyFilesDirectory = join(siteDir, 'test-data', 'many-files');
+                mkdirSync(manyFilesDirectory, { recursive: true });
+                for (let number = 1; number <= 400; number++) {
+                    writeFileSync(
+                        join(manyFilesDirectory, `file-${number}.txt`),
+                        `content-${number}`,
+                    );
+                }
+            },
+        });
+        tempDir = createTempDir('e2e-files-pull-internal-loop');
+        clearHookState(site);
+        writeTestHooks(site, [
+            'function test_hook_before_index_batch(&$batch_items, $directory_stack) {',
+            `    $state_file = '${hookState}';`,
+            "    $state = file_exists($state_file) ? json_decode(file_get_contents($state_file), true) : array('batches' => 0);",
+            "    $state['batches']++;",
+            '    e2e_write_hook_state($state_file, $state);',
+            '    usleep(600000);',
+            '}',
+        ].join('\n'));
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('completes partial index responses in one process', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-pull', {
+            secret: getSiteSecret(site),
+            autoResume: false,
+            timeout: 120000,
+            extraArgs: [
+                '--max-exec=1',
+                '--index-batch-start=100',
+                '--index-batch-max=100',
+            ],
+        });
+
+        assert.equal(
+            result.exitCode,
+            0,
+            `Expected exit 0 from one files-pull process\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+        );
+        assert.ok(
+            readHookState(site).batches >= 3,
+            'Expected the source to emit more than one index batch',
+        );
+
+        const state = JSON.parse(readFileSync(
+            join(pullStateDirectory(tempDir, importUrl()), 'state.json'),
+            'utf-8',
+        ));
+        assert.equal(
+            state.active_resumable_command.completion_state,
+            'complete',
+            'Expected files-pull to complete within one process',
+        );
+    });
+});


### PR DESCRIPTION
files-pull now handles several partial source responses in one PHP process. It leaves the saved state partial, and keeps exit code 2, once allocated memory reaches 80% of PHP's configured limit.

The loop checks allocated PHP memory after every partial response. The new end-to-end test forces repeated partial file-index responses and requires a single files-pull process to finish them.