### PR TITLE
[PHP] Identify WP Engine by its paths and MU-loader header

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,14 @@ PHP constants, INI directives, and request handlers that the source host
 relied on. `apply-runtime` reads the preflight data, detects the source
 hosting provider, and generates the configuration files your target server needs.
 
+WP Engine detection uses its current `/nas/content/live/` or `/nas/wp/www/`
+site paths, not plugin names left over from an earlier migration. Preflight
+reads MU-plugin names from their first 8 KiB of public headers. Cleanup removes
+the WP Engine System loader under its actual filename. An unrecognized
+`mu-plugin.php` and its `wpengine-common` directory stay in place, including
+when an older exporter supplies no headers. Review those files manually if
+they still depend on WP Engine services.
+
 For PHP's built-in development server:
 
 ```bash

--- a/packages/reprint-client/src/lib/host/analyzers/class-wpengine-host-analyzer.php
+++ b/packages/reprint-client/src/lib/host/analyzers/class-wpengine-host-analyzer.php
@@ -15,8 +15,13 @@ class WpengineHostAnalyzer implements HostAnalyzer {
     public static function score(array $preflight_data): float
     {
         $runtime = $preflight_data['runtime'] ?? [];
-        foreach (['document_root', 'script_filename', 'cwd'] as $path_name) {
-            $path = $runtime[$path_name] ?? null;
+        $paths = [
+            $runtime['document_root'] ?? null,
+            $runtime['script_filename'] ?? null,
+            $runtime['cwd'] ?? null,
+            $preflight_data['database']['wp']['paths_urls']['abspath'] ?? null,
+        ];
+        foreach ($paths as $path) {
             if (!is_string($path)) {
                 continue;
             }

--- a/packages/reprint-client/src/lib/host/functions.php
+++ b/packages/reprint-client/src/lib/host/functions.php
@@ -165,7 +165,6 @@ function excluded_plugins(array $preflight_data): array
         // update-source layout. Its standalone password and comment-policy
         // plugins are portable and stay installed.
         'wp-content/plugins/wp-engine-smart-plugin-manager',
-        'wp-content/mu-plugins/wpengine-common',
         'wp-content/mu-plugins/wpe-cache-plugin',
         'wp-content/mu-plugins/wpe-cache-plugin.php',
         'wp-content/mu-plugins/wpe-update-source-selector',
@@ -188,21 +187,22 @@ function excluded_plugins(array $preflight_data): array
         $local_paths[] = 'wp-content/object-cache.php';
         $local_paths[] = 'wp-content/advanced-cache.php';
     }
-    // mu-plugin.php is WP Engine's loader, but its name is otherwise generic.
-    if (isset($matching_hosts['wpengine'])) {
-        $local_paths[] = 'wp-content/mu-plugins/mu-plugin.php';
-    }
     // A copied WP Engine loader still requires wpengine-common after the site
     // moves to another host. Exclude the pair without changing host detection.
-    // A generic mu-plugin.php alone does not identify the WP Engine loader.
+    // WP Engine documents the WP Engine System display name for this loader.
+    // A customer can also call a file mu-plugin.php, so that name alone must
+    // never authorize removing it. Older exporters without headers leave the
+    // ambiguous loader and its package together, not a missing dependency.
     foreach ($preflight_data['wp_content']['roots'] ?? [] as $root) {
-        $mu_plugin_names = array_column($root['mu_plugins'] ?? [], 'name');
-        if (
-            in_array('mu-plugin.php', $mu_plugin_names, true)
-            && in_array('wpengine-common', $mu_plugin_names, true)
-        ) {
-            $local_paths[] = 'wp-content/mu-plugins/mu-plugin.php';
-            break;
+        foreach ($root['mu_plugins'] ?? [] as $plugin) {
+            $name = $plugin['name'] ?? '';
+            if (( $plugin['type'] ?? '' ) === 'file'
+                && ( $plugin['headers']['name'] ?? '' ) === 'WP Engine System'
+                && is_string($name) && basename($name) === $name
+                && substr($name, -4) === '.php') {
+                $local_paths[] = 'wp-content/mu-plugins/wpengine-common';
+                $local_paths[] = 'wp-content/mu-plugins/' . $name;
+            }
         }
     }
 

--- a/packages/reprint-client/src/lib/host/functions.php
+++ b/packages/reprint-client/src/lib/host/functions.php
@@ -86,15 +86,20 @@ function matching_host_analyzer_scores(array $preflight_data): array
 }
 
 /**
- * Resolve plugins, MU plugins, and drop-ins excluded from a local import.
+ * Lists source-host plugins and drop-ins to omit from the local site.
  *
  * Host platform integrations are excluded when cleanup is requested. Portable
  * cache, backup, security, and password-policy plugins stay, even when a host
  * bundles them.
- * Generic drop-ins enter the exclusion list only when current preflight paths
- * identify WP Cloud or WP Engine.
- * Source paths use the actual WordPress directories reported by preflight,
- * including custom plugin and MU-plugin locations.
+ *
+ * Paths in the fixed list are selected on every host. Two cases need more
+ * context from preflight, the source inspection performed before a download:
+ * generic cache drop-ins such as object-cache.php require current WP Cloud or
+ * WP Engine filesystem paths; WP Engine's MU-plugin loader requires its Plugin
+ * Name header. Finding a copied host plugin does not identify the current host.
+ *
+ * Source paths use the WordPress directories reported by preflight, including
+ * custom plugin and MU-plugin directories, rather than assuming wp-content.
  * Pantheon's package stays because its generic loader.php requires it even
  * outside Pantheon. Its platform features require PANTHEON_ENVIRONMENT.
  *
@@ -187,12 +192,13 @@ function excluded_plugins(array $preflight_data): array
         $local_paths[] = 'wp-content/object-cache.php';
         $local_paths[] = 'wp-content/advanced-cache.php';
     }
-    // A copied WP Engine loader still requires wpengine-common after the site
-    // moves to another host. Exclude the pair without changing host detection.
-    // WP Engine documents the WP Engine System display name for this loader.
-    // A customer can also call a file mu-plugin.php, so that name alone must
-    // never authorize removing it. Older exporters without headers leave the
-    // ambiguous loader and its package together, not a missing dependency.
+    // WordPress loads top-level MU-plugin PHP files automatically. WP Engine's
+    // loader then requires files from wpengine-common, even on another host,
+    // so removing only the package would leave a fatal require on the target.
+    // Its documented Plugin Name, "WP Engine System", identifies the pair
+    // without treating any customer file named mu-plugin.php as platform code.
+    // Exporters without header metadata leave the loader and package together.
+    // Excluding a recognized pair does not select the site's current host.
     foreach ($preflight_data['wp_content']['roots'] ?? [] as $root) {
         foreach ($root['mu_plugins'] ?? [] as $plugin) {
             $name = $plugin['name'] ?? '';

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2458,6 +2458,7 @@ function endpoint_preflight(array $config): array
                 $root_entry["mu_plugins"][] = [
                     "name" => $entry,
                     "type" => is_dir($path) ? "dir" : "file",
+                    "headers" => is_file($path) ? reprint_read_preflight_plugin_headers($path) : [],
                 ];
             }
             usort(
@@ -2628,6 +2629,32 @@ function endpoint_preflight(array $config): array
         "status" => $response["ok"] ? "ok" : "error",
         "stats" => $response,
     ];
+}
+
+/**
+ * Read public plugin headers without loading the plugin or returning PHP code.
+ *
+ * WordPress also limits plugin header parsing to the first 8 KiB. The file
+ * contents and arbitrary constants must not enter the preflight response.
+ *
+ * @return array {
+ *     Recognized public metadata, or an empty array for an unreadable file.
+ *     @type string $name Plugin Name header, when present.
+ * }
+ */
+function reprint_read_preflight_plugin_headers(string $path): array
+{
+    if (!is_readable($path)) {
+        return [];
+    }
+    $header = file_get_contents($path, false, null, 0, 8192);
+    if ($header === false) {
+        return [];
+    }
+    if (preg_match('/^[ \t\/*#@]*Plugin Name:(.*)$/mi', str_replace("\r", "\n", $header), $matches) !== 1) {
+        return [];
+    }
+    return ['name' => trim(preg_replace('/\s*(?:\*\/|\?>).*/', '', $matches[1]))];
 }
 
 /**

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2638,7 +2638,7 @@ function endpoint_preflight(array $config): array
  * contents and arbitrary constants must not enter the preflight response.
  *
  * @return array {
- *     Recognized public metadata, or an empty array for an unreadable file.
+ *     Recognized public metadata, or an empty array when unavailable or not UTF-8.
  *     @type string $name Plugin Name header, when present.
  * }
  */
@@ -2654,7 +2654,13 @@ function reprint_read_preflight_plugin_headers(string $path): array
     if (preg_match('/^[ \t\/*#@]*Plugin Name:(.*)$/mi', str_replace("\r", "\n", $header), $matches) !== 1) {
         return [];
     }
-    return ['name' => trim(preg_replace('/\s*(?:\*\/|\?>).*/', '', $matches[1]))];
+    $name = trim(preg_replace('/\s*(?:\*\/|\?>).*/', '', $matches[1]));
+    // PHP comments may use legacy encodings; preflight JSON requires UTF-8.
+    // Omit an unreadable name rather than guessing which encoding it uses.
+    if (preg_match('//u', $name) !== 1) {
+        return [];
+    }
+    return ['name' => $name];
 }
 
 /**

--- a/packages/reprint-server/src/export.php
+++ b/packages/reprint-server/src/export.php
@@ -2632,14 +2632,16 @@ function endpoint_preflight(array $config): array
 }
 
 /**
- * Read public plugin headers without loading the plugin or returning PHP code.
+ * Extracts a MU plugin's public Plugin Name for the preflight response.
  *
- * WordPress also limits plugin header parsing to the first 8 KiB. The file
- * contents and arbitrary constants must not enter the preflight response.
+ * Preflight describes the source site before downloading it. The importer uses
+ * this name to recognize host-specific loaders without receiving or executing
+ * their PHP code. Only the first 8 KiB are scanned, matching WordPress's header
+ * limit; unrelated file contents and constants are not returned.
  *
  * @return array {
- *     Recognized public metadata, or an empty array when unavailable or not UTF-8.
- *     @type string $name Plugin Name header, when present.
+ *     Public metadata, or an empty array when no readable UTF-8 header was found.
+ *     @type string $name Trimmed Plugin Name value, when available.
  * }
  */
 function reprint_read_preflight_plugin_headers(string $path): array
@@ -2655,8 +2657,9 @@ function reprint_read_preflight_plugin_headers(string $path): array
         return [];
     }
     $name = trim(preg_replace('/\s*(?:\*\/|\?>).*/', '', $matches[1]));
-    // PHP comments may use legacy encodings; preflight JSON requires UTF-8.
-    // Omit an unreadable name rather than guessing which encoding it uses.
+    // A working PHP plugin can have non-UTF-8 comments, but including such a
+    // name would make JSON encoding fail for the entire preflight response.
+    // Omit that metadata without guessing an encoding or changing the file.
     if (preg_match('//u', $name) !== 1) {
         return [];
     }

--- a/tests/Import/HostImportRulesTest.php
+++ b/tests/Import/HostImportRulesTest.php
@@ -93,7 +93,6 @@ class HostImportRulesTest extends TestCase {
                 'wp-content/plugins/spinupwp',
                 'wp-content/mu-plugins/vip-go-mu-plugins',
                 'wp-content/plugins/wp-engine-smart-plugin-manager',
-                'wp-content/mu-plugins/wpengine-common',
                 'wp-content/mu-plugins/wpe-cache-plugin',
                 'wp-content/mu-plugins/wpe-cache-plugin.php',
                 'wp-content/mu-plugins/wpe-update-source-selector',
@@ -111,7 +110,8 @@ class HostImportRulesTest extends TestCase {
 
     public function testKeepsPortablePluginsEvenOnWpengine(): void
     {
-        $preflight_data = $this->preflight([], []);
+        $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
+        $preflight_data['wp_content']['roots'][0]['mu_plugins'][0]['headers'] = ['name' => 'WP Engine System'];
         $preflight_data['runtime']['document_root'] = '/nas/content/live/example';
         $excluded_paths = array_column(\excluded_plugins($preflight_data), 'local_path');
 
@@ -180,12 +180,13 @@ class HostImportRulesTest extends TestCase {
         $excluded_local_paths = array_column(\excluded_plugins($preflight_data), 'local_path');
         $this->assertContains('wp-content/object-cache.php', $excluded_local_paths);
         $this->assertContains('wp-content/advanced-cache.php', $excluded_local_paths);
-        $this->assertContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
+        $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 
     public function testExcludedPluginSourcePathsUseDirectoriesReportedByPreflight(): void
     {
-        $preflight_data = $this->preflight([], []);
+        $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
+        $preflight_data['wp_content']['roots'][0]['mu_plugins'][0]['headers'] = ['name' => 'WP Engine System'];
         $preflight_data['runtime']['document_root'] = '/nas/content/live/example';
         $preflight_data['database']['wp']['paths_urls'] = [
             'abspath' => '/opt/wordpress/',
@@ -259,6 +260,7 @@ class HostImportRulesTest extends TestCase {
     public function testCopiedWpengineLoaderIsExcludedWithoutSelectingWpengine(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
+        $preflight_data['wp_content']['roots'][0]['mu_plugins'][0]['headers'] = ['name' => 'WP Engine System'];
         $preflight_data['runtime']['document_root'] = '/var/www/html';
         $preflight_data['database']['wp']['paths_urls']['mu_plugins_dir'] = '/srv/custom-mu-plugins';
 
@@ -270,6 +272,29 @@ class HostImportRulesTest extends TestCase {
         $this->assertContains('/srv/custom-mu-plugins/wpengine-common', array_column($excluded_plugins, 'source_path'));
         $this->assertNotContains('wp-content/object-cache.php', array_column($excluded_plugins, 'local_path'));
         $this->assertNotContains('wp-content/advanced-cache.php', array_column($excluded_plugins, 'local_path'));
+    }
+
+    /** A shared filename and an unknown header do not identify platform code. */
+    public function testCustomerMuPluginAndPackageAreNotExcludedOnWpengine(): void
+    {
+        $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
+        $preflight_data['runtime']['document_root'] = '/nas/content/live/example';
+        foreach ([[], ['name' => 'Customer checkout rules']] as $headers) {
+            $preflight_data['wp_content']['roots'][0]['mu_plugins'][0]['headers'] = $headers;
+            $excluded_local_paths = array_column(\excluded_plugins($preflight_data), 'local_path');
+            $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
+            $this->assertNotContains('wp-content/mu-plugins/wpengine-common', $excluded_local_paths);
+        }
+    }
+
+    /** The documented WP Engine System header identifies a renamed loader. */
+    public function testRecognizedLoaderIsExcludedUnderItsActualFilename(): void
+    {
+        $preflight_data = $this->preflight([], ['platform-loader.php', 'wpengine-common']);
+        $preflight_data['wp_content']['roots'][0]['mu_plugins'][0]['headers'] = ['name' => 'WP Engine System'];
+        $excluded_local_paths = array_column(\excluded_plugins($preflight_data), 'local_path');
+        $this->assertContains('wp-content/mu-plugins/platform-loader.php', $excluded_local_paths);
+        $this->assertContains('wp-content/mu-plugins/wpengine-common', $excluded_local_paths);
     }
 
     public function testUnpairedGenericMuPluginIsNotExcluded(): void

--- a/tests/Import/HostImportRulesTest.php
+++ b/tests/Import/HostImportRulesTest.php
@@ -58,7 +58,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertSame('other', \detect_host($preflight_data));
     }
 
-    /** The unconditional list does not include the shared WP Engine loader or package. */
+    /** The fixed exclusion list must not remove WP Engine's loader and package without a matching header. */
     public function testListsEveryPluginExcludedFromAllImports(): void
     {
         $excluded_plugins = \excluded_plugins($this->preflight([], []));
@@ -141,7 +141,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertContains('wp-content/mu-plugins/mu-plugin.php', $excluded_paths);
     }
 
-    /** Runtime path matches do not replace the public-header check for a shared loader. */
+    /** Host paths can select cache drop-ins, but only a plugin header can identify WP Engine's loader. */
     public function testWpcloudRuntimeAndWpengineExclusionsAreAppliedIndependently(): void
     {
         $preflight_data = $this->preflight(
@@ -185,7 +185,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 
-    /** Recognized loaders and packages use the reported custom MU-plugin directory. */
+    /** Exclusions must refer to the actual source directories, including relocated MU plugins. */
     public function testExcludedPluginSourcePathsUseDirectoriesReportedByPreflight(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
@@ -260,7 +260,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 
-    /** The public header identifies a copied loader without changing the current host. */
+    /** Copied WP Engine code needs removal on another host without removing that host's generic cache files. */
     public function testCopiedWpengineLoaderIsExcludedWithoutSelectingWpengine(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
@@ -278,7 +278,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertNotContains('wp-content/advanced-cache.php', array_column($excluded_plugins, 'local_path'));
     }
 
-    /** A shared filename and an unknown header do not identify platform code. */
+    /** Even on WP Engine, mu-plugin.php may be customer code that needs the adjacent package. */
     public function testCustomerMuPluginAndPackageAreNotExcludedOnWpengine(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
@@ -291,7 +291,7 @@ class HostImportRulesTest extends TestCase {
         }
     }
 
-    /** The documented WP Engine System header identifies a renamed loader. */
+    /** The Plugin Name identifies the loader even when its PHP filename is no longer mu-plugin.php. */
     public function testRecognizedLoaderIsExcludedUnderItsActualFilename(): void
     {
         $preflight_data = $this->preflight([], ['platform-loader.php', 'wpengine-common']);

--- a/tests/Import/HostImportRulesTest.php
+++ b/tests/Import/HostImportRulesTest.php
@@ -58,6 +58,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertSame('other', \detect_host($preflight_data));
     }
 
+    /** The unconditional list does not include the shared WP Engine loader or package. */
     public function testListsEveryPluginExcludedFromAllImports(): void
     {
         $excluded_plugins = \excluded_plugins($this->preflight([], []));
@@ -140,6 +141,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertContains('wp-content/mu-plugins/mu-plugin.php', $excluded_paths);
     }
 
+    /** Runtime path matches do not replace the public-header check for a shared loader. */
     public function testWpcloudRuntimeAndWpengineExclusionsAreAppliedIndependently(): void
     {
         $preflight_data = $this->preflight(
@@ -183,6 +185,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 
+    /** Recognized loaders and packages use the reported custom MU-plugin directory. */
     public function testExcludedPluginSourcePathsUseDirectoriesReportedByPreflight(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);
@@ -257,6 +260,7 @@ class HostImportRulesTest extends TestCase {
         $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 
+    /** The public header identifies a copied loader without changing the current host. */
     public function testCopiedWpengineLoaderIsExcludedWithoutSelectingWpengine(): void
     {
         $preflight_data = $this->preflight([], ['mu-plugin.php', 'wpengine-common']);

--- a/tests/Import/PreflightPluginHeadersTest.php
+++ b/tests/Import/PreflightPluginHeadersTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-server/src/export.php';
+
+class PreflightPluginHeadersTest extends TestCase {
+    /** Only the public header crosses preflight; code and secret values do not. */
+    public function testHeaderReadDoesNotExecuteOrExportPluginCode(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'reprint-header-');
+        try {
+            file_put_contents($path, "<?php\n/*\nPlugin Name: WP Engine System\n*/\nthrow new Exception('must-not-execute-secret');");
+            $this->assertSame(['name' => 'WP Engine System'], reprint_read_preflight_plugin_headers($path));
+            file_put_contents($path, "<?php\n/* Plugin Name: Customer checkout rules */\n");
+            $this->assertSame(['name' => 'Customer checkout rules'], reprint_read_preflight_plugin_headers($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /** A large plugin body does not extend the bounded public-header scan. */
+    public function testHeadersPastWordpressHeaderLimitAreNotRead(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'reprint-header-');
+        try {
+            file_put_contents($path, str_repeat(' ', 8192) . "\nPlugin Name: WP Engine System\n");
+            $this->assertSame([], reprint_read_preflight_plugin_headers($path));
+        } finally {
+            unlink($path);
+        }
+    }
+}

--- a/tests/Import/PreflightPluginHeadersTest.php
+++ b/tests/Import/PreflightPluginHeadersTest.php
@@ -19,6 +19,23 @@ class PreflightPluginHeadersTest extends TestCase {
         }
     }
 
+    /** Legacy PHP comments may use non-UTF-8 bytes, which JSON cannot encode. */
+    public function testNonUtf8NamesAreOmittedButUtf8NamesRemainReadable(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'reprint-header-');
+        try {
+            file_put_contents($path, "<?php\n/* Plugin Name: Caf\xe9 customer tools */\n");
+            $this->assertSame([], reprint_read_preflight_plugin_headers($path));
+            file_put_contents($path, "<?php\n/* Plugin Name: Café customer tools */\n");
+            $this->assertSame(['name' => 'Café customer tools'], reprint_read_preflight_plugin_headers($path));
+            // The 8 KiB read stops after the first byte of a valid UTF-8 character.
+            file_put_contents($path, "Plugin Name:" . str_repeat(' ', 8179) . "é\n");
+            $this->assertSame([], reprint_read_preflight_plugin_headers($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
     /** A large plugin body does not extend the bounded public-header scan. */
     public function testHeadersPastWordpressHeaderLimitAreNotRead(): void
     {

--- a/tests/Import/PreflightPluginHeadersTest.php
+++ b/tests/Import/PreflightPluginHeadersTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../packages/reprint-server/src/export.php';
 
 class PreflightPluginHeadersTest extends TestCase {
-    /** Only the public header crosses preflight; code and secret values do not. */
+    /** Extracting Plugin Name must neither execute the plugin nor return its other contents. */
     public function testHeaderReadDoesNotExecuteOrExportPluginCode(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'reprint-header-');
@@ -19,7 +19,7 @@ class PreflightPluginHeadersTest extends TestCase {
         }
     }
 
-    /** Legacy PHP comments may use non-UTF-8 bytes, which JSON cannot encode. */
+    /** Invalid UTF-8 names must be omitted so one plugin cannot break preflight JSON encoding. */
     public function testNonUtf8NamesAreOmittedButUtf8NamesRemainReadable(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'reprint-header-');
@@ -28,7 +28,8 @@ class PreflightPluginHeadersTest extends TestCase {
             $this->assertSame([], reprint_read_preflight_plugin_headers($path));
             file_put_contents($path, "<?php\n/* Plugin Name: Café customer tools */\n");
             $this->assertSame(['name' => 'Café customer tools'], reprint_read_preflight_plugin_headers($path));
-            // The 8 KiB read stops after the first byte of a valid UTF-8 character.
+            // Even a UTF-8 file can yield an invalid name when the 8 KiB read
+            // stops between the two bytes of its final character.
             file_put_contents($path, "Plugin Name:" . str_repeat(' ', 8179) . "é\n");
             $this->assertSame([], reprint_read_preflight_plugin_headers($path));
         } finally {
@@ -36,7 +37,7 @@ class PreflightPluginHeadersTest extends TestCase {
         }
     }
 
-    /** A large plugin body does not extend the bounded public-header scan. */
+    /** Plugin Name beyond WordPress's first 8 KiB is not metadata and must not extend the scan. */
     public function testHeadersPastWordpressHeaderLimitAreNotRead(): void
     {
         $path = tempnam(sys_get_temp_dir(), 'reprint-header-');

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -724,7 +724,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     // ---- WP Engine-specific tests ----
 
-    /** Remove a recognized loader with its package so the remaining MU plugins still boot. */
+    /** Loading the remaining MU plugins must not require a WP Engine package that cleanup removed. */
     public function testCopiedWpengineLoaderDoesNotRequireRemovedPackageAfterCleanup(): void
     {
         $state = $this->preflightWithoutWpcloudSignals('/var/www/html');
@@ -783,7 +783,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->assertSame($custom_plugin, file_get_contents($mu_plugins . '/mu-plugin.php'));
     }
 
-    /** A public header selects the shared loader while unrelated customer code stays. */
+    /** Cleanup must remove the header-identified WP Engine loader without touching other MU-plugin PHP files. */
     public function testWpengineRemovesPlatformMuPluginsAndPreservesCustomMuPlugins(): void
     {
         $state = $this->preflightWithoutWpcloudSignals('/nas/content/live/example');

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -730,7 +730,7 @@ class ProductionDropInRemovalTest extends TestCase
         $state['webhost'] = 'other';
         $state['preflight']['data']['wp_content']['roots'] = [
             ['mu_plugins' => [
-                ['name' => 'mu-plugin.php', 'type' => 'file'],
+                ['name' => 'mu-plugin.php', 'type' => 'file', 'headers' => ['name' => 'WP Engine System']],
                 ['name' => 'wpengine-common', 'type' => 'dir'],
             ]],
         ];
@@ -740,7 +740,7 @@ class ProductionDropInRemovalTest extends TestCase
         mkdir($mu_plugins . '/wpengine-common', 0755, true);
         // WP Engine's loader requires its package even after moving to another host.
         // https://github.com/Gnovus-Inc/sports-nerd-nonsense/blob/6dbc25ecf0db13c7ea82d81b9d32ea7114589001/wp-content/mu-plugins/mu-plugin.php#L18
-        file_put_contents($mu_plugins . '/mu-plugin.php', "<?php require_once __DIR__ . '/wpengine-common/plugin.php';");
+        file_put_contents($mu_plugins . '/mu-plugin.php', "<?php\n/* Plugin Name: WP Engine System */\nrequire_once __DIR__ . '/wpengine-common/plugin.php';");
         file_put_contents($mu_plugins . '/wpengine-common/plugin.php', "<?php // WP Engine package\n");
         file_put_contents($mu_plugins . '/custom.php', "<?php echo 'custom-plugin-loaded';");
 
@@ -784,15 +784,20 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testWpengineRemovesPlatformMuPluginsAndPreservesCustomMuPlugins(): void
     {
-        $this->writeState(array_replace_recursive(
-            ['webhost' => 'wpengine'],
-            $this->preflightWithoutWpcloudSignals('/nas/content/live/example'),
-        ));
+        $state = $this->preflightWithoutWpcloudSignals('/nas/content/live/example');
+        $state['webhost'] = 'wpengine';
+        $state['preflight']['data']['wp_content']['roots'] = [
+            ['mu_plugins' => [[
+                'name' => 'mu-plugin.php', 'type' => 'file',
+                'headers' => ['name' => 'WP Engine System'],
+            ]]],
+        ];
+        $this->writeState($state);
 
         $mu_plugins = $this->fsRoot . '/wp-content/mu-plugins';
         mkdir($mu_plugins . '/wpengine-common', 0755, true);
         mkdir($mu_plugins . '/wpe-update-source-selector', 0755, true);
-        file_put_contents($mu_plugins . '/mu-plugin.php', "<?php // WP Engine loader\n");
+        file_put_contents($mu_plugins . '/mu-plugin.php', "<?php\n/* Plugin Name: WP Engine System */\n");
         file_put_contents($mu_plugins . '/stop-long-comments.php', "<?php // WP Engine comment guard\n");
         file_put_contents($mu_plugins . '/my-custom-plugin.php', "<?php // custom\n");
 

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -724,6 +724,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     // ---- WP Engine-specific tests ----
 
+    /** Remove a recognized loader with its package so the remaining MU plugins still boot. */
     public function testCopiedWpengineLoaderDoesNotRequireRemovedPackageAfterCleanup(): void
     {
         $state = $this->preflightWithoutWpcloudSignals('/var/www/html');
@@ -782,6 +783,7 @@ class ProductionDropInRemovalTest extends TestCase
         $this->assertSame($custom_plugin, file_get_contents($mu_plugins . '/mu-plugin.php'));
     }
 
+    /** A public header selects the shared loader while unrelated customer code stays. */
     public function testWpengineRemovesPlatformMuPluginsAndPreservesCustomMuPlugins(): void
     {
         $state = $this->preflightWithoutWpcloudSignals('/nas/content/live/example');

--- a/tests/Import/WpengineHostAnalyzerTest.php
+++ b/tests/Import/WpengineHostAnalyzerTest.php
@@ -88,6 +88,7 @@ class WpengineHostAnalyzerTest extends TestCase {
         $this->assertSame(0.0, \WpengineHostAnalyzer::score($preflight));
     }
 
+    /** A current platform path excludes cache drop-ins, not a generic loader without headers. */
     public function testWpenginePathsAreExcludedFromTheImport(): void
     {
         $preflight = $this->wpenginePreflight([

--- a/tests/Import/WpengineHostAnalyzerTest.php
+++ b/tests/Import/WpengineHostAnalyzerTest.php
@@ -45,7 +45,7 @@ class WpengineHostAnalyzerTest extends TestCase {
         $this->assertGreaterThanOrEqual(0.5, \WpengineHostAnalyzer::score($preflight));
     }
 
-    /** WordPress can live behind a different nginx entry path. */
+    /** WordPress's ABSPATH can identify WP Engine when the web server's entry paths do not. */
     public function testScoreIdentifiesCurrentWpengineWordpressRoot(): void
     {
         $preflight = $this->wpenginePreflight();
@@ -88,7 +88,7 @@ class WpengineHostAnalyzerTest extends TestCase {
         $this->assertSame(0.0, \WpengineHostAnalyzer::score($preflight));
     }
 
-    /** A current platform path excludes cache drop-ins, not a generic loader without headers. */
+    /** Current host paths identify generic cache drop-ins but do not identify the contents of mu-plugin.php. */
     public function testWpenginePathsAreExcludedFromTheImport(): void
     {
         $preflight = $this->wpenginePreflight([

--- a/tests/Import/WpengineHostAnalyzerTest.php
+++ b/tests/Import/WpengineHostAnalyzerTest.php
@@ -45,6 +45,14 @@ class WpengineHostAnalyzerTest extends TestCase {
         $this->assertGreaterThanOrEqual(0.5, \WpengineHostAnalyzer::score($preflight));
     }
 
+    /** WordPress can live behind a different nginx entry path. */
+    public function testScoreIdentifiesCurrentWpengineWordpressRoot(): void
+    {
+        $preflight = $this->wpenginePreflight();
+        $preflight['database']['wp']['paths_urls']['abspath'] = '/nas/wp/www/my-site/';
+        $this->assertGreaterThanOrEqual(0.5, \WpengineHostAnalyzer::score($preflight));
+    }
+
     public function testDetectHostReturnsWpengine(): void
     {
         $preflight = $this->wpenginePreflight([
@@ -90,6 +98,6 @@ class WpengineHostAnalyzerTest extends TestCase {
         $excluded_local_paths = array_column($excluded_plugins, 'local_path');
         $this->assertContains('wp-content/advanced-cache.php', $excluded_local_paths);
         $this->assertContains('wp-content/object-cache.php', $excluded_local_paths);
-        $this->assertContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
+        $this->assertNotContains('wp-content/mu-plugins/mu-plugin.php', $excluded_local_paths);
     }
 }

--- a/tests/e2e/lib/migrated-wordpress.js
+++ b/tests/e2e/lib/migrated-wordpress.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { openSync, closeSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { once } from 'node:events';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { runImporter, createTempDir, cleanupTempDir, getSiteUrl, getSiteDir, getSiteSecret } from './test-helpers.js';
+
+/** Pull a real WordPress site, serve its generated runtime, and inspect it before cleanup. */
+export async function withMigratedWordPress(site, inspect) {
+    const temporaryDirectory = createTempDir(`e2e-migrated-${site}`);
+    const flatDirectory = join(temporaryDirectory, 'flat');
+    const runtimeDirectory = join(temporaryDirectory, 'runtime');
+    const importUrl = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    let server;
+    try {
+        const listener = createServer();
+        listener.listen(0, '127.0.0.1');
+        await once(listener, 'listening');
+        const port = listener.address().port;
+        await new Promise((resolve, reject) => listener.close(error => error ? reject(error) : resolve()));
+        const targetUrl = `http://localhost:${port}`;
+        const result = runImporter(importUrl, temporaryDirectory, 'pull', {
+            secret: getSiteSecret(site), skipPreflight: true, autoResume: false, timeout: 180000,
+            extraArgs: [
+                '--runtime=php-builtin', '--start-runtime=none', '--target-engine=sqlite',
+                `--new-site-url=${targetUrl}`, `--flatten-to=${flatDirectory}`, `--output-dir=${runtimeDirectory}`,
+            ],
+        });
+        assert.equal(result.exitCode, 0, `Pull failed:\n${result.stdout}\n${result.stderr}`);
+
+        const serverLog = join(temporaryDirectory, 'target-server.log');
+        const log = openSync(serverLog, 'a');
+        // Even when the importer uses Playground, the generated php-builtin
+        // runtime is served by native PHP, as it would be on the target host.
+        server = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', flatDirectory, join(runtimeDirectory, 'runtime.php')], {
+            stdio: ['ignore', log, log],
+        });
+        closeSync(log);
+        let response;
+        const deadline = Date.now() + 10000;
+        while (Date.now() < deadline && server.exitCode === null) {
+            try {
+                response = await fetch(targetUrl, { redirect: 'manual', signal: AbortSignal.timeout(5000) });
+                break;
+            } catch {
+                await sleep(50);
+            }
+        }
+        assert.ok(response, `Target did not listen:\n${readFileSync(serverLog, 'utf8').slice(-4000)}`);
+        const html = await response.text();
+        assert.equal(response.status, 200,
+            `Target returned HTTP ${response.status}, Location: ${response.headers.get('location')}\n${html.slice(0, 1000)}\n${readFileSync(serverLog, 'utf8').slice(-4000)}`);
+        assert.ok(html.includes('Hello world!'), 'The target must render the migrated WordPress post');
+        await inspect({ temporaryDirectory, flatDirectory, runtimeDirectory, importUrl, targetUrl, result, html });
+    } finally {
+        if (server && server.exitCode === null) {
+            const exited = once(server, 'exit');
+            server.kill();
+            await exited;
+        }
+        cleanupTempDir(temporaryDirectory);
+    }
+}

