### PR TITLE
[PHP] Stop recounting remote indexes at pull checkpoints

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -12501,7 +12501,6 @@ class ImportClient
             throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->pull_state_file}");
         }
 
-        $remote_index_entry_count = $this->remote_index_entry_count();
         $files_pulled = $this->files_pulled; // Completed in this run
         $has_cursor =
             !empty($state["active_resumable_command"]["remote_cursor"] ?? null) ||
@@ -12511,8 +12510,7 @@ class ImportClient
 
         $this->audit_log(
             sprintf(
-                "SAVE CURSOR | remote_index_entries=%d | completed_this_run=%d | %s",
-                $remote_index_entry_count,
+                "SAVE CURSOR | completed_this_run=%d | %s",
                 $files_pulled,
                 $cursor_info,
             ),

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -184,6 +184,22 @@ class FilesPullStateTest extends TestCase
         }
     }
 
+    public function testSavingStateDoesNotReadTheRemoteIndex()
+    {
+        $client = $this->getMockBuilder(\ImportClient::class)
+            ->setConstructorArgs([
+                'http://fake.url',
+                $this->stateDir,
+                $this->filesystem_root,
+            ])
+            ->onlyMethods(['remote_index_entry_count'])
+            ->getMock();
+        $client->expects($this->never())
+            ->method('remote_index_entry_count');
+
+        $client->save_state();
+    }
+
     /**
      * After --abort, the state should not be "complete".
      */


### PR DESCRIPTION
`files-pull` no longer rereads the retained remote index at every durable state write, cutting client CPU by about 46% in a 30,000-file pull.

## Background

This started by looking at the internal partial-response loop added in #722. That change keeps the local PHP process alive and starts another source request while memory permits. The question was whether each trip through that loop repeated enough parsing and index-diff work to justify keeping more of it in memory.

The saved `current_stage` already prevents completed index and diff stages from running again. The remaining repeated work includes source path-list parsing, applying the pull index WAL after each response, and the normal state writes around durable file-part boundaries.

The benchmark used `reprintlargetestsite.wpcomstaging.com`, restricted to `/srv/htdocs/wp-content/extra-files`: 30,000 small files. A normal pull used four `file_fetch` requests with batches of 8,533, 8,533, 8,533, and 4,401 paths.

The dominant cost was outside the loop itself. `save_state()` ran 30,179 times and called `remote_index_entry_count()` only to include `remote_index_entries` in each `SAVE CURSOR` audit line. As the remote index grew, those counts reread about 336 million JSONL lines.

| Measurement | Before | This PR | Change |
| --- | ---: | ---: | ---: |
| Wall time, pair 1 | 48.24 s | 35.48 s | -26% |
| Wall time, pair 2 | 115.34 s | 86.97 s | -25% |
| Client CPU, pair 1 | 34.59 s | 18.35 s | -47% |
| Client CPU, pair 2 | 37.51 s | 20.18 s | -46% |
| No-change delta | 2.60 s | 2.14 s | -18% |

Wall time varied with local disk load. The paired reduction and client CPU reduction stayed consistent.

The other suspected work was small:

- Four WAL-to-index merges took 0.92 seconds. One final merge took 0.57 seconds, a possible 0.35-second saving.
- A one-second source budget forced seven fetch requests and three partial responses. Seven merges took 1.09 seconds, versus 0.57 seconds for one final merge.
- Reported source work was 5.14 seconds with four requests and 5.08 seconds with seven requests. Repeating the uploaded path-list parsing was below run-to-run noise.

Deferring the index merges would therefore save about 0.35–0.52 seconds here while making interruption recovery harder. This PR leaves that behavior alone.

## This change

`save_state()` still writes the durable state and progress file at the same boundaries. It stops counting the complete remote index for the audit-only `SAVE CURSOR` message. Lifecycle, resume, shutdown, and completion output still count the index where that number is useful to a person.

A focused test prevents state saving from calling `remote_index_entry_count()` again.

## Testing

Pulled all 30,000 selected files twice before and after the change, then repeated the pull with a one-second source budget to force partial responses. Each completed pull produced 30,000 local files. The focused state, request-sizing, and pull-state tests pass, and PHPStan reports no errors.
