### PR TITLE
[CLI] Report unset environment names read by copied wp-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,18 @@ into SQLite through the bundled `sqlite-database-integration` driver.
 
 #### Step 6 — Generate runtime configuration.
 
+`apply-runtime` also checks literal `getenv('NAME')` reads in the downloaded
+`wp-config.php`. If a name is absent from the importing process, it reports
+the name and config path without copying or printing its value. Check whether
+your target web server needs that variable. A fallback in the config, or a
+separate PHP-FPM environment, may already cover it; the warning does not stop
+the migration.
+
+This check does not execute the config. It does not follow includes or resolve
+dynamic variable names. Config files larger than 256 KiB get a manual-check
+warning rather than a partial scan.
+
+
 The downloaded files need server-specific configuration to actually work —
 PHP constants, INI directives, and request handlers that the source host
 relied on. `apply-runtime` reads the preflight data, detects the source

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4989,6 +4989,49 @@ class ImportClient
             $this->audit_log("APPLY-RUNTIME | removed {$rel_path} (production-only)");
         }
 
+        // A copied wp-config.php can still read values supplied by its old
+        // host. Report names only; copying those values could expose secrets.
+        $config_paths = [];
+        if (!empty($flat_document_root)) {
+            $config_paths[] = wp_join_unix_paths($local_document_root, 'wp-config.php');
+        } else {
+            foreach ($preflight_data['wp_detect']['roots'] ?? [] as $root) {
+                $remote_config = $this->clean_preflight_path($root['wp_config_path'] ?? null);
+                if ($remote_config !== null) {
+                    $config_paths[] = wp_join_unix_paths($this->filesystem_root, $remote_config);
+                }
+            }
+        }
+        foreach (array_unique($config_paths) as $config_path) {
+            if (!is_file($config_path)) {
+                continue;
+            }
+            // Tokenizing is bounded independently of the size of an unusual
+            // generated config. Do not inspect a prefix and call it complete.
+            $config = file_get_contents($config_path, false, null, 0, 262145);
+            if ($config === false || strlen($config) > 262144) {
+                $message = "Could not inspect {$config_path} within the 256 KiB configuration limit. Check its environment settings manually.";
+                $summary[] = $message;
+                $this->output_progress(['type' => 'warning', 'reason' => 'config_not_inspected', 'message' => $message], true);
+                continue;
+            }
+            foreach (config_environment_names($config) as $name) {
+                if (getenv($name) !== false) {
+                    continue;
+                }
+                $message = "{$config_path} reads {$name}, which is not set in this process. "
+                    . "Check whether the target server needs it; the config may provide a fallback.";
+                $summary[] = $message;
+                $this->output_progress([
+                    'type' => 'warning',
+                    'reason' => 'config_environment_missing',
+                    'variable_name' => $name,
+                    'config_path' => $config_path,
+                    'message' => $message,
+                ], true);
+            }
+        }
+
         foreach ($summary as $line) {
             $this->audit_log("APPLY-RUNTIME | {$line}");
         }

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -4989,8 +4989,11 @@ class ImportClient
             $this->audit_log("APPLY-RUNTIME | removed {$rel_path} (production-only)");
         }
 