--- a/tests/e2e/lib/migrated-wordpress.js
+++ b/tests/e2e/lib/migrated-wordpress.js
@@ -7,7 +7,12 @@ import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { runImporter, createTempDir, cleanupTempDir, getSiteUrl, getSiteDir, getSiteSecret } from './test-helpers.js';
 
-/** Pull a real WordPress site, serve its generated runtime, and inspect it before cleanup. */
+/**
+ * Migrates a source WordPress site to SQLite and serves the generated PHP runtime.
+ * Calls inspect with the CLI result, target HTML, and paths only after the target
+ * renders the migrated post. The server and temporary files stay available until
+ * inspect finishes; both are cleaned up even if migration or assertions fail.
+ */
 export async function withMigratedWordPress(site, inspect) {
     const temporaryDirectory = createTempDir(`e2e-migrated-${site}`);
     const flatDirectory = join(temporaryDirectory, 'flat');
@@ -32,8 +37,9 @@ export async function withMigratedWordPress(site, inspect) {
 
         const serverLog = join(temporaryDirectory, 'target-server.log');
         const log = openSync(serverLog, 'a');
-        // Even when the importer uses Playground, the generated php-builtin
-        // runtime is served by native PHP, as it would be on the target host.
+        // PHP_BINARY selects the importer under test and may be a Playground
+        // wrapper. The requested php-builtin target needs a native PHP server,
+        // so do not reuse that importer command to serve the migrated site.
         server = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', flatDirectory, join(runtimeDirectory, 'runtime.php')], {
             stdio: ['ignore', log, log],
         });

