### PR TITLE
[PHP] Encode pull filesystem path parameters as base64

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -10943,9 +10943,30 @@ class ImportClient
         ?string $cursor,
         array $params = []
     ): string {
-        $url = $this->remote_reprint_api_url;
+        $preflight_record = $this->get_state()->preflight_record();
+        // Preflight keeps the legacy path parameters so a new client can learn
+        // whether an older server supports the base64 form before using it.
+        $server_supports_base64_paths = $endpoint !== 'preflight'
+            && !empty($preflight_record['data']['capabilities']['base64_path_parameters']);
+        $url = $server_supports_base64_paths
+            ? self::encode_url_path_parameters($this->remote_reprint_api_url)
+            : $this->remote_reprint_api_url;
         $separator = strpos($url, "?") === false ? "?" : "&";
 
+        if ($server_supports_base64_paths) {
+            foreach (["directory", "list_dir", "pulled_before"] as $parameter) {
+                if (!array_key_exists($parameter, $params)) {
+                    continue;
+                }
+                if (is_array($params[$parameter])) {
+                    foreach ($params[$parameter] as $key => $path) {
+                        $params[$parameter][$key] = base64_encode($path);
+                    }
+                } else {
+                    $params[$parameter] = base64_encode($params[$parameter]);
+                }
+            }
+        }
         $params["endpoint"] = $endpoint;
         if ($cursor) {
             // Also include cursor in query params as a fallback when headers are stripped.
@@ -10954,6 +10975,36 @@ class ImportClient
         $params["_cache_bust"] = time() . "-" . rand(0, 999999);
 
         return $url . $separator . http_build_query($params);
+    }
+
+    /**
+     * Base64-encode and rename path parameters already present in an API URL.
+     */
+    private static function encode_url_path_parameters(string $url): string
+    {
+        $query_start = strpos($url, '?');
+        if ($query_start === false) {
+            return $url;
+        }
+
+        $url_prefix = substr($url, 0, $query_start + 1);
+        $query_parts = explode('&', substr($url, $query_start + 1));
+        foreach ($query_parts as $index => $query_part) {
+            $value_start = strpos($query_part, '=');
+            if ($value_start === false) {
+                continue;
+            }
+            $decoded_key = urldecode(substr($query_part, 0, $value_start));
+            $key = preg_replace('/\[.*\]$/', '', $decoded_key);
+            if (!in_array($key, ['directory', 'list_dir', 'pulled_before'], true)) {
+                continue;
+            }
+            $path = urldecode(substr($query_part, $value_start + 1));
+            $query_parts[$index] = substr($query_part, 0, $value_start)
+                . '=' . rawurlencode(base64_encode($path));
+        }
+
+        return $url_prefix . implode('&', $query_parts);
     }
 
     /**

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -237,6 +237,40 @@ final class HTTPServer {
                 if (is_array($decoded)) {
                     $value = $decoded;
                 }
+            } elseif (in_array($key, ['directory', 'list_dir', 'pulled_before'], true)) {
+                $path_values = is_array($value) ? $value : [$value];
+                $decoded_paths = [];
+                foreach ($path_values as $path_key => $path_value) {
+                    // Do not decode first: PHP accepts a raw path such as /tmp
+                    // as strict base64 and turns it into unrelated bytes. Raw
+                    // absolute paths start with /; their base64 form starts with L.
+                    if (is_string($path_value) && substr($path_value, 0, 1) === '/') {
+                        $decoded_path = $path_value;
+                    } else {
+                        $decoded_path = is_string($path_value)
+                            ? base64_decode($path_value, true)
+                            : false;
+                    }
+                    if (
+                        $decoded_path === false
+                        || $decoded_path === ''
+                        || substr($decoded_path, 0, 1) !== '/'
+                    ) {
+                        $entry = is_array($value) ? ' entry ' . $path_key : '';
+                        $observed = is_string($path_value)
+                            ? json_encode($path_value)
+                            : gettype($path_value);
+                        // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The exception reports the rejected HTTP parameter and value to the API caller.
+                        throw new InvalidArgumentException(
+                            $key . $entry
+                            . ' must be an absolute path or a base64-encoded absolute path; observed '
+                            . $observed . '.'
+                        );
+                        // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                    }
+                    $decoded_paths[$path_key] = $decoded_path;
+                }
+                $value = is_array($value) ? $decoded_paths : reset($decoded_paths);
             }
 
             $config[$key] = $value;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2455,6 +2455,9 @@ function endpoint_preflight(array $config): array
         "error" => $preflight_error,
         "timestamp" => time(),
         "protocol_version" => EXPORT_PROTOCOL_VERSION,
+        "capabilities" => [
+            "base64_path_parameters" => true,
+        ],
         "wp_detect" => [
             "found" => !empty($wp_detect["roots"]),
             "searched" => $wp_detect["searched"],

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -28,6 +28,50 @@ final class ExportHttpServerTest extends TestCase
         $this->assertTrue($config['create_table_query']);
     }
 
+    public function testParsesBase64EncodedPathParameters(): void
+    {
+        $server = new \WordPress\Reprint\Server\HTTPServer();
+        $config = $server->parse_http_config([
+            'endpoint' => 'file_index',
+            'directory' => [
+                base64_encode('/srv/site'),
+                base64_encode("/srv/binary-\xff"),
+            ],
+            'list_dir' => base64_encode('/srv/site'),
+            'pulled_before' => [base64_encode('/srv/site/removed')],
+        ]);
+
+        $this->assertSame(['/srv/site', "/srv/binary-\xff"], $config['directory']);
+        $this->assertSame('/srv/site', $config['list_dir']);
+        $this->assertSame(['/srv/site/removed'], $config['pulled_before']);
+    }
+
+    public function testRejectsInvalidBase64EncodedPathParameter(): void
+    {
+        $server = new \WordPress\Reprint\Server\HTTPServer();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'directory entry 1 must be an absolute path or a base64-encoded absolute path; observed "not base64".'
+        );
+
+        $server->parse_http_config([
+            'endpoint' => 'file_index',
+            'directory' => [base64_encode('/srv/site'), 'not base64'],
+        ]);
+    }
+
+    public function testKeepsLegacyRawPathParameterForProtocolNegotiation(): void
+    {
+        $server = new \WordPress\Reprint\Server\HTTPServer();
+        $config = $server->parse_http_config([
+            'endpoint' => 'preflight',
+            'directory' => ['/tmp', '/srv/site'],
+        ]);
+
+        $this->assertSame(['/tmp', '/srv/site'], $config['directory']);
+    }
+
     public function testNormalizeConfigAppliesDefaultDirectoryAndDecodesCursorHeader(): void
     {
         $server = new \WordPress\Reprint\Server\HTTPServer([

--- a/tests/HttpServerServeTest.php
+++ b/tests/HttpServerServeTest.php
@@ -21,7 +21,7 @@ final class HttpServerServeTest extends TestCase
     {
         $script = <<<PHP
         \$_GET['endpoint'] = 'preflight';
-        \$_GET['directory'] = sys_get_temp_dir();
+        \$_GET['directory'] = base64_encode(sys_get_temp_dir());
 
         require '{$this->classPath()}';
 
@@ -48,7 +48,7 @@ final class HttpServerServeTest extends TestCase
     {
         $script = <<<PHP
         \$_GET['endpoint'] = 'preflight';
-        \$_GET['directory'] = sys_get_temp_dir();
+        \$_GET['directory'] = base64_encode(sys_get_temp_dir());
 
         require '{$this->classPath()}';
         require '{$this->exportPath()}';

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -1544,6 +1544,9 @@ final class FilesPullLocalIndexTest extends TestCase
             'http_code' => 200,
             'data' => [
                 'ok' => true,
+                'capabilities' => [
+                    'base64_path_parameters' => true,
+                ],
                 'runtime' => [
                     'document_root' =>
                         'base64:'
@@ -1653,7 +1656,10 @@ uksort($remote_index, static function (string $left, string $right): int {
 
 $endpoint = $_GET['endpoint'] ?? null;
 $request_cursor = $_GET['cursor'] ?? null;
-$selected_directories = $_GET['directory'] ?? array();
+$selected_directories = array_map(
+    'base64_decode',
+    (array) ($_GET['directory'] ?? array())
+);
 if ($endpoint === 'file_index' && count($selected_directories) > 0) {
     $remote_index = array_filter(
         $remote_index,
@@ -1674,6 +1680,9 @@ if ($endpoint === 'preflight') {
     header('Content-Type: application/json');
     echo json_encode(array(
         'ok' => true,
+        'capabilities' => array(
+            'base64_path_parameters' => true,
+        ),
         'runtime' => array(
             'document_root' => '/var/www/html',
             'ini_get_all' => array(),

--- a/tests/Import/OnlyCliParseTest.php
+++ b/tests/Import/OnlyCliParseTest.php
@@ -93,7 +93,9 @@ class OnlyCliParseTest extends TestCase
 $log = %s;
 file_put_contents($log, json_encode(array(
     'endpoint' => $_GET['endpoint'] ?? null,
-    'directory' => $_GET['directory'] ?? null,
+    'directory' => isset($_GET['directory'])
+        ? array_map('base64_decode', (array) $_GET['directory'])
+        : null,
     'exclude_path' => $_GET['exclude_path'] ?? null,
 ), JSON_UNESCAPED_SLASHES) . "\n", FILE_APPEND);
 
@@ -158,6 +160,9 @@ PHP, var_export($requestsLog, true)));
     {
         $data = array(
             'ok' => true,
+            'capabilities' => array(
+                'base64_path_parameters' => true,
+            ),
             'database' => array(
                 'wp' => array(
                     'paths_urls' => array(

--- a/tests/Import/RequestUrlPathEncodingTest.php
+++ b/tests/Import/RequestUrlPathEncodingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Classes.OpeningBraceSameLine.BraceOnNewLine -- Match existing importer test class style.
+// phpcs:disable Generic.WhiteSpace.ArbitraryParenthesesSpacing -- Match existing importer test call style.
+// phpcs:disable WordPress.WhiteSpace.CastStructureSpacing -- Match existing importer test cast style.
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+final class RequestUrlPathEncodingTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/request-url-path-encoding-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/state', 0700, true);
+        mkdir($this->root . '/files', 0700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove_tree($this->root);
+    }
+
+    public function testPathParametersAreBase64Encoded(): void
+    {
+        $client = new \ImportClient(
+            'https://example.com/?reprint-api',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+        $client->get_state()->set_preflight_record([
+            'data' => ['capabilities' => ['base64_path_parameters' => true]],
+        ]);
+        $build_url = (new \ReflectionClass($client))->getMethod('build_url');
+        $binary_path = "/srv/binary-\xff";
+
+        $url = $build_url->invoke($client, 'file_index', null, [
+            'directory' => ['/srv/site', $binary_path],
+            'list_dir' => '/srv/site',
+            'pulled_before' => ['/srv/site/removed'],
+        ]);
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertSame(
+            [base64_encode('/srv/site'), base64_encode($binary_path)],
+            $query['directory']
+        );
+        $this->assertSame(base64_encode('/srv/site'), $query['list_dir']);
+        $this->assertSame(
+            [base64_encode('/srv/site/removed')],
+            $query['pulled_before']
+        );
+    }
+
+    public function testPathParametersInApiUrlAreBase64Encoded(): void
+    {
+        $client = new \ImportClient(
+            'https://example.com/?reprint-api&directory%5B%5D=%2Fsrv%2Fsite'
+                . '&directory%5B%5D=%2Fsrv%2Fshared&unrelated=value',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+        $client->get_state()->set_preflight_record([
+            'data' => ['capabilities' => ['base64_path_parameters' => true]],
+        ]);
+        $build_url = (new \ReflectionClass($client))->getMethod('build_url');
+
+        $url = $build_url->invoke($client, 'file_index', null);
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertSame(
+            [base64_encode('/srv/site'), base64_encode('/srv/shared')],
+            $query['directory']
+        );
+        $this->assertSame('value', $query['unrelated']);
+    }
+
+    public function testFallsBackToRawPathsWithoutServerCapability(): void
+    {
+        $client = new \ImportClient(
+            'https://example.com/?reprint-api&directory=%2Fsrv%2Fsite',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+        $build_url = (new \ReflectionClass($client))->getMethod('build_url');
+
+        $url = $build_url->invoke($client, 'file_index', null, [
+            'list_dir' => '/srv/site',
+        ]);
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertSame('/srv/site', $query['directory']);
+        $this->assertSame('/srv/site', $query['list_dir']);
+    }
+
+    public function testPreflightKeepsRawPathsAfterCapabilityWasRecorded(): void
+    {
+        $client = new \ImportClient(
+            'https://example.com/?reprint-api&directory=%2Fsrv%2Fsite',
+            $this->root . '/state',
+            $this->root . '/files'
+        );
+        $client->get_state()->set_preflight_record([
+            'data' => ['capabilities' => ['base64_path_parameters' => true]],
+        ]);
+        $build_url = (new \ReflectionClass($client))->getMethod('build_url');
+
+        $url = $build_url->invoke($client, 'preflight', null);
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertSame('/srv/site', $query['directory']);
+        $this->assertArrayNotHasKey('directory_b64', $query);
+    }
+
+    private function remove_tree(string $path): void
+    {
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                $this->remove_tree($path . '/' . $entry);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/Import/RuntimeFilesRootPathTest.php
+++ b/tests/Import/RuntimeFilesRootPathTest.php
@@ -94,7 +94,9 @@ final class RuntimeFilesRootPathTest extends TestCase
 <?php
 $request = array(
     'endpoint' => $_GET['endpoint'] ?? null,
-    'directory' => $_GET['directory'] ?? null,
+    'directory' => isset($_GET['directory'])
+        ? (array) $_GET['directory']
+        : null,
 );
 file_put_contents(
     %s,

--- a/tests/e2e/lib/app-firewall-fixture.js
+++ b/tests/e2e/lib/app-firewall-fixture.js
@@ -2,8 +2,9 @@
  * Local reverse proxy which models an application firewall around WordPress.
  *
  * Reprint requests are accepted only when their Referer points to the same
- * origin's WordPress Media Library page. It injects the planned HTTP errors,
- * then streams later requests to the real E2E WordPress site.
+ * origin's WordPress Media Library page. After preflight, path query values
+ * must not expose absolute filesystem paths. It injects the planned HTTP
+ * errors, then streams later requests to the real E2E WordPress site.
  */
 import http from 'node:http';
 import { appendFileSync } from 'node:fs';
@@ -38,8 +39,15 @@ const server = http.createServer((request, response) => {
         requestUrl.searchParams.has('site-export-api');
     const expectedReferer = `http://${request.headers.host}/wp-admin/upload.php`;
     const referer = request.headers.referer || '';
-    const allowed = !isReprintRequest || referer === expectedReferer;
     const endpoint = requestUrl.searchParams.get('endpoint') || '';
+    const rawPathParameter = ['directory', 'list_dir', 'pulled_before']
+        .flatMap(parameter => requestUrl.searchParams.getAll(parameter))
+        .find(value => value.startsWith('/')) || null;
+    const allowed = !isReprintRequest || (
+        referer === expectedReferer && (
+            endpoint === 'preflight' || rawPathParameter === null
+        )
+    );
     const injectedStatuses = injectedStatusesByEndpoint.get(endpoint) || [];
     const injectedResponseCount = injectedResponseCounts.get(endpoint) || 0;
     const injectedStatus = allowed
@@ -62,6 +70,7 @@ const server = http.createServer((request, response) => {
         endpoint,
         referer,
         expectedReferer,
+        rawPathParameter,
         isReprintRequest,
         allowed,
         action,

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -65,7 +65,7 @@ export async function apiRequest(siteName, endpoint, params = {}, options = {}) 
     const url = new URL(options.url || getSiteUrl(siteName));
     url.searchParams.set('endpoint', endpoint);
     for (const [k, v] of Object.entries(params)) {
-        url.searchParams.set(k, String(v));
+        setApiRequestParameter(url, k, v);
     }
 
     const body = options.body || '';
@@ -655,7 +655,7 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
     const url = new URL(getSiteUrl(siteName));
     url.searchParams.set('endpoint', 'file_fetch');
     for (const [k, v] of Object.entries(params)) {
-        url.searchParams.set(k, String(v));
+        setApiRequestParameter(url, k, v);
     }
 
     const fileListJson = JSON.stringify(filePaths.map(path => ({
@@ -719,6 +719,21 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
         text: await response.text(),
         headers: Object.fromEntries(response.headers.entries()),
     };
+}
+
+function setApiRequestParameter(url, parameter, value) {
+    const pathParameters = ['directory', 'list_dir', 'pulled_before'];
+    const values = Array.isArray(value) ? value : [value];
+    url.searchParams.delete(parameter);
+    url.searchParams.delete(`${parameter}[]`);
+    for (const item of values) {
+        url.searchParams.append(
+            Array.isArray(value) ? `${parameter}[]` : parameter,
+            pathParameters.includes(parameter)
+                ? Buffer.from(String(item)).toString('base64')
+                : String(item)
+        );
+    }
 }
 
 /**

--- a/tests/e2e/tests/import-21-preflight.test.js
+++ b/tests/e2e/tests/import-21-preflight.test.js
@@ -33,6 +33,10 @@ describe('Import: Preflight Endpoint', () => {
         assert.ok(preflight.protocol_version >= 1, `Expected protocol_version >= 1, got ${preflight.protocol_version}`);
     });
 
+    it('reports base64 path parameter support', () => {
+        assert.equal(preflight.capabilities.base64_path_parameters, true);
+    });
+
     it('detects WordPress installation', () => {
         assert.ok(preflight.wp_detect, 'Expected wp_detect in response');
         assert.ok(preflight.wp_detect.found, 'Expected WordPress to be found');

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -105,7 +105,9 @@ _site_export_handle_api_request();
 
         // Build the URL with array-style directory[] params manually,
         // then pass it to apiRequest via the url option.
-        const url = `${getSiteUrl(site)}&directory%5B%5D=${encodeURIComponent(wpDir)}&directory%5B%5D=${encodeURIComponent(docRoot)}`;
+        const encodedWpDir = encodeURIComponent(Buffer.from(wpDir).toString('base64'));
+        const encodedDocRoot = encodeURIComponent(Buffer.from(docRoot).toString('base64'));
+        const url = `${getSiteUrl(site)}&directory%5B%5D=${encodedWpDir}&directory%5B%5D=${encodedDocRoot}`;
         const response = await apiRequest(site, 'file_index', {
             list_dir: wpDir,
             follow_symlinks: '1',

--- a/tests/e2e/tests/import-60-application-firewall.test.js
+++ b/tests/e2e/tests/import-60-application-firewall.test.js
@@ -3,7 +3,8 @@
  *
  * Runs a complete pull through a local HTTP reverse proxy which rejects
  * Reprint requests unless they have a same-origin WordPress admin Referer.
- * Before forwarding each streaming endpoint, the proxy also returns two
+ * After preflight reports base64 path support, the proxy also rejects clear
+ * path query values. Before forwarding each streaming endpoint, it returns two
  * potentially transient HTTP errors. The third request reaches the real E2E
  * site, so the pull must recover without hitting its three-failure limit.
  */
@@ -150,6 +151,23 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
         }
     });
 
+    it('base64-encodes filesystem path query values', () => {
+        const encodedPaths = readRequestRecords()
+            .filter(record => record.isReprintRequest && record.endpoint !== 'preflight')
+            .flatMap(record => {
+                const url = new URL(record.path, firewallOrigin);
+                return ['directory', 'list_dir', 'pulled_before']
+                    .flatMap(parameter => url.searchParams.getAll(parameter));
+            });
+
+        assert.ok(encodedPaths.length > 0, 'Expected path query values');
+        for (const encodedPath of encodedPaths) {
+            const decodedPath = Buffer.from(encodedPath, 'base64');
+            assert.equal(decodedPath.toString('base64'), encodedPath);
+            assert.ok(decodedPath.toString().startsWith('/'));
+        }
+    });
+
     it('retries two potentially transient HTTP errors at every pull streaming endpoint', () => {
         const expectedStatusesByEndpoint = new Map([
             ['file_index', [408, 418]],
@@ -232,6 +250,16 @@ describe('Import: Application firewall compatibility', { timeout: 240000 }, () =
     it('rejects a Reprint GET without the Referer', async () => {
         const response = await fetch(
             `${firewallOrigin}/?reprint-api&endpoint=preflight`,
+        );
+
+        assert.equal(response.status, 403);
+        assert.equal(response.headers.get('x-app-firewall'), 'blocked');
+    });
+
+    it('rejects a clear absolute path after preflight', async () => {
+        const response = await fetch(
+            `${firewallOrigin}/?reprint-api&endpoint=file_index&directory=/srv/site`,
+            { headers: { Referer: `${firewallOrigin}/wp-admin/upload.php` } },
         );
 
         assert.equal(response.status, 403);


### PR DESCRIPTION
Reprint now base64-encodes filesystem path query values after the server reports support. This keeps clear paths such as `/srv/htdocs` out of requests inspected by application firewalls.

The protocol version stays unchanged. Old clients keep working with the new server, and the new client sends raw paths when an old server does not report support.

Raw absolute paths start with `/`; their base64 form starts with `L`. The server uses that difference instead of decoding first, because PHP also accepts a raw path such as `/tmp` as strict base64 and turns it into unrelated bytes.

## Testing

Run a pull through an application firewall which rejects clear paths after preflight. Confirm that the pull completes. Repeat with an older server and confirm that raw paths still work.
