### PR TITLE
Reprint Server: Canonicalize E2E fixtures and documentation

### DIFF
--- a/.github/workflows/e2e-playground.yml
+++ b/.github/workflows/e2e-playground.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar-playground
+          name: client-phar-playground
           path: reprint.phar
 
   e2e-playground:
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: importer-phar-playground
+          name: client-phar-playground
 
       - uses: actions/setup-node@v4
         with:
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: tests/e2e/package-lock.json
 
       # The export side still needs real PHP-FPM + nginx.
-      # Use PHP 8.2 for the server; the importer runs under PHP.wasm.
+      # Use PHP 8.2 for the server; the client runs under PHP.wasm.
       # PHP comes from the runner's pre-cached toolcache via this
       # action; we don't try to apt-install ondrej/php ourselves
       # because every Launchpad endpoint flakes regularly.
@@ -100,7 +100,7 @@ jobs:
 
       - name: Provision basic site and smoke-test API
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/reprint.phar
           PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
         working-directory: tests/e2e
         run: |
@@ -117,7 +117,7 @@ jobs:
           console.log("Basic site provisioned");
           NODESCRIPT
 
-          # Quick smoke test: use the Playground CLI PHP to run the importer
+          # Quick smoke test: use the Playground CLI PHP to run the client
           SECRET="test-secret-basic"
           BASE="http://127.0.0.1:8081/?reprint-api"
           DIR="/srv/e2e-sites/basic"
@@ -141,12 +141,12 @@ jobs:
             exit 1
           fi
 
-          echo "=== Playground CLI importer preflight ==="
-          timeout 120 "$PHP_BINARY" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          echo "=== Playground CLI client preflight ==="
+          timeout 120 "$PHP_BINARY" "$CLIENT_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
       - name: Run E2E tests
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/reprint.phar
           PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
         working-directory: tests/e2e
         # Run every test file once across four runners because each WASM PHP

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar
+          name: client-phar
           path: reprint.phar
 
   build-server-plugin:
@@ -56,7 +56,7 @@ jobs:
     # Keep the existing source E2E rows running if only the Reprint Server
     # artifact build fails. The PHP 5.6 row will fail when its artifact is absent.
     if: ${{ always() && !cancelled() && needs['build-phar'].result == 'success' }}
-    name: E2E (exporter PHP ${{ matrix.exporter_php }}, importer PHP ${{ matrix.importer_php }})
+    name: E2E (server PHP ${{ matrix.server_php }}, client PHP ${{ matrix.client_php }})
     needs: [build-phar, build-server-plugin]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -64,25 +64,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - exporter_php: '5.6'
-            importer_php: '8.2'
+          - server_php: '5.6'
+            client_php: '8.2'
             wordpress_version: '6.2.9'
-          - exporter_php: '7.2'
-            importer_php: '8.2'
-          - exporter_php: '7.4'
-            importer_php: '7.4'
-          - exporter_php: '8.0'
-            importer_php: '8.0'
-          - exporter_php: '8.1'
-            importer_php: '8.1'
-          - exporter_php: '8.2'
-            importer_php: '8.2'
-          - exporter_php: '8.3'
-            importer_php: '8.3'
-          - exporter_php: '8.4'
-            importer_php: '8.4'
-          - exporter_php: '8.5'
-            importer_php: '8.5'
+          - server_php: '7.2'
+            client_php: '8.2'
+          - server_php: '7.4'
+            client_php: '7.4'
+          - server_php: '8.0'
+            client_php: '8.0'
+          - server_php: '8.1'
+            client_php: '8.1'
+          - server_php: '8.2'
+            client_php: '8.2'
+          - server_php: '8.3'
+            client_php: '8.3'
+          - server_php: '8.4'
+            client_php: '8.4'
+          - server_php: '8.5'
+            client_php: '8.5'
 
     steps:
       - uses: actions/checkout@v5
@@ -91,33 +91,33 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: importer-phar
+          name: client-phar
 
       - uses: actions/download-artifact@v4
-        if: matrix.exporter_php == '5.6'
+        if: matrix.server_php == '5.6'
         with:
           name: server-plugin
           path: ${{ runner.temp }}/server-plugin-download
 
       - name: Extract generated Reprint Server plugin
-        if: matrix.exporter_php == '5.6'
+        if: matrix.server_php == '5.6'
         run: |
           artifact_root="$RUNNER_TEMP/generated-server-plugin"
           mkdir -p "$artifact_root/reprint-server-wp"
           unzip -q \
             "$RUNNER_TEMP/server-plugin-download/reprint-exporter-wp.zip" \
             -d "$artifact_root/reprint-server-wp"
-          echo "E2E_EXPORTER_PROJECT_ROOT=$artifact_root" >> "$GITHUB_ENV"
+          echo "E2E_SERVER_PROJECT_ROOT=$artifact_root" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
 
-      - name: Setup importer PHP
-        if: matrix.importer_php != matrix.exporter_php
+      - name: Setup client PHP
+        if: matrix.client_php != matrix.server_php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.importer_php }}
+          php-version: ${{ matrix.client_php }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
@@ -126,22 +126,22 @@ jobs:
       # because every Launchpad endpoint flakes regularly.
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.exporter_php }}
+          php-version: ${{ matrix.server_php }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
       - name: Setup infrastructure
-        run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.exporter_php }}"
+        run: tests/e2e/ci/setup-infrastructure.sh "${{ matrix.server_php }}"
 
       - name: Start Oracle MySQL 8 target
-        if: matrix.exporter_php == '8.2'
+        if: matrix.server_php == '8.2'
         run: tests/e2e/ci/start-mysql8-target.sh
 
