### PR TITLE
Cap source request budget at PHP execution limit

### DIFF
--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -390,6 +390,13 @@ final class HTTPServer {
             1,
             60
         );
+        $ini_max_execution_time = (int) ini_get('max_execution_time');
+        if ($ini_max_execution_time > 0) {
+            $max_execution_time = min(
+                $max_execution_time,
+                $ini_max_execution_time
+            );
+        }
         $memory_threshold = require_float_range(
             'memory_threshold',
             (float) ($config['memory_threshold'] ?? 0.8),

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -111,12 +111,34 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame(['from' => 'file_index'], $calls[0][1]);
     }
 
-    public function testDefaultResourceBudgetAllowsFifteenSeconds(): void
+    public function testDefaultResourceBudgetAllowsFifteenSecondsWhenPhpIsUnlimited(): void
     {
         require_once __DIR__ . '/../packages/reprint-server/src/export.php';
-        $server = new \WordPress\Reprint\Server\HTTPServer();
+        $previous_max_execution_time = ini_get('max_execution_time');
+        $this->assertNotFalse(ini_set('max_execution_time', '0'));
 
-        $this->assertSame(15, $server->create_resource_budget([])->max_time);
+        try {
+            $server = new \WordPress\Reprint\Server\HTTPServer();
+
+            $this->assertSame(15, $server->create_resource_budget([])->max_time);
+        } finally {
+            ini_set('max_execution_time', (string) $previous_max_execution_time);
+        }
+    }
+
+    public function testResourceBudgetDoesNotExceedPhpExecutionLimit(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-server/src/export.php';
+        $previous_max_execution_time = ini_get('max_execution_time');
+        $this->assertNotFalse(ini_set('max_execution_time', '7'));
+
+        try {
+            $server = new \WordPress\Reprint\Server\HTTPServer();
+
+            $this->assertSame(7, $server->create_resource_budget([])->max_time);
+        } finally {
+            ini_set('max_execution_time', (string) $previous_max_execution_time);
+        }
     }
 
     public function testClassifiesOnlyTheRegisteredPushEndpoints(): void


### PR DESCRIPTION
Source requests now use no more execution time than PHP permits.

For example, a source configured with `max_execution_time=7` receives a 7-second Reprint budget. A source with no PHP execution limit keeps the 15-second default introduced in #723.

## Testing

`cd tests && ../vendor/bin/phpunit Import/AdaptiveTunerTest.php ExportHttpServerTest.php`

`git diff --check`