### PR TITLE
[PHP] Limit progress.json writes during active pulls

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -12525,19 +12525,23 @@ class ImportClient
             $this->state->active_resumable_command->completion_state;
 
         /**
-         * state.json records where an interrupted pull can restart, so it must
-         * be written after every completed unit of work. progress.json is only
-         * a status snapshot for external tools to poll. It does not need to be
-         * rewritten at every state checkpoint.
+         * save_state() writes two files for different readers:
          *
-         * A 30,000-file pull produced 30,179 checkpoints. progress.json was
-         * only about 185 bytes, but writing it atomically at every checkpoint
-         * also meant 30,179 temporary-file writes and renames. Limit active
-         * status updates by elapsed time because polling readers care how old
-         * the snapshot is, while checkpoint frequency varies with the number
-         * and size of files. One update per second keeps the snapshot recent
-         * without repeating that filesystem work. Cleared, partial, and
-         * complete states are still written immediately.
+         * 1. state.json tells the next PHP process where to resume. Write it
+         *    after every completed unit of work so a stopped pull can continue.
+         * 2. progress.json tells a polling UI what the pull is doing. The UI
+         *    needs a recent update, but it does not need every checkpoint.
+         *
+         * In a test with 30,000 files, save_state() ran 30,179 times. Each
+         * progress.json update wrote about 185 bytes to a temporary file and
+         * renamed that file over the old copy. Updating once per checkpoint
+         * therefore caused 30,179 writes and 30,179 renames.
+         *
+         * Limit active progress updates to once per second. Time is the useful
+         * limit because the UI cares how old its status is, and the number of
+         * checkpoints per second changes with the files being pulled. Write a
+         * cleared, partial, or complete state immediately because the command
+         * may not save another checkpoint afterward.
          */
         if (
             $completion_state !== "in_progress"

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -12501,7 +12501,6 @@ class ImportClient
             throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->pull_state_file}");
         }
 
-        $remote_index_entry_count = $this->remote_index_entry_count();
         $files_pulled = $this->files_pulled; // Completed in this run
         $has_cursor =
             !empty($state["active_resumable_command"]["remote_cursor"] ?? null) ||
@@ -12511,8 +12510,7 @@ class ImportClient
 
         $this->audit_log(
             sprintf(
-                "SAVE CURSOR | remote_index_entries=%d | completed_this_run=%d | %s",
-                $remote_index_entry_count,
+                "SAVE CURSOR | completed_this_run=%d | %s",
                 $files_pulled,
                 $cursor_info,
             ),

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -260,7 +260,10 @@ class ImportClient
      */
     private $last_progress_output = 0;
 
-    /** @var float Minimum seconds between progress output lines. */
+    /** @var float Timestamp of the last successful progress.json write. */
+    private $last_progress_file_write = 0;
+
+    /** @var float Minimum seconds between recurring progress reports. */
     private $progress_throttle = 1.0;
 
     /** @var string Retained filesystem-root snapshot for this remote state directory. */
@@ -8888,6 +8891,7 @@ class ImportClient
                                     // Broken pipe — save state and exit cleanly so the
                                     // pipe reader (e.g. `mysql`) can finish on its own.
                                     $this->save_state();
+                                    $this->write_progress_file();
                                     exit(0);
                                 }
                                 $sql_bytes_written += $bytes;
@@ -12517,7 +12521,24 @@ class ImportClient
             false,
         );
 