--- a/tests/e2e/lib/site-setup.js
+++ b/tests/e2e/lib/site-setup.js
@@ -167,6 +167,7 @@ function createSampleFiles(siteDir) {
  * Idempotent site creation. Creates WP files, DB via wp core install, plugin files.
  *
  * Options:
+ *   directory: absolute site directory (default: SITE_ROOT/name) — set before WordPress first loads
  *   db: 'standard' (default) | 'none' | 'custom'
  *   files: 'sample' (default) | 'none'
  *   customDb: async (dbName, conn) => {} — adds extra tables on top of real WP tables
@@ -177,7 +178,7 @@ function createSampleFiles(siteDir) {
  *   afterPermissions: async (siteDir) => {} — runs after final chown/chmod (for chmod 000 etc.)
  */
 export async function ensureSite(name, options = {}) {
-    const siteDir = join(SITE_ROOT, name);
+    const siteDir = options.directory || join(SITE_ROOT, name);
     const markerPath = join(siteDir, MARKER);
 
     if (existsSync(markerPath)) {

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -119,6 +119,15 @@
     "siteground-plugins": {
       "port": 8117
     },
+    "wpengine-recognized-loader": {
+      "port": 8147
+    },
+    "wpengine-customer-loader": {
+      "port": 8148
+    },
+    "wpengine-copied-plugins": {
+      "port": 8149
+    },
     "plugin-auth": {
       "port": 8119
     },

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -123,7 +123,7 @@
       "port": 8147
     },
     "wpengine-customer-loader": {
-      "port": 8148
+      "port": 8153
     },
     "wpengine-copied-plugins": {
       "port": 8149

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -416,9 +416,11 @@ describe.each([
     });
 });
 
-// Use harmless PHP fixtures, not the real host services. The same complete tree
-// is installed on the source and as stale local files before apply-runtime.
-// Regular plugins have valid plugin headers so WordPress recognizes them.
+/**
+ * Use harmless PHP fixtures, not the real host services. The same complete tree
+ * is installed on the source and as stale local files before apply-runtime.
+ * Regular plugins have valid plugin headers so WordPress recognizes them.
+ */
 function writeExcludedPluginFiles(root, paths) {
     for (const path of paths) {
         const absolutePath = join(root, path);

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -429,7 +429,7 @@ function writeExcludedPluginFiles(root, paths) {
         if (path.endsWith('.php')) {
             mkdirSync(dirname(absolutePath), { recursive: true });
             const contents = path.endsWith('/mu-plugin.php')
-                ? "<?php require_once __DIR__ . '/wpengine-common/plugin.php';"
+                ? "<?php\n/* Plugin Name: WP Engine System */\nrequire_once __DIR__ . '/wpengine-common/plugin.php';"
                 : '<?php // Source-host MU-plugin fixture';
             writeFileSync(absolutePath, contents);
         } else {

--- a/tests/e2e/tests/import-45-siteground-plugins.test.js
+++ b/tests/e2e/tests/import-45-siteground-plugins.test.js
@@ -417,9 +417,11 @@ describe.each([
 });
 
 /**
- * Use harmless PHP fixtures, not the real host services. The same complete tree
- * is installed on the source and as stale local files before apply-runtime.
- * Regular plugins have valid plugin headers so WordPress recognizes them.
+ * Creates host-plugin fixtures without requiring the hosting platform's services.
+ * Tests use the same tree on the source to check download exclusions and on the
+ * target to check cleanup of files already present before apply-runtime. Plugin
+ * headers let WordPress discover regular plugins; the MU loader requires its
+ * package so removing only that package would leave a broken dependency.
  */
 function writeExcludedPluginFiles(root, paths) {
     for (const path of paths) {

--- a/tests/e2e/tests/import-69-host-file-identification.test.js
+++ b/tests/e2e/tests/import-69-host-file-identification.test.js
@@ -1,11 +1,11 @@
 /** Exercise real preflight and cleanup with platform, customer, and copied host files. */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { ensureSite } from '../lib/site-setup.js';
-import { getSiteDir, getSiteUrl, pullStateDirectory } from '../lib/test-helpers.js';
+import { apiRequest, getSiteDir, getSiteUrl, pullStateDirectory } from '../lib/test-helpers.js';
 import { withMigratedWordPress } from '../lib/migrated-wordpress.js';
 
 describe('Import: identify host files before removal', () => {
@@ -114,5 +114,31 @@ require_once __DIR__ . '/wpengine-common/bootstrap.php';
             assert.ok(html.includes('CUSTOMER_DEPENDENCY_RUNNING'));
             assert.ok(html.includes('PORTABLE_PLUGIN_RUNNING'));
         });
+    }, 240000);
+
+    it('migrates a working MU plugin whose public name contains Windows-1252 bytes', async () => {
+        const site = sites[2];
+        const sourcePath = join(getSiteDir(site), 'wp-content/mu-plugins/legacy-customer.php');
+        const plugin = Buffer.from(`<?php
+/** Plugin Name: Café customer tools */
+add_action('wp_footer', function () { echo '<p>LEGACY_CUSTOMER_RUNNING</p>'; });
+`, 'latin1');
+        writeFileSync(sourcePath, plugin);
+        try {
+            const source = await fetch(new URL(getSiteUrl(site)).origin);
+            assert.equal(source.status, 200);
+            assert.ok((await source.text()).includes('LEGACY_CUSTOMER_RUNNING'));
+            const preflight = await apiRequest(site, 'preflight');
+            assert.equal(preflight.status, 200, JSON.stringify(preflight.json));
+            const plugins = preflight.json.wp_content.roots.flatMap(root => root.mu_plugins);
+            assert.deepEqual(plugins.find(entry => entry.name === 'legacy-customer.php').headers, []);
+            await withMigratedWordPress(site, ({ flatDirectory, html }) => {
+                assert.deepEqual(readFileSync(join(flatDirectory, 'wp-content/mu-plugins/legacy-customer.php')), plugin);
+                assert.ok(html.includes('LEGACY_CUSTOMER_RUNNING'));
+                assert.deepEqual(readFileSync(sourcePath), plugin);
+            });
+        } finally {
+            unlinkSync(sourcePath);
+        }
     }, 240000);
 });

--- a/tests/e2e/tests/import-69-host-file-identification.test.js
+++ b/tests/e2e/tests/import-69-host-file-identification.test.js
@@ -1,7 +1,7 @@
 /** Exercise real preflight and cleanup with platform, customer, and copied host files. */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { ensureSite } from '../lib/site-setup.js';
@@ -18,6 +18,11 @@ add_action('wp_footer', function () { echo '<p>PORTABLE_PLUGIN_RUNNING</p>'; });
 /** Plugin Name: Customer site tools */
 add_action('wp_footer', function () { echo '<p>CUSTOMER_LOADER_RUNNING</p>'; });
 `;
+
+    const legacyPlugin = Buffer.from(`<?php
+/** Plugin Name: Café customer tools */
+add_action('wp_footer', function () { echo '<p>LEGACY_CUSTOMER_RUNNING</p>'; });
+`, 'latin1');
 
     beforeAll(async () => {
         for (const site of sites) {
@@ -44,6 +49,9 @@ add_action('wp_footer', function () { echo '<p>CUSTOMER_DEPENDENCY_RUNNING</p>';
 $private_value = 'MU_PLUGIN_CODE_MUST_NOT_ENTER_PREFLIGHT';
 require_once __DIR__ . '/wpengine-common/bootstrap.php';
 `);
+                    }
+                    if (site === sites[2]) {
+                        writeFileSync(join(muPlugins, 'legacy-customer.php'), legacyPlugin);
                     }
                     const plugins = join(siteDirectory, 'wp-content/plugins/portable-cache');
                     mkdirSync(plugins, { recursive: true });
@@ -119,26 +127,17 @@ require_once __DIR__ . '/wpengine-common/bootstrap.php';
     it('migrates a working MU plugin whose public name contains Windows-1252 bytes', async () => {
         const site = sites[2];
         const sourcePath = join(getSiteDir(site), 'wp-content/mu-plugins/legacy-customer.php');
-        const plugin = Buffer.from(`<?php
-/** Plugin Name: Café customer tools */
-add_action('wp_footer', function () { echo '<p>LEGACY_CUSTOMER_RUNNING</p>'; });
-`, 'latin1');
-        writeFileSync(sourcePath, plugin);
-        try {
-            const source = await fetch(new URL(getSiteUrl(site)).origin);
-            assert.equal(source.status, 200);
-            assert.ok((await source.text()).includes('LEGACY_CUSTOMER_RUNNING'));
-            const preflight = await apiRequest(site, 'preflight');
-            assert.equal(preflight.status, 200, JSON.stringify(preflight.json));
-            const plugins = preflight.json.wp_content.roots.flatMap(root => root.mu_plugins);
-            assert.deepEqual(plugins.find(entry => entry.name === 'legacy-customer.php').headers, []);
-            await withMigratedWordPress(site, ({ flatDirectory, html }) => {
-                assert.deepEqual(readFileSync(join(flatDirectory, 'wp-content/mu-plugins/legacy-customer.php')), plugin);
-                assert.ok(html.includes('LEGACY_CUSTOMER_RUNNING'));
-                assert.deepEqual(readFileSync(sourcePath), plugin);
-            });
-        } finally {
-            unlinkSync(sourcePath);
-        }
+        const source = await fetch(new URL(getSiteUrl(site)).origin);
+        assert.equal(source.status, 200);
+        assert.ok((await source.text()).includes('LEGACY_CUSTOMER_RUNNING'));
+        const preflight = await apiRequest(site, 'preflight');
+        assert.equal(preflight.status, 200, JSON.stringify(preflight.json));
+        const plugins = preflight.json.wp_content.roots.flatMap(root => root.mu_plugins);
+        assert.deepEqual(plugins.find(entry => entry.name === 'legacy-customer.php').headers, []);
+        await withMigratedWordPress(site, ({ flatDirectory, html }) => {
+            assert.deepEqual(readFileSync(join(flatDirectory, 'wp-content/mu-plugins/legacy-customer.php')), legacyPlugin);
+            assert.ok(html.includes('LEGACY_CUSTOMER_RUNNING'));
+            assert.deepEqual(readFileSync(sourcePath), legacyPlugin);
+        });
     }, 240000);
 });

