### PR TITLE
[PHP] Migrate oversized spatial values through bounded SQL statements

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -194,6 +194,8 @@ class ImportClient
     // Change this UUID whenever the progress-table schema changes.
     private const DATABASE_IMPORT_POSITION_TABLE =
         self::DATABASE_IMPORT_POSITION_TABLE_PREFIX . "49acb118-a97a-45c7-814d-8e670db7f6b4";
+    private const DATABASE_IMPORT_SPATIAL_STAGING_TABLE =
+        self::DATABASE_IMPORT_POSITION_TABLE_PREFIX . "spatial";
     private const SQL_GROUP_MARKER = "-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 ";
 
     /**
@@ -9158,31 +9160,8 @@ class ImportClient
     private function reset_database_import_position(DatabaseConnection $database): void
     {
         $table = self::DATABASE_IMPORT_POSITION_TABLE;
-        // An unfinished spatial value keeps its binary staging table for a
-        // later resume. A fresh import discards that table before it forgets
-        // the target cursor which names it.
-        $result = $database->query(
-            "SELECT `source_cursor` FROM `{$table}` WHERE `id` = 1"
-        );
-        $encoded_cursor = $result->fetchColumn();
-        $result->closeCursor();
-        if (is_string($encoded_cursor)) {
-            $cursor_json = base64_decode($encoded_cursor, true);
-            $cursor = $cursor_json === false ? null : json_decode($cursor_json, true);
-            $spatial_staging_table = is_array($cursor)
-                ? ( $cursor["spatial_staging_table"] ?? null )
-                : null;
-            if (
-                is_string($spatial_staging_table) &&
-                preg_match(
-                    '/^__reprint_db_pull_progress_spatial_[a-f0-9]{24}$/D',
-                    $spatial_staging_table
-                )
-            ) {
-                $quoted_staging_table = '`' . str_replace('`', '``', $spatial_staging_table) . '`';
-                $database->exec("DROP TABLE IF EXISTS {$quoted_staging_table}");
-            }
-        }
+        $spatial_staging_table = self::DATABASE_IMPORT_SPATIAL_STAGING_TABLE;
+        $database->exec("DROP TABLE IF EXISTS `{$spatial_staging_table}`");
         $query = "DELETE FROM `{$table}` WHERE `id` = 1";
         $database->exec($query);
     }

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -9158,6 +9158,31 @@ class ImportClient
     private function reset_database_import_position(DatabaseConnection $database): void
     {
         $table = self::DATABASE_IMPORT_POSITION_TABLE;
+        // An unfinished spatial value keeps its binary staging table for a
+        // later resume. A fresh import discards that table before it forgets
+        // the target cursor which names it.
+        $result = $database->query(
+            "SELECT `source_cursor` FROM `{$table}` WHERE `id` = 1"
+        );
+        $encoded_cursor = $result->fetchColumn();
+        $result->closeCursor();
+        if (is_string($encoded_cursor)) {
+            $cursor_json = base64_decode($encoded_cursor, true);
+            $cursor = $cursor_json === false ? null : json_decode($cursor_json, true);
+            $spatial_staging_table = is_array($cursor)
+                ? ( $cursor["spatial_staging_table"] ?? null )
+                : null;
+            if (
+                is_string($spatial_staging_table) &&
+                preg_match(
+                    '/^__reprint_db_pull_progress_spatial_[a-f0-9]{24}$/D',
+                    $spatial_staging_table
+                )
+            ) {
+                $quoted_staging_table = '`' . str_replace('`', '``', $spatial_staging_table) . '`';
+                $database->exec("DROP TABLE IF EXISTS {$quoted_staging_table}");
+            }
+        }
         $query = "DELETE FROM `{$table}` WHERE `id` = 1";
         $database->exec($query);
     }
@@ -9306,10 +9331,22 @@ class ImportClient
             return;
         }
 
-        // Large values are written by UPDATE statements which append pieces.
-        // A non-transactional table may keep one piece, so repeating the UPDATE
-        // could append those bytes twice.
-        if (!empty($cursor_data["oversized_queue"])) {
+        // Large text and binary values append pieces directly to the target
+        // row. A non-transactional table may keep one piece, so repeating that
+        // UPDATE could append those bytes twice. Spatial pieces go into a
+        // separate staging row with an expected-length guard, and the final
+        // target assignment is safe to repeat.
+        $has_direct_oversized_update = false;
+        foreach ($cursor_data["oversized_queue"] ?? [] as $oversized_value) {
+            if (
+                !is_array($oversized_value) ||
+                !array_key_exists("spatial_staging_initialized", $oversized_value)
+            ) {
+                $has_direct_oversized_update = true;
+                break;
+            }
+        }
+        if ($has_direct_oversized_update) {
             throw new RuntimeException(
                 "Cannot continue {$command} in target table `{$current_table}` because {$engine} may have " .
                 "already appended part of a large value. Run {$command} --abort to rebuild the target."

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -8703,6 +8703,15 @@ class ImportClient
                 false,
                 'db-pull',
             );
+            if ($this->max_allowed_packet === null) {
+                $packet_result = $mysql_conn->query(
+                    "SELECT @@max_allowed_packet AS max_allowed_packet"
+                );
+                $this->max_allowed_packet = (int) $packet_result->fetchColumn();
+                $packet_result->closeCursor();
+                $this->get_state()->max_allowed_packet = $this->max_allowed_packet;
+                $this->save_state();
+            }
             if ($starts_mysql_output) {
                 // Keep the mysql-start stage until the old target position is gone.
                 // If this process stops before save_state(), the next process
@@ -9312,21 +9321,21 @@ class ImportClient
 
         if ( ( $cursor_data["state"] ?? null ) === "stage_oversized_spatial" ) {
             // No INSERT for this source row has been emitted in this phase.
-            // Only the transactional helper table has changed, and its chunk
-            // updates require the saved byte length, so each is safe to repeat.
+            // Only the transactional helper table has changed. Each chunk has
+            // its own primary key, so replay replaces it instead of appending it.
             return;
         }
 
         // Large text and binary values append pieces directly to the target
         // row. A non-transactional table may keep one piece, so repeating that
         // UPDATE could append those bytes twice. Spatial pieces go into a
-        // separate staging row with an expected-length guard, and the final
+        // separate staging rows keyed by chunk number, and the final
         // INSERT reads the complete value and is safe to repeat.
         $has_direct_oversized_update = false;
         foreach ($cursor_data["oversized_queue"] ?? [] as $oversized_value) {
             if (
                 !is_array($oversized_value) ||
-                !array_key_exists("spatial_staging_initialized", $oversized_value)
+                !array_key_exists("spatial_staging_id", $oversized_value)
             ) {
                 $has_direct_oversized_update = true;
                 break;

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -9310,11 +9310,18 @@ class ImportClient
             return;
         }
 
+        if ( ( $cursor_data["state"] ?? null ) === "stage_oversized_spatial" ) {
+            // No INSERT for this source row has been emitted in this phase.
+            // Only the transactional helper table has changed, and its chunk
+            // updates require the saved byte length, so each is safe to repeat.
+            return;
+        }
+
         // Large text and binary values append pieces directly to the target
         // row. A non-transactional table may keep one piece, so repeating that
         // UPDATE could append those bytes twice. Spatial pieces go into a
         // separate staging row with an expected-length guard, and the final
-        // target assignment is safe to repeat.
+        // INSERT reads the complete value and is safe to repeat.
         $has_direct_oversized_update = false;
         foreach ($cursor_data["oversized_queue"] ?? [] as $oversized_value) {
             if (

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -85,6 +85,15 @@ class DatabaseRowsReader {
     /** @var int|null */
     private $query_time_limit_ms = null;
 
+    /** @var int|null Largest spatial value returned by the ordered row query. */
+    private $maximum_inline_spatial_bytes = null;
+
+    /** @var array<string,int|null> Byte lengths for spatial values in the retained row. */
+    private $current_spatial_value_lengths = [];
+
+    /** @var array<string,string> Internal length aliases keyed by spatial column name. */
+    private $spatial_length_aliases = [];
+
     /** @var array<string,list<array{column:string,value:string}>> Row exclusions keyed by table. */
     private $exclude_rows_by_table = [];
 
@@ -102,6 +111,7 @@ class DatabaseRowsReader {
      *     @type array|null $tables_to_process   Tables to read, or null to discover them.
      *     @type int        $batch_size          Maximum records per query.
      *     @type int|null   $query_time_limit_ms Maximum query duration in milliseconds.
+     *     @type int|null   $maximum_inline_spatial_bytes Largest spatial value returned inline.
      *     @type array      $exclude_rows        Table, column, and value exclusion rules.
      *     @type string[]   $exclude_tables      Table names to omit from automatic discovery.
      * }
