### PR TITLE
[PHP] Remove WP Engine platform plugins from imported sites

### DIFF
--- a/packages/reprint-client/src/lib/host/analyzers/class-wpengine-host-analyzer.php
+++ b/packages/reprint-client/src/lib/host/analyzers/class-wpengine-host-analyzer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Host analyzer for WP Engine.
+ *
+ * WP Engine installs platform MU plugins for caching, updates, sign-on,
+ * security logging, and its wp-admin integration. The analyzer removes them
+ * after a site moves away from WP Engine.
+ */
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Host analyzers use established global class names.
+class WpengineHostAnalyzer implements HostAnalyzer {
+    /**
+     * Score the WP Engine-specific MU-plugin names reported by preflight.
+     *
+     * One name is kept below the detection threshold because a copied plugin
+     * may remain after an earlier migration. The standard wpengine-common
+     * directory and its mu-plugin.php loader form a strong match together.
+     */
+    public static function score(array $preflight_data): float
+    {
+        $mu_plugin_names = [];
+        foreach ($preflight_data['wp_content']['roots'] ?? [] as $root) {
+            foreach ($root['mu_plugins'] ?? [] as $mu_plugin) {
+                $name = $mu_plugin['name'] ?? null;
+                if (is_string($name)) {
+                    $mu_plugin_names[$name] = true;
+                }
+            }
+        }
+
+        $wpengine_mu_plugin_names = [
+            'wpengine-common',
+            'wpe-cache-plugin',
+            'wpe-cache-plugin.php',
+            'wpe-update-source-selector',
+            'wpe-update-source-selector.php',
+            'wpe-wp-sign-on-plugin',
+            'wpe-wp-sign-on-plugin.php',
+            'wpengine-security-auditor.php',
+        ];
+        $matches = 0;
+        foreach ($wpengine_mu_plugin_names as $wpengine_mu_plugin_name) {
+            if (isset($mu_plugin_names[$wpengine_mu_plugin_name])) {
+                ++$matches;
+            }
+        }
+
+        if (
+            $matches >= 2
+            || (
+                isset($mu_plugin_names['wpengine-common'])
+                && isset($mu_plugin_names['mu-plugin.php'])
+            )
+        ) {
+            return 0.9;
+        }
+
+        return $matches === 1 ? 0.3 : 0.0;
+    }
+
+    public function analyze(array $preflight_data): RuntimeManifest
+    {
+        $manifest = new RuntimeManifest('wpengine');
+        $manifest->php_ini = extract_php_ini($preflight_data);
+        $manifest->constants = extract_constants($preflight_data);
+
+        // WP Engine tells sites moving to another host to remove its cache
+        // drop-ins and platform MU plugins. The cache and update-source files
+        // extend that published list with the current layout reported by a
+        // WP Engine site.
+        $manifest->paths_to_remove = [
+            'wp-content/advanced-cache.php',
+            'wp-content/object-cache.php',
+            'wp-content/mu-plugins/mu-plugin.php',
+            'wp-content/mu-plugins/wpengine-common',
+            'wp-content/mu-plugins/slt-force-strong-passwords.php',
+            'wp-content/mu-plugins/force-strong-passwords',
+            'wp-content/mu-plugins/stop-long-comments.php',
+            'wp-content/mu-plugins/wpe-cache-plugin',
+            'wp-content/mu-plugins/wpe-cache-plugin.php',
+            'wp-content/mu-plugins/wpe-update-source-selector',
+            'wp-content/mu-plugins/wpe-update-source-selector.php',
+            'wp-content/mu-plugins/wpe-wp-sign-on-plugin',
+            'wp-content/mu-plugins/wpe-wp-sign-on-plugin.php',
+            'wp-content/mu-plugins/wpengine-security-auditor.php',
+        ];
+
+        return $manifest;
+    }
+}

--- a/packages/reprint-client/src/lib/host/functions.php
+++ b/packages/reprint-client/src/lib/host/functions.php
@@ -18,6 +18,7 @@ function host_analyzer_registry(): array
     return [
         'wpcloud' => WpcloudHostAnalyzer::class,
         'siteground' => SitegroundHostAnalyzer::class,
+        'wpengine' => WpengineHostAnalyzer::class,
     ];
 }
 

--- a/packages/reprint-client/src/lib/host/load.php
+++ b/packages/reprint-client/src/lib/host/load.php
@@ -8,4 +8,5 @@ require_once __DIR__ . '/interface-host-analyzer.php';
 require_once __DIR__ . '/analyzers/class-default-host-analyzer.php';
 require_once __DIR__ . '/analyzers/class-wpcloud-host-analyzer.php';
 require_once __DIR__ . '/analyzers/class-siteground-host-analyzer.php';
+require_once __DIR__ . '/analyzers/class-wpengine-host-analyzer.php';
 require_once __DIR__ . '/functions.php';

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -511,4 +511,40 @@ class ProductionDropInRemovalTest extends TestCase
         );
     }
 
+    // ---- WP Engine-specific tests ----
+
+    public function testWpengineRemovesPlatformMuPluginsAndPreservesCustomMuPlugins(): void
+    {
+        $this->writeState([
+            'webhost' => 'wpengine',
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '',
+                        'env_names' => [],
+                        'ini_get_all' => [],
+                    ],
+                    'filesystem' => ['directories' => []],
+                    'wp_detect' => ['roots' => []],
+                ],
+            ],
+        ]);
+
+        $mu_plugins = $this->fsRoot . '/wp-content/mu-plugins';
+        mkdir($mu_plugins . '/wpengine-common', 0755, true);
+        mkdir($mu_plugins . '/wpe-update-source-selector', 0755, true);
+        file_put_contents($mu_plugins . '/mu-plugin.php', "<?php // WP Engine loader\n");
+        file_put_contents($mu_plugins . '/stop-long-comments.php', "<?php // WP Engine comment guard\n");
+        file_put_contents($mu_plugins . '/my-custom-plugin.php', "<?php // custom\n");
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertDirectoryDoesNotExist($mu_plugins . '/wpengine-common');
+        $this->assertDirectoryDoesNotExist($mu_plugins . '/wpe-update-source-selector');
+        $this->assertFileDoesNotExist($mu_plugins . '/mu-plugin.php');
+        $this->assertFileDoesNotExist($mu_plugins . '/stop-long-comments.php');
+        $this->assertFileExists($mu_plugins . '/my-custom-plugin.php');
+    }
 }

