### PR TITLE
[PHP] Reject rewritten WordPress home domains during preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ php reprint.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" 
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json` under the `preflight` key.
 
+The server also sends a base64 copy of the WordPress home domain. If it differs
+from the domain in the plain home URL, preflight fails and reports both domains.
+This detects host response filters that replace the site's domain with a preview
+domain. Low-level pull commands also reject that mismatch in saved preflight data.
+Older servers that omit the copy, or report `null` because no domain was available,
+remain compatible. The comparison checks the home domain, not every URL in the response.
+
 All other commands check that a preflight has been completed and refuse to start without one.
 
 To run very basic diagnostics that confirms the remote server replied and it has a

--- a/README.md
+++ b/README.md
@@ -218,10 +218,17 @@ php reprint.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" 
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json` under the `preflight` key.
 
-The server also sends a base64 copy of the WordPress home domain. If it differs
-from the domain in the plain home URL, preflight fails and reports both domains.
-This detects host response filters that replace the site's domain with a preview
-domain. Low-level pull commands also reject that mismatch in saved preflight data.
+Some hosts, including [Hostinger](https://www.hostinger.com/support/2489693-how-to-access-your-website-content-without-a-domain-in-hostinger/),
+provide preview domains so you can browse a site before its real domain points
+at the host. They replace the real domain in outgoing pages so links and assets
+stay on the preview while the stored WordPress home URL stays unchanged.
+Hostinger also applies this rewriting to JSON responses.
+
+The server sends a base64 copy of the WordPress home domain to detect this.
+For a home URL of `https://example.com:8443/blog`, the domain is `example.com`,
+without the scheme, port, or path. If the decoded copy differs from the domain
+in the plain home URL, preflight fails and reports both domains. Low-level pull
+commands also reject that mismatch in saved preflight data.
 Older servers that omit the copy, or report `null` because no domain was available,
 remain compatible. The comparison checks the home domain, not every URL in the response.
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2570,6 +2570,36 @@ class ImportClient
             $this->audit_log("USER-AGENT BLOCKED | {$ua}", false);
         }
 
+        $domain_error = null;
+        $wordpress = null;
+        if (is_array($payload)) {
+            $wordpress = $payload["database"]["wp"] ?? null;
+        }
+        if (
+            is_array($wordpress)
+            && array_key_exists("home_domain_b64", $wordpress)
+            && $wordpress["home_domain_b64"] !== null
+        ) {
+            $encoded_domain = $wordpress["home_domain_b64"];
+            $home = $wordpress["home"] ?? null;
+            $plain_domain = is_string($home) ? parse_url($home, PHP_URL_HOST) : null;
+            $decoded_domain = is_string($encoded_domain)
+                ? base64_decode($encoded_domain, true)
+                : false;
+            if (!is_string($plain_domain) || $plain_domain === "" || $decoded_domain === false) {
+                $domain_error = "The preflight response contains an invalid plaintext or base64 site domain.";
+            } elseif ($plain_domain !== $decoded_domain) {
+                $domain_error = "The preflight response changed the site domain from "
+                    . "'{$decoded_domain}' to '{$plain_domain}'. A host response filter likely rewrote the response body.";
+            }
+        }
+        if ($domain_error !== null && is_array($payload)) {
+            // Keep the response available for diagnosis, but make every pull
+            // path reject it before using values which may have been rewritten.
+            $payload["ok"] = false;
+            $payload["error"] = $domain_error;
+        }
+
         $entry = [
             "timestamp" => time(),
             "url" => $url,
@@ -2596,6 +2626,15 @@ class ImportClient
             $this->get_state()->remote_protocol_version = (int) $payload["protocol_version"];
         } else {
             $this->get_state()->remote_protocol_version = null;
+        }
+
+        if ($domain_error !== null) {
+            $this->save_state();
+            $this->audit_log(
+                "PREFLIGHT RESULT | " . json_encode($entry),
+                false,
+            );
+            return;
         }
 
         // Detect webhost environment from preflight data.

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2571,8 +2571,7 @@ class ImportClient
         }
 
         // Compare the readable WordPress home domain with its base64 copy to
-        // detect response filters which rewrite domain names. Older servers
-        // without the encoded copy remain compatible.
+        // detect response filters which rewrite domain names.
         $domain_error = null;
         $wordpress = null;
         if (is_array($payload)) {

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2570,6 +2570,9 @@ class ImportClient
             $this->audit_log("USER-AGENT BLOCKED | {$ua}", false);
         }
 
