### PR TITLE
Reprint Server: Extract the UI-independent configuration layer

### DIFF
--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -120,6 +120,24 @@ if ($myRouter->matches('/export')) {
 Platform configuration. Direct `lib.php` embedders pass them as the function's
 array argument and do not use the WordPress filter.
 
+An embedding WordPress plugin which wants the option-backed connection token
+and its push-authorization revocation hooks may opt into that integration
+without loading the bundled administrator:
+
+```php
+use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
+
+require_once '/path/to/reprint-server-wp/lib.php';
+require_once '/path/to/reprint-server-wp/wordpress/configuration.php';
+
+register_wordpress_configuration();
+```
+
+The embedding plugin may then use the namespaced `get_configuration_state()`,
+`change_connection_token()`, and `change_push_access()` operations to render
+and process its own administrator surface. It should not require
+`wordpress/site-export.php` unless it explicitly wants the bundled page.
+
 `lib.php` defines these constants in `WordPress\Reprint\Server\Plugin`
 (using WordPress's `plugin_dir_path`):
 

--- a/reprint-server-wp/index.php
+++ b/reprint-server-wp/index.php
@@ -41,5 +41,7 @@ if (isset($_GET['reprint-api'])) {
     exit;
 }
 
-// Register the settings page.
+// Register the option-backed configuration, then the settings page.
+require_once __DIR__ . '/wordpress/configuration.php';
+\WordPress\Reprint\Server\Plugin\register_wordpress_configuration();
 require_once __DIR__ . '/wordpress/site-export.php';

--- a/reprint-server-wp/wordpress/configuration.php
+++ b/reprint-server-wp/wordpress/configuration.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace WordPress\Reprint\Server\Plugin;
+
+/**
+ * UI-independent WordPress configuration integration for Reprint Server.
+ *
+ * A project embedding lib.php can require this file to get the option-backed
+ * connection token, its push-authorization revocation hooks, and the read and
+ * write operations behind them, without loading the bundled administrator.
+ */
+
+/** Register the option and hooks used by the option-backed configuration. */
+function register_wordpress_configuration(): void {
+    static $registered = false;
+
+    if ($registered) {
+        return;
+    }
+    $registered = true;
+
+    add_action('init', __NAMESPACE__ . '\\register_connection_token_setting');
+    add_action(
+        'update_option_' . CONNECTION_TOKEN_OPTION,
+        __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_change',
+        10,
+        2
+    );
+    add_action(
+        'add_option_' . CONNECTION_TOKEN_OPTION,
+        __NAMESPACE__ . '\\revoke_push_authorization_after_connection_token_added',
+        10,
+        0
+    );
+}
+
+/** Register the option so core's /wp/v2/settings endpoint can update it. */
+function register_connection_token_setting(): void {
+    register_setting(
+        'general',
+        CONNECTION_TOKEN_OPTION,
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+            'show_in_rest' => true,
+        ]
+    );
+}
+
+/**
+ * Revoke local push authorization when the effective connection token changes.
+ *
+ * The secret.php override keeps the option from becoming the effective token.
+ *
+ * @param mixed $old_value Previous option value.
+ * @param mixed $new_value New option value.
+ */
+function revoke_push_authorization_after_connection_token_change($old_value, $new_value): void {
+    if (has_connection_token_file()) {
+        return;
+    }
+
+    $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
+    $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
+    if ($old_connection_token !== $new_connection_token) {
+        update_push_authorization(false);
+    }
+}
+
+/**
+ * Revoke stale local push authorization when the connection-token option is added.
+ *
+ * WordPress uses add_option() when update_option() receives a missing option,
+ * so that path does not emit the update hook above. A secret.php override
+ * still keeps the option from becoming the effective token.
+ */
+function revoke_push_authorization_after_connection_token_added(): void {
+    if (!has_connection_token_file()) {
+        update_push_authorization(false);
+    }
+}
+
+/**
+ * Returns the configuration state used by WordPress integrations.
+ *
+ * @return array {
+ *     Current Reprint Server configuration state.
+ *
+ *     @type string    $stored_connection_token Option-backed connection token.
+ *     @type bool      $is_configured Whether an effective connection token exists.
+ *     @type bool      $has_connection_token_file Whether secret.php supplies the effective connection token.
+ *     @type bool      $push_supported Whether this PHP runtime can serve push endpoints.
+ *     @type bool|null $managed_push_enabled Hosting-provider push policy, or null when the site controls it.
+ *     @type bool      $push_enabled Whether push is authorized for the current connection token.
+ * }
+ * @phpstan-return array{
+ *     stored_connection_token:string,
+ *     is_configured:bool,
+ *     has_connection_token_file:bool,
+ *     push_supported:bool,
+ *     managed_push_enabled:bool|null,
+ *     push_enabled:bool
+ * }
+ */
+function get_configuration_state(): array {
+    $effective_connection_token = get_connection_token();
+    $push_supported = push_is_supported();
+
+    return [
+        'stored_connection_token' => get_option_connection_token(),
+        'is_configured' => $effective_connection_token !== null && $effective_connection_token !== '',
+        'has_connection_token_file' => has_connection_token_file(),
+        'push_supported' => $push_supported,
+        'managed_push_enabled' => get_managed_push_enabled(),
+        'push_enabled' => $push_supported && is_push_authorized(),
+    ];
+}
+
+/**
+ * Applies an option-backed connection-token change.
+ *
+ * @return string One of saved, unchanged, or storage_failure.
+ */
+function change_connection_token(string $connection_token): string {
+    if (get_option_connection_token() === $connection_token) {
+        return 'unchanged';
+    }
+
+    return update_connection_token($connection_token) ? 'saved' : 'storage_failure';
+}
+
+/**
+ * Applies a site-controlled push-access change.
+ *
+ * @return string One of saved, unchanged, unsupported, managed,
+ *                not_configured, or storage_failure.
+ */
+function change_push_access(bool $enabled): string {
+    if (!push_is_supported()) {
+        return 'unsupported';
+    }
+
+    if (get_managed_push_enabled() !== null) {
+        return 'managed';
+    }
+
+    $connection_token = get_connection_token();
+    if ($enabled && ( $connection_token === null || $connection_token === '' )) {
+        return 'not_configured';
+    }
+
+    $fingerprint = $enabled ? hash('sha256', $connection_token) : '';
+    if (
+        function_exists('get_option')
+        && get_option(PUSH_AUTHORIZATION_OPTION, '') === $fingerprint
+    ) {
+        return 'unchanged';
+    }
+
+    return update_push_authorization($enabled) ? 'saved' : 'storage_failure';
+}

--- a/reprint-server-wp/wordpress/site-export.php
+++ b/reprint-server-wp/wordpress/site-export.php
@@ -24,71 +24,13 @@ class Site_Export_Plugin {
     }
 
     private function __construct() {
-        add_action('init', [$this, 'register_settings']);
-        add_action(
-            'update_option_' . SITE_EXPORT_SECRET_OPTION,
-            [$this, 'revoke_push_authorization_after_connection_token_change'],
-            10,
-            2
-        );
-        add_action(
-            'add_option_' . SITE_EXPORT_SECRET_OPTION,
-            [$this, 'revoke_push_authorization_after_connection_token_added'],
-            10,
-            0
-        );
+        // The option registration and push-authorization revocation hooks live
+        // in wordpress/configuration.php, which index.php registers before
+        // loading this administrator.
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('admin_init', [$this, 'handle_settings_save']);
         add_filter('plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'), [$this, 'add_settings_link']);
         add_action('admin_bar_menu', [$this, 'add_admin_bar_node'], 100);
-    }
-
-    /** Register the option so core's /wp/v2/settings endpoint can update it. */
-    public function register_settings() {
-        register_setting(
-            'general',
-            SITE_EXPORT_SECRET_OPTION,
-            [
-                'type' => 'string',
-                'sanitize_callback' => 'sanitize_text_field',
-                'default' => '',
-                'show_in_rest' => true,
-            ]
-        );
-    }
-
-    /**
-     * Revoke local push authorization when the effective connection token changes.
-     *
-     * The secret.php override keeps the option from becoming the effective token.
-     *
-     * @param mixed $old_value Previous option value.
-     * @param mixed $new_value New option value.
-     */
-    public function revoke_push_authorization_after_connection_token_change($old_value, $new_value) {
-        if (_site_export_has_secret_file()) {
-            return;
-        }
-
-        $old_connection_token = is_string($old_value) && $old_value !== '' ? $old_value : null;
-        $new_connection_token = is_string($new_value) && $new_value !== '' ? $new_value : null;
-        if ($old_connection_token !== $new_connection_token) {
-            _site_export_update_push_authorization(false);
-        }
-    }
-
-    /**
-     * Revoke stale local push authorization when the connection-token option is added.
-     *
-     * WordPress uses add_option() when update_option() receives a missing option,
-     * so that path does not emit the update hook above. A secret.php override
-     * still keeps the option from becoming the effective token.
-     *
-     */
-    public function revoke_push_authorization_after_connection_token_added() {
-        if (!_site_export_has_secret_file()) {
-            _site_export_update_push_authorization(false);
-        }
     }
 
     /**
@@ -150,10 +92,9 @@ class Site_Export_Plugin {
             $secret = isset($_POST['site_export_secret'])
                 ? sanitize_text_field(wp_unslash($_POST['site_export_secret']))
                 : '';
-            $updated = _site_export_update_shared_secret($secret);
-            $saved = $updated || _site_export_get_option_secret() === $secret;
+            $result = \WordPress\Reprint\Server\Plugin\change_connection_token($secret);
 
-            if (!$saved) {
+            if ($result === 'storage_failure') {
                 add_settings_error('site_export', 'save_failed', 'Failed to save secret.', 'error');
                 return;
             }
@@ -167,7 +108,10 @@ class Site_Export_Plugin {
             return;
         }
 
-        if (!_site_export_push_is_supported()) {
+        $push_enabled = isset($_POST['site_export_push_enabled']);
+        $result = \WordPress\Reprint\Server\Plugin\change_push_access($push_enabled);
+
+        if ($result === 'unsupported') {
             add_settings_error(
                 'site_export',
                 'push_access_unsupported',
@@ -177,7 +121,7 @@ class Site_Export_Plugin {
             return;
         }
 
-        if (_site_export_get_managed_push_enabled() !== null) {
+        if ($result === 'managed') {
             add_settings_error(
                 'site_export',
                 'push_access_managed',
@@ -187,8 +131,9 @@ class Site_Export_Plugin {
             return;
         }
 
-        $push_enabled = isset($_POST['site_export_push_enabled']);
-        if (!_site_export_update_push_authorization($push_enabled)) {
+        // update_push_authorization() refused a missing connection token by
+        // returning false, so both outcomes keep the same failure notice.
+        if ($result === 'storage_failure' || $result === 'not_configured') {
             add_settings_error('site_export', 'push_access_save_failed', 'Failed to save push access.', 'error');
             return;
         }
@@ -204,14 +149,14 @@ class Site_Export_Plugin {
             return;
         }
 
-        $stored_secret = _site_export_get_option_secret();
-        $effective_secret = _site_export_get_shared_secret() ?? '';
+        $configuration = \WordPress\Reprint\Server\Plugin\get_configuration_state();
+        $stored_secret = $configuration['stored_connection_token'];
         $api_url = home_url('?reprint-api');
-        $is_configured = $effective_secret !== '';
-        $has_file_override = _site_export_has_secret_file();
-        $push_supported = _site_export_push_is_supported();
-        $managed_push_enabled = _site_export_get_managed_push_enabled();
-        $push_enabled = $push_supported && _site_export_is_push_authorized();
+        $is_configured = $configuration['is_configured'];
+        $has_file_override = $configuration['has_connection_token_file'];
+        $push_supported = $configuration['push_supported'];
+        $managed_push_enabled = $configuration['managed_push_enabled'];
+        $push_enabled = $configuration['push_enabled'];
 
         ?>
         <style>

--- a/tests/ReprintServerPluginTest.php
+++ b/tests/ReprintServerPluginTest.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
  * deleted together with compat.php.
  */
 
