### PR TITLE
[PHP] Retry reverse-proxy origin failures and log failed response headers

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -206,6 +206,9 @@ class ImportClient
      */
     private const MAX_CONSECUTIVE_INTERRUPTED_RESPONSES = 3;
 
+    /** Maximum response header bytes retained for failed request audit logging. */
+    private const MAX_AUDIT_RESPONSE_HEADER_BYTES = 65536;
+
     /**
      * cURL error numbers that can be temporary, often meaning the peer cut the transfer short.
      * We can attempt some retries from these errors before giving up.
@@ -236,6 +239,11 @@ class ImportClient
         502, // Bad Gateway
         503, // Service Unavailable
         504, // Gateway Timeout
+        520, // Cloudflare received an unknown response from the origin
+        521, // Cloudflare could not connect to the origin
+        522, // Cloudflare timed out connecting to the origin
+        523, // Cloudflare could not reach the origin
+        524, // Cloudflare timed out waiting for the origin response
     ];
 
     /** @var string Remote Reprint API URL. */
@@ -11898,6 +11906,7 @@ class ImportClient
         $last_progress_check = microtime(true);
         $last_bytes_received = 0;
         $error_body = "";
+        $response_headers = "";
 
         // Build headers to look like a real browser
         $headers = [
@@ -11969,9 +11978,33 @@ class ImportClient
             CURLOPT_HEADERFUNCTION => function ($ch, $header_line) use (
                 &$parser,
                 $context,
-                &$current_chunk
+                &$current_chunk,
+                &$response_headers
             ) {
                 $len = strlen($header_line);
+
+                $audit_header_line = rtrim($header_line, "\r\n");
+                if (
+                    preg_match(
+                        '/^(Set-Cookie|Authorization|Proxy-Authorization|X-Auth-[^:]+):/i',
+                        $audit_header_line,
+                        $sensitive_header_match,
+                    )
+                ) {
+                    $audit_header_line = $sensitive_header_match[1] . ': [redacted]';
+                }
+                if (
+                    $audit_header_line !== '' &&
+                    strlen($response_headers) < self::MAX_AUDIT_RESPONSE_HEADER_BYTES
+                ) {
+                    $remaining_header_bytes =
+                        self::MAX_AUDIT_RESPONSE_HEADER_BYTES - strlen($response_headers);
+                    $response_headers .= substr(
+                        $audit_header_line . "\n",
+                        0,
+                        $remaining_header_bytes,
+                    );
+                }
 
                 // Parse Content-Type to extract boundary
                 if (stripos($header_line, "Content-Type:") === 0) {
@@ -12174,10 +12207,16 @@ class ImportClient
                 ]);
             }
 
+            $response_headers_for_log = $response_headers !== ''
+                ? rtrim($response_headers, "\n")
+                : '(none)';
+
             // Log what we received
             $this->audit_log(
                 "HTTP error {$http_code} | error_body length: " .
-                    strlen($error_body),
+                    strlen($error_body) .
+                    " | response_headers:\n" .
+                    $response_headers_for_log,
                 true,
             );
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -239,11 +239,12 @@ class ImportClient
         502, // Bad Gateway
         503, // Service Unavailable
         504, // Gateway Timeout
-        520, // Cloudflare received an unknown response from the origin
-        521, // Cloudflare could not connect to the origin
-        522, // Cloudflare timed out connecting to the origin
-        523, // Cloudflare could not reach the origin
-        524, // Cloudflare timed out waiting for the origin response
+        // Non-standard reverse-proxy origin failures, most often from Cloudflare.
+        520, // Unknown origin response
+        521, // Origin refused the connection
+        522, // Origin connection timed out
+        523, // Origin could not be reached
+        524, // Origin response timed out
     ];
 
     /** @var string Remote Reprint API URL. */

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -234,6 +234,73 @@ class CurlTimeoutRecoveryTest extends TestCase
         );
     }
 