+        // Compare the readable WordPress home domain with its base64 copy to
+        // detect response filters which rewrite domain names. Older servers
+        // without the encoded copy remain compatible.
         $domain_error = null;
         $wordpress = null;
         if (is_array($payload)) {

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2588,16 +2588,20 @@ class ImportClient
             $decoded_domain = is_string($encoded_domain)
                 ? base64_decode($encoded_domain, true)
                 : false;
-            if (!is_string($plain_domain) || $plain_domain === "" || $decoded_domain === false) {
-                $domain_error = "The preflight response contains an invalid plaintext or base64 site domain.";
+            if (!is_string($plain_domain) || $plain_domain === "") {
+                $domain_error = "The preflight response contains a WordPress home URL without a valid domain: "
+                    . json_encode($home) . ".";
+            } elseif ($decoded_domain === false || $decoded_domain === "") {
+                $domain_error = "The preflight response contains an invalid base64 WordPress home domain: "
+                    . json_encode($encoded_domain) . ".";
             } elseif ($plain_domain !== $decoded_domain) {
                 $domain_error = "The preflight response changed the site domain from "
                     . "'{$decoded_domain}' to '{$plain_domain}'. A host response filter likely rewrote the response body.";
             }
         }
         if ($domain_error !== null && is_array($payload)) {
-            // Keep the response available for diagnosis, but make every pull
-            // path reject it before using values which may have been rewritten.
+            // Keep the response available for diagnosis, but mark it failed so
+            // pulls stop instead of downloading with rewritten URLs.
             $payload["ok"] = false;
             $payload["error"] = $domain_error;
         }
@@ -2609,7 +2613,7 @@ class ImportClient
             "elapsed" => (float) ($result["elapsed"] ?? 0),
             "ok" => is_array($payload) ? ($payload["ok"] ?? null) : null,
             "data" => $payload,
-            "error" => $result["error"] ?? null,
+            "error" => $domain_error ?? $result["error"] ?? null,
             "response_body_preview" => $payload === null && isset($result["body"])
                 ? substr((string) $result["body"], 0, 200)
                 : null,
@@ -2891,6 +2895,11 @@ class ImportClient
             throw new RuntimeException(
                 "No preflight data found. Run 'preflight' or 'preflight-assert' first.",
             );
+        }
+        if (!empty($entry["error"])) {
+            // The client rejected this response; keep it for diagnosis, not downloads.
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error, never HTML.
+            throw new RuntimeException($entry["error"]);
         }
     }
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2570,8 +2570,13 @@ class ImportClient
             $this->audit_log("USER-AGENT BLOCKED | {$ua}", false);
         }
 
