### PR TITLE
[PHP] Retry HTTP 421 responses on a fresh connection

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -233,6 +233,7 @@ class ImportClient
         408, // Request Timeout
         413, // Content Too Large (adaptive tuner will adjust)
         418, // Observed when an upstream bot filter replaced a Reprint response
+        421, // Misdirected Request (retry opens a fresh cURL handle)
         425, // Too Early
         429, // Too Many Requests
         500, // Internal Server Error

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -180,15 +180,18 @@ class CurlTimeoutRecoveryTest extends TestCase
         );
     }
 
-    public function testSqlDownloadRetriesHttp400ThenCompletes()
+    /** @dataProvider potentiallyTransientHttpResponseProvider */
+    public function testSqlDownloadRetriesPotentiallyTransientHttpResponseThenCompletes(
+        string $status_line
+    )
     {
         if (!function_exists('curl_init') || !function_exists('pcntl_fork')) {
             $this->markTestSkipped('HTTP retry coverage requires PHP curl and pcntl.');
         }
 
         $cursor = base64_encode('{"table":"wp_posts","pk":42}');
-        $http400 = $this->httpResponse(
-            '400 Bad Request',
+        $temporary_response = $this->httpResponse(
+            $status_line,
             'text/html',
             '<!doctype html><title>Temporary upstream response</title>',
         );
@@ -202,7 +205,7 @@ class CurlTimeoutRecoveryTest extends TestCase
             . "\r\n"
             . "--{$boundary}--\r\n";
         $server = $this->startSqlResponseServer([
-            $http400,
+            $temporary_response,
             $this->httpResponse(
                 '200 OK',
                 "multipart/mixed; boundary={$boundary}",
@@ -232,6 +235,14 @@ class CurlTimeoutRecoveryTest extends TestCase
             $client->last_error_code,
             'A successful repeated request must clear the earlier HTTP error code.',
         );
+    }
+
+    public static function potentiallyTransientHttpResponseProvider(): array
+    {
+        return [
+            'bad request' => ['400 Bad Request'],
+            'misdirected request' => ['421 Misdirected Request'],
+        ];
     }
 
     public function testSqlDownloadRetriesHttp520AndLogsResponseHeaders()

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -253,6 +253,10 @@ class DiagnoseHttpErrorTest extends TestCase
 
     public function testPotentiallyTransientHttpErrorClassification()
     {
+        $this->assertTrue($this->isPotentiallyTransientHttpError(
+            421,
+            '<!doctype html><title>Misdirected Request</title>',
+        ));
         foreach ([520, 521, 522, 523, 524] as $http_code) {
             $this->assertTrue(
                 $this->isPotentiallyTransientHttpError(


### PR DESCRIPTION
Retries HTTP 421 responses from the last durable pull cursor instead of stopping the pull.

A 421 means the request reached a server that cannot answer for the requested origin. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.20) permits repeating it over a different connection. `fetch_streaming()` closes its cURL handle before it classifies the response, so the existing retry creates a new handle.

The wire test now returns 421 on the first request and a valid completion response on the second request. The classification test also keeps 421 in the temporary status list.

## Testing

- `../vendor/bin/phpunit Import/DiagnoseHttpErrorTest.php Import/CurlTimeoutRecoveryTest.php`
- `vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-client/src`
- `vendor/bin/phpstan analyze packages/reprint-client/src/import.php --memory-limit=1G`
- `git diff --check`
