### PR TITLE
[Tests] Establish WP Cloud paths before plugin activation

### DIFF
--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -7,10 +7,10 @@
  */
 import {
     cpSync, existsSync, writeFileSync, mkdirSync,
-    openSync, closeSync, unlinkSync, constants,
+    openSync, closeSync, unlinkSync, constants, renameSync, symlinkSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { createRequire } from 'node:module';
 import { createConnection } from 'mysql2/promise';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -88,7 +88,10 @@ async function ensureWpTemplate() {
  * Write a full wp-config.php that WordPress/WP-CLI can load.
  * Includes wp-settings.php — required by wp core install.
  */
-function writeFullWpConfig(siteDir, dbHost, dbName, dbUser, dbPass, tablePrefix = 'wp_') {
+function writeFullWpConfig(siteDir, dbHost, dbName, dbUser, dbPass, tablePrefix = 'wp_', wpContentDir = null) {
+    const wpContentDirDefinition = wpContentDir === null
+        ? ''
+        : `define('WP_CONTENT_DIR', ${JSON.stringify(wpContentDir)});\n`;
     writeFileSync(join(siteDir, 'wp-config.php'), `<?php
 define('DB_HOST', '${dbHost}');
 define('DB_NAME', '${dbName}');
@@ -106,7 +109,7 @@ define('AUTH_SALT',        'e2e-test-salt-1');
 define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
 define('LOGGED_IN_SALT',   'e2e-test-salt-3');
 define('NONCE_SALT',       'e2e-test-salt-4');
-$table_prefix = '${tablePrefix}';
+${wpContentDirDefinition}$table_prefix = '${tablePrefix}';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/' );
 }
@@ -169,6 +172,7 @@ function createSampleFiles(siteDir) {
  *   customDb: async (dbName, conn) => {} — adds extra tables on top of real WP tables
  *   wpConfig: { DB_USER: '...', ... } — override wp-config.php creds AFTER install
  *   tablePrefix: 'wp_' — table prefix to write into wp-config.php before install
+ *   wpContentDir: '/path/to/wp-content' — establish an external content directory before WordPress loads
  *   afterCreate: async (siteDir, dbName) => {} — post-creation hook (dir is writable)
  *   afterPermissions: async (siteDir) => {} — runs after final chown/chmod (for chmod 000 etc.)
  */
@@ -218,6 +222,7 @@ export async function ensureSite(name, options = {}) {
     const port = REGISTRY.sites[name]?.port;
     const siteUrl = port ? `http://127.0.0.1:${port}` : 'http://127.0.0.1';
     const tablePrefix = options.tablePrefix || 'wp_';
+    const wpContentDir = options.wpContentDir || null;
 
     const log = (msg) => console.log(`  [${name}] ${msg}`);
     log(`Setting up site (db: ${dbName})`);
@@ -235,8 +240,15 @@ export async function ensureSite(name, options = {}) {
     mkdirSync(join(siteDir, 'wp-content', 'plugins'), { recursive: true });
     mkdirSync(join(siteDir, 'test-data'), { recursive: true });
 
+    if (wpContentDir !== null) {
+        execSync(`sudo rm -rf ${JSON.stringify(wpContentDir)}`, { timeout: 30000 });
+        mkdirSync(dirname(wpContentDir), { recursive: true });
+        renameSync(join(siteDir, 'wp-content'), wpContentDir);
+        symlinkSync(wpContentDir, join(siteDir, 'wp-content'));
+    }
+
     // Write full wp-config.php with admin creds (needed for wp core install)
-    writeFullWpConfig(siteDir, DB_HOST, dbName, DB_USER, DB_PASS, tablePrefix);
+    writeFullWpConfig(siteDir, DB_HOST, dbName, DB_USER, DB_PASS, tablePrefix, wpContentDir);
 
     // Copy the built plugin bundle, including its bundled Composer vendor tree.
     cpSync(
@@ -291,7 +303,7 @@ export async function ensureSite(name, options = {}) {
         const wpDbPass = options.wpConfig.DB_PASSWORD || DB_PASS;
         const wpDbName = options.wpConfig.DB_NAME || dbName;
         const wpDbHost = options.wpConfig.DB_HOST || DB_HOST;
-        writeFullWpConfig(siteDir, wpDbHost, wpDbName, wpDbUser, wpDbPass, tablePrefix);
+        writeFullWpConfig(siteDir, wpDbHost, wpDbName, wpDbUser, wpDbPass, tablePrefix, wpContentDir);
     }
 
     // Create sample files (pure Node fs)

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -17,7 +17,7 @@ import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     existsSync, readFileSync, readlinkSync,
-    mkdirSync, writeFileSync, symlinkSync, lstatSync, renameSync,
+    mkdirSync, realpathSync, symlinkSync, lstatSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -37,19 +37,20 @@ describe('Import: Flat Document Root (WP Cloud-like layout)', () => {
 
     beforeAll(async () => {
         await ensureSite(site, {
+            // Establish the final path before WordPress installs or activates
+            // the plugin. Moving an active plugin later lets PHP encounter its
+            // classes through both the old and new path.
+            wpContentDir: `${CONTENT_DIR}/wp-content`,
             afterCreate: async (siteDir) => {
                 // Simulate WP Cloud layout:
                 //   wp-admin and wp-includes live behind __wp__ in a separate dir
                 //   wp-content lives in a completely separate dir
                 //
-                // Clean up previous external dirs first (may be nginx-owned
-                // from prior run).  This must happen inside afterCreate so
-                // that the dirs are only deleted when they will be recreated.
-                // Deleting them before ensureSite breaks re-runs: the marker
-                // file still exists → afterCreate is skipped → broken symlinks.
-                execSync(`sudo rm -rf ${CORE_DIR} ${CONTENT_DIR}`);
+                // Clean up the previous core directory first; it may be
+                // nginx-owned from a prior run. This stays inside afterCreate
+                // so a completed site's marker does not leave broken links.
+                execSync(`sudo rm -rf ${CORE_DIR}`);
                 mkdirSync(CORE_DIR, { recursive: true });
-                mkdirSync(CONTENT_DIR, { recursive: true });
 
                 // Move wp-admin and wp-includes to the core directory
                 execSync(`mv "${join(siteDir, 'wp-admin')}" "${CORE_DIR}/wp-admin"`);
@@ -62,33 +63,6 @@ describe('Import: Flat Document Root (WP Cloud-like layout)', () => {
                 symlinkSync('__wp__/wp-admin', join(siteDir, 'wp-admin'));
                 symlinkSync('__wp__/wp-includes', join(siteDir, 'wp-includes'));
 
-                // Move wp-content to separate location
-                renameSync(join(siteDir, 'wp-content'), `${CONTENT_DIR}/wp-content`);
-                symlinkSync(CONTENT_DIR + '/wp-content', join(siteDir, 'wp-content'));
-
-                // Rewrite wp-config.php to define WP_CONTENT_DIR
-                writeFileSync(join(siteDir, 'wp-config.php'), `<?php
-define('DB_HOST', '127.0.0.1');
-define('DB_NAME', 'e2e_wpcloud_flatten');
-define('DB_USER', 'e2e_admin');
-define('DB_PASSWORD', 'e2e_password');
-define('DB_CHARSET', 'utf8mb4');
-define('DB_COLLATE', '');
-define('AUTH_KEY',         'e2e-test-key-1');
-define('SECURE_AUTH_KEY',  'e2e-test-key-2');
-define('LOGGED_IN_KEY',    'e2e-test-key-3');
-define('NONCE_KEY',        'e2e-test-key-4');
-define('AUTH_SALT',        'e2e-test-salt-1');
-define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
-define('LOGGED_IN_SALT',   'e2e-test-salt-3');
-define('NONCE_SALT',       'e2e-test-salt-4');
-define('WP_CONTENT_DIR', '${CONTENT_DIR}/wp-content');
-$table_prefix = 'wp_';
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/' );
-}
-require_once ABSPATH . 'wp-settings.php';
-`);
             },
             afterPermissions: async () => {
                 execSync(`sudo chown -R nginx:nginx ${CORE_DIR} ${CONTENT_DIR}`);
@@ -105,6 +79,24 @@ require_once ABSPATH . 'wp-settings.php';
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
+
+    it('configures the final wp-content path before WordPress loads', () => {
+        const siteDir = getSiteDir(site);
+        const wpConfig = readFileSync(join(siteDir, 'wp-config.php'), 'utf-8');
+        const contentDefinition = `define('WP_CONTENT_DIR', "${CONTENT_DIR}/wp-content");`;
+        const wordpressLoad = "require_once ABSPATH . 'wp-settings.php';";
+
+        assert.ok(wpConfig.includes(contentDefinition), 'wp-config.php defines the external wp-content path');
+        assert.ok(
+            wpConfig.indexOf(contentDefinition) < wpConfig.indexOf(wordpressLoad),
+            'the external wp-content path is set before WordPress loads',
+        );
+        assert.equal(
+            realpathSync(join(siteDir, 'wp-content')),
+            `${CONTENT_DIR}/wp-content`,
+            'the document-root link resolves to the path WordPress loaded',
+        );
+    });
 
     it('preflight reports resolved wp_admin_path and wp_includes_path', () => {
         const result = runImporter(importUrl(), tempDir, 'preflight', {


### PR DESCRIPTION
The WP Cloud E2E site now puts `wp-content` in its final external directory before WordPress installs and activates Reprint Server.

## Background

The fixture previously did this:

1. Install and activate Reprint Server under `/srv/e2e-sites/wpcloud-flatten/wp-content`.
2. Move that `wp-content` directory to `/tmp/e2e-wpcloud-wpcontent/wp-content`.
3. Leave a link from the old path to the new path.

PHP could then encounter the same Reprint class through the old path and the new path. Composer could load one path, followed by a direct `require_once` of the other path. PHP treats those as two declarations of the same class and stops the request.

## This change

The site helper creates the external `wp-content` directory and writes `WP_CONTENT_DIR` before WordPress loads. It then installs WordPress, copies the plugin, and activates the plugin in that final location. Reprint Server therefore has one stable path for the whole test.

The WP Cloud test checks that `WP_CONTENT_DIR` is set before `wp-settings.php` loads and that the document-root link resolves to that same directory.

Production class loading is unchanged.

## Testing

CI should run the WP Cloud E2E test across the PHP matrix. The changed JavaScript files pass Node's syntax check, Vitest can collect the complete WP Cloud test file, and the diff passes Git's whitespace check.
