### PR TITLE
[PHP] Index only the requested followed symlink target

### DIFF
--- a/packages/reprint-server/src/class-file-index-processor.php
+++ b/packages/reprint-server/src/class-file-index-processor.php
@@ -95,7 +95,8 @@ final class FileIndexProcessor {
     private $closed = false;
 
     /**
-     * Starts a traversal at the requested root and schedules the other roots.
+     * Starts a traversal at the requested root. A configured start also
+     * schedules the other configured roots.
      *
      * @param FileIndexRoot[] $roots       Structured roots scheduled for this index.
      * @param FileIndexRoot   $start_root  Root scheduled first. It may be an
@@ -127,20 +128,25 @@ final class FileIndexProcessor {
 
         $configured_directories = self::resolved_directory_roots($roots, $follow_symlinks);
 
-        // Visit the requested directory first, followed by every other root in
-        // stable byte order. Stable ordering makes a cursor independent of the
-        // order in which configuration discovered the additional roots.
+        // The initial request starts at a configured root and visits every
+        // configured root. A request which follows an external directory
+        // symlink must visit only that target, or each link would also repeat
+        // the complete configured traversal.
         $ordered_roots = [$start_root];
-        $extra_roots = [];
-        foreach ($roots as $root) {
-            if ($root["requested_path"] !== $start_root["requested_path"]) {
-                $extra_roots[] = $root;
+        if ($start_root_is_configured) {
+            $extra_roots = [];
+            foreach ($roots as $root) {
+                if ($root["requested_path"] !== $start_root["requested_path"]) {
+                    $extra_roots[] = $root;
+                }
             }
+            // Stable ordering makes a cursor independent of the order in
+            // which configuration discovered the additional roots.
+            usort($extra_roots, static function (array $left, array $right): int {
+                return strcmp($left["requested_path"], $right["requested_path"]);
+            });
+            $ordered_roots = array_merge($ordered_roots, $extra_roots);
         }
-        usort($extra_roots, static function (array $left, array $right): int {
-            return strcmp($left["requested_path"], $right["requested_path"]);
-        });
-        $ordered_roots = array_merge($ordered_roots, $extra_roots);
 
         // A selected directory symlink has two responsibilities: emit its
         // requested link entry and traverse its resolved target. Keep the

--- a/tests/FileIndexFilePathRootTest.php
+++ b/tests/FileIndexFilePathRootTest.php
@@ -53,7 +53,7 @@ final class FileIndexFilePathRootTest extends TestCase
         $this->assertContains($pluginsPath . '/hello/hello.php', $paths);
     }
 
-    public function testEndpointIndexesAFollowedTargetOutsideTheConfiguredRoot(): void
+    public function testEndpointIndexesOnlyTheFollowedTargetOutsideTheConfiguredRoot(): void
     {
         $site = $this->tempDir . '/site';
         $shared = $this->tempDir . '/shared';
@@ -65,7 +65,7 @@ final class FileIndexFilePathRootTest extends TestCase
         $target = (string) realpath($shared . '/theme');
         $paths = $this->runFileIndex([$site . '/theme'], $target);
 
-        $this->assertContains($site . '/theme', $paths);
+        $this->assertNotContains($site . '/theme', $paths);
         $this->assertContains($target . '/style.css', $paths);
     }
 

--- a/tests/FileIndexNamedRootTest.php
+++ b/tests/FileIndexNamedRootTest.php
@@ -64,7 +64,7 @@ final class FileIndexNamedRootTest extends TestCase
         );
     }
 
-    public function testFollowedTargetOutsideConfiguredRootsCanStartAnIndex(): void
+    public function testFollowedTargetOutsideConfiguredRootsIndexesOnlyTheTarget(): void
     {
         $site = $this->tempDir . '/site';
         $shared = $this->tempDir . '/shared';
@@ -78,8 +78,9 @@ final class FileIndexNamedRootTest extends TestCase
             $this->root($site . '/theme', $target, 'symlink'),
         ], $target);
 
-        $this->assertContains($site . '/theme', array_column($entries, 'path'));
-        $this->assertContains($target . '/style.css', array_column($entries, 'path'));
+        $paths = array_column($entries, 'path');
+        $this->assertNotContains($site . '/theme', $paths);
+        $this->assertContains($target . '/style.css', $paths);
     }
 
     public function testParentSymlinkIsEmittedAtRequestedPathAndFileAtResolvedPath(): void


### PR DESCRIPTION
Follow-up file-index requests now traverse only the external directory named by `list_dir`, so each followed symlink no longer repeats every configured root.

The first request still starts at a configured root and schedules all configured roots in stable order. A regression test confirms that an external start emits its target contents without re-emitting the configured symlink root.

Testing: `cd tests && ../vendor/bin/phpunit FileIndexProcessorTest.php FileIndexNamedRootTest.php FileIndexDedupTest.php`