-        $this->write_progress_file();
+        $completion_state =
+            $this->state->active_resumable_command->completion_state;
+
+        /**
+         * A 30,000-file pull saved state 30,179 times. Replacing the roughly
+         * 185-byte progress.json at every checkpoint wrote only 5.3 MiB of
+         * payload, but also performed 30,179 temporary-file writes and
+         * renames. Keep state.json durable at every checkpoint while limiting
+         * this status file's recurring filesystem work to once per second.
+         * Cleared, partial, and complete states are always written immediately.
+         */
+        if (
+            $completion_state !== "in_progress"
+            || microtime(true) - $this->last_progress_file_write >=
+                $this->progress_throttle
+        ) {
+            $this->write_progress_file();
+        }
     }
 
     /**
@@ -12552,8 +12573,11 @@ class ImportClient
             return; // Best-effort — don't crash the pull over a progress file
         }
         $tmp = $this->progress_file . ".tmp";
-        if (file_put_contents($tmp, $json) !== false) {
-            rename($tmp, $this->progress_file);
+        if (
+            file_put_contents($tmp, $json) !== false
+            && rename($tmp, $this->progress_file)
+        ) {
+            $this->last_progress_file_write = microtime(true);
         }
     }
 
@@ -12631,6 +12655,9 @@ class ImportClient
         // Save current state (with timeout protection)
         try {
             $this->save_state();
+            // The process is about to be killed, so do not leave the final
+            // in-progress snapshot behind the one-second throttle.
+            $this->write_progress_file();
             $this->progress->show_lifecycle_line("✓ State saved successfully\n");
             $this->output_progress([
                 "type" => "state_saved",
@@ -12692,6 +12719,7 @@ class ImportClient
             if ($written === false) {
                 // Broken pipe — save state and exit cleanly
                 $this->save_state();
+                $this->write_progress_file();
                 exit(0);
             }
             @flush();

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -12525,12 +12525,19 @@ class ImportClient
             $this->state->active_resumable_command->completion_state;
 
         /**
-         * A 30,000-file pull saved state 30,179 times. Replacing the roughly
-         * 185-byte progress.json at every checkpoint wrote only 5.3 MiB of
-         * payload, but also performed 30,179 temporary-file writes and
-         * renames. Keep state.json durable at every checkpoint while limiting
-         * this status file's recurring filesystem work to once per second.
-         * Cleared, partial, and complete states are always written immediately.
+         * state.json records where an interrupted pull can restart, so it must
+         * be written after every completed unit of work. progress.json is only
+         * a status snapshot for external tools to poll. It does not need to be
+         * rewritten at every state checkpoint.
+         *
+         * A 30,000-file pull produced 30,179 checkpoints. progress.json was
+         * only about 185 bytes, but writing it atomically at every checkpoint
+         * also meant 30,179 temporary-file writes and renames. Limit active
+         * status updates by elapsed time because polling readers care how old
+         * the snapshot is, while checkpoint frequency varies with the number
+         * and size of files. One update per second keeps the snapshot recent
+         * without repeating that filesystem work. Cleared, partial, and
+         * complete states are still written immediately.
          */
         if (
             $completion_state !== "in_progress"

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -184,6 +184,22 @@ class FilesPullStateTest extends TestCase
         }
     }
 
+    public function testSavingStateDoesNotReadTheRemoteIndex()
+    {
+        $client = $this->getMockBuilder(\ImportClient::class)
+            ->setConstructorArgs([
+                'http://fake.url',
+                $this->stateDir,
+                $this->filesystem_root,
+            ])
+            ->onlyMethods(['remote_index_entry_count'])
+            ->getMock();
+        $client->expects($this->never())
+            ->method('remote_index_entry_count');
+
+        $client->save_state();
+    }
+
     /**
      * After --abort, the state should not be "complete".
      */

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -200,6 +200,172 @@ class FilesPullStateTest extends TestCase
         $client->save_state();
     }
 