-        // A copied wp-config.php can still read values supplied by its old
-        // host. Report names only; copying those values could expose secrets.
+        // wp-config.php may read environment variables supplied by the source
+        // host, which a file copy cannot carry over. Inspect the copied PHP as
+        // text and report names absent from this importer process, never values.
+        // A warning is advisory: the config may have a fallback, or the target
+        // web server may have an environment different from the CLI's.
         $config_paths = [];
         if (!empty($flat_document_root)) {
             $config_paths[] = wp_join_unix_paths($local_document_root, 'wp-config.php');
@@ -5006,8 +5009,10 @@ class ImportClient
             if (!is_file($config_path)) {
                 continue;
             }
-            // Tokenizing is bounded independently of the size of an unusual
-            // generated config. Do not inspect a prefix and call it complete.
+            // token_get_all() creates an array for the whole input. Cap its
+            // input at 256 KiB to bound memory use. Reading one extra byte
+            // detects oversized files, which need a warning rather than a
+            // partial scan that could miss environment reads near the end.
             $config = file_get_contents($config_path, false, null, 0, 262145);
             if ($config === false || strlen($config) > 262144) {
                 $message = "Could not inspect {$config_path} within the 256 KiB configuration limit. Check its environment settings manually.";

--- a/packages/reprint-client/src/lib/target-runtime/config-environment.php
+++ b/packages/reprint-client/src/lib/target-runtime/config-environment.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Finds literal getenv('NAME') reads without running the copied configuration.
+ *
+ * This does not decide whether a read is required: it may be conditional or
+ * have a fallback. Dynamic names and included files need manual inspection.
+ * Callers bound the configuration file size before tokenizing it.
+ *
+ * @return list<string> Distinct environment variable names, in source order.
+ */
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Matches shared runtime helper names.
+function config_environment_names(string $config): array
+{
+    $tokens = array_values(array_filter(token_get_all($config), static function ($token): bool {
+        return !is_array($token) || !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true);
+    }));
+    $names = [];
+    foreach ($tokens as $index => $token) {
+        if (!is_array($token) || !in_array(strtolower($token[1]), ['getenv', '\\getenv'], true)) {
+            continue;
+        }
+        $previous = $tokens[$index - 1] ?? null;
+        if (is_array($previous) && in_array($previous[1], ['->', '?->', '::', 'function'], true)) {
+            continue;
+        }
+        // PHP 7 represents a qualified function name with separate tokens.
+        // Accept \getenv(), but not a function such as vendor\getenv().
+        if (is_array($previous) && $previous[0] === T_NS_SEPARATOR) {
+            $before_separator = $tokens[$index - 2] ?? null;
+            if (is_array($before_separator) && $before_separator[0] === T_STRING) {
+                continue;
+            }
+        }
+        $argument = $tokens[$index + 2] ?? null;
+        if (( $tokens[$index + 1] ?? null ) !== '('
+            || !is_array($argument) || $argument[0] !== T_CONSTANT_ENCAPSED_STRING
+            || !in_array($tokens[$index + 3] ?? null, [')', ','], true)) {
+            continue;
+        }
+        if (preg_match('/^[\'"]([A-Za-z_][A-Za-z0-9_]*)[\'"]$/D', $argument[1], $matches) === 1) {
+            $names[$matches[1]] = true;
+        }
+    }
+    return array_keys($names);
+}

--- a/packages/reprint-client/src/lib/target-runtime/config-environment.php
+++ b/packages/reprint-client/src/lib/target-runtime/config-environment.php
@@ -1,15 +1,18 @@
 <?php
 
 /**
- * Finds literal getenv('NAME') reads without running the copied configuration.
+ * Lists environment variable names read by literal getenv('NAME') calls.
  *
- * This does not decide whether a read is required: it may be conditional or
- * have a fallback. Dynamic names and included files need manual inspection.
- * Callers bound the configuration file size before tokenizing it.
+ * Tokenizing the copied wp-config.php avoids executing site code or reading
+ * secret values. Only literal names are recognized; computed names and reads
+ * in included files are outside this scan. A listed call may be conditional
+ * or have a fallback, so it does not establish that the variable is required.
+ * The caller must limit input size because token_get_all() buffers all tokens.
  *
+ * @param string $config Complete PHP source to inspect, not a file path.
  * @return list<string> Distinct environment variable names, in source order.
  */
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Matches shared runtime helper names.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Runtime helpers use unprefixed function names.
 function config_environment_names(string $config): array
 {
     $tokens = array_values(array_filter(token_get_all($config), static function ($token): bool {
@@ -24,8 +27,9 @@ function config_environment_names(string $config): array
         if (is_array($previous) && in_array($previous[1], ['->', '?->', '::', 'function'], true)) {
             continue;
         }
-        // PHP 7 represents a qualified function name with separate tokens.
-        // Accept \getenv(), but not a function such as vendor\getenv().
+        // PHP 7 splits vendor\getenv into name and separator tokens, unlike
+        // PHP 8's combined name token. Reject that namespaced function while
+        // still accepting \getenv, which explicitly calls the global function.
         if (is_array($previous) && $previous[0] === T_NS_SEPARATOR) {
             $before_separator = $tokens[$index - 2] ?? null;
             if (is_array($before_separator) && $before_separator[0] === T_STRING) {

--- a/packages/reprint-client/src/lib/target-runtime/load.php
+++ b/packages/reprint-client/src/lib/target-runtime/load.php
@@ -10,3 +10,5 @@ require_once __DIR__ . '/class-nginx-fpm-applier.php';
 require_once __DIR__ . '/class-php-builtin-applier.php';
 require_once __DIR__ . '/class-playground-cli-applier.php';
 require_once __DIR__ . '/functions.php';
+
+require_once __DIR__ . '/config-environment.php';

--- a/tests/Import/ConfigEnvironmentTest.php
+++ b/tests/Import/ConfigEnvironmentTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+class ConfigEnvironmentTest extends TestCase {
+    /** Comments, strings, methods, and dynamic names do not identify global getenv reads. */
+    public function testOnlyLiteralEnvironmentReadsAreReportedWithoutValues(): void
+    {
+        $config = <<<'CONFIG'
+<?php
+// getenv('COMMENTED_SECRET');
+$example = "getenv('QUOTED_SECRET')";
+define('MEDIA_BUCKET', getenv('REPRINT_TEST_MISSING_BUCKET'));
+$optional = \getenv /* comment */ ('REPRINT_TEST_OPTIONAL', true) ?: 'fallback';
+$duplicate = getenv('REPRINT_TEST_MISSING_BUCKET');
+$dynamic = getenv('PREFIX_' . $name);
+$method = $object->getenv('METHOD_SECRET');
+$static = Example::getenv('STATIC_SECRET');
+$other_function = custom\getenv('CUSTOM_SECRET');
+CONFIG;
+        $this->assertSame(
+            ['REPRINT_TEST_MISSING_BUCKET', 'REPRINT_TEST_OPTIONAL'],
+            config_environment_names($config)
+        );
+    }
+
+    /** Inspecting config must not execute site code. */
+    public function testConfigIsReadAsTextAndNeverExecuted(): void
+    {
+        $config = '<?php throw new Exception("Do not execute this config"); getenv("MEDIA_BUCKET");';
+        $this->assertSame(['MEDIA_BUCKET'], config_environment_names($config));
+    }
+    /** @dataProvider runtime_layouts */
+    public function testRuntimeReportsMissingNamesWithoutCopyingOrPrintingSecrets(bool $flat): void
+    {
+        $root = sys_get_temp_dir() . '/reprint-config-' . bin2hex(random_bytes(6));
+        $site = $root . '/files/site';
+        mkdir($site, 0700, true);
+        file_put_contents($site . '/index.php', '<?php');
+        $config = '<?php throw new Exception("must not execute"); '
+            . 'getenv("REPRINT_TEST_MISSING_BUCKET"); getenv("REPRINT_TEST_PRESENT_CONFIG"); '
+            . '$secret = "source-secret-never-copy";';
+        file_put_contents($site . '/wp-config.php', $config);
+        $previous = getenv('REPRINT_TEST_PRESENT_CONFIG');
+        putenv('REPRINT_TEST_PRESENT_CONFIG=target-secret-never-print');
+        $client = new ImportClient('https://source.example', $root . '/state', $root . '/files');
+        write_current_pull_state($client, ['preflight' => ['http_code' => 200, 'data' => [
+            'ok' => true,
+            'runtime' => ['document_root' => '/site'],
+            'wp_detect' => ['roots' => [['wp_config_path' => '/site/wp-config.php']]],
+        ]]]);
+        try {
+            $options = ['runtime' => 'php-builtin', 'output_dir' => $root . '/runtime'];
+            if ($flat) {
+                $options['flat_document_root'] = $site;
+            }
+            ob_start();
+            try {
+                $client->run_apply_runtime($options);
+            } finally {
+                ob_end_clean();
+            }
+            $log = file_get_contents($root . '/state/audit.log');
+            $this->assertStringContainsString('reads REPRINT_TEST_MISSING_BUCKET', $log);
+            $this->assertStringContainsString('may provide a fallback', $log);
+            $this->assertStringNotContainsString('reads REPRINT_TEST_PRESENT_CONFIG', $log);
+            $runtime = file_get_contents($root . '/runtime/runtime.php');
+            $this->assertStringNotContainsString('source-secret-never-copy', $log . $runtime);
+            $this->assertStringNotContainsString('target-secret-never-print', $log . $runtime);
+            $this->assertSame($config, file_get_contents($site . '/wp-config.php'));
+        } finally {
+            putenv($previous === false ? 'REPRINT_TEST_PRESENT_CONFIG' : 'REPRINT_TEST_PRESENT_CONFIG=' . $previous);
+            $this->remove_tree($root);
+        }
+    }
+
+    /** Config lookup must work before and after flat-docroot. */
+    public static function runtime_layouts(): array
+    {
+        return [[false], [true]];
+    }
+
+    /** Removes only this test's temporary site and generated runtime. */
+    private function remove_tree(string $path): void
+    {
+        if (is_dir($path) && !is_link($path)) {
+            foreach (scandir($path) as $name) {
+                if ($name !== '.' && $name !== '..') {
+                    $this->remove_tree($path . '/' . $name);
+                }
+            }
+            rmdir($path);
+        } elseif (file_exists($path) || is_link($path)) {
+            unlink($path);
+        }
+    }
+}

--- a/tests/Import/ConfigEnvironmentTest.php
+++ b/tests/Import/ConfigEnvironmentTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
 
 class ConfigEnvironmentTest extends TestCase {
-    /** Comments, strings, methods, and dynamic names do not identify global getenv reads. */
+    /** Text resembling getenv() is not a read unless it is a call with a literal variable name. */
     public function testOnlyLiteralEnvironmentReadsAreReportedWithoutValues(): void
     {
         $config = <<<'CONFIG'
@@ -26,13 +26,18 @@ CONFIG;
         );
     }
 
-    /** Inspecting config must not execute site code. */
+    /** A throwing config can still be inspected because the scanner reads PHP tokens, not execution results. */
     public function testConfigIsReadAsTextAndNeverExecuted(): void
     {
         $config = '<?php throw new Exception("Do not execute this config"); getenv("MEDIA_BUCKET");';
         $this->assertSame(['MEDIA_BUCKET'], config_environment_names($config));
     }
-    /** @dataProvider runtime_layouts */
+    /**
+     * Missing names belong in warnings; config contents and environment values
+     * must not be copied into the generated runtime or printed in the audit log.
+     *
+     * @dataProvider runtime_layouts
+     */
     public function testRuntimeReportsMissingNamesWithoutCopyingOrPrintingSecrets(bool $flat): void
     {
         $root = sys_get_temp_dir() . '/reprint-config-' . bin2hex(random_bytes(6));
@@ -76,13 +81,13 @@ CONFIG;
         }
     }
 
-    /** Config lookup must work before and after flat-docroot. */
+    /** Covers both the copied source directory tree and the flattened WordPress document root. */
     public static function runtime_layouts(): array
     {
         return [[false], [true]];
     }
 
-    /** Removes only this test's temporary site and generated runtime. */
+    /** Deletes a test directory recursively, unlinking symlinks rather than following them. */
     private function remove_tree(string $path): void
     {
         if (is_dir($path) && !is_link($path)) {

--- a/tests/e2e/lib/migrated-wordpress.js
+++ b/tests/e2e/lib/migrated-wordpress.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { openSync, closeSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { once } from 'node:events';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { runImporter, createTempDir, cleanupTempDir, getSiteUrl, getSiteDir, getSiteSecret } from './test-helpers.js';
+
+/** Pull a real WordPress site, serve its generated runtime, and inspect it before cleanup. */
+export async function withMigratedWordPress(site, inspect) {
+    const temporaryDirectory = createTempDir(`e2e-migrated-${site}`);
+    const flatDirectory = join(temporaryDirectory, 'flat');
+    const runtimeDirectory = join(temporaryDirectory, 'runtime');
+    const importUrl = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    let server;
+    try {
+        const listener = createServer();
+        listener.listen(0, '127.0.0.1');
+        await once(listener, 'listening');
+        const port = listener.address().port;
+        await new Promise((resolve, reject) => listener.close(error => error ? reject(error) : resolve()));
+        const targetUrl = `http://localhost:${port}`;
+        const result = runImporter(importUrl, temporaryDirectory, 'pull', {
+            secret: getSiteSecret(site), skipPreflight: true, autoResume: false, timeout: 180000,
+            extraArgs: [
+                '--runtime=php-builtin', '--start-runtime=none', '--target-engine=sqlite',
+                `--new-site-url=${targetUrl}`, `--flatten-to=${flatDirectory}`, `--output-dir=${runtimeDirectory}`,
+            ],
+        });
+        assert.equal(result.exitCode, 0, `Pull failed:\n${result.stdout}\n${result.stderr}`);
+
+        const serverLog = join(temporaryDirectory, 'target-server.log');
+        const log = openSync(serverLog, 'a');
+        // Even when the importer uses Playground, the generated php-builtin
+        // runtime is served by native PHP, as it would be on the target host.
+        server = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', flatDirectory, join(runtimeDirectory, 'runtime.php')], {
+            stdio: ['ignore', log, log],
+        });
+        closeSync(log);
+        let response;
+        const deadline = Date.now() + 10000;
+        while (Date.now() < deadline && server.exitCode === null) {
+            try {
+                response = await fetch(targetUrl, { redirect: 'manual', signal: AbortSignal.timeout(5000) });
+                break;
+            } catch {
+                await sleep(50);
+            }
+        }
+        assert.ok(response, `Target did not listen:\n${readFileSync(serverLog, 'utf8').slice(-4000)}`);
+        const html = await response.text();
+        assert.equal(response.status, 200,
+            `Target returned HTTP ${response.status}, Location: ${response.headers.get('location')}\n${html.slice(0, 1000)}\n${readFileSync(serverLog, 'utf8').slice(-4000)}`);
+        assert.ok(html.includes('Hello world!'), 'The target must render the migrated WordPress post');
+        await inspect({ temporaryDirectory, flatDirectory, runtimeDirectory, importUrl, targetUrl, result, html });
+    } finally {
+        if (server && server.exitCode === null) {
+            const exited = once(server, 'exit');
+            server.kill();
+            await exited;
+        }
+        cleanupTempDir(temporaryDirectory);
+    }
+}

--- a/tests/e2e/lib/migrated-wordpress.js
+++ b/tests/e2e/lib/migrated-wordpress.js
@@ -7,7 +7,12 @@ import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { runImporter, createTempDir, cleanupTempDir, getSiteUrl, getSiteDir, getSiteSecret } from './test-helpers.js';
 
-/** Pull a real WordPress site, serve its generated runtime, and inspect it before cleanup. */
+/**
+ * Migrates a source WordPress site to SQLite and serves the generated PHP runtime.
+ * Calls inspect with the CLI result, target HTML, and paths only after the target
+ * renders the migrated post. The server and temporary files stay available until
+ * inspect finishes; both are cleaned up even if migration or assertions fail.
+ */
 export async function withMigratedWordPress(site, inspect) {
     const temporaryDirectory = createTempDir(`e2e-migrated-${site}`);
     const flatDirectory = join(temporaryDirectory, 'flat');
@@ -32,8 +37,9 @@ export async function withMigratedWordPress(site, inspect) {
 
         const serverLog = join(temporaryDirectory, 'target-server.log');
         const log = openSync(serverLog, 'a');
-        // Even when the importer uses Playground, the generated php-builtin
-        // runtime is served by native PHP, as it would be on the target host.
+        // PHP_BINARY selects the importer under test and may be a Playground
+        // wrapper. The requested php-builtin target needs a native PHP server,
+        // so do not reuse that importer command to serve the migrated site.
         server = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', flatDirectory, join(runtimeDirectory, 'runtime.php')], {
             stdio: ['ignore', log, log],
         });

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -155,6 +155,15 @@
     "sqlite-legacy": {
       "port": 8127
     },
+    "config-environment-present": {
+      "port": 8144
+    },
+    "config-environment-missing": {
+      "port": 8145
+    },
+    "config-environment-large": {
+      "port": 8146
+    },
     "mysql-target-cursor-resume": {
       "port": 8128
     },

--- a/tests/e2e/tests/import-68-config-environment.test.js
+++ b/tests/e2e/tests/import-68-config-environment.test.js
@@ -1,0 +1,88 @@
+/** Missing variables and oversized configs must warn without executing PHP or exposing values. */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ensureSite } from '../lib/site-setup.js';
+import { getSiteDir } from '../lib/test-helpers.js';
+import { withMigratedWordPress } from '../lib/migrated-wordpress.js';
+
+describe('Import: external wp-config environment', () => {
+    const variable = 'REPRINT_E2E_CONFIG_SECRET';
+    const secret = 'migration-environment-secret-do-not-print';
+    const sites = ['config-environment-present', 'config-environment-missing', 'config-environment-large'];
+
+    beforeAll(async () => {
+        for (const site of sites) {
+            await ensureSite(site, {
+                files: 'none',
+                afterCreate: async (siteDirectory) => {
+                    const path = join(siteDirectory, 'wp-config.php');
+                    const config = readFileSync(path, 'utf8');
+                    // This is valid source configuration: HTTP requests work,
+                    // but importing must not execute it in the CLI process.
+                    const prefix = `<?php
+if (PHP_SAPI === 'cli') { throw new RuntimeException('COPIED_CONFIG_EXECUTED'); }
+$migration_secret = getenv('${variable}') ?: '${secret}';
+// getenv('REPRINT_E2E_COMMENT_ONLY')
+$example = "getenv('REPRINT_E2E_QUOTED_EXAMPLE')";
+`;
+                    const padding = site === 'config-environment-large' ? '/*' + 'x'.repeat(262144) + '*/\n' : '';
+                    writeFileSync(path, prefix + padding + config.slice(5));
+                },
+            });
+        }
+    });
+
+    it('loads the target without a missing-variable warning when the importing process has the value', async () => {
+        const previous = process.env[variable];
+        process.env[variable] = secret;
+        try {
+            await withMigratedWordPress(sites[0], ({ result, temporaryDirectory, flatDirectory }) => {
+                const output = result.stdout + result.stderr + readFileSync(join(temporaryDirectory, 'audit.log'), 'utf8');
+                assert.ok(!output.includes('config_environment_missing'), output);
+                assert.ok(!output.includes('config_not_inspected'), output);
+                assert.ok(!output.includes(secret), 'Neither CLI output nor the audit log may print the value');
+                assert.equal(readFileSync(join(flatDirectory, 'wp-config.php'), 'utf8'),
+                    readFileSync(join(getSiteDir(sites[0]), 'wp-config.php'), 'utf8'));
+            });
+        } finally {
+            if (previous === undefined) delete process.env[variable];
+            else process.env[variable] = previous;
+        }
+    }, 240000);
+
+    it('reports the missing name and still loads the target using the config fallback', async () => {
+        const previous = process.env[variable];
+        delete process.env[variable];
+        try {
+            await withMigratedWordPress(sites[1], ({ result, temporaryDirectory, flatDirectory }) => {
+                const warnings = result.stdout.split('\n').filter(line => line.startsWith('{')).map(line => JSON.parse(line))
+                    .filter(event => event.reason === 'config_environment_missing');
+                assert.deepEqual(warnings.map(event => event.variable_name), [variable]);
+                assert.equal(warnings[0].config_path, join(flatDirectory, 'wp-config.php'));
+                assert.match(warnings[0].message, /not set in this process/);
+                const audit = readFileSync(join(temporaryDirectory, 'audit.log'), 'utf8');
+                assert.ok(audit.includes(variable), 'The audit log must name the missing variable');
+                assert.ok(!(result.stdout + result.stderr + audit).includes(secret));
+                assert.equal(readFileSync(join(flatDirectory, 'wp-config.php'), 'utf8'),
+                    readFileSync(join(getSiteDir(sites[1]), 'wp-config.php'), 'utf8'));
+            });
+        } finally {
+            if (previous !== undefined) process.env[variable] = previous;
+        }
+    }, 240000);
+
+    it('reports an oversized config as uninspected instead of presenting a partial scan as complete', async () => {
+        await withMigratedWordPress(sites[2], ({ result, temporaryDirectory, flatDirectory }) => {
+            const warnings = result.stdout.split('\n').filter(line => line.startsWith('{')).map(line => JSON.parse(line))
+                .filter(event => event.type === 'warning');
+            assert.equal(warnings.filter(event => event.reason === 'config_not_inspected').length, 1);
+            assert.ok(!warnings.some(event => event.reason === 'config_environment_missing'));
+            assert.match(warnings.find(event => event.reason === 'config_not_inspected').message, /256 KiB/);
+            assert.ok(!(result.stdout + result.stderr + readFileSync(join(temporaryDirectory, 'audit.log'), 'utf8')).includes(secret));
+            assert.equal(readFileSync(join(flatDirectory, 'wp-config.php'), 'utf8'),
+                readFileSync(join(getSiteDir(sites[2]), 'wp-config.php'), 'utf8'));
+        });
+    }, 240000);
+});

--- a/tests/e2e/tests/import-68-config-environment.test.js
+++ b/tests/e2e/tests/import-68-config-environment.test.js
@@ -1,4 +1,8 @@
-/** Missing variables and oversized configs must warn without executing PHP or exposing values. */
+/**
+ * Migrates WordPress sites whose wp-config.php reads an environment variable.
+ * Present values must stay out of output; missing names and unscanned oversized
+ * configs must produce warnings. Each target must still serve its migrated post.
+ */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -19,8 +23,9 @@ describe('Import: external wp-config environment', () => {
                 afterCreate: async (siteDirectory) => {
                     const path = join(siteDirectory, 'wp-config.php');
                     const config = readFileSync(path, 'utf8');
-                    // This is valid source configuration: HTTP requests work,
-                    // but importing must not execute it in the CLI process.
+                    // Permit normal WordPress HTTP requests, but throw if the
+                    // importer executes the copied config to inspect it. The
+                    // literal fallback lets the site run without the variable.
                     const prefix = `<?php
 if (PHP_SAPI === 'cli') { throw new RuntimeException('COPIED_CONFIG_EXECUTED'); }
 $migration_secret = getenv('${variable}') ?: '${secret}';


### PR DESCRIPTION
`apply-runtime` reports environment variable names read by the copied `wp-config.php` when they are absent from the importing process. It never copies or prints their values.

The check tokenizes literal `getenv('NAME')` calls without executing the config. It ignores comments, quoted examples, methods, and dynamically built names. The warning tells the user to check the target server: a fallback or a separate PHP-FPM environment may already supply the value, so an absent CLI variable is not treated as a failed migration. Configs above 256 KiB receive a manual-check warning.

Tests exercise raw and flattened site layouts, secret-value exclusion, and config preservation. The runtime tests fail against the original importer at the missing-name report assertion.


End-to-end coverage runs full WordPress pulls through the CLI and real HTTP source, then starts the generated target runtime and loads the migrated post. It covers a supplied variable, a missing variable with a working config fallback, and a config above the scan limit. The tests assert warning names and paths, unchanged config bytes, and secret-value exclusion from CLI output and the audit log. The missing-name and oversized-config tests fail at their warning assertions with the original importer.