--- a/tests/e2e/tests/import-69-host-file-identification.test.js
+++ b/tests/e2e/tests/import-69-host-file-identification.test.js
@@ -1,0 +1,118 @@
+/** Exercise real preflight and cleanup with platform, customer, and copied host files. */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { ensureSite } from '../lib/site-setup.js';
+import { getSiteDir, getSiteUrl, pullStateDirectory } from '../lib/test-helpers.js';
+import { withMigratedWordPress } from '../lib/migrated-wordpress.js';
+
+describe('Import: identify host files before removal', () => {
+    const sites = ['wpengine-recognized-loader', 'wpengine-customer-loader', 'wpengine-copied-plugins'];
+    const portablePlugin = `<?php
+/** Plugin Name: Portable customer cache */
+add_action('wp_footer', function () { echo '<p>PORTABLE_PLUGIN_RUNNING</p>'; });
+`;
+    const customerLoader = `<?php
+/** Plugin Name: Customer site tools */
+add_action('wp_footer', function () { echo '<p>CUSTOMER_LOADER_RUNNING</p>'; });
+`;
+
+    beforeAll(async () => {
+        for (const site of sites) {
+            await ensureSite(site, {
+                files: 'none',
+                afterCreate: async (siteDirectory) => {
+                    const muPlugins = join(siteDirectory, 'wp-content/mu-plugins');
+                    mkdirSync(join(muPlugins, 'wpengine-common'), { recursive: true });
+                    const recognized = site === sites[0];
+                    const bootstrap = recognized
+                        ? `<?php
+if (strpos(ABSPATH, '/nas/') !== 0) { throw new RuntimeException('PLATFORM_LOADER_LEFT_ON_TARGET'); }
+add_action('wp_footer', function () { echo '<p>PLATFORM_LOADER_RUNNING</p>'; });
+`
+                        : `<?php
+add_action('wp_footer', function () { echo '<p>CUSTOMER_DEPENDENCY_RUNNING</p>'; });
+`;
+                    writeFileSync(join(muPlugins, 'wpengine-common/bootstrap.php'), bootstrap);
+                    writeFileSync(join(muPlugins, 'mu-plugin.php'), customerLoader
+                        + (recognized ? '' : "require_once __DIR__ . '/wpengine-common/bootstrap.php';\n"));
+                    if (recognized) {
+                        writeFileSync(join(muPlugins, 'renamed-platform-loader.php'), `<?php
+/** Plugin Name: WP Engine System */
+$private_value = 'MU_PLUGIN_CODE_MUST_NOT_ENTER_PREFLIGHT';
+require_once __DIR__ . '/wpengine-common/bootstrap.php';
+`);
+                    }
+                    const plugins = join(siteDirectory, 'wp-content/plugins/portable-cache');
+                    mkdirSync(plugins, { recursive: true });
+                    writeFileSync(join(plugins, 'portable-cache.php'), portablePlugin);
+                },
+                afterPermissions: async (siteDirectory) => {
+                    if (site !== sites[2]) {
+                        // Keep nginx's configured entry path, but put WordPress
+                        // on a real WP Engine-style filesystem path. Preflight
+                        // must discover it over HTTP; no saved state is edited.
+                        const parent = site === sites[0] ? '/nas/content/live' : '/nas/wp/www';
+                        const physicalDirectory = join(parent, `e2e-${site}`);
+                        execFileSync('sudo', ['mkdir', '-p', parent]);
+                        execFileSync('sudo', ['mv', siteDirectory, physicalDirectory]);
+                        execFileSync('sudo', ['ln', '-s', physicalDirectory, siteDirectory]);
+                    }
+                    execFileSync(process.env.E2E_WP_CLI_PHP_BINARY || 'php', [
+                        '/tmp/wp-cli.phar', 'plugin', 'activate', 'portable-cache', `--path=${realpathSync(siteDirectory)}`,
+                        ...(process.getuid?.() === 0 ? ['--allow-root'] : []),
+                    ], { timeout: 60000, stdio: 'pipe' });
+                },
+            });
+        }
+    });
+
+    it('removes the renamed platform loader but keeps customer code and an active portable plugin', async () => {
+        const source = await fetch(new URL(getSiteUrl(sites[0])).origin);
+        assert.equal(source.status, 200);
+        assert.ok((await source.text()).includes('PLATFORM_LOADER_RUNNING'), 'The source platform loader must actually run');
+        await withMigratedWordPress(sites[0], ({ temporaryDirectory, flatDirectory, importUrl, html }) => {
+            const state = JSON.parse(readFileSync(join(pullStateDirectory(temporaryDirectory, importUrl), 'state.json'), 'utf8'));
+            assert.equal(state.webhost, 'wpengine');
+            const plugins = state.preflight.data.wp_content.roots.flatMap(root => root.mu_plugins);
+            assert.equal(plugins.find(plugin => plugin.name === 'renamed-platform-loader.php').headers.name, 'WP Engine System');
+            assert.ok(!JSON.stringify(state.preflight.data).includes('MU_PLUGIN_CODE_MUST_NOT_ENTER_PREFLIGHT'));
+            const muPlugins = join(flatDirectory, 'wp-content/mu-plugins');
+            assert.ok(!existsSync(join(muPlugins, 'renamed-platform-loader.php')));
+            assert.ok(!existsSync(join(muPlugins, 'wpengine-common')));
+            assert.equal(readFileSync(join(muPlugins, 'mu-plugin.php'), 'utf8'), customerLoader);
+            assert.equal(readFileSync(join(flatDirectory, 'wp-content/plugins/portable-cache/portable-cache.php'), 'utf8'), portablePlugin);
+            assert.ok(html.includes('CUSTOMER_LOADER_RUNNING'));
+            assert.ok(html.includes('PORTABLE_PLUGIN_RUNNING'), 'The portable plugin must stay active, not merely remain on disk');
+            assert.ok(!html.includes('PLATFORM_LOADER_RUNNING'));
+            assert.ok(existsSync(join(getSiteDir(sites[0]), 'wp-content/mu-plugins/renamed-platform-loader.php')));
+        });
+    }, 240000);
+
+    it('keeps an unknown loader and its dependency together on WP Engine', async () => {
+        await withMigratedWordPress(sites[1], ({ temporaryDirectory, flatDirectory, importUrl, html }) => {
+            const state = JSON.parse(readFileSync(join(pullStateDirectory(temporaryDirectory, importUrl), 'state.json'), 'utf8'));
+            assert.equal(state.webhost, 'wpengine');
+            for (const path of ['mu-plugin.php', 'wpengine-common/bootstrap.php']) {
+                assert.equal(readFileSync(join(flatDirectory, 'wp-content/mu-plugins', path), 'utf8'),
+                    readFileSync(join(getSiteDir(sites[1]), 'wp-content/mu-plugins', path), 'utf8'));
+            }
+            assert.ok(html.includes('CUSTOMER_LOADER_RUNNING'));
+            assert.ok(html.includes('CUSTOMER_DEPENDENCY_RUNNING'), 'Keeping a loader without its required file would break this request');
+            assert.ok(html.includes('PORTABLE_PLUGIN_RUNNING'));
+        });
+    }, 240000);
+
+    it('does not mistake copied WP Engine filenames on another host for the current host', async () => {
+        await withMigratedWordPress(sites[2], ({ temporaryDirectory, flatDirectory, importUrl, html }) => {
+            const state = JSON.parse(readFileSync(join(pullStateDirectory(temporaryDirectory, importUrl), 'state.json'), 'utf8'));
+            assert.equal(state.webhost, 'other');
+            assert.ok(existsSync(join(flatDirectory, 'wp-content/mu-plugins/wpengine-common/bootstrap.php')));
+            assert.ok(html.includes('CUSTOMER_LOADER_RUNNING'));
+            assert.ok(html.includes('CUSTOMER_DEPENDENCY_RUNNING'));
+            assert.ok(html.includes('PORTABLE_PLUGIN_RUNNING'));
+        });
+    }, 240000);
+});