--- a/tests/Import/WpengineHostAnalyzerTest.php
+++ b/tests/Import/WpengineHostAnalyzerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Matches the existing import test namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/host/load.php';
+
+class WpengineHostAnalyzerTest extends TestCase {
+    private function wpenginePreflight(array $mu_plugins): array
+    {
+        return [
+            'runtime' => [
+                'ini_get_all' => [
+                    'memory_limit' => '256M',
+                ],
+            ],
+            'wp_content' => [
+                'roots' => [
+                    [
+                        'mu_plugins' => array_map(
+                            static function (string $name): array {
+                                return ['name' => $name, 'type' => substr($name, -4) === '.php' ? 'file' : 'dir'];
+                            },
+                            $mu_plugins,
+                        ),
+                    ],
+                ],
+            ],
+            'database' => [
+                'wp' => [
+                    'paths_urls' => [
+                        'abspath' => '/var/www/html/',
+                        'content_dir' => '/var/www/html/wp-content',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testScoreIdentifiesWpengineCommonWithItsLoader(): void
+    {
+        $preflight = $this->wpenginePreflight([
+            'mu-plugin.php',
+            'wpengine-common',
+        ]);
+
+        $this->assertGreaterThanOrEqual(0.5, \WpengineHostAnalyzer::score($preflight));
+    }
+
+    public function testScoreIdentifiesCurrentWpengineMuPlugins(): void
+    {
+        $preflight = $this->wpenginePreflight([
+            'wpe-cache-plugin',
+            'wpe-update-source-selector',
+            'wpengine-security-auditor.php',
+        ]);
+
+        $this->assertGreaterThanOrEqual(0.5, \WpengineHostAnalyzer::score($preflight));
+    }
+
+    public function testDetectHostReturnsWpengine(): void
+    {
+        $preflight = $this->wpenginePreflight([
+            'mu-plugin.php',
+            'wpengine-common',
+        ]);
+
+        $this->assertSame('wpengine', \detect_host($preflight));
+    }
+
+    public function testScoreRejectsOneGenericMuPlugin(): void
+    {
+        $preflight = $this->wpenginePreflight([
+            'force-strong-passwords',
+        ]);
+
+        $this->assertLessThan(0.5, \WpengineHostAnalyzer::score($preflight));
+    }
+
+    public function testScoreRejectsUnrelatedMuPlugins(): void
+    {
+        $preflight = $this->wpenginePreflight([
+            'my-company-loader.php',
+            'my-company-tools',
+        ]);
+
+        $this->assertSame(0.0, \WpengineHostAnalyzer::score($preflight));
+    }
+
+    public function testAnalyzeListsWpengineFilesRemovedDuringMigration(): void
+    {
+        $manifest = ( new \WpengineHostAnalyzer() )->analyze($this->wpenginePreflight([]));
+
+        $this->assertSame([
+            'wp-content/advanced-cache.php',
+            'wp-content/object-cache.php',
+            'wp-content/mu-plugins/mu-plugin.php',
+            'wp-content/mu-plugins/wpengine-common',
+            'wp-content/mu-plugins/slt-force-strong-passwords.php',
+            'wp-content/mu-plugins/force-strong-passwords',
+            'wp-content/mu-plugins/stop-long-comments.php',
+            'wp-content/mu-plugins/wpe-cache-plugin',
+            'wp-content/mu-plugins/wpe-cache-plugin.php',
+            'wp-content/mu-plugins/wpe-update-source-selector',
+            'wp-content/mu-plugins/wpe-update-source-selector.php',
+            'wp-content/mu-plugins/wpe-wp-sign-on-plugin',
+            'wp-content/mu-plugins/wpe-wp-sign-on-plugin.php',
+            'wp-content/mu-plugins/wpengine-security-auditor.php',
+        ], $manifest->paths_to_remove);
+        $this->assertSame('wpengine', $manifest->source);
+    }
+}


### PR DESCRIPTION
WP Engine imports now remove platform cache drop-ins and MU plugins during `apply-runtime`, so a copied site does not load code tied to WP Engine services.

WP Engine's [migration guide](https://wpengine.com/support/best-practices-uploading-wp-engine-site-another-environment/) says to delete its cache drop-ins, `wpengine-common`, strong-password files, comment guard, sign-on plugin, and security auditor when moving a site to another host. This change uses that list and also removes the `wpe-cache-plugin` and `wpe-update-source-selector` files found in the current WP Engine layout.

Detection requires either the standard `wpengine-common` and `mu-plugin.php` pair or at least two WP Engine-specific MU-plugin names. One copied plugin stays below the host detection threshold. Unrelated MU plugins remain in place.

## Testing

```text
cd tests && ../vendor/bin/phpunit Import/WpengineHostAnalyzerTest.php Import/WpcloudHostAnalyzerTest.php Import/SitegroundHostAnalyzerTest.php Import/ProductionDropInRemovalTest.php
vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src/lib/host/analyzers/class-wpengine-host-analyzer.php
git diff --check
```
