### PR TITLE
[PHP] Use the live target packet limit for direct database pulls

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -425,7 +425,7 @@ class ImportClient
     private $hmac_client = null;
 
     /**
-     * @var int|null MySQL max_allowed_packet value for the target database connection.
+     * @var int|null Target max_allowed_packet ceiling sent to the exporter.
      * Passed to the server so it can split SQL statements to fit within this limit.
      */
     private $max_allowed_packet = null;
@@ -1089,9 +1089,8 @@ class ImportClient
             $this->filter = $this->get_state()->filter;
         }
 
-        // Persist max_allowed_packet in state so it survives across invocations.
-        // The client sends this to the server so SQL statements are capped to a
-        // size the client's MySQL instance can actually accept.
+        // Persist a configured packet ceiling across resume invocations.
+        // Direct MySQL output queries the live target when none was configured.
         if (isset($options["max_allowed_packet"])) {
             $this->max_allowed_packet = (int) $options["max_allowed_packet"];
             $this->get_state()->max_allowed_packet = $this->max_allowed_packet;
@@ -3025,8 +3024,8 @@ class ImportClient
                 ],
             ];
 
-            // Tell the server about the client's max_allowed_packet so it can
-            // cap SQL statements to a size the client can actually apply.
+            // Tell the server about the target max_allowed_packet so it can
+            // cap SQL statements to a size the target can actually apply.
             if ($this->max_allowed_packet !== null) {
                 $params["max_allowed_packet"] = $this->max_allowed_packet;
             }
@@ -8709,8 +8708,6 @@ class ImportClient
                 );
                 $this->max_allowed_packet = (int) $packet_result->fetchColumn();
                 $packet_result->closeCursor();
-                $this->get_state()->max_allowed_packet = $this->max_allowed_packet;
-                $this->save_state();
             }
             if ($starts_mysql_output) {
                 // Keep the mysql-start stage until the old target position is gone.
@@ -12955,7 +12952,7 @@ if (
             'target' => 'max_allowed_packet',
             'placeholder' => 'SIZE',
             'cast' => 'size',
-            'help' => 'Client max_allowed_packet (e.g. 16M, 64M)',
+            'help' => 'Target max_allowed_packet override (e.g. 16M, 64M)',
             'commands' => ['pull-db', 'db-pull'],
         ],
         [

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -10,7 +10,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     getDbName, compareDatabases, createMysqlConnection,
-    pullStateDirectory,
+    pullStateDirectory, readAuditLog,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -48,7 +48,10 @@ describe('Import: SQL Output Modes', () => {
                 `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
                 tempDir, 'db-pull', {
                     secret: getSiteSecret(site),
-                    extraArgs: ['--sql-output=stdout'],
+                    extraArgs: [
+                        '--sql-output=stdout',
+                        '--max-allowed-packet=1M',
+                    ],
                     skipPreflight: true,
                 },
             );
@@ -64,11 +67,23 @@ describe('Import: SQL Output Modes', () => {
             // No db.sql should be on disk
             assert.ok(!existsSync(join(tempDir, 'db.sql')),
                 'Expected no db.sql file when using --sql-output=stdout');
+
+            const stateFile = join(
+                pullStateDirectory(
+                    tempDir,
+                    `${getSiteUrl(site)}&directory=${getSiteDir(site)}`,
+                ),
+                'state.json',
+            );
+            const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+            assert.equal(state.max_allowed_packet, 1024 * 1024,
+                'Stdout output must save the configured packet value');
         });
     });
 
     describe('--sql-output=mysql', () => {
         let tempDir;
+        let targetMaxAllowedPacket;
         const importDb = 'e2e_basic_import_35_mysql';
 
         beforeAll(async () => {
@@ -76,6 +91,10 @@ describe('Import: SQL Output Modes', () => {
             const conn = await createMysqlConnection();
             await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
             await conn.query(`CREATE DATABASE \`${importDb}\``);
+            const [packetRows] = await conn.query(
+                'SELECT @@max_allowed_packet AS max_allowed_packet'
+            );
+            targetMaxAllowedPacket = Number(packetRows[0].max_allowed_packet);
             await conn.end();
         });
 
@@ -97,6 +116,7 @@ describe('Import: SQL Output Modes', () => {
                         '--mysql-host=127.0.0.1',
                         '--mysql-user=e2e_admin',
                         '--mysql-password=e2e_password',
+                        `--max-allowed-packet=${targetMaxAllowedPacket + 1}`,
                     ],
                 },
             );
@@ -114,7 +134,7 @@ describe('Import: SQL Output Modes', () => {
                 `counts=${JSON.stringify(comparison.rowCounts)}`);
         });
 
-        it('state file records sql_output mode', () => {
+        it('records and sends the configured packet limit', () => {
             const stateFile = join(
                 pullStateDirectory(
                     tempDir,
@@ -126,6 +146,17 @@ describe('Import: SQL Output Modes', () => {
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.sql_output, 'mysql',
                 `Expected sql_output=mysql in state, got ${state.sql_output}`);
+            assert.equal(
+                state.max_allowed_packet,
+                targetMaxAllowedPacket + 1,
+                'Direct MySQL output must save the configured packet value',
+            );
+            assert.ok(
+                readAuditLog(tempDir).includes(
+                    `"max_allowed_packet":${targetMaxAllowedPacket + 1}`
+                ),
+                'The SQL request must contain the configured packet value',
+            );
         });
     });
 });


### PR DESCRIPTION
Direct MySQL pulls now refresh `max_allowed_packet` from the target unless the user supplied an override.

## Background

The importer saved a value read from the target and reused it on later processes. If the target setting changed, that saved value could let the source produce statements which the target would reject.

An explicit `--max-allowed-packet` is different. It is a deliberate override and must survive resume invocations.

## This change

Direct MySQL output uses the configured or saved override when one exists. Otherwise, it reads `SELECT @@max_allowed_packet` from the open target connection before requesting SQL. A value read from the target remains in memory and is not saved in the pull state.

File and stdout output continue to use the configured value because those modes have no target connection.

## Testing

The output-mode test confirms that stdout and direct MySQL output both save a configured override, and that the outgoing SQL request contains that override.