+    public function testSavingStateThrottlesOnlyInProgressProgressFileWrites()
+    {
+        $client = $this->getMockBuilder(\ImportClient::class)
+            ->setConstructorArgs([
+                'http://fake.url',
+                $this->stateDir,
+                $this->filesystem_root,
+            ])
+            ->onlyMethods(['write_progress_file'])
+            ->getMock();
+        $written_completion_states = [];
+        $client->method('write_progress_file')
+            ->willReturnCallback(function () use (
+                $client,
+                &$written_completion_states
+            ): void {
+                $written_completion_states[] =
+                    $client->get_state()
+                        ->active_resumable_command
+                        ->completion_state;
+            });
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('last_progress_file_write')
+            ->setValue($client, microtime(true));
+        $client->get_state()->active_resumable_command->completion_state =
+            'in_progress';
+        $client->save_state();
+
+        $client->get_state()->active_resumable_command->completion_state = null;
+        $client->save_state();
+
+        $client->get_state()->active_resumable_command->completion_state =
+            'partial';
+        $client->save_state();
+
+        $client->get_state()->active_resumable_command->completion_state =
+            'complete';
+        $client->save_state();
+
+        $this->assertSame(
+            [null, 'partial', 'complete'],
+            $written_completion_states
+        );
+    }
+
+    public function testSavingStateRefreshesInProgressProgressAfterThrottle()
+    {
+        $client = $this->getMockBuilder(\ImportClient::class)
+            ->setConstructorArgs([
+                'http://fake.url',
+                $this->stateDir,
+                $this->filesystem_root,
+            ])
+            ->onlyMethods(['write_progress_file'])
+            ->getMock();
+        $client->expects($this->once())
+            ->method('write_progress_file');
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('last_progress_file_write')
+            ->setValue($client, microtime(true) - 1.1);
+        $client->get_state()->active_resumable_command->completion_state =
+            'in_progress';
+
+        $client->save_state();
+    }
+
+    public function testShutdownFlushesTheLatestProgressFile()
+    {
+        if (
+            !function_exists('pcntl_fork')
+            || !function_exists('pcntl_waitpid')
+            || !function_exists('posix_kill')
+            || !defined('SIGKILL')
+            || !defined('SIGTERM')
+        ) {
+            $this->markTestSkipped('Shutdown progress coverage requires PCNTL and POSIX.');
+        }
+
+        $child_pid = pcntl_fork();
+        if ($child_pid === -1) {
+            $this->fail('Failed to fork the shutdown progress test.');
+        }
+        if ($child_pid === 0) {
+            $client = $this->makeClient();
+            $reflection = new \ReflectionClass(\ImportClient::class);
+            $null_output = fopen('/dev/null', 'w');
+            if ($null_output === false) {
+                exit(2);
+            }
+            $reflection->getProperty('progress_fd')
+                ->setValue($client, $null_output);
+            $reflection->getProperty('progress')
+                ->setValue($client, new \TerminalProgress(false, $null_output));
+
+            $command = $client->get_state()->active_resumable_command;
+            $command->command_name = 'files-pull';
+            $command->completion_state = 'in_progress';
+            $command->current_stage = 'index';
+            $client->write_progress_file();
+
+            $command->current_stage = 'fetch';
+            $client->handle_shutdown(SIGTERM);
+            exit(1);
+        }
+
+        pcntl_waitpid($child_pid, $child_status);
+        $this->assertTrue(pcntl_wifsignaled($child_status));
+        $this->assertSame(SIGKILL, pcntl_wtermsig($child_status));
+
+        $progress = json_decode(
+            file_get_contents($this->stateDir . '/progress.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('in_progress', $progress['status']);
+        $this->assertSame('fetch', $progress['phase']);
+    }
+
+    public function testBrokenProgressOutputFlushesTheLatestProgressFile()
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('pcntl_waitpid')) {
+            $this->markTestSkipped('Broken-pipe progress coverage requires PCNTL.');
+        }
+
+        $child_pid = pcntl_fork();
+        if ($child_pid === -1) {
+            $this->fail('Failed to fork the broken-pipe progress test.');
+        }
+        if ($child_pid === 0) {
+            $client = $this->makeClient();
+            $command = $client->get_state()->active_resumable_command;
+            $command->command_name = 'files-pull';
+            $command->completion_state = 'in_progress';
+            $command->current_stage = 'index';
+            $client->write_progress_file();
+
+            $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+            if ($sockets === false) {
+                exit(2);
+            }
+            fclose($sockets[0]);
+            $reflection = new \ReflectionClass(\ImportClient::class);
+            $reflection->getProperty('progress_fd')
+                ->setValue($client, $sockets[1]);
+            $command->current_stage = 'fetch';
+            $client->output_progress(['status' => 'in_progress'], true);
+            exit(1);
+        }
+
+        pcntl_waitpid($child_pid, $child_status);
+        $this->assertTrue(pcntl_wifexited($child_status));
+        $this->assertSame(0, pcntl_wexitstatus($child_status));
+
+        $progress = json_decode(
+            file_get_contents($this->stateDir . '/progress.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('in_progress', $progress['status']);
+        $this->assertSame('fetch', $progress['phase']);
+    }
+
     /**
      * After --abort, the state should not be "complete".
      */


### PR DESCRIPTION
`progress.json` is now rewritten at most once per second while a pull remains active; cleared, partial, complete, caught-error, and interrupted outcomes still write immediately.


## Background

This started by profiling the new internal `files-pull` loop on 30,000 small files under `/srv/htdocs/wp-content/extra-files` at `reprintlargetestsite.wpcomstaging.com`. #739 removes the largest repeated cost: recounting the growing remote index during every state checkpoint.

After #739, an isolated run of 3,000 state saves took 1.82 seconds. Disabling only `progress.json` writes reduced it to 0.92 seconds. A full pull saved state 30,179 times. Its `progress.json` was about 185 bytes, so those replacements wrote only 5.3 MiB of JSON, but each one also wrote a temporary file and renamed it over the old file.

The larger write volume remains unchanged. The roughly 60.8 KiB durable `pull/state.json` still writes at every checkpoint, for about 1.71 GiB of logical writes in this benchmark. The audit log still receives every `SAVE CURSOR` record and reached about 11.9 MiB. This change therefore removes small-file and filesystem-metadata churn. It does not claim to remove most bytes written. Physical storage traffic depends on the filesystem, cache, and storage device.

| Client CPU | #739 | This PR | Change |
| --- | ---: | ---: | ---: |
| Pair 1 | 18.35 s | 16.86 s | -8% |
| Pair 2 | 20.18 s | 18.08 s | -10% |

Wall time remained dominated by variable local file creation. Both runs produced all 30,000 files. A no-change delta remained effectively unchanged.

## This change

While `completion_state` is exactly `in_progress`, `save_state()` rewrites `progress.json` no more than once per second. This reduces 30,179 recurring atomic replacements to tens of replacements during the 48–79 second benchmark runs. Every durable `pull/state.json` checkpoint remains in place.

A cleared checkpoint, `partial`, and `complete` bypass the interval. Caught errors already call `write_progress_file()` directly. Signal shutdown and both broken-pipe exit paths now flush the latest snapshot after saving state. A new process starts with no in-memory timestamp, so its first state save writes progress. The timestamp advances only after the temporary file is successfully renamed, so a failed write is tried again at the next state save.

## Progress-loss audit

This cannot discard downloaded files, WAL records, cursors, or resumable state because none of those use `progress.json`. They remain in the durable state and work files written at the existing boundaries.

An external reader may see an active snapshot that is up to one second behind the latest saved checkpoint. Many checkpoints may complete during that second, but no work is lost. A short phase may also finish between two snapshots and never appear to a polling reader; `progress.json` is a current snapshot, not an event log.

All normal trailing paths now bypass the interval:

1. `partial` and `complete` are saved with their final status.
2. A cleared command writes its null checkpoint immediately.
3. Caught failures write an error snapshot directly.
4. The SIGINT and SIGTERM handler which saves pull state then flushes the active snapshot before the process kills itself.
5. Broken progress output and broken SQL output save state and flush before exiting.

SIGKILL, a fatal PHP error, power loss, or a storage failure can still stop the process between the durable state rename and the progress-file rename. In that case only the external snapshot is stale. The next invocation refreshes it on its first state save. No code can promise a final side-file write after an uncatchable stop.

## Testing

The focused pull, progress, state, filter, and PHP 7.4 parsing suites pass: 60 tests with 233 assertions. Three trailing-path tests were also run against the earlier version of this PR and failed at the intended assertions: cleared state made two writes instead of three, and shutdown and broken-pipe exits left `phase: index` instead of the final `phase: fetch`.

PHPStan reports no errors across 101 files. The two changed files retain their previous PHPCS counts: 387 errors, 46 warnings, and 266 fixable items in total. `git diff --check` passes.