--- a/tests/e2e/tests/import-69-host-file-identification.test.js
+++ b/tests/e2e/tests/import-69-host-file-identification.test.js
@@ -31,7 +31,10 @@ add_action('wp_footer', function () { echo '<p>LEGACY_CUSTOMER_RUNNING</p>'; });
 
     beforeAll(async () => {
         for (const site of sites) {
+            const parent = site === sites[0] ? '/nas/content/live' : '/nas/wp/www';
+            const physicalDirectory = site === sites[2] ? getSiteDir(site) : join(parent, `e2e-${site}`);
             await ensureSite(site, {
+                directory: physicalDirectory,
                 files: 'none',
                 afterCreate: async (siteDirectory) => {
                     const muPlugins = join(siteDirectory, 'wp-content/mu-plugins');
@@ -64,16 +67,12 @@ require_once __DIR__ . '/wpengine-common/bootstrap.php';
                 },
                 afterPermissions: async (siteDirectory) => {
                     if (site !== sites[2]) {
-                        // Move WordPress under /nas and leave a symlink at nginx's
-                        // configured document root. The source URL stays usable,
-                        // but preflight must discover WordPress's physical path
-                        // to identify WP Engine. The state comes from that HTTP
-                        // inspection, not a test-written host label.
-                        const parent = site === sites[0] ? '/nas/content/live' : '/nas/wp/www';
-                        const physicalDirectory = join(parent, `e2e-${site}`);
-                        execFileSync('sudo', ['mkdir', '-p', parent]);
-                        execFileSync('sudo', ['mv', siteDirectory, physicalDirectory]);
-                        execFileSync('sudo', ['ln', '-s', physicalDirectory, siteDirectory]);
+                        // Keep nginx's document root outside /nas. Preflight must
+                        // discover WordPress's physical path through HTTP, rather
+                        // than read a test-written host label. Create WordPress
+                        // at that final path before installation: moving loaded
+                        // PHP files can leave cached code using the old paths.
+                        execFileSync('sudo', ['ln', '-s', siteDirectory, getSiteDir(site)]);
                     }
                     execFileSync(process.env.E2E_WP_CLI_PHP_BINARY || 'php', [
                         '/tmp/wp-cli.phar', 'plugin', 'activate', 'portable-cache', `--path=${realpathSync(siteDirectory)}`,

--- a/tests/e2e/tests/import-69-host-file-identification.test.js
+++ b/tests/e2e/tests/import-69-host-file-identification.test.js
@@ -1,4 +1,9 @@
-/** Exercise real preflight and cleanup with platform, customer, and copied host files. */
+/**
+ * Checks host detection and file removal through full WordPress migrations.
+ * Source paths identify the current host; public headers identify removable
+ * platform loaders. Target HTTP responses check that retained customer plugins
+ * still run, including when their filenames resemble WP Engine components.
+ */
 import { describe, it, beforeAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
@@ -59,9 +64,11 @@ require_once __DIR__ . '/wpengine-common/bootstrap.php';
                 },
                 afterPermissions: async (siteDirectory) => {
                     if (site !== sites[2]) {
-                        // Keep nginx's configured entry path, but put WordPress
-                        // on a real WP Engine-style filesystem path. Preflight
-                        // must discover it over HTTP; no saved state is edited.
+                        // Move WordPress under /nas and leave a symlink at nginx's
+                        // configured document root. The source URL stays usable,
+                        // but preflight must discover WordPress's physical path
+                        // to identify WP Engine. The state comes from that HTTP
+                        // inspection, not a test-written host label.
                         const parent = site === sites[0] ? '/nas/content/live' : '/nas/wp/www';
                         const physicalDirectory = join(parent, `e2e-${site}`);
                         execFileSync('sudo', ['mkdir', '-p', parent]);


### PR DESCRIPTION
Imports exclude the WP Engine System loader under its actual filename, while keeping an unrecognized `mu-plugin.php` and its `wpengine-common` directory together.

Preflight reads the public Plugin Name field from the first 8 KiB of each MU-plugin file without executing it or returning its code. WP Engine documents this loader as [WP Engine System](https://wpengine.com/support/platform-settings/). Exporters without header metadata leave the ambiguous files in place. The check runs in trunk's shared exclusion list, so it covers both download filtering and stale local files removed during runtime setup.

Host detection also checks the WordPress absolute path. This identifies a site whose WordPress files live under `/nas/content/live/` or `/nas/wp/www/` behind a different web-server entry path. Copied plugin filenames do not identify the current host.

The E2E tests run full CLI migrations from real WordPress sources, then serve the generated target runtime. They cover a renamed platform loader, a customer loader which requires the shared directory, and copied filenames on another host. Target pages must load and run the retained customer code and active portable plugin. The existing full source-host inventory E2E also runs with a properly identified WP Engine loader. After rebasing onto trunk `0282871d`, all 46 cases pass locally as a non-root user, alongside 47 focused PHP tests and PHPStan. The rebase keeps trunk's separate pull and runtime-cleanup choices, and portable plugins remain installed.

Running the same three new E2Es with trunk `6a0746c6` instead fails at the target HTTP 500, missing customer loader, and missing copied package assertions. No saved import state is edited to produce those failures.

A working MU plugin with a Windows-1252 `Café` header no longer makes preflight return HTTP 500. Preflight omits a name it cannot encode as UTF-8 instead of guessing its encoding; the plugin file is copied unchanged. The added E2E verifies the source plugin runs, preflight returns HTTP 200, and the migrated plugin still runs with identical file bytes. It fails at the HTTP 200 assertion before this change. Unit tests also cover valid UTF-8 and a multibyte character split by the 8 KiB header limit.