-        // Compare the readable WordPress home domain with its base64 copy to
-        // detect response filters which rewrite domain names.
+        // Some hosts, including Hostinger, replace the site's domain in responses
+        // so links and assets work on a preview domain before DNS points at the
+        // host. The stored WordPress home URL stays unchanged, but this rewriting
+        // can also change our JSON. For home=https://example.com:8443/blog, compare
+        // example.com (the hostname, without scheme, port, or path), not the full
+        // site URL, with the decoded server copy. Hostinger's plain-domain
+        // replacement leaves the base64 value unchanged.
         $domain_error = null;
         $wordpress = null;
         if (is_array($payload)) {

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -412,6 +412,15 @@ class Pull
      */
     private function run_stage(string $stage, array $options, int $step, int $total): void
     {
+        // A standalone preflight can replace the saved response between runs,
+        // even when this pipeline has already completed its preflight stage.
+        $preflight_error = $this->client->get_state()->preflight_record()["error"] ?? null;
+        if ($stage !== 'preflight' && !empty($preflight_error)) {
+            $this->client->exit_code = 1;
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error, never HTML.
+            throw new RuntimeException($preflight_error);
+        }
+
         switch ($stage) {
             case 'preflight':
                 $this->client->run_preflight();

--- a/packages/reprint-server/src/class-http-server.php
+++ b/packages/reprint-server/src/class-http-server.php
@@ -361,8 +361,10 @@ final class HTTPServer {
                 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
                 header('Pragma: no-cache');
                 header('Expires: 0');
-                // Hostinger preview domains rewrite real domains in application/json
-                // response bodies. Keep the JSON bytes opaque to that response filter.
+                // Hosts such as Hostinger rewrite domains so links and assets stay on a
+                // preview domain while the stored site URL still uses the real domain.
+                // This lets users preview a site before changing DNS, but also rewrites
+                // application/json bodies. Octet-stream bypasses Hostinger's filter.
                 header('Content-Type: application/octet-stream');
                 echo json_encode([
                     'status' => 'rejected',

--- a/packages/reprint-server/src/class-push-endpoints.php
+++ b/packages/reprint-server/src/class-push-endpoints.php
@@ -600,8 +600,10 @@ final class PushEndpoints {
         header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Pragma: no-cache');
         header('Expires: 0');
-        // Hostinger preview domains rewrite real domains in application/json
-        // response bodies. Keep the JSON bytes opaque to that response filter.
+        // Hosts such as Hostinger rewrite domains so links and assets stay on a
+        // preview domain while the stored site URL still uses the real domain.
+        // This lets users preview a site before changing DNS, but also rewrites
+        // application/json bodies. Octet-stream bypasses Hostinger's filter.
         header('Content-Type: application/octet-stream');
         $json = json_encode($body);
         if ($json === false) {

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2014,7 +2014,6 @@ function endpoint_preflight(array $config): array
                         $db["wp"]["theme_stylesheet"] = get_option("stylesheet");
                         $db["wp"]["theme_template"] = get_option("template");
                         $db["wp"]["siteurl"] = get_option("siteurl");
-                        $db["wp"]["home"] = get_option("home");
                         // Resolve wp-admin and wp-includes paths.
                         // These are always ABSPATH/wp-admin and ABSPATH/WPINC
                         // by WordPress convention, but on hosts like WP Cloud
@@ -2316,6 +2315,20 @@ function endpoint_preflight(array $config): array
                 $db["error"] = $e->getMessage();
             }
         }
+    }
+
+    if ($db["wp"]["wp_load_loaded"] && function_exists("get_option")) {
+        $wp_home = get_option("home");
+        $db["wp"]["home"] = $wp_home;
+        $wp_home_domain = is_string($wp_home)
+            ? parse_url($wp_home, PHP_URL_HOST)
+            : null;
+        // A response filter may rewrite the plain home URL. The importer
+        // compares its domain with this encoded copy before using the response.
+        $db["wp"]["home_domain_b64"] =
+            is_string($wp_home_domain) && $wp_home_domain !== ""
+                ? base64_encode($wp_home_domain)
+                : null;
     }
 
     // -- WordPress content inventory --

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2317,6 +2317,8 @@ function endpoint_preflight(array $config): array
         }
     }
 
+    // Send the WordPress home URL and a base64 copy of its domain so the
+    // importer can detect response filters which rewrite domain names.
     if ($db["wp"]["wp_load_loaded"] && function_exists("get_option")) {
         $wp_home = get_option("home");
         $db["wp"]["home"] = $wp_home;

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -475,8 +475,10 @@ set_error_handler(function ($errno, $errstr, $errfile, $errline) {
     }
 
     http_response_code(500);
-    // Hostinger preview domains rewrite real domains in application/json
-    // response bodies. Keep the JSON bytes opaque to that response filter.
+    // Hosts such as Hostinger rewrite domains so links and assets stay on a
+    // preview domain while the stored site URL still uses the real domain.
+    // This lets users preview a site before changing DNS, but also rewrites
+    // application/json bodies. Octet-stream bypasses Hostinger's filter.
     @header("Content-Type: application/octet-stream");
     echo json_encode($error);
     exit(1);
@@ -504,8 +506,10 @@ set_exception_handler(function ($e) {
     }
 
     http_response_code(500);
-    // Hostinger preview domains rewrite real domains in application/json
-    // response bodies. Keep the JSON bytes opaque to that response filter.
+    // Hosts such as Hostinger rewrite domains so links and assets stay on a
+    // preview domain while the stored site URL still uses the real domain.
+    // This lets users preview a site before changing DNS, but also rewrites
+    // application/json bodies. Octet-stream bypasses Hostinger's filter.
     header("Content-Type: application/octet-stream");
     echo json_encode($error);
     exit(1);
@@ -549,8 +553,10 @@ register_shutdown_function(function () {
 
     if (!headers_sent()) {
         http_response_code(500);
-        // Hostinger preview domains rewrite real domains in application/json
-        // response bodies. Keep the JSON bytes opaque to that response filter.
+        // Hosts such as Hostinger rewrite domains so links and assets stay on a
+        // preview domain while the stored site URL still uses the real domain.
+        // This lets users preview a site before changing DNS, but also rewrites
+        // application/json bodies. Octet-stream bypasses Hostinger's filter.
         @header("Content-Type: application/octet-stream");
         echo json_encode([
             "error" => $message,
@@ -2317,16 +2323,19 @@ function endpoint_preflight(array $config): array
         }
     }
 
-    // Send the WordPress home URL and a base64 copy of its domain so the
-    // importer can detect response filters which rewrite domain names.
+    // Hosts such as Hostinger replace the site's domain in responses so links
+    // and assets work on a preview domain before DNS points at the host. The
+    // stored WordPress home URL stays unchanged, but the filter also alters JSON.
+    // Send the full home URL plus an encoded hostname to detect that rewriting:
+    // for https://example.com:8443/blog, encode example.com, not the whole URL.
     if ($db["wp"]["wp_load_loaded"] && function_exists("get_option")) {
         $wp_home = get_option("home");
         $db["wp"]["home"] = $wp_home;
         $wp_home_domain = is_string($wp_home)
             ? parse_url($wp_home, PHP_URL_HOST)
             : null;
-        // A response filter may rewrite the plain home URL. The importer
-        // compares its domain with this encoded copy before using the response.
+        // The importer decodes this hostname and compares it with the hostname
+        // in the received home URL before using a possibly rewritten response.
         $db["wp"]["home_domain_b64"] =
             is_string($wp_home_domain) && $wp_home_domain !== ""
                 ? base64_encode($wp_home_domain)
@@ -2577,8 +2586,10 @@ function endpoint_preflight(array $config): array
         "database" => $db,
     ];
 
-    // Hostinger preview domains rewrite real domains in application/json
-    // response bodies. Keep the JSON bytes opaque to that response filter.
+    // Hosts such as Hostinger rewrite domains so links and assets stay on a
+    // preview domain while the stored site URL still uses the real domain.
+    // This lets users preview a site before changing DNS, but also rewrites
+    // application/json bodies. Octet-stream bypasses Hostinger's filter.
     header("Content-Type: application/octet-stream");
     $json = json_encode($response);
     if ($json === false) {

--- a/reprint-server-wp/lib.php
+++ b/reprint-server-wp/lib.php
@@ -51,8 +51,10 @@ if (!defined(__NAMESPACE__ . '\\TIMESTAMP_TOLERANCE')) {
 /** Sends a JSON error response and terminates. */
 function error(int $code, string $message): void {
     http_response_code($code);
-    // Hostinger preview domains rewrite real domains in application/json
-    // response bodies. Keep the JSON bytes opaque to that response filter.
+    // Hosts such as Hostinger rewrite domains so links and assets stay on a
+    // preview domain while the stored site URL still uses the real domain.
+    // This lets users preview a site before changing DNS, but also rewrites
+    // application/json bodies. Octet-stream bypasses Hostinger's filter.
     header('Content-Type: application/octet-stream');
     echo json_encode(['error' => $message, 'code' => $code]);
     exit;
@@ -76,8 +78,10 @@ function push_error(int $http_code, string $reason, string $detail): void {
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
     header('Expires: 0');
-    // Hostinger preview domains rewrite real domains in application/json
-    // response bodies. Keep the JSON bytes opaque to that response filter.
+    // Hosts such as Hostinger rewrite domains so links and assets stay on a
+    // preview domain while the stored site URL still uses the real domain.
+    // This lets users preview a site before changing DNS, but also rewrites
+    // application/json bodies. Octet-stream bypasses Hostinger's filter.
     header('Content-Type: application/octet-stream');
     echo json_encode([
         'status' => 'rejected',
@@ -448,8 +452,10 @@ function handle_api_request(array $options = []): void {
         ];
         error_log('Reprint Server API error: ' . json_encode($error));
         http_response_code(500);
-        // Hostinger preview domains rewrite real domains in application/json
-        // response bodies. Keep the JSON bytes opaque to that response filter.
+        // Hosts such as Hostinger rewrite domains so links and assets stay on a
+        // preview domain while the stored site URL still uses the real domain.
+        // This lets users preview a site before changing DNS, but also rewrites
+        // application/json bodies. Octet-stream bypasses Hostinger's filter.
         @header('Content-Type: application/octet-stream');
         echo json_encode($error);
         exit(1);
@@ -463,8 +469,10 @@ function handle_api_request(array $options = []): void {
         ];
         error_log('Reprint Server API exception: ' . json_encode($error));
         http_response_code(500);
-        // Hostinger preview domains rewrite real domains in application/json
-        // response bodies. Keep the JSON bytes opaque to that response filter.
+        // Hosts such as Hostinger rewrite domains so links and assets stay on a
+        // preview domain while the stored site URL still uses the real domain.
+        // This lets users preview a site before changing DNS, but also rewrites
+        // application/json bodies. Octet-stream bypasses Hostinger's filter.
         @header('Content-Type: application/octet-stream');
         echo json_encode($error);
         exit(1);
@@ -694,8 +702,10 @@ function handle_api_request(array $options = []): void {
         }
         if (!headers_sent()) {
             http_response_code(400);
-            // Hostinger preview domains rewrite real domains in application/json
-            // response bodies. Keep the JSON bytes opaque to that response filter.
+            // Hosts such as Hostinger rewrite domains so links and assets stay on a
+            // preview domain while the stored site URL still uses the real domain.
+            // This lets users preview a site before changing DNS, but also rewrites
+            // application/json bodies. Octet-stream bypasses Hostinger's filter.
             header('Content-Type: application/octet-stream');
         }
         echo json_encode([

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -287,7 +287,11 @@ class FetchRequestBodySizingTest extends TestCase
         $payload = json_encode([
             'ok' => true,
             'protocol_version' => 3,
-            'database' => ['wp' => ['wp_version' => '6.0-test']],
+            'database' => ['wp' => [
+                'wp_version' => '6.0-test',
+                'home' => 'https://example.com',
+                'home_domain_b64' => base64_encode('example.com'),
+            ]],
         ]);
         $response = "HTTP/1.1 200 OK\r\n"
             . "Content-Type: application/octet-stream\r\n"
@@ -312,6 +316,45 @@ class FetchRequestBodySizingTest extends TestCase
         $this->assertSame(
             '6.0-test',
             $client->get_state()->preflight_record()['data']['database']['wp']['wp_version'],
+        );
+    }
+
+    public function testPreflightRejectsARewrittenPlaintextDomain(): void
+    {
+        $payload = json_encode([
+            'ok' => true,
+            'protocol_version' => 3,
+            'database' => ['wp' => [
+                'home' => 'https://darkorange-emu-198875.hostingersite.com',
+                'home_domain_b64' => base64_encode('my-h-inger-test-site.com'),
+            ]],
+        ]);
+        $response = "HTTP/1.1 200 OK\r\n"
+            . "Content-Type: application/octet-stream\r\n"
+            . "Content-Length: " . strlen($payload) . "\r\n"
+            . "Connection: close\r\n\r\n"
+            . $payload;
+
+        [$url, $pid] = $this->startJsonServer($response);
+
+        $client = new \ImportClient($url, $this->stateDir, $this->filesystemRoot);
+        \write_current_pull_state($client, []);
+        $reflection = new \ReflectionClass(\ImportClient::class);
+        $reflection->getProperty('state')->setValue(
+            $client,
+            $reflection->getMethod('load_state')->invoke($client),
+        );
+        $reflection->getProperty('is_tty')->setValue($client, false);
+
+        $client->run_preflight();
+        pcntl_waitpid($pid, $status);
+
+        $preflight = $client->get_state()->preflight_record();
+        $this->assertFalse($preflight['data']['ok']);
+        $this->assertSame(
+            "The preflight response changed the site domain from 'my-h-inger-test-site.com' "
+                . "to 'darkorange-emu-198875.hostingersite.com'. A host response filter likely rewrote the response body.",
+            $preflight['data']['error'],
         );
     }
 

--- a/tests/Import/FetchRequestBodySizingTest.php
+++ b/tests/Import/FetchRequestBodySizingTest.php
@@ -282,16 +282,19 @@ class FetchRequestBodySizingTest extends TestCase
         );
     }
 
-    public function testPreflightAcceptsJsonFromAnOpaqueResponse(): void
+    /**
+     * @dataProvider acceptedPreflightDomainProvider
+     * @param array $wordpress {
+     *     @type string|false $home WordPress home URL, or false when unavailable.
+     *     @type string|null $home_domain_b64 Optional encoded domain, or null when unavailable.
+     * }
+     */
+    public function testPreflightAcceptsJsonFromAnOpaqueResponse(array $wordpress): void
     {
         $payload = json_encode([
             'ok' => true,
             'protocol_version' => 3,
-            'database' => ['wp' => [
-                'wp_version' => '6.0-test',
-                'home' => 'https://example.com',
-                'home_domain_b64' => base64_encode('example.com'),
-            ]],
+            'database' => ['wp' => $wordpress + ['wp_version' => '6.0-test']],
         ]);
         $response = "HTTP/1.1 200 OK\r\n"
             . "Content-Type: application/octet-stream\r\n"
@@ -313,21 +316,115 @@ class FetchRequestBodySizingTest extends TestCase
         $client->run_preflight();
         pcntl_waitpid($pid, $status);
 
+        $this->assertTrue($client->get_state()->preflight_record()['data']['ok']);
+        $this->assertNull($client->get_state()->preflight_record()['error']);
+        $reflection->getMethod('require_preflight')->invoke($client);
         $this->assertSame(
             '6.0-test',
             $client->get_state()->preflight_record()['data']['database']['wp']['wp_version'],
         );
     }
 
-    public function testPreflightRejectsARewrittenPlaintextDomain(): void
+    public static function acceptedPreflightDomainProvider(): array
+    {
+        return [
+            'matching domain with port and path' => [[
+                'home' => 'https://example.com:8443/wordpress',
+                'home_domain_b64' => base64_encode('example.com'),
+            ]],
+            'older server without encoded domain' => [[
+                'home' => 'https://example.com',
+            ]],
+            'server could not determine a domain' => [[
+                'home' => false,
+                'home_domain_b64' => null,
+            ]],
+        ];
+    }
+
+    /** @dataProvider rejectedPreflightCommandProvider */
+    public function testPullReportsTheRewrittenDomain(string $command, bool $resume): void
     {
         $payload = json_encode([
             'ok' => true,
             'protocol_version' => 3,
             'database' => ['wp' => [
-                'home' => 'https://darkorange-emu-198875.hostingersite.com',
-                'home_domain_b64' => base64_encode('my-h-inger-test-site.com'),
+                'home' => 'https://preview.example.com',
+                'home_domain_b64' => base64_encode('example.com'),
             ]],
+        ]);
+        [$url, $pid] = $this->startJsonServer(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n"
+                . 'Content-Length: ' . strlen($payload) . "\r\nConnection: close\r\n\r\n" . $payload,
+        );
+        $client = new \ImportClient($url, $this->stateDir, $this->filesystemRoot);
+        if ($resume) {
+            // A pull-db stopped after downloading SQL. A later standalone
+            // preflight must not let its replacement response bypass the check
+            // just because the resumed pipeline skips the preflight stage.
+            \write_current_pull_state($client, []);
+            file_put_contents(
+                $this->stateDir . '/db.sql',
+                "SELECT 1;\n-- REPRINT SQL GROUP 82d10e87-ec1b-4aa2-a522-963dc82b6bb1 "
+                    . base64_encode(json_encode(['current_table' => null])) . "\n",
+            );
+            $client->mark_pull_stage_complete('db-pull', 'pull-db', ['preflight', 'db-pull', 'db-apply']);
+            $client->run_preflight();
+        }
+
+        try {
+            ob_start();
+            $client->run([
+                'command' => $command,
+                'runtime' => 'none',
+                'target_engine' => 'sqlite',
+                'target_sqlite_path' => $this->tempDir . '/target.sqlite',
+            ]);
+        } catch (\RuntimeException $exception) {
+            $this->assertStringContainsString(
+                "from 'example.com' to 'preview.example.com'",
+                $exception->getMessage(),
+            );
+            $this->assertSame(1, $client->exit_code);
+            $this->assertFileDoesNotExist($this->tempDir . '/target.sqlite');
+            $this->assertSame(
+                $resume ? 'db-pull' : null,
+                $client->get_state()->pull_pipeline->last_completed_stage,
+            );
+            return;
+        } finally {
+            ob_end_clean();
+            pcntl_waitpid($pid, $status);
+        }
+        $this->fail('Expected the pull to reject the rewritten domain.');
+    }
+
+    public static function rejectedPreflightCommandProvider(): array
+    {
+        return [
+            ['pull', false],
+            ['pull-files', false],
+            ['pull-db', false],
+            ['pull-db', true],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedPreflightDomainProvider
+     * @param array $wordpress {
+     *     @type mixed $home WordPress home URL, including invalid values under test.
+     *     @type mixed $home_domain_b64 Encoded domain, including invalid values under test.
+     * }
+     */
+    public function testPreflightRejectsInvalidDomainsBeforeReusingSavedResponse(
+        array $wordpress,
+        string $expected_error
+    ): void
+    {
+        $payload = json_encode([
+            'ok' => true,
+            'protocol_version' => 3,
+            'database' => ['wp' => $wordpress],
         ]);
         $response = "HTTP/1.1 200 OK\r\n"
             . "Content-Type: application/octet-stream\r\n"
@@ -351,11 +448,50 @@ class FetchRequestBodySizingTest extends TestCase
 
         $preflight = $client->get_state()->preflight_record();
         $this->assertFalse($preflight['data']['ok']);
-        $this->assertSame(
-            "The preflight response changed the site domain from 'my-h-inger-test-site.com' "
-                . "to 'darkorange-emu-198875.hostingersite.com'. A host response filter likely rewrote the response body.",
-            $preflight['data']['error'],
+        $this->assertSame($expected_error, $preflight['data']['error']);
+        $this->assertSame($expected_error, $preflight['error']);
+
+        // A later low-level command reads the saved response without fetching
+        // preflight again. It must not accept the response the first run rejected.
+        $next_client = new \ImportClient($url, $this->stateDir, $this->filesystemRoot);
+        $reflection->getProperty('state')->setValue(
+            $next_client,
+            $reflection->getMethod('load_state')->invoke($next_client),
         );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($preflight['data']['error']);
+        $reflection->getMethod('require_preflight')->invoke($next_client);
+    }
+
+    public static function rejectedPreflightDomainProvider(): array
+    {
+        return [
+            'rewritten domain' => [[
+                'home' => 'https://preview.example.com',
+                'home_domain_b64' => base64_encode('example.com'),
+            ], "The preflight response changed the site domain from 'example.com' "
+                . "to 'preview.example.com'. A host response filter likely rewrote the response body."],
+            'invalid base64' => [[
+                'home' => 'https://example.com',
+                'home_domain_b64' => 'not!base64',
+            ], 'The preflight response contains an invalid base64 WordPress home domain: "not!base64".'],
+            'non-string base64' => [[
+                'home' => 'https://example.com',
+                'home_domain_b64' => 123,
+            ], 'The preflight response contains an invalid base64 WordPress home domain: 123.'],
+            'empty base64' => [[
+                'home' => 'https://example.com',
+                'home_domain_b64' => '',
+            ], 'The preflight response contains an invalid base64 WordPress home domain: "".'],
+            'home without a domain' => [[
+                'home' => 'example.com',
+                'home_domain_b64' => base64_encode('example.com'),
+            ], 'The preflight response contains a WordPress home URL without a valid domain: "example.com".'],
+            'non-string home' => [[
+                'home' => false,
+                'home_domain_b64' => base64_encode('example.com'),
+            ], 'The preflight response contains a WordPress home URL without a valid domain: false.'],
+        ];
     }
 
     public function testRunningPreflightTightensTheBoundInTheSameRun(): void

--- a/tests/PushEndpointsTest.php
+++ b/tests/PushEndpointsTest.php
@@ -1378,6 +1378,10 @@ final class PushEndpointsTest extends TestCase {
 
         $response = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('ok', $response);
+        $this->assertSame(
+            parse_url($response['database']['wp']['home'], PHP_URL_HOST),
+            base64_decode($response['database']['wp']['home_domain_b64'], true)
+        );
         $this->assertStringNotContainsString('Push endpoints require', $body);
     }
 

--- a/tests/e2e/lib/preflight-domain-rewriting-fixture.js
+++ b/tests/e2e/lib/preflight-domain-rewriting-fixture.js
@@ -1,8 +1,11 @@
 /**
- * Models a preview proxy which rewrites plain domains in JSON responses but
- * leaves octet-stream responses alone. A test-controlled Content-Type override
- * models the server's former JSON header; the body comes from real WordPress.
- * This is not a complete Hostinger proxy.
+ * Models a host preview: replace the site's domain so links and assets stay
+ * on the preview without changing the stored site URL or waiting for DNS.
+ * For https://example.com/blog, the replacement is example.com, not the full
+ * URL. Like the observed Hostinger filter, this rewrites JSON but leaves
+ * octet-stream responses alone. A test-controlled Content-Type override models
+ * the server's former JSON header; the body comes from real WordPress. This is
+ * not a complete Hostinger proxy.
  */
 import http from 'node:http';
 import { appendFileSync, readFileSync } from 'node:fs';

--- a/tests/e2e/lib/preflight-domain-rewriting-fixture.js
+++ b/tests/e2e/lib/preflight-domain-rewriting-fixture.js
@@ -1,0 +1,78 @@
+/**
+ * Models a preview proxy which rewrites plain domains in JSON responses but
+ * leaves octet-stream responses alone. A test-controlled Content-Type override
+ * models the server's former JSON header; the body comes from real WordPress.
+ * This is not a complete Hostinger proxy.
+ */
+import http from 'node:http';
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const [backendUrlString, contentTypePath, requestLogPath] = process.argv.slice(2);
+const backendUrl = new URL(backendUrlString);
+const previewDomain = 'preview.example.test';
+const maxPreflightBytes = 1024 * 1024;
+
+const server = http.createServer((request, response) => {
+    const endpoint = new URL(request.url, backendUrl).searchParams.get('endpoint');
+    appendFileSync(requestLogPath, `${JSON.stringify({ endpoint })}\n`);
+    const upstreamRequest = http.request({
+        hostname: backendUrl.hostname,
+        port: backendUrl.port,
+        method: request.method,
+        path: request.url,
+        headers: {
+            ...request.headers,
+            host: backendUrl.host,
+            'accept-encoding': 'identity',
+        },
+    }, (upstreamResponse) => {
+        if (endpoint !== 'preflight') {
+            response.writeHead(upstreamResponse.statusCode, upstreamResponse.headers);
+            upstreamResponse.pipe(response);
+            return;
+        }
+
+        const chunks = [];
+        let responseBytes = 0;
+        upstreamResponse.on('data', (chunk) => {
+            responseBytes += chunk.length;
+            if (responseBytes > maxPreflightBytes) {
+                upstreamRequest.destroy(new Error('Preflight fixture response exceeded 1 MiB'));
+                return;
+            }
+            chunks.push(chunk);
+        });
+        upstreamResponse.on('end', () => {
+            const headers = { ...upstreamResponse.headers };
+            const overrideContentType = readFileSync(contentTypePath, 'utf-8');
+            if (overrideContentType) {
+                headers['content-type'] = overrideContentType;
+            }
+            let body = Buffer.concat(chunks);
+            const rewritten = headers['content-type'].startsWith('application/json');
+            if (rewritten) {
+                const text = body.toString('utf-8');
+                const homeDomain = new URL(JSON.parse(text).database.wp.home).hostname;
+                body = Buffer.from(text.replaceAll(homeDomain, previewDomain));
+            }
+            delete headers['transfer-encoding'];
+            headers['content-length'] = body.length;
+            response.writeHead(upstreamResponse.statusCode, headers);
+            response.end(body);
+        });
+    });
+
+    upstreamRequest.on('error', (error) => {
+        response.writeHead(502, { 'Content-Type': 'text/plain' });
+        response.end(`Preview fixture could not reach WordPress: ${error.message}`);
+    });
+    request.pipe(upstreamRequest);
+});
+
+server.listen(0, '127.0.0.1', () => {
+    process.send?.({ port: server.address().port });
+});
+
+process.on('SIGTERM', () => {
+    server.close(() => process.exit(0));
+});

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -731,8 +731,10 @@ export async function apiRequestWithFileList(siteName, filePaths, params = {}) {
 /**
  * Return whether a top-level API response carries JSON.
  *
- * The server marks top-level JSON as application/octet-stream so Hostinger's
- * preview-domain response filter leaves domain strings unchanged.
+ * The server marks top-level JSON as application/octet-stream so Hostinger
+ * does not replace real domains with its preview domain. That rewriting
+ * keeps links and assets on the preview without changing the stored site
+ * URL or waiting for DNS, but would also alter our API data.
  */
 function isJsonApiResponseContentType(contentType) {
     return contentType.includes('application/octet-stream');

--- a/tests/e2e/tests/import-66-preflight-domain-rewriting.test.js
+++ b/tests/e2e/tests/import-66-preflight-domain-rewriting.test.js
@@ -1,0 +1,103 @@
+/** Test 66: Reject a preview-rewritten preflight, then recover with octet-stream. */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    apiRequest, cleanupTempDir, createTempDir, fsRootDir,
+    getSiteDir, getSiteSecret, getSiteUrl, pullStateDirectory, runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Preflight domain rewriting', { timeout: 180000 }, () => {
+    const site = 'basic';
+    let proxyProcess;
+    let importUrl;
+    let outputDirectory;
+    let contentTypePath;
+    let requestLogPath;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        outputDirectory = createTempDir('e2e-preflight-domain-rewriting');
+        contentTypePath = join(outputDirectory, 'content-type');
+        requestLogPath = join(outputDirectory, 'requests.jsonl');
+        writeFileSync(contentTypePath, 'application/json');
+        writeFileSync(requestLogPath, '');
+
+        // runImporter blocks this process, so the proxy needs its own process.
+        proxyProcess = fork(fileURLToPath(new URL(
+            '../lib/preflight-domain-rewriting-fixture.js', import.meta.url,
+        )), [getSiteUrl(site), contentTypePath, requestLogPath], {
+            stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+        });
+        const [ready] = await once(proxyProcess, 'message');
+        importUrl = `http://127.0.0.1:${ready.port}/?reprint-api&directory=` +
+            encodeURIComponent(getSiteDir(site));
+    });
+
+    afterAll(async () => {
+        if (proxyProcess && proxyProcess.exitCode === null) {
+            proxyProcess.kill('SIGTERM');
+            await once(proxyProcess, 'exit');
+        }
+        cleanupTempDir(outputDirectory);
+    });
+
+    it('stops before file transfer on rewritten JSON and pulls after restoring octet-stream', async () => {
+        const options = {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            autoResume: false,
+            extraArgs: ['--include=' + join(getSiteDir(site), 'test-data/hello.txt')],
+        };
+        const response = await apiRequest(site, 'preflight', {}, { url: importUrl, rawResponse: true });
+        const rewrittenPreflight = await response.json();
+        assert.equal(response.status, 200);
+        assert.equal(response.headers.get('content-type'), 'application/json');
+        assert.equal(rewrittenPreflight.ok, true);
+        assert.equal(new URL(rewrittenPreflight.database.wp.home).hostname, 'preview.example.test');
+        const originalDomain = Buffer.from(
+            rewrittenPreflight.database.wp.home_domain_b64, 'base64',
+        ).toString('utf-8');
+        assert.equal(originalDomain, new URL(getSiteUrl(site)).hostname);
+
+        const error = `The preflight response changed the site domain from '${originalDomain}' ` +
+            "to 'preview.example.test'";
+        for (const command of ['preflight', 'pull-files']) {
+            const result = runImporter(importUrl, outputDirectory, command, options);
+            assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+            assert.ok((result.stdout + result.stderr).includes(error), result.stdout + result.stderr);
+        }
+        const statePath = join(pullStateDirectory(outputDirectory, importUrl), 'state.json');
+        const failedState = JSON.parse(readFileSync(statePath, 'utf-8'));
+        assert.equal(failedState.preflight.data.ok, false);
+        assert.ok(failedState.preflight.error.includes(error));
+        const failedRequests = readFileSync(requestLogPath, 'utf-8').trim().split('\n').map(JSON.parse);
+        assert.ok(failedRequests.every(record => record.endpoint === 'preflight'));
+        const pulledFile = join(fsRootDir(outputDirectory), getSiteDir(site), 'test-data/hello.txt');
+        assert.equal(existsSync(pulledFile), false);
+
+        // Remove the override: the real endpoint must now supply octet-stream.
+        writeFileSync(contentTypePath, '');
+        const restoredResponse = await apiRequest(site, 'preflight', {}, { url: importUrl, rawResponse: true });
+        const restoredPreflight = await restoredResponse.json();
+        assert.ok(restoredResponse.headers.get('content-type').startsWith('application/octet-stream'));
+        assert.equal(new URL(restoredPreflight.database.wp.home).hostname, originalDomain);
+        assert.equal(
+            restoredPreflight.database.wp.home_domain_b64,
+            rewrittenPreflight.database.wp.home_domain_b64,
+        );
+        for (const command of ['preflight', 'pull-files']) {
+            const result = runImporter(importUrl, outputDirectory, command, options);
+            assert.equal(result.exitCode, 0, result.stdout + result.stderr);
+        }
+        const restoredState = JSON.parse(readFileSync(statePath, 'utf-8'));
+        assert.equal(restoredState.preflight.data.ok, true);
+        assert.equal(restoredState.preflight.error, null);
+        assert.equal(readFileSync(pulledFile, 'utf-8'), 'Hello World\n');
+    });
+});

--- a/tests/fixtures/push-endpoint-router.php
+++ b/tests/fixtures/push-endpoint-router.php
@@ -84,6 +84,9 @@ function plugin_basename(string $file): string {
 }
 
 function get_option(string $name, $fallback = false) {
+    if ($name === 'home') {
+        return 'https://example.test';
+    }
     if ($name === 'reprint_server_connection_token') {
         return trim( (string) file_get_contents( (string) getenv('REPRINT_PUSH_TEST_SECRET_CONFIG') ) );
     }

--- a/tests/phpstan/phpstan-baseline.neon
+++ b/tests/phpstan/phpstan-baseline.neon
@@ -12,7 +12,7 @@ parameters:
 
 		-
 			message: "#^Function get_option not found\\.$#"
-			count: 5
+			count: 4
 			path: ../../packages/reprint-server/src/export.php
 
 		-


### PR DESCRIPTION
Preflight now stops a pull when the WordPress home domain in the response no longer matches the domain the server encoded.

The server sends `home` and a base64 copy of its domain in `home_domain_b64`. The client compares them, reports both domains on a mismatch, and keeps the rejected response for diagnosis. Low-level pull commands reject the saved error too. Resumed pipelines also stop if a standalone preflight replaced their saved response with a rejected one.

The `application/octet-stream` response added in #756 avoids Hostinger's known response rewrite. This comparison catches changes to the home domain if a response filter still rewrites it; it does not check every URL in the response. Older servers remain compatible when `home_domain_b64` is absent. A `null` value means the server could not determine a domain and also skips the comparison.

## Testing

Tested on the live Hostinger preview at `darkorange-emu-198875.hostingersite.com`. Temporarily serving preflight as `application/json` made Hostinger replace the plain home domain with the preview domain while the encoded value still decoded to `my-h-inger-test-site.com`. The client rejected that HTTP 200 response with exit code 1 and named both domains. Restoring `application/octet-stream` preserved the original domain, cleared the saved error, and returned exit code 0 using the same client state. The live server was left on octet-stream.

The tests cover matching domains, older-server responses, invalid fields, saved-response rejection, and a resumed SQL apply that must stop before creating its target database. The focused command and real-endpoint suites pass: 155 tests, 2,954 assertions.

The E2E test sends real WordPress responses through a preview-rewriting proxy. With the former JSON header, preflight and pull-files exit with the domain-mismatch error before any file request. Removing the header override lets the endpoint's octet-stream response pass unchanged, clears the saved error, and allows the same pull to download a file. The test fails against the pre-PR client because it accepts the rewritten response. All 21 tests in the four focused E2E suites pass.
