### PR TITLE
Reprint Server: Run security plugin request checks before API handling

### DIFF
--- a/reprint-server-wp/README.md
+++ b/reprint-server-wp/README.md
@@ -15,25 +15,26 @@ Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside 
 
 ### How it works
 
-The plugin file (`index.php`) is `include`'d by WordPress during its plugin loading loop — this happens *before* the `plugins_loaded` hook fires, making it the earliest interception point available to a regular plugin.
+The plugin file (`index.php`) is `include`'d by WordPress during its plugin loading loop. It detects Reprint requests there, but waits until `template_redirect` to answer them so other active plugins can inspect the request first.
 
 When a request arrives at `https://example.com/?reprint-api`, the plugin:
 
 1. Detects `$_GET['reprint-api']` during plugin file load
-2. Reverts WordPress error display settings (`display_errors`, `html_errors`) that `wp_debug_mode()` may have turned on
-3. Clears any output buffering WordPress started
-4. Sets up error handlers, HMAC auth, and runs the export endpoint
-5. Calls `exit` — WordPress never finishes booting
+2. Registers the Reprint handler at the end of `template_redirect`
+3. Lets WordPress load the remaining plugins and run their earlier request checks
+4. Reverts WordPress error display settings (`display_errors`, `html_errors`) that `wp_debug_mode()` may have turned on
+5. Clears any output buffering WordPress started
+6. Sets up error handlers, HMAC auth, and runs the export endpoint
+7. Calls `exit` before WordPress selects or renders a theme template
 
-This gives us a clean execution environment while using WordPress's front controller as the entry point.
+This uses WordPress's front controller while allowing security plugins to enforce their normal request rules.
 
 ### Platform configuration
 
 The bundled WordPress entry point passes the result of the
 `reprint_server_api_options` filter to the request handler. A platform must
