### PR TITLE
[Tests] Keep MySQL target position pauses in separate requests

### DIFF
--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -55,6 +55,9 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
             '--sql-fragments-start=251',
             '--sql-fragments-min=251',
             '--sql-fragments-max=251',
+            // End the request after the hook's 10-second pause. This keeps the
+            // next batch in a separate request, where the test stops it.
+            '--max-exec=5',
             '--progress=jsonl',
         ];
     }


### PR DESCRIPTION
Pins the MySQL target-position E2E scenario to a five-second source request budget so its ten-second hook pause still ends the current request after the default rose to 15 seconds.

The scenario expects the next SQL batch to arrive in a new request, where the test hook stops it. Without the explicit budget, both hook pauses run in one request and the response ends without its completion part across every active PHP row.

## Testing

Run the MySQL target-position E2E scenario in the Docker test environment and confirm both tests pass.