### PR TITLE
[PHP] Serve JSON API responses as application/octet-stream

### DIFF
--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -361,7 +361,9 @@ final class HTTPServer {
                 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
                 header('Pragma: no-cache');
                 header('Expires: 0');
-                header('Content-Type: application/json');
+                // Hostinger preview domains rewrite real domains in application/json
+                // response bodies. Keep the JSON bytes opaque to that response filter.
+                header('Content-Type: application/octet-stream');
                 echo json_encode([
                     'status' => 'rejected',
                     'reason' => 'push_disabled',

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -600,7 +600,9 @@ final class PushEndpoints {
         header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Pragma: no-cache');
         header('Expires: 0');
-        header('Content-Type: application/json');
+        // Hostinger preview domains rewrite real domains in application/json
+        // response bodies. Keep the JSON bytes opaque to that response filter.
+        header('Content-Type: application/octet-stream');
         $json = json_encode($body);
         if ($json === false) {
             http_response_code(500);

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -475,7 +475,9 @@ set_error_handler(function ($errno, $errstr, $errfile, $errline) {
     }
 
     http_response_code(500);
-    @header("Content-Type: application/json");
+    // Hostinger preview domains rewrite real domains in application/json
+    // response bodies. Keep the JSON bytes opaque to that response filter.
+    @header("Content-Type: application/octet-stream");
     echo json_encode($error);
     exit(1);
 });
@@ -502,7 +504,9 @@ set_exception_handler(function ($e) {
     }
 
     http_response_code(500);
-    header("Content-Type: application/json");
+    // Hostinger preview domains rewrite real domains in application/json
+    // response bodies. Keep the JSON bytes opaque to that response filter.
+    header("Content-Type: application/octet-stream");
     echo json_encode($error);
     exit(1);
 });
@@ -545,7 +549,9 @@ register_shutdown_function(function () {
 
     if (!headers_sent()) {
         http_response_code(500);
-        @header("Content-Type: application/json");
+        // Hostinger preview domains rewrite real domains in application/json
+        // response bodies. Keep the JSON bytes opaque to that response filter.
+        @header("Content-Type: application/octet-stream");
         echo json_encode([
             "error" => $message,
             "file" => $error['file'],
@@ -2556,7 +2562,9 @@ function endpoint_preflight(array $config): array
         "database" => $db,
     ];
 
-    header("Content-Type: application/json");
+    // Hostinger preview domains rewrite real domains in application/json
+    // response bodies. Keep the JSON bytes opaque to that response filter.
+    header("Content-Type: application/octet-stream");
     $json = json_encode($response);
     if ($json === false) {
         http_response_code(500);

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -51,7 +51,9 @@ if (!defined(__NAMESPACE__ . '\\TIMESTAMP_TOLERANCE')) {
 /** Sends a JSON error response and terminates. */
 function error(int $code, string $message): void {
     http_response_code($code);
-    header('Content-Type: application/json');
+    // Hostinger preview domains rewrite real domains in application/json
+    // response bodies. Keep the JSON bytes opaque to that response filter.
+    header('Content-Type: application/octet-stream');
     echo json_encode(['error' => $message, 'code' => $code]);
     exit;
 }
@@ -74,7 +76,9 @@ function push_error(int $http_code, string $reason, string $detail): void {
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
     header('Expires: 0');
-    header('Content-Type: application/json');
+    // Hostinger preview domains rewrite real domains in application/json
+    // response bodies. Keep the JSON bytes opaque to that response filter.
+    header('Content-Type: application/octet-stream');
     echo json_encode([
         'status' => 'rejected',
         'reason' => $reason,
@@ -444,7 +448,9 @@ function handle_api_request(array $options = []): void {
         ];
         error_log('Reprint Server API error: ' . json_encode($error));
         http_response_code(500);
-        @header('Content-Type: application/json');
+        // Hostinger preview domains rewrite real domains in application/json
+        // response bodies. Keep the JSON bytes opaque to that response filter.
+        @header('Content-Type: application/octet-stream');
         echo json_encode($error);
         exit(1);
     });
@@ -457,7 +463,9 @@ function handle_api_request(array $options = []): void {
         ];
         error_log('Reprint Server API exception: ' . json_encode($error));
         http_response_code(500);
-        @header('Content-Type: application/json');
+        // Hostinger preview domains rewrite real domains in application/json
+        // response bodies. Keep the JSON bytes opaque to that response filter.
+        @header('Content-Type: application/octet-stream');
         echo json_encode($error);
         exit(1);
     });
@@ -686,7 +694,9 @@ function handle_api_request(array $options = []): void {
         }
         if (!headers_sent()) {
             http_response_code(400);
-            header('Content-Type: application/json');
+            // Hostinger preview domains rewrite real domains in application/json
+            // response bodies. Keep the JSON bytes opaque to that response filter.
+            header('Content-Type: application/octet-stream');
         }
         echo json_encode([
             'error' => $e->getMessage(),

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -282,6 +282,39 @@ class FetchRequestBodySizingTest extends TestCase
         );
     }
 
+    public function testPreflightAcceptsJsonFromAnOpaqueResponse(): void
+    {
+        $payload = json_encode([
+            'ok' => true,
+            'protocol_version' => 3,
+            'database' => ['wp' => ['wp_version' => '6.0-test']],
+        ]);
+        $response = "HTTP/1.1 200 OK\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: " . strlen($payload) . "\r\n"
+            . "Connection: close\r\n\r\n"
+            . $payload;
+
+        [$url, $pid] = $this->startJsonServer($response);
+
+        $client = new \ImportClient($url, $this->stateDir, $this->filesystemRoot);
+        \write_current_pull_state($client, []);
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client),
+        );
+        $reflection->getProperty('is_tty')->setValue($client, false);
+
+        $client->run_preflight();
+        pcntl_waitpid($pid, $status);
+
+        $this->assertSame(
+            '6.0-test',
+            $client->get_state()->preflight_record()['data']['database']['wp']['wp_version'],
+        );
+    }
+
     public function testRunningPreflightTightensTheBoundInTheSameRun(): void
     {
         // initialize_tuner() runs before run_preflight(), so until preflight

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1373,6 +1373,7 @@ final class PushEndpointsTest extends TestCase {
         $body = curl_exec($handle);
         $this->assertIsString($body);
         $this->assertSame(200, curl_getinfo($handle, CURLINFO_HTTP_CODE), $body);
+        $this->assertSame('application/octet-stream', curl_getinfo($handle, CURLINFO_CONTENT_TYPE));
         curl_close($handle);
 
         $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
@@ -1402,6 +1403,7 @@ final class PushEndpointsTest extends TestCase {
             'path' => null,
         ], json_decode($status['body'], true, 512, JSON_THROW_ON_ERROR));
         $this->assertNoCacheHeaders($status['headers']);
+        $this->assertSame(['application/octet-stream'], $status['headers']['content-type'] ?? []);
     }
 
     public function testPushAuthenticationFailureSendsNoCacheHeaders(): void
@@ -1413,6 +1415,7 @@ final class PushEndpointsTest extends TestCase {
         $this->assertSame(403, $authentication_failure['http_code'], $authentication_failure['body']);
         $this->assertSame('auth_failed', json_decode($authentication_failure['body'], true, 512, JSON_THROW_ON_ERROR)['reason']);
         $this->assertNoCacheHeaders($authentication_failure['headers']);
+        $this->assertSame(['application/octet-stream'], $authentication_failure['headers']['content-type'] ?? []);
     }
 
     public function testEndpointGuardsRejectWrongMethodContentTypeAndAuthentication(): void

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -91,7 +91,7 @@ export async function apiRequest(siteName, endpoint, params = {}, options = {}) 
 
     const contentType = response.headers.get('content-type') || '';
 
-    if (contentType.includes('application/json')) {
+    if (isJsonApiResponseContentType(contentType)) {
         return {
             status: response.status,
             json: await response.json(),
@@ -685,7 +685,7 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
 
     const contentType = response.headers.get('content-type') || '';
 
-    if (contentType.includes('application/json')) {
+    if (isJsonApiResponseContentType(contentType)) {
         return {
             status: response.status,
             json: await response.json(),
@@ -726,6 +726,17 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
         text: await response.text(),
         headers: Object.fromEntries(response.headers.entries()),
     };
+}
+
+/**
+ * Return whether a top-level API response carries JSON.
+ *
+ * The server marks top-level JSON as application/octet-stream so Hostinger's
+ * preview-domain response filter leaves domain strings unchanged.
+ */
+function isJsonApiResponseContentType(contentType) {
+    return contentType.includes('application/json')
+        || contentType.includes('application/octet-stream');
 }
 
 function setApiRequestParameter(url, parameter, value) {

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -735,8 +735,7 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
  * preview-domain response filter leaves domain strings unchanged.
  */
 function isJsonApiResponseContentType(contentType) {
-    return contentType.includes('application/json')
-        || contentType.includes('application/octet-stream');
+    return contentType.includes('application/octet-stream');
 }
 
 function setApiRequestParameter(url, parameter, value) {


### PR DESCRIPTION
All top-level Reprint JSON API responses now use `application/octet-stream` so Hostinger preview-domain filters leave domain and filesystem-path bytes unchanged. The bodies remain JSON, and each opaque Content-Type header documents why it differs from the payload format. JSON parts inside `multipart/mixed` responses remain unchanged because Hostinger selects its filter from the outer response Content-Type.

The clients already decode these bodies without requiring a JSON Content-Type. Endpoint tests check the opaque response type for preflight, successful push, and push authentication failures.

## Testing

Run the focused endpoint, importer, library-load, and WordPress plugin tests. Run PHPStan and the PHP 7.2+ server compatibility check.