@@ -119,6 +129,13 @@ class DatabaseRowsReader {
         if (isset($options["query_time_limit_ms"])) {
             $limit = (int) $options["query_time_limit_ms"];
             $this->query_time_limit_ms = $limit > 0 ? $limit : null;
+        }
+
+        if (isset($options["maximum_inline_spatial_bytes"])) {
+            $this->maximum_inline_spatial_bytes = max(
+                1,
+                (int) $options["maximum_inline_spatial_bytes"]
+            );
         }
 
         if (isset($options["exclude_rows"]) && is_array($options["exclude_rows"])) {
@@ -173,6 +190,7 @@ class DatabaseRowsReader {
             return false;
         }
 
+        $record = $this->extract_spatial_value_lengths($record);
         ++$this->rows_fetched_from_current_query;
         if ($this->current_column_names === null) {
             $this->current_column_names = array_keys($record);
@@ -237,6 +255,13 @@ class DatabaseRowsReader {
     {
         $this->current_row = null;
         $this->current_row_ends_query_batch = false;
+        $this->current_spatial_value_lengths = [];
+    }
+
+    /** Returns the retained spatial value length, or null for SQL NULL. */
+    public function get_current_spatial_value_length($column)
+    {
+        return $this->current_spatial_value_lengths[$column] ?? null;
     }
 
     /**
@@ -278,6 +303,8 @@ class DatabaseRowsReader {
                 ". The source row changed during export; run db-pull --abort and start again."
             );
         }
+
+        $record = $this->extract_spatial_value_lengths($record);
 
         $this->current_row = $record;
         $this->current_row_ends_query_batch = false;
@@ -458,6 +485,21 @@ class DatabaseRowsReader {
             foreach ($this->current_column_types as $column => $column_info) {
                 $quoted_column = $this->quote_identifier($column);
                 if (
+                    $this->maximum_inline_spatial_bytes !== null &&
+                    $this->is_spatial_type($column_info["data_type"])
+                ) {
+                    $length_alias = $this->get_spatial_length_alias($column);
+                    $quoted_length_alias = $this->quote_identifier($length_alias);
+                    $binary_value = "CAST({$quoted_column} AS BINARY)";
+                    $select_parts[] =
+                        "CASE WHEN OCTET_LENGTH({$binary_value}) <= " .
+                        $this->maximum_inline_spatial_bytes .
+                        " THEN {$binary_value} ELSE NULL END AS {$quoted_column}";
+                    $select_parts[] =
+                        "OCTET_LENGTH({$binary_value}) AS {$quoted_length_alias}";
+                    continue;
+                }
+                if (
                     $this->is_numeric_type($column_info["data_type"]) ||
                     $this->is_binary_type($column_info["data_type"])
                 ) {
@@ -473,6 +515,43 @@ class DatabaseRowsReader {
         }
 
         return $query;
+    }
+
+    /** Returns an internal SELECT alias which cannot collide with a real column. */
+    private function get_spatial_length_alias($column)
+    {
+        if (isset($this->spatial_length_aliases[$column])) {
+            return $this->spatial_length_aliases[$column];
+        }
+        $index = count($this->spatial_length_aliases);
+        $lowercase_column_names = array_map(
+            "strtolower",
+            array_keys($this->current_column_types)
+        );
+        do {
+            $alias = "__reprint_internal_spatial_length_{$index}";
+            ++$index;
+        } while (in_array(strtolower($alias), $lowercase_column_names, true));
+        $this->spatial_length_aliases[$column] = $alias;
+        return $alias;
+    }
+
+    /** Removes internal spatial length fields from one fetched row. */
+    private function extract_spatial_value_lengths($record)
+    {
+        $this->current_spatial_value_lengths = [];
+        foreach ($this->spatial_length_aliases as $column => $alias) {
+            if (!array_key_exists($alias, $record)) {
+                throw new \RuntimeException(
+                    "Spatial length field '{$alias}' is missing from the database row."
+                );
+            }
+            $this->current_spatial_value_lengths[$column] = $record[$alias] === null
+                ? null
+                : (int) $record[$alias];
+            unset($record[$alias]);
+        }
+        return $record;
     }
 
     private function build_row_exclusion_where_conditions()
@@ -625,6 +704,8 @@ class DatabaseRowsReader {
             $this->current_column_names = array_keys($this->current_column_types);
             $this->current_row = null;
             $this->current_row_ends_query_batch = false;
+            $this->current_spatial_value_lengths = [];
+            $this->spatial_length_aliases = [];
         }
         return (bool) $this->current_table;
     }

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -691,6 +691,7 @@ class DatabaseRowsReader {
                 "MULTIPOINT",
                 "MULTILINESTRING",
                 "MULTIPOLYGON",
+                "GEOMCOLLECTION",
                 "GEOMETRYCOLLECTION",
             ],
             true

--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -239,6 +239,50 @@ class DatabaseRowsReader {
         $this->current_row_ends_query_batch = false;
     }
 
+    /**
+     * Re-fetches the current keyed row without moving the ordered reader.
+     *
+     * @param array<string,mixed> $primary_key_values Values keyed by primary key column name.
+     */
+    public function reload_current_record($primary_key_values)
+    {
+        if (!$this->current_pk_columns || count($primary_key_values) !== count($this->current_pk_columns)) {
+            throw new \RuntimeException(
+                "Cannot reload the current database row without its complete primary key."
+            );
+        }
+
+        $where_parts = [];
+        foreach ($this->current_pk_columns as $column) {
+            if (!array_key_exists($column, $primary_key_values)) {
+                throw new \RuntimeException(
+                    "Cannot reload the current database row because primary key column " .
+                    $this->quote_identifier($column) . " is missing."
+                );
+            }
+            $where_parts[] = $this->build_comparison(
+                $column,
+                $primary_key_values[$column],
+                "="
+            );
+        }
+
+        $query = $this->build_byte_preserving_select_from_current_table() .
+            " WHERE " . implode(" AND ", $where_parts) . " LIMIT 1";
+        $result = $this->db->query($query);
+        $record = $result->fetch(PdoConstants::fetch_assoc());
+        if ($record === false) {
+            throw new \RuntimeException(
+                "Cannot reload the oversized row from table " .
+                $this->quote_identifier($this->current_table) .
+                ". The source row changed during export; run db-pull --abort and start again."
+            );
+        }
+
+        $this->current_row = $record;
+        $this->current_row_ends_query_batch = false;
+    }
+
     /** Returns whether the retained record is the final row of its bounded query. */
     public function is_current_record_at_query_batch_boundary()
     {
@@ -368,30 +412,7 @@ class DatabaseRowsReader {
      */
     private function build_select_query()
     {
-        $select = "SELECT";
-        if ($this->query_time_limit_ms !== null) {
-            // Prevent one slow table query from consuming the PHP time budget.
-            $select .= " /*+ MAX_EXECUTION_TIME(" . $this->query_time_limit_ms . ") */";
-        }
-
-        if ($this->current_column_types) {
-            $select_parts = [];
-            foreach ($this->current_column_types as $column => $column_info) {
-                $quoted_column = $this->quote_identifier($column);
-                if (
-                    $this->is_numeric_type($column_info["data_type"]) ||
-                    $this->is_binary_type($column_info["data_type"])
-                ) {
-                    $select_parts[] = $quoted_column;
-                } else {
-                    $select_parts[] = "CAST({$quoted_column} AS BINARY) AS {$quoted_column}";
-                }
-            }
-            $query = $select . " " . implode(", ", $select_parts) .
-                " FROM " . $this->quote_identifier($this->current_table);
-        } else {
-            $query = $select . " * FROM " . $this->quote_identifier($this->current_table);
-        }
+        $query = $this->build_byte_preserving_select_from_current_table();
 
         $where_conditions = $this->build_row_exclusion_where_conditions();
         if ($this->current_pk_columns && count($this->current_pk_columns) > 0) {
@@ -420,6 +441,37 @@ class DatabaseRowsReader {
                 $query .= " OFFSET {$this->current_offset}";
             }
         }
+        return $query;
+    }
+
+    /** Builds the byte-preserving SELECT prefix shared by ordered and exact-row reads. */
+    private function build_byte_preserving_select_from_current_table()
+    {
+        $select = "SELECT";
+        if ($this->query_time_limit_ms !== null) {
+            // Prevent one slow table query from consuming the PHP time budget.
+            $select .= " /*+ MAX_EXECUTION_TIME(" . $this->query_time_limit_ms . ") */";
+        }
+
+        if ($this->current_column_types) {
+            $select_parts = [];
+            foreach ($this->current_column_types as $column => $column_info) {
+                $quoted_column = $this->quote_identifier($column);
+                if (
+                    $this->is_numeric_type($column_info["data_type"]) ||
+                    $this->is_binary_type($column_info["data_type"])
+                ) {
+                    $select_parts[] = $quoted_column;
+                } else {
+                    $select_parts[] = "CAST({$quoted_column} AS BINARY) AS {$quoted_column}";
+                }
+            }
+            $query = $select . " " . implode(", ", $select_parts) .
+                " FROM " . $this->quote_identifier($this->current_table);
+        } else {
+            $query = $select . " * FROM " . $this->quote_identifier($this->current_table);
+        }
+
         return $query;
     }
 

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -164,7 +164,8 @@ class MySQLDumpProducer
         $this->db = $db;
         $this->emit_create_table = (bool) ( $options["create_table_query"] ?? true );
 
-        $source_max_allowed_packet = $this->detect_max_allowed_packet();
+        $detected_source_max_allowed_packet = $this->detect_max_allowed_packet();
+        $source_max_allowed_packet = $detected_source_max_allowed_packet ?? 1024 * 1024;
         $this->target_max_allowed_packet = isset($options["target_max_allowed_packet"])
             ? (int) $options["target_max_allowed_packet"]
             : $source_max_allowed_packet;
@@ -177,7 +178,9 @@ class MySQLDumpProducer
         if (isset($options["max_statement_size"])) {
             $this->max_statement_size = (int)$options["max_statement_size"];
         } else {
-            $this->max_statement_size = (int) ($source_max_allowed_packet * 0.8);
+            $this->max_statement_size = $detected_source_max_allowed_packet === null
+                ? 1024 * 1024
+                : (int) ($source_max_allowed_packet * 0.8);
         }
 
         $options["maximum_inline_spatial_bytes"] = min(
@@ -1164,7 +1167,7 @@ class MySQLDumpProducer
         return 15 + 4 * integer_divide($byte_length + 2, 3);
     }
 
-    /** Returns the source max_allowed_packet value, or 1 MiB when it cannot be read. */
+    /** Returns the source max_allowed_packet value, or null when it cannot be read. */
     private function detect_max_allowed_packet()
     {
         try {
@@ -1176,7 +1179,7 @@ class MySQLDumpProducer
         } catch (\Exception $e) {
         }
 
-        return 1024 * 1024;
+        return null;
     }
 
     /**

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -63,6 +63,8 @@ class MySQLDumpProducer
     public const ZERO_BYTE_SPATIAL_VALUE_COMMENT =
         "/* REPRINT: zero-byte spatial value */";
 
+    private const SPATIAL_STAGING_TABLE = "__reprint_db_pull_progress_spatial";
+
     const STATE_INIT = "init";
     const STATE_EMIT_HEADER = "emit_header";
     const STATE_NEXT_TABLE = "next_table";
@@ -122,9 +124,6 @@ class MySQLDumpProducer
 
     /** @var array|null */
     private $oversized_pk_values = null;
-
-    /** @var string|null Target table used to assemble complete spatial values. */
-    private $spatial_staging_table = null;
 
     /** @var bool Whether the dump has created its target spatial staging table. */
     private $spatial_staging_table_created = false;
@@ -656,7 +655,7 @@ class MySQLDumpProducer
         $footer = "\nCOMMIT;\n";
         if ($this->spatial_staging_table_created) {
             $quoted_staging_table = $this->row_reader->quote_identifier(
-                $this->spatial_staging_table
+                self::SPATIAL_STAGING_TABLE
             );
             $footer .= "DROP TABLE IF EXISTS {$quoted_staging_table};\n";
         }
@@ -724,7 +723,6 @@ class MySQLDumpProducer
          */
         $cursor_data["oversized_queue"] = $this->encode_oversized_queue_for_cursor($this->oversized_queue);
         $cursor_data["current_statement_size"] = $this->current_statement_size;
-        $cursor_data["spatial_staging_table"] = $this->spatial_staging_table;
         $cursor_data["spatial_staging_table_created"] = $this->spatial_staging_table_created;
         $cursor_data["nullable_spatial_columns"] = $this->nullable_spatial_columns;
         $cursor_data["pending_nullable_spatial_columns"] = $this->pending_nullable_spatial_columns;
@@ -848,29 +846,8 @@ class MySQLDumpProducer
                 );
             }
             $this->current_statement_size = $cursor_data["current_statement_size"] ?? 0;
-            $spatial_staging_table = $cursor_data["spatial_staging_table"] ?? null;
-            if (
-                $spatial_staging_table !== null &&
-                (
-                    !is_string($spatial_staging_table) ||
-                    !preg_match(
-                        '/^__reprint_db_pull_progress_spatial_[a-f0-9]{24}$/D',
-                        $spatial_staging_table
-                    )
-                )
-            ) {
-                throw new \InvalidArgumentException(
-                    "Invalid cursor: spatial_staging_table must be a Reprint staging table name"
-                );
-            }
-            $this->spatial_staging_table = $spatial_staging_table;
             $this->spatial_staging_table_created =
                 (bool) ( $cursor_data["spatial_staging_table_created"] ?? false );
-            if ($this->spatial_staging_table_created && $this->spatial_staging_table === null) {
-                throw new \InvalidArgumentException(
-                    "Invalid cursor: a created spatial staging table requires its table name"
-                );
-            }
             $this->nullable_spatial_columns = $this->decode_spatial_columns_from_cursor(
                 $cursor_data["nullable_spatial_columns"] ?? [],
                 "nullable_spatial_columns"
@@ -1230,11 +1207,6 @@ class MySQLDumpProducer
                         $placeholder_wkb_by_type[$normalized_data_type];
                     $replacement = $this->format_value($placeholder, 'LONGBLOB');
                     $spatial_placeholders[$col] = $replacement;
-                    if ($this->spatial_staging_table === null) {
-                        $this->spatial_staging_table =
-                            '__reprint_db_pull_progress_spatial_' .
-                            bin2hex(generate_random_bytes(12));
-                    }
                 }
                 $chunked_columns[$col] = true;
                 $replacement_bytes = strlen($replacement);
@@ -1389,7 +1361,7 @@ class MySQLDumpProducer
         $spatial_type = $this->row_reader->is_spatial_type($data_type);
         if ($spatial_type && !$this->spatial_staging_table_created) {
             $quoted_staging_table = $this->row_reader->quote_identifier(
-                $this->spatial_staging_table
+                self::SPATIAL_STAGING_TABLE
             );
             $this->current_sql_fragment =
                 "CREATE TABLE IF NOT EXISTS {$quoted_staging_table} (" .
@@ -1401,7 +1373,7 @@ class MySQLDumpProducer
         }
         if ($spatial_type && !$current['spatial_staging_initialized']) {
             $quoted_staging_table = $this->row_reader->quote_identifier(
-                $this->spatial_staging_table
+                self::SPATIAL_STAGING_TABLE
             );
             $this->current_sql_fragment =
                 "REPLACE INTO {$quoted_staging_table} (`id`, `value`) VALUES (1, '');";
@@ -1419,7 +1391,7 @@ class MySQLDumpProducer
             );
             $quoted_column = $this->row_reader->quote_identifier($column);
             $quoted_staging_table = $this->row_reader->quote_identifier(
-                $this->spatial_staging_table
+                self::SPATIAL_STAGING_TABLE
             );
             $this->current_sql_fragment =
                 "UPDATE {$quoted_table} SET {$quoted_column} = " .
@@ -1499,7 +1471,7 @@ class MySQLDumpProducer
 
         if ($spatial_type) {
             $quoted_staging_table = $this->row_reader->quote_identifier(
-                $this->spatial_staging_table
+                self::SPATIAL_STAGING_TABLE
             );
             $sql = "UPDATE {$quoted_staging_table} " .
                 "SET `value` = CONCAT(`value`, {$formatted_chunk}) " .

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -36,11 +36,9 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  *
  * Known limitations:
  *
- * - Rows too large to be SELECTed. If a row is larger than max_allowed_packet or the
- *   PHP memory_limit, it won't be exported. The underlying assumption is that WordPress
- *   wouldn't be able to use that data anyway. If that turns out to be wrong, and there
- *   are plugins that use huge blobs with byte offset queries, we'll need to add measures
- *   to detect those situations and export that data in chunks.
+ * - Large spatial values use byte-range queries, but other columns are still selected
+ *   whole. A non-spatial row larger than max_allowed_packet or PHP memory_limit cannot
+ *   be exported.
  * - Tables without a primary key can't use the oversized row handling as there's no
  *   stable row identifier for the UPDATE ... SET col = CONCAT(col, chunk) WHERE ... query.
  */
@@ -110,17 +108,20 @@ class MySQLDumpProducer
      */
     private $max_statement_size;
 
+    /** @var int Exact target max_allowed_packet used as the spatial value ceiling. */
+    private $target_max_allowed_packet;
+
     /**
      * When a row is too large for a single INSERT, its big columns are split
      * into chunks and queued here. Each entry tracks the column name, its
      * data type, the current byte offset into the value, and the total byte
      * length. Character columns also track a character offset because MySQL's
      * SUBSTRING() counts characters for those types. Spatial columns track
-     * whether their durable binary staging row is ready. The actual data is
+     * their staging id and next chunk number. The actual data is
      * re-fetched from the database on demand, keeping cursors small (a few
      * hundred bytes rather than megabytes of raw data).
      *
-     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int, character_offset?: int, spatial_staging_initialized?: bool, spatial_staging_id?: int}
+     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int, character_offset?: int, spatial_staging_id?: int, chunk_number?: int}
      */
     private $oversized_queue = [];
 
@@ -130,7 +131,7 @@ class MySQLDumpProducer
     /** @var bool Whether the dump has created its target spatial staging table. */
     private $spatial_staging_table_created = false;
 
-    /** @var array<string,int> Complete staging rows keyed by target column name. */
+    /** @var array<string,array{staging_id:int,chunk_count:int}> Complete staged chunks keyed by target column name. */
     private $staged_spatial_columns = [];
 
     /** @var int */
@@ -161,14 +162,30 @@ class MySQLDumpProducer
     public function __construct($db, $options = [])
     {
         $this->db = $db;
-        $this->row_reader = new DatabaseRowsReader($db, $options);
-        $this->emit_create_table = (bool)($options["create_table_query"] ?? true);
+        $this->emit_create_table = (bool) ( $options["create_table_query"] ?? true );
+
+        $source_max_allowed_packet = $this->detect_max_allowed_packet();
+        $this->target_max_allowed_packet = isset($options["target_max_allowed_packet"])
+            ? (int) $options["target_max_allowed_packet"]
+            : $source_max_allowed_packet;
+        if ($this->target_max_allowed_packet < 1) {
+            throw new \InvalidArgumentException(
+                "target_max_allowed_packet must be a positive byte count."
+            );
+        }
 
         if (isset($options["max_statement_size"])) {
             $this->max_statement_size = (int)$options["max_statement_size"];
         } else {
-            $this->max_statement_size = $this->detect_max_statement_size();
+            $this->max_statement_size = (int) ($source_max_allowed_packet * 0.8);
         }
+
+        $options["maximum_inline_spatial_bytes"] = min(
+            $this->max_statement_size,
+            (int) ($source_max_allowed_packet * 0.8),
+            $this->target_max_allowed_packet
+        );
+        $this->row_reader = new DatabaseRowsReader($db, $options);
 
         if (isset($options["cursor"])) {
             $this->initialize_from_cursor($options["cursor"]);
@@ -305,8 +322,8 @@ class MySQLDumpProducer
         }
 
         $current_record = $this->row_reader->get_current_record();
-        $has_zero_byte_spatial_value = $this->has_zero_byte_spatial_value($current_record);
-        $spatial_columns = $this->get_spatial_columns_to_make_nullable($current_record);
+        $has_zero_byte_spatial_value = $this->has_zero_byte_spatial_value();
+        $spatial_columns = $this->get_spatial_columns_to_make_nullable();
         if (!empty($spatial_columns)) {
             $this->reader_cursor_before_retained_record = $reader_cursor_before_current_record;
             $this->pending_nullable_spatial_columns = $spatial_columns;
@@ -385,9 +402,7 @@ class MySQLDumpProducer
             return true;
         }
 
-        $spatial_columns = $this->get_spatial_columns_to_make_nullable(
-            $this->row_reader->get_current_record()
-        );
+        $spatial_columns = $this->get_spatial_columns_to_make_nullable();
         if (!empty($spatial_columns)) {
             // Finish the INSERT before changing its table definition. The
             // retained row starts a new INSERT after the ALTER TABLE.
@@ -400,7 +415,7 @@ class MySQLDumpProducer
             return true;
         }
 
-        if ($this->has_zero_byte_spatial_value($this->row_reader->get_current_record())) {
+        if ($this->has_zero_byte_spatial_value()) {
             // MariaDB needs this row's INSERT column list to omit its
             // zero-byte geometry. Close the preceding multi-row INSERT and
             // retain the row for a one-row INSERT after this fragment.
@@ -526,14 +541,14 @@ class MySQLDumpProducer
     }
 
     /** Returns NOT NULL spatial columns which contain a zero-byte value in this row. */
-    private function get_spatial_columns_to_make_nullable($row)
+    private function get_spatial_columns_to_make_nullable()
     {
         $columns = [];
         foreach ($this->row_reader->get_current_column_names() as $column) {
             $column_metadata = $this->row_reader->get_column_metadata($column);
             if (
-                $row[$column] !== "" ||
                 !$this->row_reader->is_spatial_type($column_metadata["data_type"]) ||
+                $this->row_reader->get_current_spatial_value_length($column) !== 0 ||
                 $column_metadata["nullable"] ||
                 in_array($column, $this->nullable_spatial_columns, true)
             ) {
@@ -545,12 +560,12 @@ class MySQLDumpProducer
     }
 
     /** Returns whether this row contains a MariaDB zero-byte spatial placeholder. */
-    private function has_zero_byte_spatial_value($row)
+    private function has_zero_byte_spatial_value()
     {
         foreach ($this->row_reader->get_current_column_names() as $column) {
             if (
-                $row[$column] === "" &&
-                $this->row_reader->is_spatial_type($this->row_reader->get_data_type($column))
+                $this->row_reader->is_spatial_type($this->row_reader->get_data_type($column)) &&
+                $this->row_reader->get_current_spatial_value_length($column) === 0
             ) {
                 return true;
             }
@@ -759,10 +774,11 @@ class MySQLDumpProducer
         $cursor_data["current_statement_size"] = $this->current_statement_size;
         $cursor_data["spatial_staging_table_created"] = $this->spatial_staging_table_created;
         $cursor_data["staged_spatial_columns"] = [];
-        foreach ($this->staged_spatial_columns as $column => $staging_id) {
+        foreach ($this->staged_spatial_columns as $column => $staged_spatial_column) {
             $cursor_data["staged_spatial_columns"][] = [
                 "column" => $column,
-                "staging_id" => $staging_id,
+                "staging_id" => $staged_spatial_column["staging_id"],
+                "chunk_count" => $staged_spatial_column["chunk_count"],
             ];
         }
         $cursor_data["nullable_spatial_columns"] = $this->nullable_spatial_columns;
@@ -824,24 +840,18 @@ class MySQLDumpProducer
                 }
             }
             if ($this->row_reader->is_spatial_type($item['data_type'])) {
-                if (!array_key_exists('spatial_staging_initialized', $item)) {
-                    if ( (int) $item['byte_offset'] !== 0 ) {
-                        throw new \InvalidArgumentException(
-                            "Invalid cursor: an oversized spatial value with progress must" .
-                            " record whether its staging row was initialized"
-                        );
-                    }
-                    $decoded_item['spatial_staging_initialized'] = false;
-                } else {
-                    $decoded_item['spatial_staging_initialized'] =
-                        (bool) $item['spatial_staging_initialized'];
-                }
                 if (!isset($item['spatial_staging_id']) || (int) $item['spatial_staging_id'] < 1) {
                     throw new \InvalidArgumentException(
                         "Invalid cursor: an oversized spatial value requires a positive staging id"
                     );
                 }
                 $decoded_item['spatial_staging_id'] = (int) $item['spatial_staging_id'];
+                if (!isset($item['chunk_number']) || (int) $item['chunk_number'] < 0) {
+                    throw new \InvalidArgumentException(
+                        "Invalid cursor: an oversized spatial value requires a chunk number"
+                    );
+                }
+                $decoded_item['chunk_number'] = (int) $item['chunk_number'];
             }
             $decoded[] = $decoded_item;
         }
@@ -909,13 +919,19 @@ class MySQLDumpProducer
             foreach ($staged_spatial_columns as $staged_spatial_column) {
                 if (
                     !is_array($staged_spatial_column) ||
-                    !isset($staged_spatial_column["column"], $staged_spatial_column["staging_id"]) ||
+                    !isset(
+                        $staged_spatial_column["column"],
+                        $staged_spatial_column["staging_id"],
+                        $staged_spatial_column["chunk_count"]
+                    ) ||
                     !is_string($staged_spatial_column["column"]) ||
                     $staged_spatial_column["column"] === "" ||
-                    (int) $staged_spatial_column["staging_id"] < 1
+                    (int) $staged_spatial_column["staging_id"] < 1 ||
+                    (int) $staged_spatial_column["chunk_count"] < 1
                 ) {
                     throw new \InvalidArgumentException(
-                        "Invalid cursor: each staged spatial column requires a name and positive id"
+                        "Invalid cursor: each staged spatial column requires a name, positive id, " .
+                        "and positive chunk count"
                     );
                 }
                 $column = $staged_spatial_column["column"];
@@ -928,7 +944,10 @@ class MySQLDumpProducer
                         "Invalid cursor: staged spatial column names and ids must be unique"
                     );
                 }
-                $this->staged_spatial_columns[$column] = $staging_id;
+                $this->staged_spatial_columns[$column] = [
+                    "staging_id" => $staging_id,
+                    "chunk_count" => (int) $staged_spatial_column["chunk_count"],
+                ];
                 $staging_ids[$staging_id] = true;
             }
             foreach ($this->oversized_queue as $oversized_value) {
@@ -1136,14 +1155,23 @@ class MySQLDumpProducer
         return $wrapper_bytes + $estimated_base64_length;
     }
 
-    /** Auto-detects max_allowed_packet and uses 80% of it. Falls back to 1MB. */
-    private function detect_max_statement_size()
+    /** Estimates a non-null binary value from its raw byte length. */
+    private function estimate_formatted_binary_size($byte_length)
+    {
+        if ($byte_length === 0) {
+            return strlen("NULLIF(1, 1 " . self::ZERO_BYTE_SPATIAL_VALUE_COMMENT . ")");
+        }
+        return 15 + 4 * integer_divide($byte_length + 2, 3);
+    }
+
+    /** Returns the source max_allowed_packet value, or 1 MiB when it cannot be read. */
+    private function detect_max_allowed_packet()
     {
         try {
             $result = $this->db->query("SELECT @@max_allowed_packet as max_allowed_packet");
             $row = $result->fetch(PdoConstants::fetch_assoc());
             if ($row && isset($row['max_allowed_packet'])) {
-                return (int)($row['max_allowed_packet'] * 0.8);
+                return (int) $row['max_allowed_packet'];
             }
         } catch (\Exception $e) {
         }
@@ -1174,7 +1202,28 @@ class MySQLDumpProducer
             $value = $row[$col] ?? null;
             $raw_values[$col] = $value;
             $data_type = $this->row_reader->get_data_type($col);
-            $estimated_sizes[$col] = $this->estimate_formatted_size($value, $data_type);
+            if ($this->row_reader->is_spatial_type($data_type)) {
+                $spatial_value_length = $this->row_reader->get_current_spatial_value_length($col);
+                if (
+                    $spatial_value_length !== null &&
+                    $spatial_value_length > $this->target_max_allowed_packet
+                ) {
+                    // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
+                    throw new \RuntimeException(
+                        "Spatial column " .
+                        $this->row_reader->quote_identifier($this->row_reader->get_current_table()) . "." .
+                        $this->row_reader->quote_identifier($col) .
+                        " is {$spatial_value_length} bytes, but the target max_allowed_packet is " .
+                        "{$this->target_max_allowed_packet} bytes. Increase the target limit and start again."
+                    );
+                    // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                }
+                $estimated_sizes[$col] = $spatial_value_length === null
+                    ? 4
+                    : $this->estimate_formatted_binary_size($spatial_value_length);
+            } else {
+                $estimated_sizes[$col] = $this->estimate_formatted_size($value, $data_type);
+            }
         }
 
         $row_tuple_bytes = $this->estimate_formatted_row_tuple_bytes($row);
@@ -1195,6 +1244,15 @@ class MySQLDumpProducer
             $formatted_values = [];
             foreach ($this->row_reader->get_current_column_names() as $col) {
                 $data_type = $this->row_reader->get_data_type($col);
+                if (
+                    $this->row_reader->is_spatial_type($data_type) &&
+                    $this->row_reader->get_current_spatial_value_length($col) > 0 &&
+                    $raw_values[$col] === null
+                ) {
+                    throw new \LogicException(
+                        "A spatial value omitted from the row query cannot use a direct INSERT."
+                    );
+                }
                 $formatted_values[$col] = $this->format_value($raw_values[$col], $data_type);
             }
             return "(" . implode(",", array_values($formatted_values)) . ")";
@@ -1257,14 +1315,20 @@ class MySQLDumpProducer
                 break;
             }
 
-            $raw_value = $raw_values[$col];
-            if ($raw_value === null || $raw_value === '') {
-                continue;
-            }
-
             $data_type = $this->row_reader->get_data_type($col);
             $normalized_data_type = strtoupper($data_type);
             $spatial_type = $this->row_reader->is_spatial_type($normalized_data_type);
+            $raw_value = $raw_values[$col];
+            $spatial_value_length = $spatial_type
+                ? $this->row_reader->get_current_spatial_value_length($col)
+                : null;
+            if (
+                ( !$spatial_type && ( $raw_value === null || $raw_value === '' ) ) ||
+                ( $spatial_type &&
+                    ( $spatial_value_length === null || $spatial_value_length === 0 ) )
+            ) {
+                continue;
+            }
             if (
                 !$this->row_reader->is_binary_type($normalized_data_type) &&
                 !$this->row_reader->is_character_string_type($normalized_data_type) &&
@@ -1273,45 +1337,50 @@ class MySQLDumpProducer
                 $unchunkable_data_types[$normalized_data_type] = true;
                 continue;
             }
-            $value_length = strlen($raw_value);
-            $chunk_size = $this->compute_chunk_size($col);
-
-            if ($value_length > $chunk_size) {
-                $replacement = "''";
-                $staging_id = 0;
-                if ($spatial_type) {
-                    $staging_id = $this->staged_spatial_columns[$col] ??
-                        $next_spatial_staging_id;
-                    $quoted_staging_table = $this->row_reader->quote_identifier(
-                        self::SPATIAL_STAGING_TABLE
-                    );
-                    $replacement =
+            $value_length = $spatial_type
+                ? $spatial_value_length
+                : strlen($raw_value);
+            $replacement = "''";
+            $staging_id = 0;
+            if ($spatial_type) {
+                $staged_spatial_column = $this->staged_spatial_columns[$col] ?? null;
+                $staging_id = $staged_spatial_column["staging_id"] ??
+                    $next_spatial_staging_id;
+                $quoted_staging_table = $this->row_reader->quote_identifier(
+                    self::SPATIAL_STAGING_TABLE
+                );
+                $chunk_count = $staged_spatial_column["chunk_count"] ??
+                    (int) ceil($value_length / $this->compute_chunk_size($col));
+                $chunk_selects = [];
+                for ($chunk_number = 0; $chunk_number < $chunk_count; ++$chunk_number) {
+                    $chunk_selects[] =
                         "(SELECT `value` FROM {$quoted_staging_table} " .
-                        "WHERE `id` = {$staging_id})";
-                    $chunked_replacements[$col] = $replacement;
-                    ++$next_spatial_staging_id;
+                        "WHERE `id` = {$staging_id} AND `chunk_number` = {$chunk_number})";
                 }
-                $chunked_columns[$col] = true;
-                $replacement_bytes = strlen($replacement);
-                $saved_bytes += $size - $replacement_bytes;
-                $excess -= $size - $replacement_bytes;
+                $replacement = "CONCAT(" . implode(",", $chunk_selects) . ")";
+                $chunked_replacements[$col] = $replacement;
+                ++$next_spatial_staging_id;
+            }
+            $chunked_columns[$col] = true;
+            $replacement_bytes = strlen($replacement);
+            $saved_bytes += $size - $replacement_bytes;
+            $excess -= $size - $replacement_bytes;
 
-                $queue_item = [
-                    'column' => $col,
-                    'data_type' => $data_type,
-                    'byte_offset' => 0,
-                    'total_length' => $value_length,
-                ];
-                if ($this->row_reader->is_character_string_type($data_type)) {
-                    $queue_item['character_offset'] = 0;
-                }
-                if ($spatial_type && !isset($this->staged_spatial_columns[$col])) {
-                    $queue_item['spatial_staging_initialized'] = false;
-                    $queue_item['spatial_staging_id'] = $staging_id;
-                }
-                if (!$spatial_type || !isset($this->staged_spatial_columns[$col])) {
-                    $this->oversized_queue[] = $queue_item;
-                }
+            $queue_item = [
+                'column' => $col,
+                'data_type' => $data_type,
+                'byte_offset' => 0,
+                'total_length' => $value_length,
+            ];
+            if ($this->row_reader->is_character_string_type($data_type)) {
+                $queue_item['character_offset'] = 0;
+            }
+            if ($spatial_type && !isset($this->staged_spatial_columns[$col])) {
+                $queue_item['spatial_staging_id'] = $staging_id;
+                $queue_item['chunk_number'] = 0;
+            }
+            if (!$spatial_type || !isset($this->staged_spatial_columns[$col])) {
+                $this->oversized_queue[] = $queue_item;
             }
         }
 
@@ -1367,10 +1436,18 @@ class MySQLDumpProducer
             if ($column_index > 0) {
                 ++$tuple_bytes;
             }
-            $tuple_bytes += $this->estimate_formatted_size(
-                $row[$column] ?? null,
-                $this->row_reader->get_data_type($column)
-            );
+            $data_type = $this->row_reader->get_data_type($column);
+            if ($this->row_reader->is_spatial_type($data_type)) {
+                $spatial_value_length = $this->row_reader->get_current_spatial_value_length($column);
+                $tuple_bytes += $spatial_value_length === null
+                    ? 4
+                    : $this->estimate_formatted_binary_size($spatial_value_length);
+            } else {
+                $tuple_bytes += $this->estimate_formatted_size(
+                    $row[$column] ?? null,
+                    $data_type
+                );
+            }
             ++$column_index;
         }
         return $tuple_bytes;
@@ -1451,23 +1528,20 @@ class MySQLDumpProducer
         if (!$this->spatial_staging_table_created) {
             $this->current_sql_fragment =
                 "CREATE TABLE IF NOT EXISTS {$quoted_staging_table} (" .
-                "`id` INT UNSIGNED NOT NULL PRIMARY KEY," .
-                "`value` LONGBLOB NOT NULL" .
+                "`id` INT UNSIGNED NOT NULL," .
+                "`chunk_number` INT UNSIGNED NOT NULL," .
+                "`value` LONGBLOB NOT NULL," .
+                "PRIMARY KEY (`id`, `chunk_number`)" .
                 ") ENGINE=InnoDB;";
             $this->spatial_staging_table_created = true;
             return true;
         }
 
-        if (!$current['spatial_staging_initialized']) {
-            $this->current_sql_fragment =
-                "REPLACE INTO {$quoted_staging_table} (`id`, `value`) " .
-                "VALUES ({$staging_id}, '');";
-            $this->oversized_queue[$spatial_queue_index]['spatial_staging_initialized'] = true;
-            return true;
-        }
-
         if ($current['byte_offset'] >= $current['total_length']) {
-            $this->staged_spatial_columns[$current['column']] = $staging_id;
+            $this->staged_spatial_columns[$current['column']] = [
+                "staging_id" => $staging_id,
+                "chunk_count" => $current['chunk_number'],
+            ];
             unset($this->oversized_queue[$spatial_queue_index]);
             $this->oversized_queue = array_values($this->oversized_queue);
             return false;
@@ -1475,12 +1549,11 @@ class MySQLDumpProducer
 
         $chunk = $this->read_next_oversized_chunk($current);
         $formatted_chunk = $this->format_value($chunk['value'], 'LONGBLOB');
-        $byte_offset = $current['byte_offset'];
         $this->current_sql_fragment =
-            "UPDATE {$quoted_staging_table} " .
-            "SET `value` = CONCAT(`value`, {$formatted_chunk}) " .
-            "WHERE `id` = {$staging_id} AND OCTET_LENGTH(`value`) = {$byte_offset};";
+            "REPLACE INTO {$quoted_staging_table} (`id`, `chunk_number`, `value`) " .
+            "VALUES ({$staging_id}, {$current['chunk_number']}, {$formatted_chunk});";
         $this->oversized_queue[$spatial_queue_index]['byte_offset'] += $chunk['byte_length'];
+        ++$this->oversized_queue[$spatial_queue_index]['chunk_number'];
         return true;
     }
 

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -29,6 +29,9 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  *
  * For keyed rows, eligible large columns can be inserted as empty strings and then
  * filled via UPDATE ... SET col = CONCAT(col, chunk) statements.
+ * Spatial columns use a valid value of the same declared type while their exact
+ * bytes are assembled in a durable helper table. One final UPDATE replaces the
+ * valid value after every byte has arrived, then the dump footer drops the helper.
  *
  * Known limitations:
  *
@@ -108,7 +111,8 @@ class MySQLDumpProducer
      * into chunks and queued here. Each entry tracks the column name, its
      * data type, the current byte offset into the value, and the total byte
      * length. Character columns also track a character offset because MySQL's
-     * SUBSTRING() counts characters for those types. The actual data is
+     * SUBSTRING() counts characters for those types. Spatial columns track
+     * whether their durable binary staging row is ready. The actual data is
      * re-fetched from the database on demand, keeping cursors small (a few
      * hundred bytes rather than megabytes of raw data).
      *
@@ -118,6 +122,12 @@ class MySQLDumpProducer
 
     /** @var array|null */
     private $oversized_pk_values = null;
+
+    /** @var string|null Target table used to assemble complete spatial values. */
+    private $spatial_staging_table = null;
+
+    /** @var bool Whether the dump has created its target spatial staging table. */
+    private $spatial_staging_table_created = false;
 
     /** @var int */
     private $current_statement_size = 0;
@@ -643,8 +653,14 @@ class MySQLDumpProducer
     /** Emits COMMIT and restores the session variables saved in the header. */
     private function emit_sql_footer()
     {
-        $footer =
-            "\nCOMMIT;\n" .
+        $footer = "\nCOMMIT;\n";
+        if ($this->spatial_staging_table_created) {
+            $quoted_staging_table = $this->row_reader->quote_identifier(
+                $this->spatial_staging_table
+            );
+            $footer .= "DROP TABLE IF EXISTS {$quoted_staging_table};\n";
+        }
+        $footer .=
             "SET SQL_MODE=@OLD_SQL_MODE;\n" .
             "SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;\n" .
             "SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;\n";
@@ -708,6 +724,8 @@ class MySQLDumpProducer
          */
         $cursor_data["oversized_queue"] = $this->encode_oversized_queue_for_cursor($this->oversized_queue);
         $cursor_data["current_statement_size"] = $this->current_statement_size;
+        $cursor_data["spatial_staging_table"] = $this->spatial_staging_table;
+        $cursor_data["spatial_staging_table_created"] = $this->spatial_staging_table_created;
         $cursor_data["nullable_spatial_columns"] = $this->nullable_spatial_columns;
         $cursor_data["pending_nullable_spatial_columns"] = $this->pending_nullable_spatial_columns;
 
@@ -766,6 +784,20 @@ class MySQLDumpProducer
                     $decoded_item['character_offset'] = (int) $item['character_offset'];
                 }
             }
+            if ($this->row_reader->is_spatial_type($item['data_type'])) {
+                if (!array_key_exists('spatial_staging_initialized', $item)) {
+                    if ( (int) $item['byte_offset'] !== 0 ) {
+                        throw new \InvalidArgumentException(
+                            "Invalid cursor: an oversized spatial value with progress must" .
+                            " record whether its staging row was initialized"
+                        );
+                    }
+                    $decoded_item['spatial_staging_initialized'] = false;
+                } else {
+                    $decoded_item['spatial_staging_initialized'] =
+                        (bool) $item['spatial_staging_initialized'];
+                }
+            }
             $decoded[] = $decoded_item;
         }
         return $decoded;
@@ -816,6 +848,29 @@ class MySQLDumpProducer
                 );
             }
             $this->current_statement_size = $cursor_data["current_statement_size"] ?? 0;
+            $spatial_staging_table = $cursor_data["spatial_staging_table"] ?? null;
+            if (
+                $spatial_staging_table !== null &&
+                (
+                    !is_string($spatial_staging_table) ||
+                    !preg_match(
+                        '/^__reprint_db_pull_progress_spatial_[a-f0-9]{24}$/D',
+                        $spatial_staging_table
+                    )
+                )
+            ) {
+                throw new \InvalidArgumentException(
+                    "Invalid cursor: spatial_staging_table must be a Reprint staging table name"
+                );
+            }
+            $this->spatial_staging_table = $spatial_staging_table;
+            $this->spatial_staging_table_created =
+                (bool) ( $cursor_data["spatial_staging_table_created"] ?? false );
+            if ($this->spatial_staging_table_created && $this->spatial_staging_table === null) {
+                throw new \InvalidArgumentException(
+                    "Invalid cursor: a created spatial staging table requires its table name"
+                );
+            }
             $this->nullable_spatial_columns = $this->decode_spatial_columns_from_cursor(
                 $cursor_data["nullable_spatial_columns"] ?? [],
                 "nullable_spatial_columns"
@@ -1106,6 +1161,7 @@ class MySQLDumpProducer
 
         $this->oversized_queue = [];
         $chunked_columns = [];
+        $spatial_placeholders = [];
 
         $excess = max(
             $projected_statement_size - $maximum_insert_statement_bytes,
@@ -1134,9 +1190,11 @@ class MySQLDumpProducer
 
             $data_type = $this->row_reader->get_data_type($col);
             $normalized_data_type = strtoupper($data_type);
+            $spatial_type = $this->row_reader->is_spatial_type($normalized_data_type);
             if (
                 !$this->row_reader->is_binary_type($normalized_data_type) &&
-                !$this->row_reader->is_character_string_type($normalized_data_type)
+                !$this->row_reader->is_character_string_type($normalized_data_type) &&
+                !$spatial_type
             ) {
                 $unchunkable_data_types[$normalized_data_type] = true;
                 continue;
@@ -1145,9 +1203,43 @@ class MySQLDumpProducer
             $chunk_size = $this->compute_chunk_size($col);
 
             if ($value_length > $chunk_size) {
+                $replacement = "''";
+                if ($spatial_type) {
+                    $unpacked_srid = unpack('Vsrid', substr($raw_value, 0, 4));
+                    // Raw geometry bytes work for MySQL, MariaDB, and the
+                    // MySQL-on-SQLite target, which has no ST_GeomFromText().
+                    $point_wkb = pack('CVe2', 1, 1, 0.0, 0.0);
+                    $linestring_wkb =
+                        pack('CVV', 1, 2, 2) . pack('e4', 0.0, 0.0, 1.0, 1.0);
+                    $polygon_wkb =
+                        pack('CVVV', 1, 3, 1, 4) .
+                        pack('e8', 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+                    $placeholder_wkb_by_type = [
+                        'GEOMETRY' => $point_wkb,
+                        'POINT' => $point_wkb,
+                        'LINESTRING' => $linestring_wkb,
+                        'POLYGON' => $polygon_wkb,
+                        'MULTIPOINT' => pack('CVV', 1, 4, 1) . $point_wkb,
+                        'MULTILINESTRING' => pack('CVV', 1, 5, 1) . $linestring_wkb,
+                        'MULTIPOLYGON' => pack('CVV', 1, 6, 1) . $polygon_wkb,
+                        'GEOMCOLLECTION' => pack('CVV', 1, 7, 1) . $point_wkb,
+                        'GEOMETRYCOLLECTION' => pack('CVV', 1, 7, 1) . $point_wkb,
+                    ];
+                    $placeholder =
+                        pack('V', (int) $unpacked_srid['srid']) .
+                        $placeholder_wkb_by_type[$normalized_data_type];
+                    $replacement = $this->format_value($placeholder, 'LONGBLOB');
+                    $spatial_placeholders[$col] = $replacement;
+                    if ($this->spatial_staging_table === null) {
+                        $this->spatial_staging_table =
+                            '__reprint_db_pull_progress_spatial_' .
+                            bin2hex(generate_random_bytes(12));
+                    }
+                }
                 $chunked_columns[$col] = true;
-                $saved_bytes += $size - 2; // Saved bytes (size minus the '' replacement)
-                $excess -= $size - 2;
+                $replacement_bytes = strlen($replacement);
+                $saved_bytes += $size - $replacement_bytes;
+                $excess -= $size - $replacement_bytes;
 
                 $queue_item = [
                     'column' => $col,
@@ -1157,6 +1249,9 @@ class MySQLDumpProducer
                 ];
                 if ($this->row_reader->is_character_string_type($data_type)) {
                     $queue_item['character_offset'] = 0;
+                }
+                if ($spatial_type) {
+                    $queue_item['spatial_staging_initialized'] = false;
                 }
                 $this->oversized_queue[] = $queue_item;
             }
@@ -1195,7 +1290,7 @@ class MySQLDumpProducer
         $formatted_values = [];
         foreach ($this->row_reader->get_current_column_names() as $col) {
             if (isset($chunked_columns[$col])) {
-                $formatted_values[$col] = "''";
+                $formatted_values[$col] = $spatial_placeholders[$col] ?? "''";
                 continue;
             }
             $data_type = $this->row_reader->get_data_type($col);
@@ -1291,6 +1386,49 @@ class MySQLDumpProducer
         $byte_offset = $current['byte_offset'];
         $total_length = $current['total_length'];
 
+        $spatial_type = $this->row_reader->is_spatial_type($data_type);
+        if ($spatial_type && !$this->spatial_staging_table_created) {
+            $quoted_staging_table = $this->row_reader->quote_identifier(
+                $this->spatial_staging_table
+            );
+            $this->current_sql_fragment =
+                "CREATE TABLE IF NOT EXISTS {$quoted_staging_table} (" .
+                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
+                "`value` LONGBLOB NOT NULL" .
+                ") ENGINE=InnoDB;";
+            $this->spatial_staging_table_created = true;
+            return true;
+        }
+        if ($spatial_type && !$current['spatial_staging_initialized']) {
+            $quoted_staging_table = $this->row_reader->quote_identifier(
+                $this->spatial_staging_table
+            );
+            $this->current_sql_fragment =
+                "REPLACE INTO {$quoted_staging_table} (`id`, `value`) VALUES (1, '');";
+            $this->oversized_queue[0]['spatial_staging_initialized'] = true;
+            return true;
+        }
+        if ($spatial_type && $byte_offset >= $total_length) {
+            $where_parts = [];
+            foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
+                $where_parts[] = $this->row_reader->build_comparison($pk_col, $pk_value, "=");
+            }
+            $where_clause = implode(" AND ", $where_parts);
+            $quoted_table = $this->row_reader->quote_identifier(
+                $this->row_reader->get_current_table()
+            );
+            $quoted_column = $this->row_reader->quote_identifier($column);
+            $quoted_staging_table = $this->row_reader->quote_identifier(
+                $this->spatial_staging_table
+            );
+            $this->current_sql_fragment =
+                "UPDATE {$quoted_table} SET {$quoted_column} = " .
+                "(SELECT `value` FROM {$quoted_staging_table} WHERE `id` = 1) " .
+                "WHERE {$where_clause};";
+            array_shift($this->oversized_queue);
+            return true;
+        }
+
         $chunk_size = $this->compute_chunk_size($column);
 
         // MySQL SUBSTRING() counts characters for character strings, while
@@ -1348,7 +1486,10 @@ class MySQLDumpProducer
             // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
 
-        $formatted_chunk = $this->format_value($chunk, $data_type);
+        $formatted_chunk = $this->format_value(
+            $chunk,
+            $spatial_type ? 'LONGBLOB' : $data_type
+        );
 
         $where_parts = [];
         foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
@@ -1356,9 +1497,18 @@ class MySQLDumpProducer
         }
         $where_clause = implode(" AND ", $where_parts);
 
-        $quoted_table = $this->row_reader->quote_identifier($this->row_reader->get_current_table());
-        $quoted_column = $this->row_reader->quote_identifier($column);
-        $sql = "UPDATE {$quoted_table} SET {$quoted_column} = CONCAT({$quoted_column}, {$formatted_chunk}) WHERE {$where_clause};";
+        if ($spatial_type) {
+            $quoted_staging_table = $this->row_reader->quote_identifier(
+                $this->spatial_staging_table
+            );
+            $sql = "UPDATE {$quoted_staging_table} " .
+                "SET `value` = CONCAT(`value`, {$formatted_chunk}) " .
+                "WHERE `id` = 1 AND OCTET_LENGTH(`value`) = {$byte_offset};";
+        } else {
+            $quoted_table = $this->row_reader->quote_identifier($this->row_reader->get_current_table());
+            $quoted_column = $this->row_reader->quote_identifier($column);
+            $sql = "UPDATE {$quoted_table} SET {$quoted_column} = CONCAT({$quoted_column}, {$formatted_chunk}) WHERE {$where_clause};";
+        }
 
         $this->current_sql_fragment = $sql;
 
@@ -1366,7 +1516,10 @@ class MySQLDumpProducer
         if ($character_string) {
             $this->oversized_queue[0]['character_offset'] += $chunk_result['value_length'];
         }
-        if ($this->oversized_queue[0]['byte_offset'] >= $total_length) {
+        if (
+            !$spatial_type &&
+            $this->oversized_queue[0]['byte_offset'] >= $total_length
+        ) {
             array_shift($this->oversized_queue);
         }
 

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -19,7 +19,8 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  *
  *   INIT → EMIT_HEADER → NEXT_TABLE → CREATE_TABLE → TABLE_HEADER →
  *   START_INSERT ⇄ EMIT_ROW → (EMIT_NULLABLE_SPATIAL_COLUMNS) →
- *   (EMIT_OVERSIZED_UPDATE) → … → EMIT_FOOTER → FINISHED
+ *   (STAGE_OVERSIZED_SPATIAL) → (EMIT_OVERSIZED_UPDATE) → … →
+ *   EMIT_FOOTER → FINISHED
  *
  * All values are base64-encoded in the SQL output (via FROM_BASE64('...')). This avoids
  * charset-related corruption: MySQL interprets string literals according to the
@@ -27,11 +28,11 @@ require_once __DIR__ . "/class-database-rows-reader.php";
  * directly to the column's declared charset. JSON columns are a special case — MySQL
  * rejects binary charset input for JSON, so those get an extra CONVERT(... USING utf8mb4).
  *
- * For keyed rows, eligible large columns can be inserted as empty strings and then
- * filled via UPDATE ... SET col = CONCAT(col, chunk) statements.
- * Spatial columns use a valid value of the same declared type while their exact
- * bytes are assembled in a durable helper table. One final UPDATE replaces the
- * valid value after every byte has arrived, then the dump footer drops the helper.
+ * For keyed rows, eligible large text and binary columns can be inserted as empty
+ * strings and then filled via UPDATE ... SET col = CONCAT(col, chunk) statements.
+ * Complete spatial values are assembled in a durable helper table before the row
+ * is inserted, so constraints never inspect an invented geometry. The INSERT reads
+ * the complete bytes from the helper, then the dump footer drops the helper.
  *
  * Known limitations:
  *
@@ -73,6 +74,7 @@ class MySQLDumpProducer
     const STATE_START_INSERT = "start_insert";
     const STATE_EMIT_ROW = "emit_row";
     const STATE_EMIT_NULLABLE_SPATIAL_COLUMNS = "emit_nullable_spatial_columns";
+    const STATE_STAGE_OVERSIZED_SPATIAL = "stage_oversized_spatial";
     const STATE_EMIT_OVERSIZED_UPDATE = "emit_oversized_update";
     const STATE_EMIT_FOOTER = "emit_footer";
     const STATE_FINISHED = "finished";
@@ -100,9 +102,9 @@ class MySQLDumpProducer
 
     /**
      * Derived from MySQL's max_allowed_packet (at 80% to leave headroom for
-     * protocol framing). Rows whose formatted SQL exceeds this limit are split
-     * into an INSERT with empty placeholders followed by UPDATE ... CONCAT()
-     * statements that append the real data in chunks.
+     * protocol framing). Rows whose formatted SQL exceeds this limit use
+     * empty text or binary values followed by UPDATE ... CONCAT() chunks.
+     * Spatial values are staged completely before their INSERT.
      *
      * @var int
      */
@@ -118,7 +120,7 @@ class MySQLDumpProducer
      * re-fetched from the database on demand, keeping cursors small (a few
      * hundred bytes rather than megabytes of raw data).
      *
-     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int, character_offset?: int}
+     * @var array Array of {column: string, data_type: string, byte_offset: int, total_length: int, character_offset?: int, spatial_staging_initialized?: bool, spatial_staging_id?: int}
      */
     private $oversized_queue = [];
 
@@ -127,6 +129,9 @@ class MySQLDumpProducer
 
     /** @var bool Whether the dump has created its target spatial staging table. */
     private $spatial_staging_table_created = false;
+
+    /** @var array<string,int> Complete staging rows keyed by target column name. */
+    private $staged_spatial_columns = [];
 
     /** @var int */
     private $current_statement_size = 0;
@@ -258,6 +263,13 @@ class MySQLDumpProducer
                     $this->current_fragment_must_be_its_own_part = true;
                     return true;
 
+                case self::STATE_STAGE_OVERSIZED_SPATIAL:
+                    if ($this->stage_oversized_spatial_value()) {
+                        $this->current_fragment_must_be_its_own_part = true;
+                        return true;
+                    }
+                    break;
+
                 case self::STATE_EMIT_OVERSIZED_UPDATE:
                     if ($this->emit_oversized_update()) {
                         $this->current_fragment_must_be_its_own_part = true;
@@ -319,6 +331,17 @@ class MySQLDumpProducer
         );
         $this->current_statement_size += strlen($first_row_sql);
 
+        if ($this->has_pending_spatial_staging()) {
+            // Keep this row out of the target until each spatial value is
+            // complete. The ordered reader remains after this row. A resumed
+            // producer re-fetches it by primary key for the final INSERT.
+            $this->reader_cursor_before_retained_record = null;
+            $this->current_statement_size = 0;
+            $this->rows_in_batch = 0;
+            $this->state = self::STATE_STAGE_OVERSIZED_SPATIAL;
+            return false;
+        }
+
         $this->row_reader->clear_current_record();
         $this->reader_cursor_before_retained_record = null;
         $this->rows_in_batch = 1;
@@ -326,6 +349,7 @@ class MySQLDumpProducer
         // Oversized updates require closing this INSERT with a semicolon so the
         // subsequent UPDATE statements are syntactically separate.
         $has_oversized = $this->has_pending_oversized_updates();
+        $this->staged_spatial_columns = [];
 
         if (
             $current_record_ends_query_batch ||
@@ -415,11 +439,20 @@ class MySQLDumpProducer
             $this->row_reader->get_current_record(),
             strlen($this->on_duplicate_key()) + 1
         );
+        if ($this->has_pending_spatial_staging()) {
+            $this->reader_cursor_before_retained_record = null;
+            $this->current_sql_fragment = $this->on_duplicate_key() . ';';
+            $this->current_statement_size = 0;
+            $this->rows_in_batch = 0;
+            $this->state = self::STATE_STAGE_OVERSIZED_SPATIAL;
+            return true;
+        }
         $this->current_statement_size += strlen($row_sql) + 1;
         $this->row_reader->clear_current_record();
         $this->rows_in_batch++;
 
         $has_oversized = $this->has_pending_oversized_updates();
+        $this->staged_spatial_columns = [];
 
         if (
             $current_record_ends_query_batch ||
@@ -681,6 +714,7 @@ class MySQLDumpProducer
             $this->rows_in_batch = 0;
             $this->oversized_queue = [];
             $this->oversized_pk_values = null;
+            $this->staged_spatial_columns = [];
             $this->current_statement_size = 0;
             $this->reader_cursor_before_retained_record = null;
             $this->nullable_spatial_columns = [];
@@ -724,6 +758,13 @@ class MySQLDumpProducer
         $cursor_data["oversized_queue"] = $this->encode_oversized_queue_for_cursor($this->oversized_queue);
         $cursor_data["current_statement_size"] = $this->current_statement_size;
         $cursor_data["spatial_staging_table_created"] = $this->spatial_staging_table_created;
+        $cursor_data["staged_spatial_columns"] = [];
+        foreach ($this->staged_spatial_columns as $column => $staging_id) {
+            $cursor_data["staged_spatial_columns"][] = [
+                "column" => $column,
+                "staging_id" => $staging_id,
+            ];
+        }
         $cursor_data["nullable_spatial_columns"] = $this->nullable_spatial_columns;
         $cursor_data["pending_nullable_spatial_columns"] = $this->pending_nullable_spatial_columns;
 
@@ -795,6 +836,12 @@ class MySQLDumpProducer
                     $decoded_item['spatial_staging_initialized'] =
                         (bool) $item['spatial_staging_initialized'];
                 }
+                if (!isset($item['spatial_staging_id']) || (int) $item['spatial_staging_id'] < 1) {
+                    throw new \InvalidArgumentException(
+                        "Invalid cursor: an oversized spatial value requires a positive staging id"
+                    );
+                }
+                $decoded_item['spatial_staging_id'] = (int) $item['spatial_staging_id'];
             }
             $decoded[] = $decoded_item;
         }
@@ -838,9 +885,12 @@ class MySQLDumpProducer
             $encoded_queue = $cursor_data["oversized_queue"] ?? [];
             $this->oversized_queue = $this->decode_oversized_queue_from_cursor($encoded_queue);
             $this->oversized_pk_values = null;
-            if ($this->state === self::STATE_EMIT_OVERSIZED_UPDATE) {
+            if (
+                $this->state === self::STATE_STAGE_OVERSIZED_SPATIAL ||
+                $this->state === self::STATE_EMIT_OVERSIZED_UPDATE
+            ) {
                 // The last emitted primary key identifies the row whose
-                // oversized columns are still being appended.
+                // oversized values are being staged or appended.
                 $this->oversized_pk_values = $this->row_reader->decode_database_values_from_cursor(
                     $cursor_data["last_pk_values"] ?? null
                 );
@@ -848,6 +898,51 @@ class MySQLDumpProducer
             $this->current_statement_size = $cursor_data["current_statement_size"] ?? 0;
             $this->spatial_staging_table_created =
                 (bool) ( $cursor_data["spatial_staging_table_created"] ?? false );
+            $staged_spatial_columns = $cursor_data["staged_spatial_columns"] ?? [];
+            if (!is_array($staged_spatial_columns)) {
+                throw new \InvalidArgumentException(
+                    "Invalid cursor: staged_spatial_columns must be an array"
+                );
+            }
+            $this->staged_spatial_columns = [];
+            $staging_ids = [];
+            foreach ($staged_spatial_columns as $staged_spatial_column) {
+                if (
+                    !is_array($staged_spatial_column) ||
+                    !isset($staged_spatial_column["column"], $staged_spatial_column["staging_id"]) ||
+                    !is_string($staged_spatial_column["column"]) ||
+                    $staged_spatial_column["column"] === "" ||
+                    (int) $staged_spatial_column["staging_id"] < 1
+                ) {
+                    throw new \InvalidArgumentException(
+                        "Invalid cursor: each staged spatial column requires a name and positive id"
+                    );
+                }
+                $column = $staged_spatial_column["column"];
+                $staging_id = (int) $staged_spatial_column["staging_id"];
+                if (
+                    isset($this->staged_spatial_columns[$column]) ||
+                    isset($staging_ids[$staging_id])
+                ) {
+                    throw new \InvalidArgumentException(
+                        "Invalid cursor: staged spatial column names and ids must be unique"
+                    );
+                }
+                $this->staged_spatial_columns[$column] = $staging_id;
+                $staging_ids[$staging_id] = true;
+            }
+            foreach ($this->oversized_queue as $oversized_value) {
+                if (!$this->row_reader->is_spatial_type($oversized_value["data_type"])) {
+                    continue;
+                }
+                $staging_id = $oversized_value["spatial_staging_id"];
+                if (isset($staging_ids[$staging_id])) {
+                    throw new \InvalidArgumentException(
+                        "Invalid cursor: oversized spatial staging ids must be unique"
+                    );
+                }
+                $staging_ids[$staging_id] = true;
+            }
             $this->nullable_spatial_columns = $this->decode_spatial_columns_from_cursor(
                 $cursor_data["nullable_spatial_columns"] ?? [],
                 "nullable_spatial_columns"
@@ -1062,8 +1157,9 @@ class MySQLDumpProducer
      * The approach is estimate-first: compute the approximate encoded size of
      * each column before doing the actual (expensive) base64 encoding. If the
      * row fits the statement and part-body limits, encode everything. If it
-     * doesn't, replace eligible large non-PK columns with '' and queue their
-     * real values as UPDATE ... CONCAT() chunks in $this->oversized_queue.
+     * doesn't, replace eligible large non-PK text and binary columns with ''
+     * and queue their real values as UPDATE ... CONCAT() chunks. Spatial
+     * values use scalar subqueries after their complete bytes are staged.
      *
      * Tables without a primary key can't use the UPDATE fallback because
      * there is no stable row identifier for the WHERE clause. Reject those
@@ -1138,7 +1234,8 @@ class MySQLDumpProducer
 
         $this->oversized_queue = [];
         $chunked_columns = [];
-        $spatial_placeholders = [];
+        $chunked_replacements = [];
+        $next_spatial_staging_id = 1;
 
         $excess = max(
             $projected_statement_size - $maximum_insert_statement_bytes,
@@ -1181,32 +1278,18 @@ class MySQLDumpProducer
 
             if ($value_length > $chunk_size) {
                 $replacement = "''";
+                $staging_id = 0;
                 if ($spatial_type) {
-                    $unpacked_srid = unpack('Vsrid', substr($raw_value, 0, 4));
-                    // Raw geometry bytes work for MySQL, MariaDB, and the
-                    // MySQL-on-SQLite target, which has no ST_GeomFromText().
-                    $point_wkb = pack('CVe2', 1, 1, 0.0, 0.0);
-                    $linestring_wkb =
-                        pack('CVV', 1, 2, 2) . pack('e4', 0.0, 0.0, 1.0, 1.0);
-                    $polygon_wkb =
-                        pack('CVVV', 1, 3, 1, 4) .
-                        pack('e8', 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-                    $placeholder_wkb_by_type = [
-                        'GEOMETRY' => $point_wkb,
-                        'POINT' => $point_wkb,
-                        'LINESTRING' => $linestring_wkb,
-                        'POLYGON' => $polygon_wkb,
-                        'MULTIPOINT' => pack('CVV', 1, 4, 1) . $point_wkb,
-                        'MULTILINESTRING' => pack('CVV', 1, 5, 1) . $linestring_wkb,
-                        'MULTIPOLYGON' => pack('CVV', 1, 6, 1) . $polygon_wkb,
-                        'GEOMCOLLECTION' => pack('CVV', 1, 7, 1) . $point_wkb,
-                        'GEOMETRYCOLLECTION' => pack('CVV', 1, 7, 1) . $point_wkb,
-                    ];
-                    $placeholder =
-                        pack('V', (int) $unpacked_srid['srid']) .
-                        $placeholder_wkb_by_type[$normalized_data_type];
-                    $replacement = $this->format_value($placeholder, 'LONGBLOB');
-                    $spatial_placeholders[$col] = $replacement;
+                    $staging_id = $this->staged_spatial_columns[$col] ??
+                        $next_spatial_staging_id;
+                    $quoted_staging_table = $this->row_reader->quote_identifier(
+                        self::SPATIAL_STAGING_TABLE
+                    );
+                    $replacement =
+                        "(SELECT `value` FROM {$quoted_staging_table} " .
+                        "WHERE `id` = {$staging_id})";
+                    $chunked_replacements[$col] = $replacement;
+                    ++$next_spatial_staging_id;
                 }
                 $chunked_columns[$col] = true;
                 $replacement_bytes = strlen($replacement);
@@ -1222,10 +1305,13 @@ class MySQLDumpProducer
                 if ($this->row_reader->is_character_string_type($data_type)) {
                     $queue_item['character_offset'] = 0;
                 }
-                if ($spatial_type) {
+                if ($spatial_type && !isset($this->staged_spatial_columns[$col])) {
                     $queue_item['spatial_staging_initialized'] = false;
+                    $queue_item['spatial_staging_id'] = $staging_id;
                 }
-                $this->oversized_queue[] = $queue_item;
+                if (!$spatial_type || !isset($this->staged_spatial_columns[$col])) {
+                    $this->oversized_queue[] = $queue_item;
+                }
             }
         }
 
@@ -1262,7 +1348,7 @@ class MySQLDumpProducer
         $formatted_values = [];
         foreach ($this->row_reader->get_current_column_names() as $col) {
             if (isset($chunked_columns[$col])) {
-                $formatted_values[$col] = $spatial_placeholders[$col] ?? "''";
+                $formatted_values[$col] = $chunked_replacements[$col] ?? "''";
                 continue;
             }
             $data_type = $this->row_reader->get_data_type($col);
@@ -1334,6 +1420,70 @@ class MySQLDumpProducer
         return (int)$size;
     }
 
+    /** Builds complete spatial values before their target row is inserted. */
+    private function stage_oversized_spatial_value()
+    {
+        $spatial_queue_index = null;
+        foreach ($this->oversized_queue as $queue_index => $queue_item) {
+            if ($this->row_reader->is_spatial_type($queue_item['data_type'])) {
+                $spatial_queue_index = $queue_index;
+                break;
+            }
+        }
+
+        if ($spatial_queue_index === null) {
+            // The row is re-formatted after staging. That pass rebuilds any
+            // text and binary updates which must run after the INSERT.
+            $this->oversized_queue = [];
+            if ($this->row_reader->get_current_record() === null) {
+                $this->row_reader->reload_current_record($this->oversized_pk_values);
+            }
+            $this->state = self::STATE_START_INSERT;
+            return false;
+        }
+
+        $current = $this->oversized_queue[$spatial_queue_index];
+        $staging_id = $current['spatial_staging_id'];
+        $quoted_staging_table = $this->row_reader->quote_identifier(
+            self::SPATIAL_STAGING_TABLE
+        );
+
+        if (!$this->spatial_staging_table_created) {
+            $this->current_sql_fragment =
+                "CREATE TABLE IF NOT EXISTS {$quoted_staging_table} (" .
+                "`id` INT UNSIGNED NOT NULL PRIMARY KEY," .
+                "`value` LONGBLOB NOT NULL" .
+                ") ENGINE=InnoDB;";
+            $this->spatial_staging_table_created = true;
+            return true;
+        }
+
+        if (!$current['spatial_staging_initialized']) {
+            $this->current_sql_fragment =
+                "REPLACE INTO {$quoted_staging_table} (`id`, `value`) " .
+                "VALUES ({$staging_id}, '');";
+            $this->oversized_queue[$spatial_queue_index]['spatial_staging_initialized'] = true;
+            return true;
+        }
+
+        if ($current['byte_offset'] >= $current['total_length']) {
+            $this->staged_spatial_columns[$current['column']] = $staging_id;
+            unset($this->oversized_queue[$spatial_queue_index]);
+            $this->oversized_queue = array_values($this->oversized_queue);
+            return false;
+        }
+
+        $chunk = $this->read_next_oversized_chunk($current);
+        $formatted_chunk = $this->format_value($chunk['value'], 'LONGBLOB');
+        $byte_offset = $current['byte_offset'];
+        $this->current_sql_fragment =
+            "UPDATE {$quoted_staging_table} " .
+            "SET `value` = CONCAT(`value`, {$formatted_chunk}) " .
+            "WHERE `id` = {$staging_id} AND OCTET_LENGTH(`value`) = {$byte_offset};";
+        $this->oversized_queue[$spatial_queue_index]['byte_offset'] += $chunk['byte_length'];
+        return true;
+    }
+
     /**
      * Emits one UPDATE ... SET col = CONCAT(col, chunk) statement.
      *
@@ -1358,49 +1508,65 @@ class MySQLDumpProducer
         $byte_offset = $current['byte_offset'];
         $total_length = $current['total_length'];
 
-        $spatial_type = $this->row_reader->is_spatial_type($data_type);
-        if ($spatial_type && !$this->spatial_staging_table_created) {
-            $quoted_staging_table = $this->row_reader->quote_identifier(
-                self::SPATIAL_STAGING_TABLE
+        if ($this->row_reader->is_spatial_type($data_type)) {
+            throw new \LogicException(
+                "Spatial values must be complete before their target row is inserted."
             );
-            $this->current_sql_fragment =
-                "CREATE TABLE IF NOT EXISTS {$quoted_staging_table} (" .
-                "`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY," .
-                "`value` LONGBLOB NOT NULL" .
-                ") ENGINE=InnoDB;";
-            $this->spatial_staging_table_created = true;
-            return true;
-        }
-        if ($spatial_type && !$current['spatial_staging_initialized']) {
-            $quoted_staging_table = $this->row_reader->quote_identifier(
-                self::SPATIAL_STAGING_TABLE
-            );
-            $this->current_sql_fragment =
-                "REPLACE INTO {$quoted_staging_table} (`id`, `value`) VALUES (1, '');";
-            $this->oversized_queue[0]['spatial_staging_initialized'] = true;
-            return true;
-        }
-        if ($spatial_type && $byte_offset >= $total_length) {
-            $where_parts = [];
-            foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
-                $where_parts[] = $this->row_reader->build_comparison($pk_col, $pk_value, "=");
-            }
-            $where_clause = implode(" AND ", $where_parts);
-            $quoted_table = $this->row_reader->quote_identifier(
-                $this->row_reader->get_current_table()
-            );
-            $quoted_column = $this->row_reader->quote_identifier($column);
-            $quoted_staging_table = $this->row_reader->quote_identifier(
-                self::SPATIAL_STAGING_TABLE
-            );
-            $this->current_sql_fragment =
-                "UPDATE {$quoted_table} SET {$quoted_column} = " .
-                "(SELECT `value` FROM {$quoted_staging_table} WHERE `id` = 1) " .
-                "WHERE {$where_clause};";
-            array_shift($this->oversized_queue);
-            return true;
         }
 
+        $chunk = $this->read_next_oversized_chunk($current);
+        $formatted_chunk = $this->format_value($chunk['value'], $data_type);
+
+        $where_parts = [];
+        foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
+            $where_parts[] = $this->row_reader->build_comparison($pk_col, $pk_value, "=");
+        }
+        $where_clause = implode(" AND ", $where_parts);
+
+        $quoted_table = $this->row_reader->quote_identifier($this->row_reader->get_current_table());
+        $quoted_column = $this->row_reader->quote_identifier($column);
+        $this->current_sql_fragment =
+            "UPDATE {$quoted_table} SET {$quoted_column} = " .
+            "CONCAT({$quoted_column}, {$formatted_chunk}) WHERE {$where_clause};";
+
+        $this->oversized_queue[0]['byte_offset'] += $chunk['byte_length'];
+        if ($chunk['character_string']) {
+            $this->oversized_queue[0]['character_offset'] += $chunk['value_length'];
+        }
+        if ($this->oversized_queue[0]['byte_offset'] >= $total_length) {
+            array_shift($this->oversized_queue);
+        }
+
+        return true;
+    }
+
+    /**
+     * Reads and validates one bounded piece of an oversized source value.
+     *
+     * @param array $current {
+     *     Oversized value progress.
+     *
+     *     @type string $column           Column name.
+     *     @type string $data_type        Column data type.
+     *     @type int    $byte_offset      Next byte offset.
+     *     @type int    $total_length     Complete value length in bytes.
+     *     @type int    $character_offset Next character offset for text values.
+     * }
+     * @return array {
+     *     The next bounded source piece.
+     *
+     *     @type string $value            Raw bytes.
+     *     @type int    $byte_length      Raw byte length.
+     *     @type int    $value_length     Character or byte length used by the source range.
+     *     @type bool   $character_string Whether the source range counts characters.
+     * }
+     */
+    private function read_next_oversized_chunk($current)
+    {
+        $column = $current['column'];
+        $data_type = $current['data_type'];
+        $byte_offset = $current['byte_offset'];
+        $total_length = $current['total_length'];
         $chunk_size = $this->compute_chunk_size($column);
 
         // MySQL SUBSTRING() counts characters for character strings, while
@@ -1430,8 +1596,7 @@ class MySQLDumpProducer
             $value_length,
             $character_string
         );
-        $chunk = $chunk_result['value'];
-        $chunk_bytes = strlen($chunk);
+        $chunk_bytes = strlen($chunk_result['value']);
 
         if ($chunk_bytes === 0 && $byte_offset < $total_length) {
             // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol error returned as authenticated API data, never HTML.
@@ -1458,44 +1623,12 @@ class MySQLDumpProducer
             // phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
 
-        $formatted_chunk = $this->format_value(
-            $chunk,
-            $spatial_type ? 'LONGBLOB' : $data_type
-        );
-
-        $where_parts = [];
-        foreach ($this->oversized_pk_values as $pk_col => $pk_value) {
-            $where_parts[] = $this->row_reader->build_comparison($pk_col, $pk_value, "=");
-        }
-        $where_clause = implode(" AND ", $where_parts);
-
-        if ($spatial_type) {
-            $quoted_staging_table = $this->row_reader->quote_identifier(
-                self::SPATIAL_STAGING_TABLE
-            );
-            $sql = "UPDATE {$quoted_staging_table} " .
-                "SET `value` = CONCAT(`value`, {$formatted_chunk}) " .
-                "WHERE `id` = 1 AND OCTET_LENGTH(`value`) = {$byte_offset};";
-        } else {
-            $quoted_table = $this->row_reader->quote_identifier($this->row_reader->get_current_table());
-            $quoted_column = $this->row_reader->quote_identifier($column);
-            $sql = "UPDATE {$quoted_table} SET {$quoted_column} = CONCAT({$quoted_column}, {$formatted_chunk}) WHERE {$where_clause};";
-        }
-
-        $this->current_sql_fragment = $sql;
-
-        $this->oversized_queue[0]['byte_offset'] += $chunk_bytes;
-        if ($character_string) {
-            $this->oversized_queue[0]['character_offset'] += $chunk_result['value_length'];
-        }
-        if (
-            !$spatial_type &&
-            $this->oversized_queue[0]['byte_offset'] >= $total_length
-        ) {
-            array_shift($this->oversized_queue);
-        }
-
-        return true;
+        return [
+            'value' => $chunk_result['value'],
+            'byte_length' => $chunk_bytes,
+            'value_length' => $chunk_result['value_length'],
+            'character_string' => $character_string,
+        ];
     }
 
     /**
@@ -1554,5 +1687,16 @@ class MySQLDumpProducer
     private function has_pending_oversized_updates()
     {
         return !empty($this->oversized_queue);
+    }
+
+    /** Returns whether this row still has a spatial value to build before insertion. */
+    private function has_pending_spatial_staging()
+    {
+        foreach ($this->oversized_queue as $queue_item) {
+            if ($this->row_reader->is_spatial_type($queue_item['data_type'])) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -788,6 +788,7 @@ function endpoint_sql_chunk(
     if (!empty($config["max_allowed_packet"])) {
         $client_max = (int) $config["max_allowed_packet"];
         if ($client_max >= 1048576 && $client_max <= 1073741824) {
+            $producer_options["target_max_allowed_packet"] = $client_max;
             $client_statement_size = (int) ($client_max * 0.8);
             $server_statement_size = null;
             try {

--- a/tests/MySQLDumpProducer/EmptyGeometryTest.php
+++ b/tests/MySQLDumpProducer/EmptyGeometryTest.php
@@ -245,6 +245,51 @@ class EmptyGeometryTest extends TestCase {
         }
     }
 
+    /** @dataProvider targetDatabaseProvider */
+    public function testOversizedSpatialValueRoundTripsToRealTargets(string $target): void
+    {
+        $this->source_pdo->exec(
+            'CREATE TABLE oversized_route (' .
+            'id INT PRIMARY KEY, route LINESTRING NOT NULL, ' .
+            'SPATIAL INDEX route_index (route))'
+        );
+        $points = [];
+        for ($point = 0; $point < 3000; ++$point) {
+            $latitude = ($point % 179) - 89;
+            $longitude = ($point % 359) - 179;
+            $points[] = $latitude . ' ' . $longitude;
+        }
+        $statement = $this->source_pdo->prepare(
+            'INSERT INTO oversized_route VALUES (1, ST_GeomFromText(?, 4326))'
+        );
+        $statement->execute(['LINESTRING(' . implode(',', $points) . ')']);
+        $source_value = $this->source_pdo
+            ->query('SELECT CAST(route AS BINARY) FROM oversized_route')
+            ->fetchColumn();
+
+        $sql = $this->exportWithResumeAfterEveryFragment([
+            'batch_size' => 1,
+            'max_statement_size' => 8 * 1024,
+            'tables_to_process' => ['oversized_route'],
+        ]);
+        $target_pdo = $this->executeDump($sql, $target);
+        $target_value = $target_pdo
+            ->query('SELECT CAST(route AS BINARY) FROM oversized_route')
+            ->fetchColumn();
+
+        $this->assertSame($source_value, $target_value);
+        $this->assertSame(
+            0,
+            (int) $target_pdo
+                ->query(
+                    "SELECT COUNT(*) FROM information_schema.tables " .
+                    "WHERE table_schema = DATABASE() " .
+                    "AND table_name LIKE '__reprint_db_pull_progress_spatial_%'"
+                )
+                ->fetchColumn()
+        );
+    }
+
     public function testNullableAlterPreservesCompleteColumnDefinition(): void
     {
         $column = "location,\n`north";

--- a/tests/MySQLDumpProducer/EmptyGeometryTest.php
+++ b/tests/MySQLDumpProducer/EmptyGeometryTest.php
@@ -284,7 +284,7 @@ class EmptyGeometryTest extends TestCase {
                 ->query(
                     "SELECT COUNT(*) FROM information_schema.tables " .
                     "WHERE table_schema = DATABASE() " .
-                    "AND table_name LIKE '__reprint_db_pull_progress_spatial_%'"
+                    "AND table_name = '__reprint_db_pull_progress_spatial'"
                 )
                 ->fetchColumn()
         );

--- a/tests/MySQLDumpProducer/EmptyGeometryTest.php
+++ b/tests/MySQLDumpProducer/EmptyGeometryTest.php
@@ -290,6 +290,39 @@ class EmptyGeometryTest extends TestCase {
         );
     }
 
+    /** @dataProvider targetDatabaseProvider */
+    public function testOversizedSpatialValuePassesCheckConstraintOnFirstInsert(string $target): void
+    {
+        $this->source_pdo->exec(
+            'CREATE TABLE constrained_oversized_route (' .
+            'id INT PRIMARY KEY, route LINESTRING NOT NULL, ' .
+            'CONSTRAINT route_has_more_than_two_points CHECK (ST_NumPoints(route) > 2))'
+        );
+        $points = [];
+        for ($point = 0; $point < 3000; ++$point) {
+            $points[] = $point . ' ' . $point;
+        }
+        $statement = $this->source_pdo->prepare(
+            'INSERT INTO constrained_oversized_route VALUES (1, ST_GeomFromText(?))'
+        );
+        $statement->execute(['LINESTRING(' . implode(',', $points) . ')']);
+        $source_value = $this->source_pdo
+            ->query('SELECT CAST(route AS BINARY) FROM constrained_oversized_route')
+            ->fetchColumn();
+
+        $sql = $this->exportWithResumeAfterEveryFragment([
+            'batch_size' => 1,
+            'max_statement_size' => 8 * 1024,
+            'tables_to_process' => ['constrained_oversized_route'],
+        ]);
+        $target_pdo = $this->executeDump($sql, $target);
+        $target_value = $target_pdo
+            ->query('SELECT CAST(route AS BINARY) FROM constrained_oversized_route')
+            ->fetchColumn();
+
+        $this->assertSame($source_value, $target_value);
+    }
+
     public function testNullableAlterPreservesCompleteColumnDefinition(): void
     {
         $column = "location,\n`north";

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -357,19 +357,18 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         }
         $sql = implode("\n", $fragments);
         $this->assertStringNotContainsString('ST_GeomFromText(', $sql);
-        $this->assertMatchesRegularExpression(
-            '/UPDATE `__reprint_db_pull_progress_spatial_[a-f0-9]+` ' .
-                'SET `value` = CONCAT/s',
+        $this->assertStringContainsString(
+            'UPDATE `__reprint_db_pull_progress_spatial` SET `value` = CONCAT',
             $sql
         );
         $this->assertStringContainsString(
-            'SET `content` = (SELECT `value` FROM `__reprint_db_pull_progress_spatial_',
+            'SET `content` = (SELECT `value` FROM `__reprint_db_pull_progress_spatial`',
             $sql
         );
         $this->assertSame(
             1,
             preg_match(
-                "/UPDATE `__reprint_db_pull_progress_spatial_[a-f0-9]+` " .
+                "/UPDATE `__reprint_db_pull_progress_spatial` " .
                     "SET `value` = CONCAT\\(`value`, FROM_BASE64\\('[A-Za-z0-9+\\/=]+'\\)\\) " .
                     "WHERE `id` = 1 AND OCTET_LENGTH\\(`value`\\) = 0;/",
                 $sql,
@@ -397,7 +396,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
                 ->query(
                     "SELECT COUNT(*) FROM information_schema.tables " .
                     "WHERE table_schema = DATABASE() " .
-                    "AND table_name LIKE '__reprint_db_pull_progress_spatial_%'"
+                    "AND table_name = '__reprint_db_pull_progress_spatial'"
                 )
                 ->fetchColumn()
         );
@@ -453,11 +452,11 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = $this->getDumpSQL(['max_statement_size' => 8 * 1024]);
         $this->assertSame(
             1,
-            substr_count($sql, 'CREATE TABLE IF NOT EXISTS `__reprint_db_pull_progress_spatial_')
+            substr_count($sql, 'CREATE TABLE IF NOT EXISTS `__reprint_db_pull_progress_spatial`')
         );
         $this->assertSame(
             2,
-            substr_count($sql, 'REPLACE INTO `__reprint_db_pull_progress_spatial_')
+            substr_count($sql, 'REPLACE INTO `__reprint_db_pull_progress_spatial`')
         );
 
         $import_pdo = $this->executeDumpInNewDatabase($sql);
@@ -515,7 +514,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
 
     public function testStartingNewImportDropsSavedSpatialStagingTable(): void
     {
-        $staging_table = '__reprint_db_pull_progress_spatial_' . str_repeat('a', 24);
+        $staging_table = '__reprint_db_pull_progress_spatial';
         $this->pdo->exec(
             "CREATE TABLE `{$staging_table}` (" .
             '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, `value` LONGBLOB NOT NULL)'
@@ -532,9 +531,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             'DATABASE_IMPORT_POSITION_TABLE'
         );
         $this->assertIsString($position_table);
-        $cursor = base64_encode(json_encode([
-            'spatial_staging_table' => $staging_table,
-        ]));
+        $cursor = base64_encode(json_encode([]));
         $statement = $this->pdo->prepare(
             "REPLACE INTO `{$position_table}` " .
             '(`id`, `source_hash`, `source_cursor`, `file_byte_offset`) ' .

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/MySQLDumpProducerTestBase.php';
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
 use Reprint\Importer\Database\PdoDatabaseConnection;
+use WordPress\Reprint\Server\DatabaseRowsReader;
 use WordPress\Reprint\Server\MySQLDumpProducer;
 
 /**
@@ -358,23 +359,24 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $sql = implode("\n", $fragments);
         $this->assertStringNotContainsString('ST_GeomFromText(', $sql);
         $this->assertStringContainsString(
-            'UPDATE `__reprint_db_pull_progress_spatial` SET `value` = CONCAT',
+            'REPLACE INTO `__reprint_db_pull_progress_spatial` (`id`, `chunk_number`, `value`)',
             $sql
         );
         $this->assertStringContainsString(
-            '(1,(SELECT `value` FROM `__reprint_db_pull_progress_spatial` WHERE `id` = 1))',
+            '(1,CONCAT((SELECT `value` FROM `__reprint_db_pull_progress_spatial` ' .
+                'WHERE `id` = 1 AND `chunk_number` = 0)',
             $sql
         );
         $this->assertLessThan(
             strpos($sql, 'INSERT INTO `oversized_geometry_value`'),
-            strpos($sql, 'UPDATE `__reprint_db_pull_progress_spatial`')
+            strpos($sql, 'REPLACE INTO `__reprint_db_pull_progress_spatial`')
         );
         $this->assertSame(
             1,
             preg_match(
-                "/UPDATE `__reprint_db_pull_progress_spatial` " .
-                    "SET `value` = CONCAT\\(`value`, FROM_BASE64\\('[A-Za-z0-9+\\/=]+'\\)\\) " .
-                    "WHERE `id` = 1 AND OCTET_LENGTH\\(`value`\\) = 0;/",
+                "/REPLACE INTO `__reprint_db_pull_progress_spatial` " .
+                    "\\(`id`, `chunk_number`, `value`\\) VALUES " .
+                    "\\(1, 0, FROM_BASE64\\('[A-Za-z0-9+\\/=]+'\\)\\);/",
                 $sql,
                 $first_chunk,
                 PREG_OFFSET_CAPTURE
@@ -420,6 +422,64 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
                 'GEOMETRYCOLLECTION(LINESTRING(%s))',
             ],
         ];
+    }
+
+    public function testOrderedRowQueryOmitsSpatialValueAboveItsInlineLimit(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE deferred_spatial_value (' .
+            'id INT PRIMARY KEY, route LINESTRING NOT NULL)'
+        );
+        $points = [];
+        for ($point = 0; $point < 1000; ++$point) {
+            $points[] = $point . ' ' . $point;
+        }
+        $statement = $this->pdo->prepare(
+            'INSERT INTO deferred_spatial_value VALUES (1, ST_GeomFromText(?))'
+        );
+        $statement->execute(['LINESTRING(' . implode(',', $points) . ')']);
+        $expected_length = (int) $this->pdo
+            ->query(
+                'SELECT OCTET_LENGTH(CAST(route AS BINARY)) FROM deferred_spatial_value'
+            )
+            ->fetchColumn();
+
+        $reader = new DatabaseRowsReader($this->pdo, [
+            'tables_to_process' => ['deferred_spatial_value'],
+            'maximum_inline_spatial_bytes' => 1024,
+        ]);
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertTrue($reader->next_record());
+
+        $this->assertNull($reader->get_current_record()['route']);
+        $this->assertSame(
+            $expected_length,
+            $reader->get_current_spatial_value_length('route')
+        );
+    }
+
+    public function testSpatialValueAboveTargetPacketLimitStopsBeforeStaging(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE spatial_value_above_target_packet (' .
+            'id INT PRIMARY KEY, route LINESTRING NOT NULL)'
+        );
+        $points = [];
+        for ($point = 0; $point < 2000; ++$point) {
+            $points[] = $point . ' ' . $point;
+        }
+        $statement = $this->pdo->prepare(
+            'INSERT INTO spatial_value_above_target_packet VALUES (1, ST_GeomFromText(?))'
+        );
+        $statement->execute(['LINESTRING(' . implode(',', $points) . ')']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('but the target max_allowed_packet is 16384 bytes');
+
+        $this->collectAllFragments($this->createProducer([
+            'max_statement_size' => 8 * 1024,
+            'target_max_allowed_packet' => 16 * 1024,
+        ]));
     }
 
     public function testMultipleOversizedSpatialColumnsReuseOneStagingTable(): void
@@ -480,7 +540,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             1,
             substr_count($sql, 'CREATE TABLE IF NOT EXISTS `__reprint_db_pull_progress_spatial`')
         );
-        $this->assertSame(
+        $this->assertGreaterThan(
             2,
             substr_count($sql, 'REPLACE INTO `__reprint_db_pull_progress_spatial`')
         );
@@ -516,7 +576,8 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
                 'data_type' => 'GEOMETRY',
                 'byte_offset' => 8192,
                 'total_length' => 16384,
-                'spatial_staging_initialized' => true,
+                'spatial_staging_id' => 1,
+                'chunk_number' => 1,
             ]],
         ];
         $database = new PdoDatabaseConnection($this->pdo);
@@ -544,7 +605,7 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         array_shift($cursor['oversized_queue']);
         $cursor['state'] = 'emit_oversized_update';
 
-        unset($cursor['oversized_queue'][0]['spatial_staging_initialized']);
+        unset($cursor['oversized_queue'][0]['spatial_staging_id']);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('may have already appended part of a large value');
         $assert_resume->invoke(
@@ -640,8 +701,8 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $this->assertEquals('small value', $row['small_col']);
     }
 
-    /** Combined values must fail before an over-limit fragment is formatted. */
-    public function testCombinedValuesAbovePartBodyLimitThrowBeforeFormatting(): void
+    /** Combined values may use one bounded update apiece. */
+    public function testCombinedValuesAbovePartBodyLimitUseBoundedUpdates(): void
     {
         $this->pdo->exec("
             CREATE TABLE combined_fragment_limit (
@@ -658,11 +719,21 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         );
         $stmt->execute([$blob1, $blob2]);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('cannot fit the SQL size limits');
-        $this->expectExceptionMessage('SQL part body limit is 16777216 bytes');
-
-        $this->getDumpSQL(['max_statement_size' => 64 * 1024 * 1024]);
+        $fragments = $this->collectAllFragments($this->createProducer([
+            'max_statement_size' => 64 * 1024 * 1024,
+        ]));
+        foreach ($fragments as $fragment) {
+            $this->assertLessThanOrEqual(
+                MySQLDumpProducer::MAX_SQL_PART_BODY_BYTES,
+                strlen($fragment)
+            );
+        }
+        $target = $this->executeDumpInNewDatabase(implode("\n", $fragments));
+        $row = $target
+            ->query('SELECT blob1, blob2 FROM combined_fragment_limit WHERE id = 1')
+            ->fetch();
+        $this->assertSame($blob1, $row['blob1']);
+        $this->assertSame($blob2, $row['blob2']);
     }
 
     /** Text and binary chunks must both stay below the packet target. */

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -1,7 +1,9 @@
 <?php
 
 require_once __DIR__ . '/MySQLDumpProducerTestBase.php';
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
+use Reprint\Importer\Database\PdoDatabaseConnection;
 use WordPress\Reprint\Server\MySQLDumpProducer;
 
 /**
@@ -297,30 +299,270 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $producer->next_sql_fragment();
     }
 
-    /** Geometry cannot be built from an empty value and partial byte strings. */
-    public function testOversizedGeometryIsRejectedBeforeInvalidSqlIsEmitted(): void
+    /**
+     * Geometry bytes use durable binary staging until the complete value is valid.
+     *
+     * @dataProvider oversizedSpatialColumnProvider
+     */
+    public function testOversizedGeometryRoundTripsAcrossBoundedStatements(
+        string $column_type,
+        string $wkt_format
+    ): void
     {
         $this->pdo->exec("
             CREATE TABLE oversized_geometry_value (
                 id INT PRIMARY KEY,
-                content GEOMETRY
+                content {$column_type} NOT NULL,
+                SPATIAL INDEX content_index (content)
             )
         ");
         $points = [];
         for ($point = 0; $point < 3000; ++$point) {
-            $points[] = $point . ' ' . $point;
+            $latitude = ($point % 179) - 89;
+            $longitude = ($point % 359) - 179;
+            $points[] = $latitude . ' ' . $longitude;
         }
-        $line_string = 'LINESTRING(' . implode(',', $points) . ')';
+        $coordinates = implode(',', $points);
+        $closed_coordinates = $coordinates . ',' . $points[0];
+        $wkt = sprintf($wkt_format, $coordinates, $closed_coordinates);
         $statement = $this->pdo->prepare(
-            "INSERT INTO oversized_geometry_value VALUES (1, ST_GeomFromText(?))"
+            "INSERT INTO oversized_geometry_value VALUES (1, ST_GeomFromText(?, 4326))"
         );
-        $statement->execute([$line_string]);
+        $statement->execute([$wkt]);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'cannot use UPDATE ... CONCAT() chunks for data type GEOMETRY'
+        $source_value = $this->pdo
+            ->query('SELECT CAST(content AS BINARY) FROM oversized_geometry_value')
+            ->fetchColumn();
+        $max_statement_size = 10 * 1024;
+        $options = [
+            'max_statement_size' => $max_statement_size,
+            'batch_size' => 1,
+        ];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        for ($step = 0; $step < 200; ++$step) {
+            if (!$producer->next_sql_fragment()) {
+                break;
+            }
+            $fragments[] = $producer->get_sql_fragment();
+            if (!$producer->is_finished()) {
+                $options['cursor'] = $producer->get_reentrancy_cursor();
+                $producer = $this->createProducer($options);
+            }
+        }
+
+        $this->assertTrue($producer->is_finished());
+        foreach ($fragments as $fragment) {
+            $this->assertLessThanOrEqual($max_statement_size, strlen($fragment));
+        }
+        $sql = implode("\n", $fragments);
+        $this->assertStringNotContainsString('ST_GeomFromText(', $sql);
+        $this->assertMatchesRegularExpression(
+            '/UPDATE `__reprint_db_pull_progress_spatial_[a-f0-9]+` ' .
+                'SET `value` = CONCAT/s',
+            $sql
         );
-        $this->getDumpSQL(['max_statement_size' => 10 * 1024]);
+        $this->assertStringContainsString(
+            'SET `content` = (SELECT `value` FROM `__reprint_db_pull_progress_spatial_',
+            $sql
+        );
+        $this->assertSame(
+            1,
+            preg_match(
+                "/UPDATE `__reprint_db_pull_progress_spatial_[a-f0-9]+` " .
+                    "SET `value` = CONCAT\\(`value`, FROM_BASE64\\('[A-Za-z0-9+\\/=]+'\\)\\) " .
+                    "WHERE `id` = 1 AND OCTET_LENGTH\\(`value`\\) = 0;/",
+                $sql,
+                $first_chunk,
+                PREG_OFFSET_CAPTURE
+            )
+        );
+        $first_chunk_sql = $first_chunk[0][0];
+        $first_chunk_offset = $first_chunk[0][1];
+        $sql = substr_replace(
+            $sql,
+            $first_chunk_sql . "\n" . $first_chunk_sql,
+            $first_chunk_offset,
+            strlen($first_chunk_sql)
+        );
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $imported_value = $import_pdo
+            ->query('SELECT CAST(content AS BINARY) FROM oversized_geometry_value')
+            ->fetchColumn();
+        $this->assertSame($source_value, $imported_value);
+        $this->assertSame(
+            0,
+            (int) $import_pdo
+                ->query(
+                    "SELECT COUNT(*) FROM information_schema.tables " .
+                    "WHERE table_schema = DATABASE() " .
+                    "AND table_name LIKE '__reprint_db_pull_progress_spatial_%'"
+                )
+                ->fetchColumn()
+        );
+    }
+
+    public static function oversizedSpatialColumnProvider(): array
+    {
+        return [
+            'geometry' => ['GEOMETRY', 'LINESTRING(%s)'],
+            'linestring' => ['LINESTRING', 'LINESTRING(%s)'],
+            'polygon' => ['POLYGON', 'POLYGON((%2$s))'],
+            'multipoint' => ['MULTIPOINT', 'MULTIPOINT(%s)'],
+            'multilinestring' => ['MULTILINESTRING', 'MULTILINESTRING((%s))'],
+            'multipolygon' => ['MULTIPOLYGON', 'MULTIPOLYGON(((%2$s)))'],
+            'geometrycollection' => [
+                'GEOMETRYCOLLECTION',
+                'GEOMETRYCOLLECTION(LINESTRING(%s))',
+            ],
+        ];
+    }
+
+    public function testMultipleOversizedSpatialColumnsReuseOneStagingTable(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE multiple_spatial_values (
+                id INT PRIMARY KEY,
+                route LINESTRING NOT NULL,
+                routes MULTILINESTRING NOT NULL
+            )
+        ");
+        $points = [];
+        for ($point = 0; $point < 2000; ++$point) {
+            $latitude = ($point % 179) - 89;
+            $longitude = ($point % 359) - 179;
+            $points[] = $latitude . ' ' . $longitude;
+        }
+        $coordinates = implode(',', $points);
+        $statement = $this->pdo->prepare(
+            "INSERT INTO multiple_spatial_values VALUES (" .
+            "1, ST_GeomFromText(?, 4326), ST_GeomFromText(?, 4326))"
+        );
+        $statement->execute([
+            'LINESTRING(' . $coordinates . ')',
+            'MULTILINESTRING((' . $coordinates . '))',
+        ]);
+        $source_row = $this->pdo
+            ->query(
+                'SELECT CAST(route AS BINARY) AS route, ' .
+                'CAST(routes AS BINARY) AS routes FROM multiple_spatial_values'
+            )
+            ->fetch();
+
+        $sql = $this->getDumpSQL(['max_statement_size' => 8 * 1024]);
+        $this->assertSame(
+            1,
+            substr_count($sql, 'CREATE TABLE IF NOT EXISTS `__reprint_db_pull_progress_spatial_')
+        );
+        $this->assertSame(
+            2,
+            substr_count($sql, 'REPLACE INTO `__reprint_db_pull_progress_spatial_')
+        );
+
+        $import_pdo = $this->executeDumpInNewDatabase($sql);
+        $imported_row = $import_pdo
+            ->query(
+                'SELECT CAST(route AS BINARY) AS route, ' .
+                'CAST(routes AS BINARY) AS routes FROM multiple_spatial_values'
+            )
+            ->fetch();
+        $this->assertSame($source_row, $imported_row);
+    }
+
+    public function testMyIsamResumeAcceptsStagedSpatialChunks(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE myisam_spatial_resume (' .
+            'id INT PRIMARY KEY, content GEOMETRY NOT NULL) ENGINE=MyISAM'
+        );
+        $client = ( new ReflectionClass(ImportClient::class) )->newInstanceWithoutConstructor();
+        $assert_resume = new ReflectionMethod(
+            ImportClient::class,
+            'assert_mysql_import_can_repeat_next_group'
+        );
+        $assert_resume->setAccessible(true);
+        $cursor = [
+            'state' => 'emit_oversized_update',
+            'current_table' => 'myisam_spatial_resume',
+            'oversized_queue' => [[
+                'column' => 'content',
+                'data_type' => 'GEOMETRY',
+                'byte_offset' => 8192,
+                'total_length' => 16384,
+                'spatial_staging_initialized' => true,
+            ]],
+        ];
+        $database = new PdoDatabaseConnection($this->pdo);
+
+        $this->assertNull($assert_resume->invoke(
+            $client,
+            $database,
+            base64_encode(json_encode($cursor)),
+            'db-pull'
+        ));
+
+        unset($cursor['oversized_queue'][0]['spatial_staging_initialized']);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may have already appended part of a large value');
+        $assert_resume->invoke(
+            $client,
+            $database,
+            base64_encode(json_encode($cursor)),
+            'db-pull'
+        );
+    }
+
+    public function testStartingNewImportDropsSavedSpatialStagingTable(): void
+    {
+        $staging_table = '__reprint_db_pull_progress_spatial_' . str_repeat('a', 24);
+        $this->pdo->exec(
+            "CREATE TABLE `{$staging_table}` (" .
+            '`id` TINYINT UNSIGNED NOT NULL PRIMARY KEY, `value` LONGBLOB NOT NULL)'
+        );
+        $client_reflection = new ReflectionClass(ImportClient::class);
+        $client = $client_reflection->newInstanceWithoutConstructor();
+        $database = new PdoDatabaseConnection($this->pdo);
+        $create_position_table = $client_reflection->getMethod(
+            'create_database_import_position_table'
+        );
+        $create_position_table->setAccessible(true);
+        $create_position_table->invoke($client, $database);
+        $position_table = $client_reflection->getConstant(
+            'DATABASE_IMPORT_POSITION_TABLE'
+        );
+        $this->assertIsString($position_table);
+        $cursor = base64_encode(json_encode([
+            'spatial_staging_table' => $staging_table,
+        ]));
+        $statement = $this->pdo->prepare(
+            "REPLACE INTO `{$position_table}` " .
+            '(`id`, `source_hash`, `source_cursor`, `file_byte_offset`) ' .
+            "VALUES (1, REPEAT('a', 64), ?, 0)"
+        );
+        $statement->execute([$cursor]);
+
+        $reset_position = $client_reflection->getMethod(
+            'reset_database_import_position'
+        );
+        $reset_position->setAccessible(true);
+        $reset_position->invoke($client, $database);
+
+        $this->assertSame(
+            0,
+            (int) $this->pdo
+                ->query(
+                    "SELECT COUNT(*) FROM information_schema.tables " .
+                    "WHERE table_schema = DATABASE() AND table_name = '{$staging_table}'"
+                )
+                ->fetchColumn()
+        );
+        $this->assertSame(
+            0,
+            (int) $this->pdo
+                ->query("SELECT COUNT(*) FROM `{$position_table}`")
+                ->fetchColumn()
+        );
     }
 
     /**

--- a/tests/MySQLDumpProducer/OversizedRowsTest.php
+++ b/tests/MySQLDumpProducer/OversizedRowsTest.php
@@ -362,8 +362,12 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             $sql
         );
         $this->assertStringContainsString(
-            'SET `content` = (SELECT `value` FROM `__reprint_db_pull_progress_spatial`',
+            '(1,(SELECT `value` FROM `__reprint_db_pull_progress_spatial` WHERE `id` = 1))',
             $sql
+        );
+        $this->assertLessThan(
+            strpos($sql, 'INSERT INTO `oversized_geometry_value`'),
+            strpos($sql, 'UPDATE `__reprint_db_pull_progress_spatial`')
         );
         $this->assertSame(
             1,
@@ -424,7 +428,8 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             CREATE TABLE multiple_spatial_values (
                 id INT PRIMARY KEY,
                 route LINESTRING NOT NULL,
-                routes MULTILINESTRING NOT NULL
+                routes MULTILINESTRING NOT NULL,
+                payload LONGBLOB NOT NULL
             )
         ");
         $points = [];
@@ -436,20 +441,41 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $coordinates = implode(',', $points);
         $statement = $this->pdo->prepare(
             "INSERT INTO multiple_spatial_values VALUES (" .
-            "1, ST_GeomFromText(?, 4326), ST_GeomFromText(?, 4326))"
+            "1, ST_GeomFromText(?, 4326), ST_GeomFromText(?, 4326), ?)"
         );
         $statement->execute([
             'LINESTRING(' . $coordinates . ')',
             'MULTILINESTRING((' . $coordinates . '))',
+            str_repeat('mixed spatial and binary ', 4000),
+        ]);
+        $statement = $this->pdo->prepare(
+            "INSERT INTO multiple_spatial_values VALUES (" .
+            "2, ST_GeomFromText(?), ST_GeomFromText(?), ?)"
+        );
+        $statement->execute([
+            'LINESTRING(0 0,1 1)',
+            'MULTILINESTRING((0 0,1 1))',
+            'row after staged values',
         ]);
         $source_row = $this->pdo
             ->query(
-                'SELECT CAST(route AS BINARY) AS route, ' .
-                'CAST(routes AS BINARY) AS routes FROM multiple_spatial_values'
+                'SELECT id, CAST(route AS BINARY) AS route, ' .
+                'CAST(routes AS BINARY) AS routes, payload ' .
+                'FROM multiple_spatial_values ORDER BY id'
             )
-            ->fetch();
+            ->fetchAll();
 
-        $sql = $this->getDumpSQL(['max_statement_size' => 8 * 1024]);
+        $options = ['max_statement_size' => 8 * 1024];
+        $producer = $this->createProducer($options);
+        $fragments = [];
+        while ($producer->next_sql_fragment()) {
+            $fragments[] = $producer->get_sql_fragment();
+            if (!$producer->is_finished()) {
+                $options['cursor'] = $producer->get_reentrancy_cursor();
+                $producer = $this->createProducer($options);
+            }
+        }
+        $sql = implode("\n", $fragments);
         $this->assertSame(
             1,
             substr_count($sql, 'CREATE TABLE IF NOT EXISTS `__reprint_db_pull_progress_spatial`')
@@ -462,10 +488,11 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
         $import_pdo = $this->executeDumpInNewDatabase($sql);
         $imported_row = $import_pdo
             ->query(
-                'SELECT CAST(route AS BINARY) AS route, ' .
-                'CAST(routes AS BINARY) AS routes FROM multiple_spatial_values'
+                'SELECT id, CAST(route AS BINARY) AS route, ' .
+                'CAST(routes AS BINARY) AS routes, payload ' .
+                'FROM multiple_spatial_values ORDER BY id'
             )
-            ->fetch();
+            ->fetchAll();
         $this->assertSame($source_row, $imported_row);
     }
 
@@ -500,6 +527,22 @@ class OversizedRowsTest extends MySQLDumpProducerTestBase
             base64_encode(json_encode($cursor)),
             'db-pull'
         ));
+
+        $cursor['state'] = 'stage_oversized_spatial';
+        array_unshift($cursor['oversized_queue'], [
+            'column' => 'label',
+            'data_type' => 'LONGBLOB',
+            'byte_offset' => 0,
+            'total_length' => 16384,
+        ]);
+        $this->assertNull($assert_resume->invoke(
+            $client,
+            $database,
+            base64_encode(json_encode($cursor)),
+            'db-pull'
+        ));
+        array_shift($cursor['oversized_queue']);
+        $cursor['state'] = 'emit_oversized_update';
 
         unset($cursor['oversized_queue'][0]['spatial_staging_initialized']);
         $this->expectException(RuntimeException::class);

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -191,7 +191,7 @@
       "noPdoMysql": true
     },
     "empty-geometry-cross-engine": {
-      "port": 8140
+      "port": 8141
     }
   }
 }

--- a/tests/e2e/tests/import-00-site-registry.test.js
+++ b/tests/e2e/tests/import-00-site-registry.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const REGISTRY = createRequire(import.meta.url)('../site-registry.json');
+
+describe('E2E site registry', () => {
+    it('assigns a different port to every site', () => {
+        const siteByPort = new Map();
+
+        for (const [site, config] of Object.entries(REGISTRY.sites)) {
+            assert.equal(
+                siteByPort.has(config.port),
+                false,
+                `${site} and ${siteByPort.get(config.port)} both use port ${config.port}`,
+            );
+            siteByPort.set(config.port, site);
+        }
+    });
+});


### PR DESCRIPTION
Large spatial values now migrate through bounded SQL statements without inserting partial geometry into target columns.

## Background

A large text or binary value can start as an empty value and receive later chunks with `UPDATE ... CONCAT()`. A spatial column cannot hold those incomplete bytes because they are not valid geometry. Constraints, generated columns, and spatial indexes may also inspect the value during the first insert.

Reading the complete source geometry in the ordered row query can also exceed the source packet limit. Temporarily changing the real target column to `LONGBLOB` would avoid that first problem, but would change the table schema during the pull and require rebuilding the exact column definition and spatial indexes.

## This change

The ordered source query reads each spatial value's byte length. It returns the bytes inline only when they fit the query limit. Larger values are read with bounded `SUBSTRING(CAST(... AS BINARY), ...)` queries.

Each geometry chunk is emitted once into a helper-table row keyed by `(id, chunk_number)`. Repeating a statement replaces the same row instead of appending its bytes again. After all rows exist, the target `INSERT` joins them with ordered scalar subqueries inside one `CONCAT()`. That final statement refers to the helper rows; it does not emit the chunk bytes again.

Direct MySQL output reads the target `max_allowed_packet` and sends it to the exporter. A spatial value larger than that limit stops before staging begins. File and stdout output use `--max-allowed-packet` when supplied, or the source packet limit when it is absent.

## Limits

A same-length source change during the pull can still mix old and new chunks. This change does not lock source rows or add a content fingerprint. Non-spatial rows are still read whole by the ordered source query.

## Testing

There is no useful manual test for packet boundaries and interruption points. Review the focused tests and rely on CI.