+use function WordPress\Reprint\Server\Plugin\change_connection_token;
+use function WordPress\Reprint\Server\Plugin\change_push_access;
+use function WordPress\Reprint\Server\Plugin\get_configuration_state;
 use function WordPress\Reprint\Server\Plugin\get_connection_token;
 use function WordPress\Reprint\Server\Plugin\get_managed_push_enabled;
 use function WordPress\Reprint\Server\Plugin\get_push_authorization_error;
 use function WordPress\Reprint\Server\Plugin\is_push_authorized;
+use function WordPress\Reprint\Server\Plugin\register_connection_token_setting;
 use function WordPress\Reprint\Server\Plugin\update_connection_token;
 use function WordPress\Reprint\Server\Plugin\update_push_authorization;
 use function WordPress\Reprint\Server\Plugin\verify_hmac;
@@ -50,7 +54,7 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
 
     public function testPluginRegistersConnectionTokenOptionForCoreSettingsRestEndpoint(): void
     {
-        Site_Export_Plugin::get_instance()->register_settings();
+        register_connection_token_setting();
 
         $setting = $GLOBALS['reprint_server_registered_settings'][CONNECTION_TOKEN_OPTION] ?? null;
         $this->assertNotNull($setting);
@@ -163,7 +167,7 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
     {
         $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'token-a';
         $this->assertTrue(update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
+        register_connection_token_setting();
 
         update_option(CONNECTION_TOKEN_OPTION, 'token-b');
         update_option(CONNECTION_TOKEN_OPTION, 'token-a');
@@ -176,7 +180,7 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
     {
         file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'token-a';\n");
         $this->assertTrue(update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
+        register_connection_token_setting();
 
         unlink(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE);
         $this->assertFalse(is_push_authorized());
@@ -191,7 +195,7 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
         $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'option-token-a';
         file_put_contents(REPRINT_SERVER_TEST_CONNECTION_TOKEN_FILE, "<?php return 'file-token';\n");
         $this->assertTrue(update_push_authorization(true));
-        Site_Export_Plugin::get_instance()->register_settings();
+        register_connection_token_setting();
 
         update_option(CONNECTION_TOKEN_OPTION, 'option-token-b');
 
@@ -200,6 +204,27 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
             $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
         );
         $this->assertTrue(is_push_authorized());
+    }
+
+    /**
+     * Enabling push without a connection token must stay a failure notice.
+     *
+     * The extracted operation reports this as not_configured, where the
+     * inlined update_push_authorization() call simply returned false.
+     */
+    public function testPushAccessFormWithoutAConnectionTokenReportsFailure(): void
+    {
+        $_POST = [
+            'site_export_save_push_access' => '1',
+            'site_export_push_enabled' => '1',
+        ];
+
+        Site_Export_Plugin::get_instance()->handle_settings_save();
+
+        $codes = array_column($GLOBALS['reprint_server_settings_errors'], 'code');
+        $this->assertContains('push_access_save_failed', $codes);
+        $this->assertNotContains('push_access_saved', $codes);
+        $this->assertFalse(is_push_authorized());
     }
 
     public function testPushAccessFormAuthorizesTheCurrentConnectionToken(): void
@@ -254,5 +279,84 @@ final class ReprintServerPluginTest extends ReprintServerPluginTestCase
         $this->assertStringContainsString('Push access is managed by your hosting provider.', $html);
         $this->assertStringContainsString('name="site_export_push_enabled" value="1" checked disabled', $html);
         $this->assertStringNotContainsString('name="site_export_save_push_access"', $html);
+    }
+
+    public function testConnectionTokenOperationReturnsExplicitOutcomes(): void
+    {
+        $this->assertSame('saved', change_connection_token('new-token'));
+        $this->assertSame('unchanged', change_connection_token('new-token'));
+
+        $GLOBALS['reprint_server_fail_option_updates'][] = CONNECTION_TOKEN_OPTION;
+        $this->assertSame('storage_failure', change_connection_token('other-token'));
+    }
+
+    public function testConfigurationIntegrationRegistersOutsideTheAdministratorAdapter(): void
+    {
+        $init_hooks = $GLOBALS['reprint_server_test_actions']['init'] ?? [];
+        $update_hooks = $GLOBALS['reprint_server_test_actions']['update_option_' . CONNECTION_TOKEN_OPTION] ?? [];
+        $add_hooks = $GLOBALS['reprint_server_test_actions']['add_option_' . CONNECTION_TOKEN_OPTION] ?? [];
+
+        $this->assertNotEmpty($init_hooks);
+        $this->assertSame(
+            'WordPress\\Reprint\\Server\\Plugin\\register_connection_token_setting',
+            $init_hooks[0]['callback']
+        );
+        $this->assertNotEmpty($update_hooks);
+        $this->assertSame(
+            'WordPress\\Reprint\\Server\\Plugin\\revoke_push_authorization_after_connection_token_change',
+            $update_hooks[0]['callback']
+        );
+        $this->assertNotEmpty($add_hooks);
+        $this->assertSame(
+            'WordPress\\Reprint\\Server\\Plugin\\revoke_push_authorization_after_connection_token_added',
+            $add_hooks[0]['callback']
+        );
+    }
+
+    public function testPushAccessOperationAuthorizesTheCurrentConnectionToken(): void
+    {
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+
+        $this->assertSame('saved', change_push_access(true));
+        $this->assertSame(
+            hash('sha256', 'current-token'),
+            $GLOBALS['reprint_server_test_options'][PUSH_AUTHORIZATION_OPTION]
+        );
+        $this->assertTrue(is_push_authorized());
+    }
+
+    public function testPushAccessOperationReturnsExplicitOutcomes(): void
+    {
+        $this->assertSame('not_configured', change_push_access(true));
+
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $this->assertSame('saved', change_push_access(true));
+        $this->assertSame('unchanged', change_push_access(true));
+
+        putenv('REPRINT_SERVER_PUSH_ENABLED=false');
+        $this->assertSame('managed', change_push_access(false));
+    }
+
+    public function testPushAccessOperationReportsStorageFailure(): void
+    {
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+        $GLOBALS['reprint_server_fail_option_updates'][] = PUSH_AUTHORIZATION_OPTION;
+
+        $this->assertSame('storage_failure', change_push_access(true));
+        $this->assertFalse(is_push_authorized());
+    }
+
+    public function testConfigurationStateDescribesTheEffectiveConnection(): void
+    {
+        $GLOBALS['reprint_server_test_options'][CONNECTION_TOKEN_OPTION] = 'current-token';
+
+        $configuration = get_configuration_state();
+
+        $this->assertSame('current-token', $configuration['stored_connection_token']);
+        $this->assertTrue($configuration['is_configured']);
+        $this->assertFalse($configuration['has_connection_token_file']);
+        $this->assertTrue($configuration['push_supported']);
+        $this->assertNull($configuration['managed_push_enabled']);
+        $this->assertFalse($configuration['push_enabled']);
     }
 }

--- a/tests/lib/ReprintServerPluginTestCase.php
+++ b/tests/lib/ReprintServerPluginTestCase.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use function WordPress\Reprint\Server\Plugin\register_wordpress_configuration;
+
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/');
 }
