### PR TITLE
Raise default source request budget to 15 seconds

### DIFF
--- a/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
+++ b/packages/reprint-client/src/lib/tuning/class-adaptive-tuner.php
@@ -327,7 +327,7 @@ class AdaptiveTuner
         $defaults = [
             "enabled" => true,
             "use_server_time" => true,
-            "max_execution_time" => 5,
+            "max_execution_time" => 15,
             "memory_threshold" => 0.8,
             "duty" => 0.5,
             "duty_min" => 0.35,

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -386,7 +386,7 @@ final class HTTPServer {
     private function default_budget_factory(array $config) {
         $max_execution_time = require_int_range(
             'max_execution_time',
-            (int) ($config['max_execution_time'] ?? 5),
+            (int) ($config['max_execution_time'] ?? 15),
             1,
             60
         );

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -111,6 +111,14 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame(['from' => 'file_index'], $calls[0][1]);
     }
 
+    public function testDefaultResourceBudgetAllowsFifteenSeconds(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-server/src/export.php';
+        $server = new \WordPress\Reprint\Server\HTTPServer();
+
+        $this->assertSame(15, $server->create_resource_budget([])->max_time);
+    }
+
     public function testClassifiesOnlyTheRegisteredPushEndpoints(): void
     {
         $server = new \WordPress\Reprint\Server\HTTPServer();

--- a/tests/Import/AdaptiveTunerTest.php
+++ b/tests/Import/AdaptiveTunerTest.php
@@ -12,7 +12,7 @@ class AdaptiveTunerTest extends TestCase
     private function makeTuner(array $config = [], array $state = []): AdaptiveTuner
     {
         return new AdaptiveTuner(array_merge([
-            "max_execution_time" => 5,
+            "max_execution_time" => 15,
             "duty" => 0.5,
         ], $config), $state);
     }
@@ -56,7 +56,7 @@ class AdaptiveTunerTest extends TestCase
         $state = $tuner->get_state();
 
         $this->assertTrue($config["enabled"]);
-        $this->assertSame(5, $config["max_execution_time"]);
+        $this->assertSame(15, $config["max_execution_time"]);
         $this->assertSame(0.5, $config["duty"]);
         $this->assertSame(5 * 1024 * 1024, $state["file_chunk_size"]);
         $this->assertSame(5000, $state["index_batch_size"]);
@@ -107,7 +107,7 @@ class AdaptiveTunerTest extends TestCase
         $params = $tuner->get_request_params("file_fetch");
 
         $this->assertSame(2048, $params["chunk_size"]);
-        $this->assertSame(5, $params["max_execution_time"]);
+        $this->assertSame(15, $params["max_execution_time"]);
         $this->assertArrayHasKey("memory_threshold", $params);
         $this->assertArrayNotHasKey("batch_size", $params);
     }


### PR DESCRIPTION
File pulls now request up to 15 seconds of source work, reducing continuation requests on sources that can stream longer.

A finite PHP `max_execution_time` caps that budget. An unlimited PHP setting keeps the 15-second Reprint default.

## Testing

`cd tests && ../vendor/bin/phpunit Import/AdaptiveTunerTest.php ExportHttpServerTest.php`

`git diff --check`