### PR TITLE
[Tests] Wait for MySQL TCP readiness before starting E2E tests

### DIFF
--- a/tests/e2e/ci/start-mysql8-target.sh
+++ b/tests/e2e/ci/start-mysql8-target.sh
@@ -12,12 +12,16 @@ docker run --detach --name "$container" \
     --publish "127.0.0.1:${port}:3306" \
     mysql:8.0
 
+# The image first starts a socket-only server to initialize the database, then
+# shuts it down. Use TCP so readiness waits for the final server, not that
+# temporary server disappearing between this probe and the version query.
 ready=0
 for _attempt in $(seq 1 60); do
     if docker exec \
         --env MYSQL_PWD="$root_password" \
         "$container" \
-        mysql --user=root --execute='SELECT 1' >/dev/null 2>&1; then
+        mysql --protocol=TCP --host=127.0.0.1 \
+        --user=root --execute='SELECT 1' >/dev/null 2>&1; then
         ready=1
         break
     fi
@@ -34,7 +38,8 @@ version="$({
     docker exec \
         --env MYSQL_PWD="$root_password" \
         "$container" \
-        mysql --user=root --batch --skip-column-names --execute='SELECT VERSION()'
+        mysql --protocol=TCP --host=127.0.0.1 \
+        --user=root --batch --skip-column-names --execute='SELECT VERSION()'
 } 2>/dev/null)"
 if [[ "$version" != 8.0.* ]] || [[ "$version" == *MariaDB* ]]; then
     echo "Expected Oracle MySQL 8.0, got ${version}." >&2


### PR DESCRIPTION
The E2E setup now waits for MySQL's final TCP server before declaring the Oracle MySQL 8 target ready.

[Trunk's PHP 8.2 job](https://github.com/WordPress/reprint/actions/runs/34038311258/job/101500443477) exited during setup while the MySQL image was stopping its temporary initialization server. The readiness probe used a local socket, so that temporary server could satisfy `SELECT 1` and disappear before the version query.

Use TCP on `127.0.0.1` for both queries. The image starts its temporary server with `--skip-networking`, so only the final server can pass. The existing wait limit stays unchanged; no retries are added to the E2E tests.

## Testing

With an eight-second SQL initializer in a disposable MySQL 8.0.46 container, the old script declared readiness before initialization finished. The changed script waited for initialization to finish and accepted a TCP query afterward. Three fresh starts with the unmodified MySQL image also passed. Shell syntax, PHPStan, and the whitespace check passed.


All 29 CI checks passed on `7cbeefc8`. The [PHP 8.2 E2E job](https://github.com/WordPress/reprint/actions/runs/34038817101/job/101501800842) completed MySQL startup and all three cross-engine migration cases.