-      - name: Restore importer PHP and Composer for CLI tools
-        if: matrix.exporter_php == '5.6'
+      - name: Restore client PHP and Composer for CLI tools
+        if: matrix.server_php == '5.6'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.importer_php }}
+          php-version: ${{ matrix.client_php }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
@@ -155,8 +155,8 @@ jobs:
       - name: Provision basic site and smoke-test API
         env:
           E2E_WORDPRESS_VERSION: ${{ matrix.wordpress_version }}
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
-          IMPORTER_PHP: php${{ matrix.importer_php }}
+          CLIENT_PATH: ${{ github.workspace }}/reprint.phar
+          CLIENT_PHP: php${{ matrix.client_php }}
         working-directory: tests/e2e
         run: |
           # Download WP-CLI (normally done by Vitest globalSetup, but we need it here)
@@ -172,14 +172,14 @@ jobs:
           console.log("Basic site provisioned");
           NODESCRIPT
 
-          # Quick smoke test: use the importer CLI to hit the export API.
+          # Quick smoke test: use the client CLI to hit the export API.
           SECRET="test-secret-basic"
           BASE="http://127.0.0.1:8081/?reprint-api"
           DIR="/srv/e2e-sites/basic"
           STATE_DIR="/tmp/e2e-smoke-state"
           FS_ROOT="/tmp/e2e-smoke-fs"
 
-          # Warm up the export endpoint before any time-boxed importer command.
+          # Warm up the export endpoint before any time-boxed client command.
           # ensureSite only provisions files + DB via wp-cli; the first HTTP
           # request still pays the full PHP-FPM cold start (worker spawn, WP
           # bootstrap, Composer autoload, export.php require). Poll until the
@@ -202,37 +202,37 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
+          if [ "${{ matrix.server_php }}" = "5.6" ]; then
             # API dispatch exits before index.php loads the plugin's WordPress
             # admin-registration file. A regular page request covers that path
             # with the PHP 5.6 FPM worker too. The API warmup accepts any HTTP
             # response, so it does not prove that a regular WordPress request
             # is ready yet. Retry transient HTTP failures while keeping a
             # lasting plugin-load failure fatal.
-            echo "=== Loading WordPress with the exporter on PHP 5.6 ==="
+            echo "=== Loading WordPress with the server on PHP 5.6 ==="
             curl --retry 10 --retry-delay 1 --retry-connrefused \
               -fsS -o /dev/null -m 30 "http://127.0.0.1:8081/"
           fi
 
-          if [ "$IMPORTER_PHP" = "php7.4" ] || [ "$IMPORTER_PHP" = "php8.0" ]; then
-            echo "=== Importer files-push PHP version gate ==="
+          if [ "$CLIENT_PHP" = "php7.4" ] || [ "$CLIENT_PHP" = "php8.0" ]; then
+            echo "=== Client files-push PHP version gate ==="
             PUSH_STATE_DIR="/tmp/e2e-files-push-version-state"
             PUSH_FS_ROOT="/tmp/e2e-files-push-version-files"
-            PUSH_PROBE="files-push-version-${{ matrix.importer_php }}"
+            PUSH_PROBE="files-push-version-${{ matrix.client_php }}"
             rm -rf "$PUSH_STATE_DIR" "$PUSH_FS_ROOT"
             mkdir -p "$PUSH_FS_ROOT"
             PUSH_REMOTE_URL="${BASE}&directory=${DIR}&version_gate_probe=${PUSH_PROBE}"
             # Seed the mandatory preflight, then clear that setup request so the
             # access-log assertion below covers only files-push.
-            "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" >/dev/null
+            "$CLIENT_PHP" "$CLIENT_PATH" preflight "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" >/dev/null
             sudo truncate -s 0 /var/log/nginx/access.log
             set +e
-            files_push_version_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" --force-http 2>&1)"
+            files_push_version_output="$("$CLIENT_PHP" "$CLIENT_PATH" files-push "$PUSH_REMOTE_URL" --state-dir="${PUSH_STATE_DIR}" --fs-root="${PUSH_FS_ROOT}" --secret="${SECRET}" --force-http 2>&1)"
             files_push_version_status=$?
             set -e
             if [ "$files_push_version_status" -ne 1 ]; then
               echo "$files_push_version_output"
-              echo "Expected files-push to exit 1 on ${IMPORTER_PHP}; got ${files_push_version_status}"
+              echo "Expected files-push to exit 1 on ${CLIENT_PHP}; got ${files_push_version_status}"
               exit 1
             fi
             echo "$files_push_version_output" | grep -F 'reprint push requires PHP 8.1 or newer'
@@ -247,10 +247,10 @@ jobs:
             fi
           fi
 
-          echo "=== Importer preflight ==="
+          echo "=== Client preflight ==="
           # The shell timeout is deliberately larger than curl's own 30s
           # CURLOPT_TIMEOUT so a stalled request produces a clean, diagnosable
-          # curl error the importer can report — rather than an uncatchable
+          # curl error the client can report — rather than an uncatchable
           # SIGTERM at the exact 30s boundary (the old exit-124 flake). Retry a
           # few times so a single transient stall doesn't fail the whole job,
           # mirroring the files-pull loop below.
@@ -258,7 +258,7 @@ jobs:
           preflight_attempt=0
           while [ "$preflight_status" -ne 0 ] && [ "$preflight_attempt" -lt 3 ]; do
             preflight_attempt=$((preflight_attempt + 1))
-            preflight_output="$(timeout 45 "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" && preflight_status=0 || preflight_status=$?
+            preflight_output="$(timeout 45 "$CLIENT_PHP" "$CLIENT_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" && preflight_status=0 || preflight_status=$?
             echo "$preflight_output" | head -50
             if [ "$preflight_status" -ne 0 ]; then
               echo "preflight failed (exit ${preflight_status}); retrying (attempt ${preflight_attempt})"
@@ -270,30 +270,30 @@ jobs:
             exit "$preflight_status"
           fi
 
-          if [ "${{ matrix.exporter_php }}" = "5.6" ]; then
-            echo "=== Exporter push endpoint PHP version gate ==="
-            PUSH_STATE_DIR="/tmp/e2e-exporter-push-version-state"
-            PUSH_FS_ROOT="/tmp/e2e-exporter-push-version-files"
+          if [ "${{ matrix.server_php }}" = "5.6" ]; then
+            echo "=== Server push endpoint PHP version gate ==="
+            PUSH_STATE_DIR="/tmp/e2e-server-push-version-state"
+            PUSH_FS_ROOT="/tmp/e2e-server-push-version-files"
             mkdir -p "$PUSH_FS_ROOT"
             printf 'push must stay disabled on PHP 5.6\n' > "$PUSH_FS_ROOT/probe.txt"
-            "$IMPORTER_PHP" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" >/dev/null
+            "$CLIENT_PHP" "$CLIENT_PATH" preflight "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" >/dev/null
             set +e
-            exporter_push_output="$("$IMPORTER_PHP" "$IMPORTER_PATH" files-push "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" --force-http 2>&1)"
-            exporter_push_status=$?
+            server_push_output="$("$CLIENT_PHP" "$CLIENT_PATH" files-push "${BASE}&directory=${DIR}" --state-dir="$PUSH_STATE_DIR" --fs-root="$PUSH_FS_ROOT" --secret="$SECRET" --force-http 2>&1)"
+            server_push_status=$?
             set -e
-            if [ "$exporter_push_status" -ne 1 ]; then
-              echo "$exporter_push_output"
-              echo "Expected the PHP 5.6 exporter to reject files-push; got ${exporter_push_status}"
+            if [ "$server_push_status" -ne 1 ]; then
+              echo "$server_push_output"
+              echo "Expected the PHP 5.6 server to reject files-push; got ${server_push_status}"
               exit 1
             fi
-            echo "$exporter_push_output" | grep -F 'Push endpoints require PHP 7.2 or newer'
+            echo "$server_push_output" | grep -F 'Push endpoints require PHP 7.2 or newer'
           fi
 
-          echo "=== Importer files-pull ==="
+          echo "=== Client files-pull ==="
           # One files-pull invocation has no wall-clock self-limit on the CLI
           # (max_execution_time is 0), so on a slow runner it can still be
           # mid-download when the shell `timeout` fires and SIGTERMs it
-          # (exit 124). That is a resumable state — the importer saves its
+          # (exit 124). That is a resumable state — the client saves its
           # cursor on SIGTERM — so resume and retry, exactly like a normal
           # partial (exit 2). A forward-progress check on a timeout keeps a
           # genuine stall from looping silently to the attempt cap.
@@ -304,7 +304,7 @@ jobs:
           while { [ "$files_pull_status" -eq 2 ] || [ "$files_pull_status" -eq 124 ]; } \
                 && [ "$files_pull_attempt" -lt "$files_pull_max_attempts" ]; do
             files_pull_attempt=$((files_pull_attempt + 1))
-            files_pull_output="$(timeout 60 "$IMPORTER_PHP" "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" && files_pull_status=0 || files_pull_status=$?
+            files_pull_output="$(timeout 60 "$CLIENT_PHP" "$CLIENT_PATH" files-pull "${BASE}&directory=${DIR}" --state-dir="${STATE_DIR}" --fs-root="${FS_ROOT}" --secret="${SECRET}" 2>&1)" && files_pull_status=0 || files_pull_status=$?
             echo "$files_pull_output" | head -50
             files_pull_count="$(find "$FS_ROOT" -type f 2>/dev/null | wc -l | tr -d ' ')"
             if [ "$files_pull_status" -eq 2 ]; then
@@ -327,22 +327,22 @@ jobs:
           fi
 
       - name: Run full pull from PHP 5.6 site
-        if: matrix.exporter_php == '5.6'
+        if: matrix.server_php == '5.6'
         env:
-          E2E_EXPECTED_EXPORTER_PHP_VERSION: ${{ matrix.exporter_php }}
+          E2E_EXPECTED_SERVER_PHP_VERSION: ${{ matrix.server_php }}
           E2E_WORDPRESS_VERSION: ${{ matrix.wordpress_version }}
-          E2E_WP_CLI_PHP_BINARY: php${{ matrix.importer_php }}
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
-          PHP_BINARY: php${{ matrix.importer_php }}
+          E2E_WP_CLI_PHP_BINARY: php${{ matrix.client_php }}
+          CLIENT_PATH: ${{ github.workspace }}/reprint.phar
+          PHP_BINARY: php${{ matrix.client_php }}
         working-directory: tests/e2e
         run: npx vitest run tests/import-46-pull-basic.test.js --test-timeout=180000
 
       - name: Run E2E tests
-        if: matrix.exporter_php != '5.6' && matrix.exporter_php != '7.2'
+        if: matrix.server_php != '5.6' && matrix.server_php != '7.2'
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/reprint.phar
         working-directory: tests/e2e
-        # Individual importer subprocesses have their own tighter timeouts;
+        # Individual client subprocesses have their own tighter timeouts;
         # the Vitest budget must cover slow PHP-FPM matrix runs.
         run: npx vitest run --test-timeout=120000
 
@@ -358,7 +358,7 @@ jobs:
           echo "--- Nginx config test ---"
           sudo nginx -t 2>&1 || true
           echo "--- PHP-FPM journal ---"
-          sudo journalctl -u "php${{ matrix.exporter_php }}-fpm" --no-pager -n 30 2>/dev/null || true
+          sudo journalctl -u "php${{ matrix.server_php }}-fpm" --no-pager -n 30 2>/dev/null || true
           echo "--- Nginx journal ---"
           sudo journalctl -u nginx --no-pager -n 30 2>/dev/null || true
           echo "--- MariaDB journal ---"

--- a/.github/workflows/perf-history-backfill.yml
+++ b/.github/workflows/perf-history-backfill.yml
@@ -142,8 +142,8 @@ jobs:
               cd host/tests/e2e
               sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file
               sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock
-              IMPORTER_PATH="$GITHUB_WORKSPACE/src-historical/reprint.phar" \
-              E2E_EXPORTER_PROJECT_ROOT="$GITHUB_WORKSPACE/src-historical" \
+              CLIENT_PATH="$GITHUB_WORKSPACE/src-historical/reprint.phar" \
+              E2E_SERVER_PROJECT_ROOT="$GITHUB_WORKSPACE/src-historical" \
               BENCH_LABEL=backfill \
               BENCH_JSON_OUT="$GITHUB_WORKSPACE/bench.json" \
               BENCH_MD_OUT="$GITHUB_WORKSPACE/bench.md" \

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar-trunk
+          name: client-phar-trunk
           path: reprint.phar
 
   bench-and-publish:
@@ -56,7 +56,7 @@ jobs:
       - name: Download trunk phar
         uses: actions/download-artifact@v4
         with:
-          name: importer-phar-trunk
+          name: client-phar-trunk
           path: phars/trunk
 
       - uses: actions/setup-node@v4
@@ -92,7 +92,7 @@ jobs:
       - name: Bench trunk
         working-directory: tests/e2e
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
           BENCH_LABEL: trunk
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar-pr
+          name: client-phar-pr
           path: reprint.phar
 
   build-trunk-phar:
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar-trunk
+          name: client-phar-trunk
           path: reprint.phar
 
   bench:
@@ -108,13 +108,13 @@ jobs:
       - name: Download PR phar
         uses: actions/download-artifact@v4
         with:
-          name: importer-phar-pr
+          name: client-phar-pr
           path: phars/pr
 
       - name: Download trunk phar
         uses: actions/download-artifact@v4
         with:
-          name: importer-phar-trunk
+          name: client-phar-trunk
           path: phars/trunk
 
       - uses: actions/setup-node@v4
@@ -150,12 +150,12 @@ jobs:
       - name: Bench PR
         working-directory: tests/e2e
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
           BENCH_LABEL: pr
           BENCH_JSON_OUT: bench-pr.json
           BENCH_MD_OUT: bench-pr.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
-          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
+          E2E_SERVER_PROJECT_ROOT: ${{ github.workspace }}
           # Keep the PHP.wasm SQLite benchmark large enough to exercise the
           # parser without pushing a PR check into the workflow timeout.
           BENCH_SEED_POSTS: '10000'
@@ -174,15 +174,15 @@ jobs:
       - name: Bench trunk
         working-directory: tests/e2e
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
+          CLIENT_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
           BENCH_LABEL: trunk
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
-          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
+          E2E_SERVER_PROJECT_ROOT: ${{ github.workspace }}
           BENCH_SEED_POSTS: '10000'
           BENCH_SEED_POSTMETA: '25000'
-          BENCH_PREFLIGHT_IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_PREFLIGHT_CLIENT_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
           BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
           PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
           PLAYGROUND_PHP_VERSION: '8.3'

--- a/docs/PUSH-SYNC.md
+++ b/docs/PUSH-SYNC.md
@@ -71,9 +71,10 @@ change from stranding a partial commit and its maintenance marker.
 Personal consent stores only the current connection token's SHA-256
 fingerprint. Rotating the token therefore revokes push access. A hosting
 provider may override local consent by defining the boolean
-`SITE_EXPORT_PUSH_ENABLED` constant before active plugins load or by setting
-the environment variable of the same name. Managed `true` enables push and
-managed `false` hard-disables push without abandoning durable commit recovery.
+`WordPress\Reprint\Server\Plugin\PUSH_ENABLED` constant before active plugins
+load or by setting `REPRINT_SERVER_PUSH_ENABLED` in the environment. Managed
+`true` enables push and managed `false` hard-disables push without abandoning
+durable commit recovery.
 
 ## Change detection: local machine compared against itself
 
@@ -221,7 +222,7 @@ request can resume from a durable checkpoint instead of repeating a delete.
 
 ## The push session
 
-`Site_Export_Push_Session` stores each session at
+`WordPress\Reprint\Server\PushSession` stores each session at
 `<reprint-directory>/.reprint/push/<push-session-id>/`. `push.json` is the
 push identity and policy plus whether the work-delete stream is complete.
 `commit.json` holds the bounded commit cursor. Both are atomically replaced
@@ -299,8 +300,9 @@ cursor before continuing.
 
 The WordPress plugin passes the platform-supplied `docroot` to push endpoints,
 defaulting to the web server's `DOCUMENT_ROOT`. A platform supplies the complete
-trusted API-options array through the early `site_export_api_options` filter; a
-direct embedder passes the same array to `_site_export_handle_api_request()`.
+trusted API-options array through the early `reprint_server_api_options` filter;
+a direct embedder passes the same array to
+`WordPress\Reprint\Server\Plugin\handle_api_request()`.
 The document-root path must resolve to an existing directory. `ABSPATH` remains
 the default only for pull endpoints because it may point at a separate shared
 WordPress core tree. Push work lives in a document-root-specific private

--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -768,7 +768,8 @@ final class FileIndexProcessor {
 
         // Tests may change the scanned names to exercise traversal boundaries.
         // Production traversal has no hook and uses scandir() results directly.
-        if (getenv("SITE_EXPORT_TEST_MODE") && function_exists("_e2e_call_hook")) {
+        $test_mode_enabled = getenv("REPRINT_SERVER_TEST_MODE");
+        if ($test_mode_enabled && function_exists("_e2e_call_hook")) {
             $hook_arguments = [$canonical_directory, &$directory_names];
             _e2e_call_hook("test_hook_during_dir_scan", $hook_arguments);
         }

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -556,11 +556,11 @@ register_shutdown_function(function () {
 });
 
 // ============================================================================
-// E2E Test Hook System (only active when SITE_EXPORT_TEST_MODE env var is set)
+// E2E Test Hook System (only active when REPRINT_SERVER_TEST_MODE is set).
 // We don't want anyone to interfere with the export process, which is why those
 // hooks are not registered in production.
 // ============================================================================
-if (getenv('SITE_EXPORT_TEST_MODE')) {
+if (getenv('REPRINT_SERVER_TEST_MODE')) {
     /**
      * Load test hooks from a well-known path relative to the site root.
      * The hook file can define callback functions that are called at key
@@ -586,7 +586,7 @@ if (getenv('SITE_EXPORT_TEST_MODE')) {
             foreach ($dirs as $d) {
                 $candidates[] = wp_join_unix_paths(
                     $d,
-                    'wp-content/plugins/site-export/test-hooks.php'
+                    'wp-content/plugins/reprint-server/test-hooks.php'
                 );
             }
         }
@@ -862,7 +862,7 @@ function endpoint_sql_chunk(
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(true);
 
     // E2E test hook: after gzip stream initialization
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
         $hook_args = [$gz, $boundary];
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
@@ -1028,7 +1028,7 @@ function endpoint_sql_chunk(
             }
 
             // E2E test hook: before SQL batch is emitted
-            if (getenv('SITE_EXPORT_TEST_MODE')) {
+            if (getenv('REPRINT_SERVER_TEST_MODE')) {
                 $hook_args = [&$sql, $cursor];
                 _e2e_call_hook('test_hook_before_sql_batch', $hook_args);
             }
@@ -1111,7 +1111,7 @@ function endpoint_sql_chunk(
         : ($reader->is_finished() && $deferred_fragment === null ? "complete" : "partial");
 
     // E2E test hook: before completion chunk
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         $hook_args = [$status, $gz, $boundary];
         _e2e_call_hook('test_hook_before_completion', $hook_args);
     }
@@ -1165,7 +1165,7 @@ function endpoint_db_index(
 
     $creds = resolve_db_credentials();
 
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
     }
 
@@ -1287,7 +1287,7 @@ function endpoint_db_index(
 
     $completion_failure = null;
     try {
-        if (getenv('SITE_EXPORT_TEST_MODE')) {
+        if (getenv('REPRINT_SERVER_TEST_MODE')) {
             $hook_status = $aborted ? "partial" : $status;
             $hook_args = [$hook_status, $gz, $boundary];
             _e2e_call_hook('test_hook_before_completion', $hook_args);
@@ -2585,7 +2585,7 @@ function stream_file_producer(
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(false, $gzip);
 
     // E2E test hook: after gzip stream initialization (file producer)
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
         $hook_args = [$gz, $boundary];
         _e2e_call_hook('test_hook_after_gzip_init', $hook_args);
@@ -2761,7 +2761,7 @@ function stream_file_producer(
                 $gz->sync();
             } else {
                 // E2E test hook: before file chunk is emitted
-                if (getenv('SITE_EXPORT_TEST_MODE')) {
+                if (getenv('REPRINT_SERVER_TEST_MODE')) {
                     $hook_data = $chunk["data"];
                     $hook_args = [$chunk["path"], $chunk["offset"], &$hook_data];
                     _e2e_call_hook('test_hook_before_file_chunk', $hook_args);
@@ -2846,7 +2846,7 @@ function stream_file_producer(
         $status = $is_complete ? "complete" : "partial";
 
         // E2E test hook: before completion chunk (file producer)
-        if (getenv('SITE_EXPORT_TEST_MODE')) {
+        if (getenv('REPRINT_SERVER_TEST_MODE')) {
             $hook_args = [$status, $gz, $boundary];
             _e2e_call_hook('test_hook_before_completion', $hook_args);
         }
@@ -2977,7 +2977,7 @@ function endpoint_file_index(
         );
     }
 
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         _e2e_load_test_hooks_if_needed($config);
     }
 
@@ -3158,7 +3158,7 @@ function emit_file_index_batch(
     array &$batch_items,
     FileIndexProcessor $file_index
 ): void {
-    if (getenv('SITE_EXPORT_TEST_MODE')) {
+    if (getenv('REPRINT_SERVER_TEST_MODE')) {
         $directory_stack = [];
         foreach ($file_index->get_cursor()["stack"] as $encoded_frame) {
             $directory_stack[] = [

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -257,14 +257,36 @@ final class ExportLibraryLoadTest extends TestCase {
         $this->assertTrue($state['configuration']);
     }
 
-    /**
-     * @return array {
-     *     Export runner result.
-     *
-     *     @type string $output Captured output.
-     * }
-     * @phpstan-return array{output:string}
-     */
+    public function testCanonicalTestModeLoadsTheCanonicalPluginHookPath(): void
+    {
+        $tmp_dir = sys_get_temp_dir() . '/reprint-server-test-hook-' . uniqid('', true);
+        $canonical_hook_directory = $tmp_dir . '/wp-content/plugins/reprint-server';
+        mkdir($canonical_hook_directory, 0755, true);
+        file_put_contents(
+            $canonical_hook_directory . '/test-hooks.php',
+            "<?php function reprint_server_test_hook_marker(): void { echo 'canonical'; }\n"
+        );
+
+        $export_path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($export_path, 'export.php must exist');
+
+        try {
+            $php_code = '<?php' . "\n"
+                . 'putenv(\'REPRINT_SERVER_TEST_MODE=1\');' . "\n"
+                . 'require base64_decode(\'' . base64_encode($export_path) . '\', true);' . "\n"
+                . '_e2e_load_test_hooks_if_needed([\'directory\' => base64_decode(\''
+                . base64_encode($tmp_dir) . '\', true)]);' . "\n"
+                . 'reprint_server_test_hook_marker();' . "\n";
+
+            $result = $this->runPhpCode($php_code);
+
+            $this->assertSame(0, $result['status'], $result['output']);
+            $this->assertSame('canonical', trim($result['output']));
+        } finally {
+            $this->removePath($tmp_dir);
+        }
+    }
+
     private function runExportWith(string $setup_script): array
     {
         $export_path = realpath(self::EXPORT_PATH);

--- a/tests/FileIndexProcessorTest.php
+++ b/tests/FileIndexProcessorTest.php
@@ -8,21 +8,47 @@ use function WordPress\Reprint\Server\relative_path_under;
 
 require_once dirname(__DIR__) . '/packages/reprint-server/src/class-file-index-processor.php';
 
+$GLOBALS['reprint_server_directory_scan_hook_calls'] = 0;
+if (!function_exists('_e2e_call_hook')) {
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Production test-hook stub.
+    function _e2e_call_hook(string $name, array &$arguments = []): void
+    {
+        if ($name === 'test_hook_during_dir_scan' && isset($arguments[1])) {
+            ++$GLOBALS['reprint_server_directory_scan_hook_calls'];
+        }
+    }
+}
+
+// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Test stub mirrors the production hook.
 final class FileIndexProcessorTest extends TestCase {
 
     private string $tempDir;
+
+    /** @var string|false */
+    private $originalCanonicalTestMode;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/file-index-processor-' . uniqid();
         mkdir($this->tempDir, 0755, true);
+        $this->originalCanonicalTestMode = getenv('REPRINT_SERVER_TEST_MODE');
+        putenv('REPRINT_SERVER_TEST_MODE');
+        $GLOBALS['reprint_server_directory_scan_hook_calls'] = 0;
     }
 
     protected function tearDown(): void
     {
         $this->deleteTree($this->tempDir);
+        $this->restoreEnvironment('REPRINT_SERVER_TEST_MODE', $this->originalCanonicalTestMode);
         parent::tearDown();
+    }
+
+    public function testCanonicalTestModeRunsDirectoryScanHook(): void
+    {
+        putenv('REPRINT_SERVER_TEST_MODE=1');
+
+        $this->assertDirectoryScanHookRuns();
     }
 
     public function testResumeAfterEveryStepMatchesOneOpenProcessor(): void
@@ -476,6 +502,33 @@ final class FileIndexProcessorTest extends TestCase {
             $followSymlinks,
             $storagePath
         );
+    }
+
+    private function assertDirectoryScanHookRuns(): void
+    {
+        $docroot = $this->tempDir . '/test-mode-site';
+        mkdir($docroot, 0755, true);
+        file_put_contents($docroot . '/index.php', '<?php');
+        $processor = $this->startProcessor([$docroot], $docroot, false, '');
+
+        try {
+            $this->assertTrue($processor->next_index_step());
+            $this->assertGreaterThan(0, $GLOBALS['reprint_server_directory_scan_hook_calls']);
+        } finally {
+            $processor->close();
+        }
+    }
+
+    /**
+     * @param string|false $value Original environment value.
+     */
+    private function restoreEnvironment(string $name, $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+            return;
+        }
+        putenv($name . '=' . $value);
     }
 
     /**

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -107,7 +107,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 
 ; Keep open_basedir in its own worker pool. A request-level value can remain
 ; active when the same worker handles a request for another test site.
@@ -134,7 +134,7 @@ php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 # ---------- PHP-FPM master without pdo_mysql ----------
@@ -184,7 +184,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 cat <<EOF | sudo tee /etc/systemd/system/php-e2e-no-pdo-mysql.service >/dev/null
@@ -259,7 +259,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -291,7 +291,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -328,7 +328,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_buffering on;
         fastcgi_buffer_size 128k;

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -54,7 +54,7 @@ php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 
 ; Keep open_basedir in its own worker pool. A request-level value can remain
 ; active when the same worker handles a request for another test site.
@@ -78,7 +78,7 @@ php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
 php_admin_value[open_basedir] = ${SITE_ROOT}/open-basedir:/tmp
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 rm -f "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
 "php-fpm${PHP_VERSION}" --nodaemonize &
@@ -127,7 +127,7 @@ php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
 php_admin_value[realpath_cache_ttl] = 0
-env[SITE_EXPORT_TEST_MODE] = 1
+env[REPRINT_SERVER_TEST_MODE] = 1
 EOF
 
 PHP_INI_SCAN_DIR="$NO_PDO_MYSQL_CONF_D" "php-fpm${PHP_VERSION}" \
@@ -166,7 +166,7 @@ NGINXCONF
 rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
 
 # Standard sites — serve from WordPress root so that index.php
-# bootstraps WordPress and the site-export plugin handles the request.
+# bootstraps WordPress and the Reprint Server plugin handles the request.
 jq -r '.sites | to_entries[] | select((.value.nginx // "standard") == "standard") | [.key, .value.port, (.value.openBasedir // false), (.value.noPdoMysql // false)] | @tsv' "$REGISTRY" | while IFS=$'\t' read -r site port open_basedir no_pdo_mysql; do
     site_fpm_socket="$FPM_SOCKET"
     if [ "$open_basedir" = "true" ]; then
@@ -186,7 +186,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -215,7 +215,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_send_timeout 120s;
     }
@@ -246,7 +246,7 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_param SITE_EXPORT_TEST_MODE "1";
+        fastcgi_param REPRINT_SERVER_TEST_MODE "1";
         fastcgi_read_timeout 120s;
         fastcgi_buffering on;
         fastcgi_buffer_size 128k;

--- a/tests/e2e/lib/hmac-client.js
+++ b/tests/e2e/lib/hmac-client.js
@@ -1,5 +1,5 @@
 /**
- * HMAC authentication client for Site Export API.
+ * HMAC authentication client for the Reprint Server API.
  * JavaScript implementation matching the PHP Site_Export_HMAC_Client.
  *
  * Signature = HMAC-SHA256(nonce + timestamp + SHA256(body), secret)

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -253,13 +253,13 @@ export async function ensureSite(name, options = {}) {
     // Copy the built plugin bundle, including its bundled Composer vendor tree.
     cpSync(
         PLUGIN_SRC,
-        join(siteDir, 'wp-content', 'plugins', 'site-export'),
+        join(siteDir, 'wp-content', 'plugins', 'reprint-server'),
         { recursive: true }
     );
 
     // Write secret.php after copying the plugin bundle so the target directory exists.
     writeFileSync(
-        join(siteDir, 'wp-content', 'plugins', 'site-export', 'secret.php'),
+        join(siteDir, 'wp-content', 'plugins', 'reprint-server', 'secret.php'),
         `<?php return '${secret}';\n`
     );
     log('Files copied');
@@ -281,7 +281,7 @@ export async function ensureSite(name, options = {}) {
         log('wp core install done');
 
         // Activate the Reprint Server plugin so WordPress loads index.php on requests.
-        wpPluginActivate(siteDir, 'site-export');
+        wpPluginActivate(siteDir, 'reprint-server');
 
         // Run customDb hook to add extra tables on top of real WP
         if (options.customDb) {

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -25,12 +25,12 @@ const DB_PASS = REGISTRY.dbPass;
 const WP_VERSION = process.env.E2E_WORDPRESS_VERSION || REGISTRY.wpVersion;
 const WP_CLI_PHP_BINARY = process.env.E2E_WP_CLI_PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const EXPORTER_PROJECT_ROOT = process.env.E2E_EXPORTER_PROJECT_ROOT || PROJECT_ROOT;
-// E2E_EXPORTER_PROJECT_ROOT may point at a historical checkout that predates
+const SERVER_PROJECT_ROOT = process.env.E2E_SERVER_PROJECT_ROOT || PROJECT_ROOT;
+// E2E_SERVER_PROJECT_ROOT may point at a historical checkout that predates
 // the reprint-server-wp rename.
-const PLUGIN_SRC = existsSync(join(EXPORTER_PROJECT_ROOT, 'reprint-server-wp'))
-    ? join(EXPORTER_PROJECT_ROOT, 'reprint-server-wp')
-    : join(EXPORTER_PROJECT_ROOT, 'reprint-exporter-wp');
+const PLUGIN_SRC = existsSync(join(SERVER_PROJECT_ROOT, 'reprint-server-wp'))
+    ? join(SERVER_PROJECT_ROOT, 'reprint-server-wp')
+    : join(SERVER_PROJECT_ROOT, 'reprint-exporter-wp');
 const WP_TARBALL = `/tmp/wordpress-${WP_VERSION}.tar.gz`;
 const WP_TEMPLATE = '/tmp/wordpress-template';
 const WP_READY = '/tmp/wordpress-template/.wp-ready';

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -16,7 +16,7 @@ const REGISTRY = createRequire(import.meta.url)('../site-registry.json');
 
 const SITE_ROOT = REGISTRY.siteRoot;
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
+const CLIENT_PATH = process.env.CLIENT_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const DB_HOST = REGISTRY.dbHost;
 const DB_USER = REGISTRY.dbUser;
@@ -244,7 +244,7 @@ export function runImporter(url, outputDir, command, options = {}) {
 
     function runImporterOnce(cmd, extraArgs = []) {
         const args = [
-            IMPORTER_PATH,
+            CLIENT_PATH,
             cmd,
             url,
             `--state-dir=${outputDir}`,

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -560,7 +560,7 @@ export async function compareDatabases(sourceDb, importDb) {
  * Write a test-hooks.php file for a site.
  */
 export function writeTestHooks(siteName, phpCode) {
-    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'site-export', 'test-hooks.php');
+    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'reprint-server', 'test-hooks.php');
     const code = `<?php
 // PHP hooks and Node assertions can touch this file at the same time. Write
 // the complete next JSON value beside the old one, then replace it in one
@@ -592,7 +592,7 @@ ${phpCode}
  * Remove test-hooks.php for a site.
  */
 export function removeTestHooks(siteName) {
-    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'site-export', 'test-hooks.php');
+    const hookPath = join(SITE_ROOT, siteName, 'wp-content', 'plugins', 'reprint-server', 'test-hooks.php');
     try {
         execSync(`sudo rm -f ${JSON.stringify(hookPath)}`);
     } catch {

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -65,7 +65,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';
@@ -97,7 +97,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             fastcgi_send_timeout 120s;
           '';
@@ -122,7 +122,7 @@ let
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include ${pkgs.nginx}/conf/fastcgi_params;
-            fastcgi_param SITE_EXPORT_TEST_MODE "1";
+            fastcgi_param REPRINT_SERVER_TEST_MODE "1";
             fastcgi_read_timeout 120s;
             # Enable proxy buffering to simulate Apache-like buffering
             fastcgi_buffering on;
@@ -208,7 +208,7 @@ in {
       "php_admin_value[realpath_cache_ttl]" = "0";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 
@@ -234,7 +234,7 @@ in {
       "php_admin_value[realpath_cache_ttl]" = "0";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 
@@ -262,7 +262,7 @@ in {
       "php_admin_value[open_basedir]" = "${siteRoot}/open-basedir:/tmp";
     };
     phpEnv = {
-      SITE_EXPORT_TEST_MODE = "1";
+      REPRINT_SERVER_TEST_MODE = "1";
     };
   };
 

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -22,8 +22,8 @@ describe('Import: Custom WP Content', () => {
     beforeAll(async () => {
         await ensureSite(site, {
             afterCreate: async (siteDir) => {
-                const customPlugin = join(siteDir, 'custom-content', 'plugins', 'site-export');
-                const srcPlugin = join(siteDir, 'wp-content', 'plugins', 'site-export');
+                const customPlugin = join(siteDir, 'custom-content', 'plugins', 'reprint-server');
+                const srcPlugin = join(siteDir, 'wp-content', 'plugins', 'reprint-server');
                 mkdirSync(join(siteDir, 'custom-content', 'plugins'), { recursive: true });
                 cpSync(srcPlugin, customPlugin, { recursive: true });
             },

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -88,7 +88,7 @@ describe('Import: Request Cutoff', () => {
         // source. It is test setup rather than site content.
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot, {
-            exclude: ['wp-content/plugins/site-export/test-hooks.php'],
+            exclude: ['wp-content/plugins/reprint-server/test-hooks.php'],
         });
     });
 

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -84,7 +84,7 @@ describe('Import: Follow Symlinks', () => {
             // Start a PHP built-in server for this site as a fallback.
         }
 
-        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'reprint-server');
         fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8101', '-t', fsRoot], {
             stdio: 'ignore',
         });

--- a/tests/e2e/tests/import-35-sqlite-export.test.js
+++ b/tests/e2e/tests/import-35-sqlite-export.test.js
@@ -125,7 +125,7 @@ async function ensureSqliteSite(site, pluginVersion) {
 
             // Activate the Reprint Server plugin.
             execSync(
-                `php /tmp/wp-cli.phar plugin activate site-export` +
+                `php /tmp/wp-cli.phar plugin activate reprint-server` +
                 ` --path=${JSON.stringify(siteDir)}` +
                 allowRoot,
                 { timeout: 30000, stdio: 'pipe' },

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -20,7 +20,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
+const CLIENT_PATH = process.env.CLIENT_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
 const itWhenRustExtensionConfigured = process.env.WP_MYSQL_PARSER_EXTENSION_MANIFEST ? it : it.skip;
 
 describe('Import: Playground CLI runtime', () => {
@@ -104,7 +104,7 @@ describe('Import: Playground CLI runtime', () => {
 
     it('apply-runtime generates playground-cli files', () => {
         execFileSync(PHP_BINARY, [
-            IMPORTER_PATH,
+            CLIENT_PATH,
             'apply-runtime',
             importUrl(),
             `--state-dir=${tempDir}`,

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -55,32 +55,32 @@ describe('Import: Atomic-style split roots (__wp__ + document root)', () => {
                 writeFileSync(join(siteDir, 'wp-load.php'), '<?php /* stub */ ?>');
                 writeFileSync(join(siteDir, 'wp-config.php'), '<?php /* stub config */ ?>');
 
-                // index.php loads the exporter directly, bypassing WordPress.
-                // lib.php's _site_export_handle_api_request() authenticates
+                // index.php loads Reprint Server directly, bypassing WordPress.
+                // lib.php's namespaced request handler authenticates
                 // via HMAC and dispatches the request — same path as the
                 // WordPress plugin, just without WP bootstrapped.
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('ABSPATH', __DIR__ . '/__wp__/');
-define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');
-define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+define('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR', __DIR__ . '/wp-content/plugins/reprint-server/');
+define('WordPress\\Reprint\\Server\\Plugin\\SECRET_FILE', constant('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR') . 'secret.php');
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }
 }
-require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';
-_site_export_handle_api_request();
+require_once constant('WordPress\\Reprint\\Server\\Plugin\\PLUGIN_DIR') . 'lib.php';
+\\WordPress\\Reprint\\Server\\Plugin\\handle_api_request();
 `);
 
                 // Create site's own wp-content
-                mkdirSync(join(siteDir, 'wp-content', 'plugins', 'site-export'), { recursive: true });
+                mkdirSync(join(siteDir, 'wp-content', 'plugins', 'reprint-server'), { recursive: true });
                 mkdirSync(join(siteDir, 'wp-content', 'themes'), { recursive: true });
 
                 // Copy server plugin
-                const pluginSrc = join(wpDir, 'wp-content', 'plugins', 'site-export');
+                const pluginSrc = join(wpDir, 'wp-content', 'plugins', 'reprint-server');
                 if (existsSync(pluginSrc)) {
-                    execSync(`cp -a "${pluginSrc}/." "${join(siteDir, 'wp-content', 'plugins', 'site-export')}/"`)
+                    execSync(`cp -a "${pluginSrc}/." "${join(siteDir, 'wp-content', 'plugins', 'reprint-server')}/"`)
                 }
                 writeFileSync(
-                    join(siteDir, 'wp-content', 'plugins', 'site-export', 'secret.php'),
+                    join(siteDir, 'wp-content', 'plugins', 'reprint-server', 'secret.php'),
                     `<?php return 'test-secret-${site}';\n`
                 );
 

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -179,8 +179,8 @@ describe('Import: SiteGround plugin stripping', () => {
             );
             // Confirm non-SG plugins survived.
             assert.ok(
-                raw.includes('site-export'),
-                `active_plugins should still contain site-export, got: ${raw}`,
+                raw.includes('reprint-server'),
+                `active_plugins should still contain reprint-server, got: ${raw}`,
             );
         });
 
@@ -241,7 +241,7 @@ describe('Import: SiteGround plugin stripping', () => {
         it('unrelated plugins are preserved on disk', () => {
             const flatDir = join(tempDir, 'flattened');
             assert.ok(
-                existsSync(join(flatDir, 'wp-content', 'plugins', 'site-export')),
+                existsSync(join(flatDir, 'wp-content', 'plugins', 'reprint-server')),
                 'Reprint Server plugin should still exist after apply-runtime',
             );
         });

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -22,7 +22,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
+const CLIENT_PATH = process.env.CLIENT_PATH || join(PROJECT_ROOT, 'packages', 'reprint-client', 'bin', 'reprint-client');
 
 describe('Import: SiteGround plugin stripping', () => {
     const site = 'siteground-plugins';
@@ -208,7 +208,7 @@ describe('Import: SiteGround plugin stripping', () => {
                 `flat-docroot failed:\n${flatResult.stderr}`);
 
             execFileSync('php', [
-                IMPORTER_PATH,
+                CLIENT_PATH,
                 'apply-runtime',
                 importUrl(),
                 `--state-dir=${tempDir}`,

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -70,12 +70,12 @@ describe('Import: Pull Basic', { timeout: 180000 }, () => {
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
         assertPullPipelineComplete(state);
 
-        const expectedExporterPhpVersion = process.env.E2E_EXPECTED_EXPORTER_PHP_VERSION;
-        if (expectedExporterPhpVersion) {
+        const expectedServerPhpVersion = process.env.E2E_EXPECTED_SERVER_PHP_VERSION;
+        if (expectedServerPhpVersion) {
             const exporterPhpVersion = state.preflight?.data?.php?.version;
             assert.ok(
-                exporterPhpVersion?.startsWith(`${expectedExporterPhpVersion}.`),
-                `Expected exporter PHP ${expectedExporterPhpVersion}.x, got ${exporterPhpVersion ?? 'missing'}`,
+                exporterPhpVersion?.startsWith(`${expectedServerPhpVersion}.`),
+                `Expected exporter PHP ${expectedServerPhpVersion}.x, got ${exporterPhpVersion ?? 'missing'}`,
             );
         }
     });

--- a/tests/e2e/tests/import-56-db-rewrite-urls-resume.test.js
+++ b/tests/e2e/tests/import-56-db-rewrite-urls-resume.test.js
@@ -17,7 +17,7 @@ import {
 } from '../lib/test-helpers.js';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const IMPORTER_PATH = process.env.IMPORTER_PATH || join(
+const CLIENT_PATH = process.env.CLIENT_PATH || join(
     PROJECT_ROOT,
     'packages',
     'reprint-client',
@@ -245,7 +245,7 @@ describeWithSignals(
 
         function startRewrite(extraArgs) {
             const child = spawn(PHP_BINARY, [
-                IMPORTER_PATH,
+                CLIENT_PATH,
                 'db-rewrite-urls',
                 `--state-dir=${tempDir}`,
                 '--progress=jsonl',

--- a/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
+++ b/tests/e2e/tests/import-56-mysql-session-settings-resume.test.js
@@ -32,7 +32,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
     const progressTable = '__reprint_db_pull_progress_49acb118-a97a-45c7-814d-8e670db7f6b4';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
-    const importerPath = process.env.IMPORTER_PATH
+    const clientPath = process.env.CLIENT_PATH
         || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
     const phpBinary = process.env.PHP_BINARY || 'php';
     let tempDir;
@@ -70,7 +70,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
     function spawnDatabasePull() {
         const output = { stdout: '', stderr: '' };
         const childProcess = spawn(phpBinary, [
-            importerPath,
+            clientPath,
             'db-pull',
             importUrl(),
             `--state-dir=${tempDir}`,
@@ -94,7 +94,7 @@ describeWithHostPhpProcess('Import: MySQL session settings after restart', { tim
     function spawnDatabaseApply(stateDir) {
         const output = { stdout: '', stderr: '' };
         const childProcess = spawn(phpBinary, [
-            importerPath,
+            clientPath,
             'db-apply',
             importUrl(),
             `--state-dir=${stateDir}`,

--- a/tests/e2e/tests/import-57-mysql-target-position.test.js
+++ b/tests/e2e/tests/import-57-mysql-target-position.test.js
@@ -33,7 +33,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     const previousProgressTable = '__reprint_db_pull_progress_11111111-2222-4333-8444-555555555555';
     const targetDb = `${getDbName(site)}_import`;
     const projectRoot = join(import.meta.dirname, '..', '..', '..');
-    const importerPath = process.env.IMPORTER_PATH
+    const clientPath = process.env.CLIENT_PATH
         || join(projectRoot, 'packages', 'reprint-client', 'bin', 'reprint-client');
     const phpBinary = process.env.PHP_BINARY || 'php';
     const activeChildren = new Set();
@@ -65,7 +65,7 @@ describeWithHostPhpProcess('Import: source position saved in MySQL target', { ti
     function spawnDatabasePull() {
         const output = { stdout: '', stderr: '' };
         const childProcess = spawn(phpBinary, [
-            importerPath,
+            clientPath,
             'db-pull',
             importUrl(),
             `--state-dir=${tempDir}`,

--- a/tests/e2e/tests/import-59-files-pull-mirror.test.js
+++ b/tests/e2e/tests/import-59-files-pull-mirror.test.js
@@ -390,7 +390,7 @@ describe('Import: files-pull mirror and catch-up modes', { timeout: 300000 }, ()
         );
 
         assertTreesMatch(getSiteDir(site), localSiteRoot(mirrorTempDir), {
-            exclude: ['wp-content/plugins/site-export/test-hooks.php'],
+            exclude: ['wp-content/plugins/reprint-server/test-hooks.php'],
         });
         assert.ok(
             !existsSync(join(localSiteRoot(mirrorTempDir), 'test-data', 'local-only')),

--- a/tests/e2e/tests/import-60-preflight-open-basedir.test.js
+++ b/tests/e2e/tests/import-60-preflight-open-basedir.test.js
@@ -109,7 +109,7 @@ describe('Import: Pull with an open_basedir boundary', { timeout: 180000 }, () =
         const importedWpContent = join(importedSiteDir, 'wp-content');
         assert.ok(existsSync(importedWpContent), `Expected ${importedWpContent} to exist`);
         assert.equal(
-            readFileSync(join(importedWpContent, 'plugins', 'site-export', 'secret.php'), 'utf-8'),
+            readFileSync(join(importedWpContent, 'plugins', 'reprint-server', 'secret.php'), 'utf-8'),
             `<?php return '${getSiteSecret(site)}';\n`,
         );
         assert.ok(!existsSync(join(importedSiteDir, 'wp-load.php')),


### PR DESCRIPTION
Renames the E2E test-mode environment variable and plugin slug to the Reprint Server names, keeping the Site Export ones as aliases so existing fixtures keep working.