### PR TITLE
[Tests] Measure index sort memory without counting file cache

### DIFF
--- a/packages/reprint-client/src/lib/sort-index-file.php
+++ b/packages/reprint-client/src/lib/sort-index-file.php
@@ -139,8 +139,9 @@ function try_exec_sort_index_file(
     fclose($input);
     fclose($output);
 
+    // A host's memory limit can also count cached temporary-file data.
     $command =
-        'LC_ALL=C sort -S 32M --parallel=1 -T ' .
+        'LC_ALL=C sort -S 8M --parallel=1 -T ' .
         escapeshellarg(dirname($path)) .
         " -t '\t' -k1,1 " .
         escapeshellarg($keyed) .

--- a/packages/reprint-client/src/lib/sort-index-file.php
+++ b/packages/reprint-client/src/lib/sort-index-file.php
@@ -139,9 +139,8 @@ function try_exec_sort_index_file(
     fclose($input);
     fclose($output);
 
-    // A host's memory limit can also count cached temporary-file data.
     $command =
-        'LC_ALL=C sort -S 8M --parallel=1 -T ' .
+        'LC_ALL=C sort -S 32M --parallel=1 -T ' .
         escapeshellarg(dirname($path)) .
         " -t '\t' -k1,1 " .
         escapeshellarg($keyed) .

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -74,7 +74,7 @@ final class SortIndexFileTest extends TestCase
         $this->assertIsArray($arguments);
         $buffer_size_option = array_search('-S', $arguments, true);
         $this->assertIsInt($buffer_size_option);
-        $this->assertSame('8M', $arguments[$buffer_size_option + 1]);
+        $this->assertSame('32M', $arguments[$buffer_size_option + 1]);
         $this->assertContains('--parallel=1', $arguments);
         $temporary_directory_option = array_search('-T', $arguments, true);
         $this->assertIsInt($temporary_directory_option);
@@ -131,18 +131,22 @@ final class SortIndexFileTest extends TestCase
         fclose($input);
         $input_size = filesize($path);
         $this->assertIsInt($input_size);
-        $this->assertGreaterThan(64 * 1024 * 1024, $input_size);
+        $this->assertGreaterThan(128 * 1024 * 1024, $input_size);
 
         // The PHPUnit workflow already pulls this image for its MariaDB
-        // service. Run only GNU sort in a 64 MiB cgroup so the limit includes
-        // the complete child process, as it does on a constrained host.
+        // service. The cgroup counts the complete child process and file
+        // cache, not just sort's 32 MiB buffer. Leave cache headroom at
+        // 128 MiB; the input itself exceeds that limit so an in-memory
+        // sort still fails.
+        $container_name = 'reprint-sort-memory-' . uniqid();
         $sort_directory = $this->temporary_directory . '/memory-limited-sort-bin';
         mkdir($sort_directory);
         file_put_contents(
             $sort_directory . '/sort',
             "#!/bin/sh\nexec " . escapeshellarg($docker_path)
-                . " run --rm --network=none"
-                . " --memory=64m --memory-swap=64m"
+                . " run --network=none --name " . escapeshellarg($container_name)
+                . " --memory=128m --memory-swap=128m"
+                . " --env LC_ALL"
                 . ' -v ' . escapeshellarg(
                     $this->temporary_directory . ':' . $this->temporary_directory
                 )
@@ -153,16 +157,29 @@ final class SortIndexFileTest extends TestCase
         $original_path = getenv('PATH');
         putenv('PATH=' . $sort_directory . ':' . $original_path);
         try {
+            $completed = try_exec_sort_index_file(
+                $path,
+                $path . '.sorted',
+                fn(string $line): ?string => $this->index_path_from_line($line)
+            );
+            $container_state = [];
+            exec(
+                escapeshellarg($docker_path) . ' inspect --format '
+                    . escapeshellarg('{{json .State}}') . ' '
+                    . escapeshellarg($container_name) . ' 2>&1',
+                $container_state
+            );
             $this->assertTrue(
-                try_exec_sort_index_file(
-                    $path,
-                    $path . '.sorted',
-                    fn(string $line): ?string => $this->index_path_from_line($line)
-                ),
-                'GNU sort must complete while the child process is limited to 64 MiB.'
+                $completed,
+                'GNU sort must complete inside a 128 MiB cgroup. '
+                    . implode("\n", $container_state)
             );
         } finally {
             putenv('PATH=' . $original_path);
+            exec(
+                escapeshellarg($docker_path) . ' rm -f '
+                    . escapeshellarg($container_name) . ' >/dev/null 2>&1'
+            );
         }
 
         $sorted_input = fopen($path, 'r');

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -74,7 +74,7 @@ final class SortIndexFileTest extends TestCase
         $this->assertIsArray($arguments);
         $buffer_size_option = array_search('-S', $arguments, true);
         $this->assertIsInt($buffer_size_option);
-        $this->assertSame('32M', $arguments[$buffer_size_option + 1]);
+        $this->assertSame('8M', $arguments[$buffer_size_option + 1]);
         $this->assertContains('--parallel=1', $arguments);
         $temporary_directory_option = array_search('-T', $arguments, true);
         $this->assertIsInt($temporary_directory_option);
@@ -119,7 +119,7 @@ final class SortIndexFileTest extends TestCase
         $this->assertIsResource($input);
         $path_prefix = '/wp-content/uploads/';
         $path_suffix = '-' . str_repeat('x', 180) . '.jpg';
-        for ($index = 100000; $index >= 1; --$index) {
+        for ($index = 500000; $index >= 1; --$index) {
             fwrite(
                 $input,
                 $this->index_line(
@@ -131,6 +131,7 @@ final class SortIndexFileTest extends TestCase
         fclose($input);
         $input_size = filesize($path);
         $this->assertIsInt($input_size);
+        $this->assertGreaterThan(64 * 1024 * 1024, $input_size);
 
         // The PHPUnit workflow already pulls this image for its MariaDB
         // service. Run only GNU sort in a 64 MiB cgroup so the limit includes

--- a/tests/Import/SortIndexFileTest.php
+++ b/tests/Import/SortIndexFileTest.php
@@ -88,33 +88,18 @@ final class SortIndexFileTest extends TestCase
         );
     }
 
-    public function testSystemSortCompletesInsideTheCiMemoryLimit(): void
+    /**
+     * Check sort's peak process memory without counting cached spill files.
+     */
+    public function testSystemSortKeepsPeakProcessMemoryBelow128MiB(): void
     {
-        if (getenv('GITHUB_ACTIONS') !== 'true' || PHP_VERSION_ID < 80400) {
-            $this->markTestSkipped('The constrained-memory sort runs once in the PHPUnit CI matrix.');
+        if (getenv('GITHUB_ACTIONS') !== 'true' || PHP_VERSION_ID < 80400 || PHP_OS_FAMILY !== 'Linux') {
+            $this->markTestSkipped('The Linux peak-memory sort runs once in the PHPUnit CI matrix.');
         }
 
-        $docker_path_output = [];
-        $docker_path_exit_code = 0;
-        exec('command -v docker', $docker_path_output, $docker_path_exit_code);
-        $this->assertSame(0, $docker_path_exit_code, 'The PHPUnit workflow must provide Docker.');
-        $docker_path = $docker_path_output[0] ?? '';
-        $this->assertNotSame('', $docker_path, 'The PHPUnit workflow must provide Docker.');
+        $this->assertTrue(is_executable('/usr/bin/sort'), 'The PHPUnit workflow must provide GNU sort.');
 
-        $docker_image_output = [];
-        $docker_image_exit_code = 0;
-        exec(
-            escapeshellarg($docker_path) . ' image inspect mariadb:10.11 2>/dev/null',
-            $docker_image_output,
-            $docker_image_exit_code
-        );
-        $this->assertSame(
-            0,
-            $docker_image_exit_code,
-            'The PHPUnit workflow must provide its mariadb:10.11 service image.'
-        );
-
-        $path = $this->temporary_directory . '/constrained-memory-index.jsonl';
+        $path = $this->temporary_directory . '/large-index.jsonl';
         $input = fopen($path, 'w');
         $this->assertIsResource($input);
         $path_prefix = '/wp-content/uploads/';
@@ -133,54 +118,51 @@ final class SortIndexFileTest extends TestCase
         $this->assertIsInt($input_size);
         $this->assertGreaterThan(128 * 1024 * 1024, $input_size);
 
-        // The PHPUnit workflow already pulls this image for its MariaDB
-        // service. The cgroup counts the complete child process and file
-        // cache, not just sort's 32 MiB buffer. Leave cache headroom at
-        // 128 MiB; the input itself exceeds that limit so an in-memory
-        // sort still fails.
-        $container_name = 'reprint-sort-memory-' . uniqid();
-        $sort_directory = $this->temporary_directory . '/memory-limited-sort-bin';
+        // A cgroup also counts cached temporary-file data. Measure peak
+        // process memory instead, without an address-space limit: GNU sort
+        // reads that limit and can shrink its buffer even when -S is missing.
+        // A fresh PHP process keeps earlier PHPUnit children out of getrusage.
+        $measure_sort_memory = <<<'PHP'
+passthru('/usr/bin/sort ' . implode(' ', array_map('escapeshellarg', array_slice($argv, 2))), $exit_code);
+file_put_contents($argv[1], (string) getrusage(1)['ru_maxrss']);
+exit($exit_code);
+PHP;
+        $memory_usage_path = $this->temporary_directory . '/sort-peak-memory-kib';
+        $sort_directory = $this->temporary_directory . '/measured-sort-bin';
         mkdir($sort_directory);
         file_put_contents(
             $sort_directory . '/sort',
-            "#!/bin/sh\nexec " . escapeshellarg($docker_path)
-                . " run --network=none --name " . escapeshellarg($container_name)
-                . " --memory=128m --memory-swap=128m"
-                . " --env LC_ALL"
-                . ' -v ' . escapeshellarg(
-                    $this->temporary_directory . ':' . $this->temporary_directory
-                )
-                . " --entrypoint /usr/bin/sort mariadb:10.11 \"$@\"\n"
+            "#!/bin/sh\nexec " . escapeshellarg(PHP_BINARY)
+                . ' -r ' . escapeshellarg($measure_sort_memory)
+                . ' ' . escapeshellarg($memory_usage_path) . " \"$@\"\n"
         );
         chmod($sort_directory . '/sort', 0755);
 
         $original_path = getenv('PATH');
         putenv('PATH=' . $sort_directory . ':' . $original_path);
         try {
-            $completed = try_exec_sort_index_file(
-                $path,
-                $path . '.sorted',
-                fn(string $line): ?string => $this->index_path_from_line($line)
-            );
-            $container_state = [];
-            exec(
-                escapeshellarg($docker_path) . ' inspect --format '
-                    . escapeshellarg('{{json .State}}') . ' '
-                    . escapeshellarg($container_name) . ' 2>&1',
-                $container_state
-            );
             $this->assertTrue(
-                $completed,
-                'GNU sort must complete inside a 128 MiB cgroup. '
-                    . implode("\n", $container_state)
+                try_exec_sort_index_file(
+                    $path,
+                    $path . '.sorted',
+                    fn(string $line): ?string => $this->index_path_from_line($line)
+                ),
+                'GNU sort must complete the large-index sort.'
             );
         } finally {
             putenv('PATH=' . $original_path);
-            exec(
-                escapeshellarg($docker_path) . ' rm -f '
-                    . escapeshellarg($container_name) . ' >/dev/null 2>&1'
-            );
         }
+
+        // Linux reports ru_maxrss in KiB, including process code and data.
+        $peak_memory_kib = file_get_contents($memory_usage_path);
+        $this->assertIsString($peak_memory_kib);
+        $this->assertMatchesRegularExpression('/^[0-9]+$/', $peak_memory_kib);
+        $this->assertGreaterThan(0, (int) $peak_memory_kib);
+        $this->assertLessThan(
+            128 * 1024,
+            (int) $peak_memory_kib,
+            'GNU sort must keep peak process memory below 128 MiB.'
+        );
 
         $sorted_input = fopen($path, 'r');
         $this->assertIsResource($sorted_input);


### PR DESCRIPTION
Checks that GNU sort's peak process memory stays below 128 MiB while sorting 500,000 index entries. The production sort buffer remains 32 MiB.

The Docker memory limit also counted cached temporary-file writes. Both 64 MiB and 128 MiB containers could kill a bounded sort in CI. The test now runs the host's GNU sort through a fresh PHP process and reads the child's peak resident memory with `getrusage(1)`. The fresh process excludes earlier PHPUnit children from the measurement.

No address-space limit is imposed: GNU sort reads that limit and can shrink its buffer even when `-S` is missing. The input itself exceeds 128 MiB, and the test still checks successful sorting and preserved output size. This measures process memory; it does not promise that the entire operation, including file cache, fits a 128 MiB container.

## Testing

All 29 CI checks pass, including the [PHPUnit matrix on PHP 8.1–8.4](https://github.com/WordPress/reprint/actions/runs/34045379671). The PHP 8.4 job runs and passes the peak-memory test.

The focused sorting suite passes in Linux: 8 tests, 34 assertions. The peak-memory test passes ten consecutive runs, and 27 related file-index tests pass. Static analysis passes, and PHPCS counts are unchanged.

Against the implementation before #750, the enlarged test fails at the peak-memory assertion: 419,308 KiB against a 131,072 KiB threshold. Review that assertion together with the unchanged 32 MiB command-argument check.
