### PR TITLE
[Tests] Give zero-byte spatial E2E site a unique port

### DIFF
--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -14,6 +14,15 @@ FPM_SOCKET="/run/php/e2e.sock"
 OPEN_BASEDIR_FPM_SOCKET="/run/php/e2e-open-basedir.sock"
 NO_PDO_MYSQL_FPM_SOCKET="/run/php/e2e-no-pdo-mysql.sock"
 
+duplicate_ports="$(
+    jq -r '.sites | to_entries | group_by(.value.port)[] | select(length > 1) | "\(.[0].value.port): \(map(.key) | join(", "))"' "$REGISTRY"
+)"
+if [[ -n "$duplicate_ports" ]]; then
+    echo "Each E2E site must use a unique port. Duplicate ports:" >&2
+    echo "$duplicate_ports" >&2
+    exit 1
+fi
+
 echo "=== Setting up infrastructure with PHP ${PHP_VERSION} ==="
 
 # ---------- PHP ----------

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -191,7 +191,7 @@
       "noPdoMysql": true
     },
     "empty-geometry-cross-engine": {
-      "port": 8140
+      "port": 8141
     }
   }
 }


### PR DESCRIPTION
Prevents the E2E server from routing `files-pull-internal-loop` requests to the new zero-byte spatial test site.

Trunk assigned both sites port 8140. Nginx kept one server block and ignored the other, so `files-pull-internal-loop` reached the wrong document root and failed with HTTP 404 in every standard PHP matrix and the Playground CLI job.

The zero-byte spatial site now uses unused port 8141. Infrastructure setup also stops with the duplicate port and site names before writing Nginx configuration.

Testing: PHPStan; shell syntax; JSON parsing; registry collision check; `git diff --check`. The full local PHPUnit suite cannot run cleanly in the desktop sandbox because many existing tests write outside the allowed paths; GitHub E2E checks cover the failing Linux setup.