@@ -45,6 +47,7 @@ $GLOBALS['reprint_server_test_options'] = [];
 $GLOBALS['reprint_server_registered_settings'] = [];
 $GLOBALS['reprint_server_settings_errors'] = [];
 $GLOBALS['reprint_server_test_actions'] = [];
+$GLOBALS['reprint_server_fail_option_updates'] = [];
 
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(string $file): string {
@@ -64,6 +67,10 @@ if (!function_exists('get_option')) {
 
 if (!function_exists('update_option')) {
     function update_option(string $name, $value, $autoload = null): bool {
+        if (in_array($name, $GLOBALS['reprint_server_fail_option_updates'], true)) {
+            return false;
+        }
+
         if (!array_key_exists($name, $GLOBALS['reprint_server_test_options'])) {
             $GLOBALS['reprint_server_test_options'][$name] = $value;
             foreach ($GLOBALS['reprint_server_test_actions']['add_option_' . $name] ?? [] as $action) {
@@ -246,6 +253,8 @@ if (!function_exists('esc_html')) {
 // phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 
 require_once __DIR__ . '/../../reprint-server-wp/lib.php';
+require_once __DIR__ . '/../../reprint-server-wp/wordpress/configuration.php';
+register_wordpress_configuration();
 require_once __DIR__ . '/../../reprint-server-wp/wordpress/site-export.php';
 abstract class ReprintServerPluginTestCase extends TestCase
 {
@@ -278,6 +287,7 @@ abstract class ReprintServerPluginTestCase extends TestCase
         $GLOBALS['reprint_server_test_options'] = [];
         $GLOBALS['reprint_server_registered_settings'] = [];
         $GLOBALS['reprint_server_settings_errors'] = [];
+        $GLOBALS['reprint_server_fail_option_updates'] = [];
         $_SERVER = [];
         $_FILES = [];
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test resets request globals.


### PR DESCRIPTION
Moves the option registration and push-authorization revocation hooks off the settings page into a UI-independent wordpress/configuration.php, which also exposes get_configuration_state(), change_connection_token(), and change_push_access() for the page and for embedding plugins to call. The page keeps its current behaviour, including the failure notice for enabling push without a connection token, which the extracted operation reports as not_configured rather than a false return.