-register this filter before the regular Reprint Server plugin file loads;
-registering it on `plugins_loaded` is too late. A must-use plugin is the usual
-place to register it:
+register this filter before `template_redirect`. A must-use plugin is the
+usual place to register it:
 
 ```php
 add_filter('reprint_server_api_options', static function (array $options): array {

--- a/reprint-server-wp/index.php
+++ b/reprint-server-wp/index.php
@@ -15,30 +15,36 @@ require_once __DIR__ . '/compat.php';
 reprint_server_compat_normalize_legacy_request();
 require_once __DIR__ . '/lib.php';
 
-// Intercept Reprint Server API requests as early as possible.
-// WordPress loads plugin files before firing `plugins_loaded`,
-// so this runs before almost anything else in the WordPress stack.
+// Detect the API request while the plugin file loads, then answer it after
+// other plugins have run their normal request checks. Security plugins such
+// as Wordfence apply request limits during `template_redirect`.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This only selects API request routing.
 if (isset($_GET['reprint-api'])) {
-    /**
-     * Filters the endpoint configuration supplied by the WordPress plugin.
-     *
-     * Platforms must register this filter before regular plugins load, for
-     * example from a must-use plugin.
-     *
-     * @param array $reprint_server_api_options Endpoint configuration overrides.
-     */
-    $reprint_server_api_options = apply_filters('reprint_server_api_options', []);
-    if (!is_array($reprint_server_api_options)) {
-        \WordPress\Reprint\Server\Plugin\push_error(
-            503,
-            'not_configured',
-            'The reprint_server_api_options filter must return an array; observed '
-            . gettype($reprint_server_api_options) . '.'
-        );
-    }
-    \WordPress\Reprint\Server\Plugin\handle_api_request($reprint_server_api_options);
-    exit;
+    add_action(
+        'template_redirect',
+        static function() {
+            /**
+             * Filters the endpoint configuration supplied by the WordPress plugin.
+             *
+             * Platforms must register this filter before `template_redirect`,
+             * for example from a must-use plugin.
+             *
+             * @param array $reprint_server_api_options Endpoint configuration overrides.
+             */
+            $reprint_server_api_options = apply_filters('reprint_server_api_options', []);
+            if (!is_array($reprint_server_api_options)) {
+                \WordPress\Reprint\Server\Plugin\push_error(
+                    503,
+                    'not_configured',
+                    'The reprint_server_api_options filter must return an array; observed '
+                    . gettype($reprint_server_api_options) . '.'
+                );
+            }
+            \WordPress\Reprint\Server\Plugin\handle_api_request($reprint_server_api_options);
+            exit;
+        },
+        PHP_INT_MAX
+    );
 }
 
 // Register the option-backed configuration, then the settings page.

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -213,6 +213,60 @@ final class ExportLibraryLoadTest extends TestCase {
         );
     }
 
+    public function testPluginEntrypointDefersApiRequestUntilTemplateRedirect(): void
+    {
+        $entrypoint_path = realpath(__DIR__ . '/../reprint-server-wp/index.php');
+        $this->assertNotFalse($entrypoint_path, 'Plugin entrypoint must exist');
+        $entrypoint_path_encoded = base64_encode($entrypoint_path);
+
+        $php_code = <<<PHP
+        <?php
+        define('ABSPATH', __DIR__ . '/');
+        \$_GET['reprint-api'] = true;
+        \$GLOBALS['registered_actions'] = [];
+        function plugin_dir_path(string \$file): string {
+            return dirname(\$file) . '/';
+        }
+        function add_action(string \$hook_name, \$callback, int \$priority = 10, int \$accepted_args = 1): void {
+            \$GLOBALS['registered_actions'][\$hook_name][] = [
+                'priority' => \$priority,
+                'accepted_args' => \$accepted_args,
+            ];
+        }
+        function add_filter(string \$hook_name, \$callback, int \$priority = 10, int \$accepted_args = 1): void {}
+        function apply_filters(string \$hook_name, \$value) {
+            return \$value;
+        }
+        function do_action(string \$hook_name): void {}
+        function get_option(string \$name, \$default = false) {
+            return \$default;
+        }
+        function update_option(string \$name, \$value, \$autoload = null): bool {
+            return true;
+        }
+        function delete_option(string \$name): bool {
+            return true;
+        }
+        function register_activation_hook(string \$file, \$callback): void {}
+        require base64_decode('{$entrypoint_path_encoded}', true);
+        echo json_encode(\$GLOBALS['registered_actions']['template_redirect'] ?? [], JSON_THROW_ON_ERROR);
+        PHP;
+
+        $result = $this->runPhpCode($php_code);
+
+        $this->assertSame(0, $result['status'], $result['output']);
+        $template_redirect_actions = json_decode(
+            trim($result['output']),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame(
+            [['priority' => PHP_INT_MAX, 'accepted_args' => 1]],
+            $template_redirect_actions
+        );
+    }
+
     public function testPluginLibraryDefinesEmbeddingFacadeWithoutRegisteringWordPressHooks(): void
     {
         $lib_path = realpath(__DIR__ . '/../reprint-server-wp/lib.php');

--- a/tests/e2e/tests/import-63-security-plugin-routing.test.js
+++ b/tests/e2e/tests/import-63-security-plugin-routing.test.js
@@ -1,0 +1,70 @@
+/**
+ * Test 63: Security plugin request hooks run before the Reprint API handler.
+ *
+ * Activates a plugin after Reprint. Its template_redirect callback marks the
+ * response, which proves the later plugin loaded and inspected the API request
+ * before Reprint answered it.
+ */
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync, execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { getSiteDir, getSiteUrl } from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Reprint Server: security plugin routing', { timeout: 120000 }, () => {
+    const site = 'basic';
+    const pluginSlug = 'reprint-security-hook-test';
+    let pluginDirectory;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+
+        pluginDirectory = join(getSiteDir(site), 'wp-content', 'plugins', pluginSlug);
+        execFileSync('sudo', ['mkdir', '-p', pluginDirectory]);
+        execFileSync('sudo', ['tee', join(pluginDirectory, 'index.php')], {
+            input: `<?php
+/**
+ * Plugin Name: Reprint security hook test
+ */
+add_action('template_redirect', static function() {
+    if (isset($_GET['reprint-api'])) {
+        header('X-Reprint-Security-Hook: ran');
+    }
+}, 1001);
+`,
+            stdio: ['pipe', 'ignore', 'pipe'],
+        });
+
+        const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
+        execSync(
+            `php /tmp/wp-cli.phar plugin activate ${pluginSlug}` +
+                ` --path=${JSON.stringify(getSiteDir(site))}` +
+                allowRoot,
+            { timeout: 30000, stdio: 'pipe' },
+        );
+    });
+
+    afterAll(() => {
+        const allowRoot = process.getuid?.() === 0 ? ' --allow-root' : '';
+        execSync(
+            `php /tmp/wp-cli.phar plugin deactivate ${pluginSlug}` +
+                ` --path=${JSON.stringify(getSiteDir(site))}` +
+                allowRoot,
+            { timeout: 30000, stdio: 'pipe' },
+        );
+        execFileSync('sudo', ['rm', '-rf', pluginDirectory]);
+    });
+
+    it('runs a later plugin template_redirect callback before answering', async () => {
+        const url = new URL(getSiteUrl(site));
+        url.searchParams.set('endpoint', 'preflight');
+
+        const response = await fetch(url);
+        const body = await response.json();
+
+        assert.equal(response.status, 200);
+        assert.equal(response.headers.get('x-reprint-security-hook'), 'ran');
+        assert.equal(body.ok, true);
+    });
+});


### PR DESCRIPTION
Reprint Server now answers API requests at the end of `template_redirect`, after active security plugins have had a chance to inspect them.

Wordfence applies its request limits on `template_redirect`. The plugin previously exited while WordPress was still loading plugin files, so Wordfence could neither load after Reprint nor count a direct Reprint request. Reprint still detects its query key during plugin loading, but the registered handler now runs at `PHP_INT_MAX` before WordPress renders a theme template.

A real WordPress E2E test activates a security plugin after Reprint. That plugin marks Reprint responses from its priority-1001 `template_redirect` callback. The entrypoint subprocess test also confirms that including the plugin registers the delayed callback without answering immediately.

On the WordPress.com staging site, a temporary Wordfence limit of 10 requests per minute counted the direct API calls after this change. Requests 1–10 reached Reprint, and requests 11–12 received the Wordfence HTTP 503 page. The original plugin file and Wordfence settings were restored afterward.

## Testing

```bash
cd tests && ../vendor/bin/phpunit ExportLibraryLoadTest.php ReprintServerPluginTest.php ReprintServerCompatTest.php
vendor/bin/phpstan analyze --memory-limit=1G
vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.2- -ps reprint-server-wp/index.php
git diff --check
```