+    public function testSqlDownloadRetriesHttp520AndLogsResponseHeaders()
+    {
+        if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
+            $this->markTestSkipped('HTTP retry coverage requires PHP curl and pcntl.');
+        }
+
+        $cursor = base64_encode('{"table":"wp_posts","pk":42}');
+        $http520 = $this->httpResponse(
+            '520 Web Server Returned an Unknown Error',
+            'text/html',
+            '<!doctype html><title>Temporary origin response</title>',
+            [
+                'Server: cloudflare',
+                'CF-Ray: 1234567890abcdef-WAW',
+                'CF-Error-Type: 52x',
+                'Retry-After: 1',
+                'Set-Cookie: session=do-not-log-me',
+            ],
+        );
+        $boundary = 'http-retry-test';
+        $completion_body = "--{$boundary}\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: 0\r\n"
+            . "X-Chunk-Type: completion\r\n"
+            . "X-Status: complete\r\n"
+            . "\r\n"
+            . "\r\n"
+            . "--{$boundary}--\r\n";
+        $server = $this->startSqlResponseServer([
+            $http520,
+            $this->httpResponse(
+                '200 OK',
+                "multipart/mixed; boundary={$boundary}",
+                $completion_body,
+            ),
+        ], $cursor);
+        $wire_client = $this->prepareWireSqlClient(
+            $server['url'],
+            $cursor,
+        );
+        $client = $wire_client['client'];
+        $reflection = $wire_client['reflection'];
+
+        try {
+            $reflection->getMethod('fetch_sql')->invoke($client);
+        } finally {
+            pcntl_waitpid($server['child_pid'], $status);
+        }
+
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+        $this->assertSame(
+            0,
+            $client->get_state()->consecutive_interrupted_responses,
+        );
+
+        $audit_log = file_get_contents($this->stateDir . '/audit.log');
+        $this->assertIsString($audit_log);
+        $this->assertStringContainsString('HTTP/1.1 520 Web Server Returned an Unknown Error', $audit_log);
+        $this->assertStringContainsString('Server: cloudflare', $audit_log);
+        $this->assertStringContainsString('CF-Ray: 1234567890abcdef-WAW', $audit_log);
+        $this->assertStringContainsString('CF-Error-Type: 52x', $audit_log);
+        $this->assertStringContainsString('Retry-After: 1', $audit_log);
+        $this->assertStringContainsString('Set-Cookie: [redacted]', $audit_log);
+        $this->assertStringNotContainsString('do-not-log-me', $audit_log);
+    }
+
     public function testSqlDownloadPreservesHttp418AfterRetryLimit()
     {
         if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
@@ -861,16 +928,22 @@ PHP);
         );
     }
 
+    /**
+     * @param string[] $additional_headers Additional response header lines.
+     */
     private function httpResponse(
         string $status_line,
         string $content_type,
-        string $body
+        string $body,
+        array $additional_headers = []
     ): string {
-        return "HTTP/1.1 {$status_line}\r\n"
+        $response = "HTTP/1.1 {$status_line}\r\n"
             . "Content-Type: {$content_type}\r\n"
-            . 'Content-Length: ' . strlen($body) . "\r\n"
-            . "Connection: close\r\n\r\n"
-            . $body;
+            . 'Content-Length: ' . strlen($body) . "\r\n";
+        foreach ($additional_headers as $header) {
+            $response .= $header . "\r\n";
+        }
+        return $response . "Connection: close\r\n\r\n" . $body;
     }
 
     /**

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -257,7 +257,7 @@ class DiagnoseHttpErrorTest extends TestCase
             $this->assertTrue(
                 $this->isPotentiallyTransientHttpError(
                     $http_code,
-                    '<!doctype html><title>Temporary Cloudflare response</title>',
+                    '<!doctype html><title>Temporary reverse-proxy response</title>',
                 ),
                 "HTTP {$http_code} should be potentially transient",
             );
@@ -266,7 +266,7 @@ class DiagnoseHttpErrorTest extends TestCase
             $this->assertFalse(
                 $this->isPotentiallyTransientHttpError(
                     $http_code,
-                    '<!doctype html><title>Cloudflare configuration error</title>',
+                    '<!doctype html><title>Reverse-proxy configuration error</title>',
                 ),
                 "HTTP {$http_code} should remain fatal",
             );

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -253,6 +253,24 @@ class DiagnoseHttpErrorTest extends TestCase
 
     public function testPotentiallyTransientHttpErrorClassification()
     {
+        foreach ([520, 521, 522, 523, 524] as $http_code) {
+            $this->assertTrue(
+                $this->isPotentiallyTransientHttpError(
+                    $http_code,
+                    '<!doctype html><title>Temporary Cloudflare response</title>',
+                ),
+                "HTTP {$http_code} should be potentially transient",
+            );
+        }
+        foreach ([525, 526, 530] as $http_code) {
+            $this->assertFalse(
+                $this->isPotentiallyTransientHttpError(
+                    $http_code,
+                    '<!doctype html><title>Cloudflare configuration error</title>',
+                ),
+                "HTTP {$http_code} should remain fatal",
+            );
+        }
         $this->assertTrue($this->isPotentiallyTransientHttpError(
             400,
             '<!doctype html><title>Temporary upstream response</title>',


### PR DESCRIPTION
Retries non-standard 520–524 responses from the last durable pull cursor instead of ending the pull after the first response.

The code treats these as temporary reverse-proxy origin failures. Cloudflare is the most likely sender and documents these codes with those meanings, but the retry rule does not depend on the proxy vendor. The existing three-failure no-progress limit still stops a pull that cannot advance. TLS failures 525 and 526 remain fatal, as does 530.

Failed streaming responses now write their response headers to the audit log, capped at 64 KiB. Cookie and authentication header values are hidden so the log can retain `Server`, `CF-Ray`, `CF-Error-Type`, and `Retry-After` without recording credentials.

Cloudflare reference: https://developers.cloudflare.com/fundamentals/reference/error-responses/

## Testing

A wire test returns HTTP 520 before a valid multipart response and confirms that the pull resumes and logs the diagnostic headers. Classification tests cover 520–524 as temporary reverse-proxy failures and keep 525, 526, and 530 fatal.

- `DiagnoseHttpErrorTest.php` and `CurlTimeoutRecoveryTest.php`: 49 tests, 165 assertions
- PHP 7.4 compatibility check
- PHPStan on the changed production file
- `git diff --check`
