### PR TITLE
[PHP] Send ZipWP access cookies with remote API requests

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -34,6 +34,7 @@ use WordPress\Reprint\Server\FileIndexProcessor;
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
+use function Reprint\Importer\apply_zipwp_access_cookie;
 use function Reprint\Importer\register_sqlite_function;
 use function Reprint\Importer\resolve_sqlite_integration_path;
 use function Reprint\Importer\resolve_sqlite_integration_plugin_path;
@@ -11856,6 +11857,7 @@ class ImportClient
         $ch = curl_init($url);
         apply_curl_proxy_from_environment($ch);
         apply_curl_ca_bundle($ch);
+        apply_zipwp_access_cookie($ch, $url);
 
         $headers = [
             ...$this->get_base_headers("application/json"),
@@ -11987,6 +11989,7 @@ class ImportClient
         $ch = curl_init($url);
         apply_curl_proxy_from_environment($ch);
         apply_curl_ca_bundle($ch);
+        apply_zipwp_access_cookie($ch, $url);
 
         $parser = null;
         $current_chunk = null;

--- a/packages/reprint-client/src/lib/import/functions.php
+++ b/packages/reprint-client/src/lib/import/functions.php
@@ -85,6 +85,25 @@ function apply_curl_proxy_from_environment($curl_handle): ?string
 }
 
 /**
+ * Send the cookie set by ZipWP's "continue with temporary site" button.
+ *
+ * @param resource|object $curl_handle            cURL handle to configure.
+ * @param string          $remote_reprint_api_url Remote Reprint API URL.
+ */
+function apply_zipwp_access_cookie($curl_handle, string $remote_reprint_api_url): void
+{
+	$host = parse_url($remote_reprint_api_url, PHP_URL_HOST);
+	if (!is_string($host) || substr(strtolower(rtrim($host, '.')), -9) !== '.zipwp.to') {
+		return;
+	}
+
+	// ZipWP serves an HTML landing page until this cookie is present, even
+	// for API requests. The button uses a random 12-character value. This
+	// cookie does not replace Reprint authentication.
+	curl_setopt($curl_handle, CURLOPT_COOKIE, 'zipwp_access=' . bin2hex(random_bytes(6)));
+}
+
+/**
  * Mirror PHP's `openssl.cafile` ini value onto the cURL handle as
  * `CURLOPT_CAINFO` — workaround for WordPress Playground, where the
  * WASM curl build doesn't honor `curl.cainfo` / `openssl.cafile`

--- a/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
+++ b/packages/reprint-client/src/lib/upload/class-multipart-push-stream-client.php
@@ -2,6 +2,7 @@
 
 use function Reprint\Importer\apply_curl_ca_bundle;
 use function Reprint\Importer\apply_curl_proxy_from_environment;
+use function Reprint\Importer\apply_zipwp_access_cookie;
 use function Reprint\Importer\unsupported_media_type_error_detail;
 use function Reprint\Importer\wordpress_admin_referer;
 
@@ -299,6 +300,7 @@ class MultipartPushStreamClient
         $header_lines[] = 'Expect:';
 
         $this->curl_handle = curl_init($request_url);
+        apply_zipwp_access_cookie($this->curl_handle, $request_url);
         if (function_exists('Reprint\\Importer\\apply_curl_proxy_from_environment')) {
             apply_curl_proxy_from_environment($this->curl_handle);
         }
@@ -833,6 +835,7 @@ class MultipartPushStreamClient
             $lines[] = $name . ': ' . $value;
         }
         $handle = curl_init($url);
+        apply_zipwp_access_cookie($handle, $url);
         if (function_exists('Reprint\\Importer\\apply_curl_proxy_from_environment')) {
             apply_curl_proxy_from_environment($handle);
         }

--- a/tests/Import/ZipwpAccessCookieTest.php
+++ b/tests/Import/ZipwpAccessCookieTest.php
@@ -1,0 +1,197 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Shared importer test namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use Reprint\Importer\StreamingContext;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+final class ZipwpAccessCookieTest extends TestCase {
+
+    private string $root;
+    /** @var resource|null */
+    private $server_process = null;
+    /** @var array<string, string|false> */
+    private array $saved_environment = [];
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/reprint-zipwp-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/remote', 0755, true);
+        $this->root = realpath($this->root);
+        file_put_contents($this->root . '/remote/example.txt', 'temporary site contents');
+
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error);
+        $this->assertIsResource($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-S', $address, __DIR__ . '/fixtures/zipwp-access-router.php'],
+            [0 => ['pipe', 'r'], 1 => ['file', $this->root . '/server.log', 'a'], 2 => ['file', $this->root . '/server.log', 'a']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($this->server_process);
+        fclose($pipes[0]);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $error_number, $error, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                break;
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $this->assertNotFalse($connection, file_get_contents($this->root . '/server.log'));
+
+        // Send the real clients to our local PHP router without changing DNS
+        // or adding a transport override to production code. PHP accepts the
+        // absolute request target used by an HTTP proxy.
+        foreach (['ALL_PROXY', 'NO_PROXY', 'no_proxy', 'http_proxy', 'HTTP_PROXY'] as $name) {
+            $this->saved_environment[$name] = getenv($name);
+            putenv($name);
+        }
+        putenv('ALL_PROXY=http://' . $address);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->saved_environment as $name => $value) {
+            putenv($value === false ? $name : $name . '=' . $value);
+        }
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            proc_close($this->server_process);
+        }
+        $this->remove_directory($this->root);
+    }
+
+    /** @dataProvider remote_urls */
+    public function testPreflightSendsCookieOnlyToZipwpSubdomains(string $remote_reprint_api_url, bool $expects_cookie): void
+    {
+        $client = $this->create_client($remote_reprint_api_url);
+        $result = ( new \ReflectionMethod($client, 'fetch_json') )->invoke($client, $remote_reprint_api_url);
+        $cookie = trim(file_get_contents($this->root . '/cookie.log'));
+
+        if ($expects_cookie) {
+            $this->assertMatchesRegularExpression('/^zipwp_access=[a-z0-9]{12}$/', $cookie);
+            $this->assertTrue($result['ok'], (string) $result['error']);
+            $this->assertIsArray($result['json']);
+        } else {
+            $this->assertSame('', $cookie);
+            $this->assertSame('HTML_RESPONSE', $result['error_code']);
+        }
+    }
+
+    public static function remote_urls(): array
+    {
+        return [
+            'temporary site' => ['http://demo.zipwp.to/?endpoint=preflight', true],
+            'nested subdomain and port' => ['http://one.demo.zipwp.to:8080/?endpoint=preflight', true],
+            'mixed case' => ['http://Demo.ZIPWP.TO/?endpoint=preflight', true],
+            'trailing DNS dot' => ['http://demo.zipwp.to./?endpoint=preflight', true],
+            'bare domain' => ['http://zipwp.to/?endpoint=preflight', false],
+            'unrelated domain' => ['http://example.test/?endpoint=preflight', false],
+            'missing label boundary' => ['http://notzipwp.to/?endpoint=preflight', false],
+            'suffix in another domain' => ['http://demo.zipwp.to.example.test/?endpoint=preflight', false],
+            'suffix in path' => ['http://example.test/demo.zipwp.to?endpoint=preflight', false],
+            'suffix in query' => ['http://example.test/?endpoint=preflight&site=demo.zipwp.to', false],
+            'suffix in user info' => ['http://demo.zipwp.to@example.test/?endpoint=preflight', false],
+        ];
+    }
+
+    public function testStreamingDownloadsPassTheTemporarySitePage(): void
+    {
+        $remote_reprint_api_url = 'http://demo.zipwp.to/?endpoint=file_fetch';
+        $client = $this->create_client($remote_reprint_api_url);
+        $fetch = new \ReflectionMethod($client, 'fetch_streaming');
+        $file_list_path = $this->root . '/file-list.json';
+        file_put_contents($file_list_path, json_encode([
+            ['path' => base64_encode($this->root . '/remote/example.txt')],
+        ]));
+        // Each fetch opens a new cURL handle and must pass the page again.
+        for ($request_number = 0; $request_number < 2; ++$request_number) {
+            $context = new StreamingContext();
+            $received = '';
+            $context->on_chunk = static function (array $chunk) use (&$received, $context): void {
+                if (( $chunk['headers']['x-chunk-type'] ?? '' ) === 'completion') {
+                    $context->saw_completion = true;
+                } elseif (( $chunk['headers']['x-chunk-type'] ?? '' ) === 'file') {
+                    $received .= $chunk['body'];
+                }
+            };
+            $fetch->invoke($client, $remote_reprint_api_url, null, $context, [
+                'file_list' => new \CURLFile($file_list_path, 'application/json', 'file-list.json'),
+            ], 'file_fetch');
+            $this->assertSame('temporary site contents', $received);
+        }
+    }
+
+    public function testCookieDoesNotReplaceTheReprintConnectionToken(): void
+    {
+        $remote_reprint_api_url = 'http://demo.zipwp.to/?endpoint=preflight';
+        $client = $this->create_client($remote_reprint_api_url, 'wrong-token');
+        $result = ( new \ReflectionMethod($client, 'fetch_json') )->invoke($client, $remote_reprint_api_url);
+        $this->assertSame(401, $result['http_code']);
+        $this->assertSame('AUTH_SECRET_MISMATCH', $result['error_code']);
+    }
+
+    public function testPushControlAndUploadRequestsPassTheTemporarySitePage(): void
+    {
+        $client = new \MultipartPushStreamClient([
+            'remote_reprint_api_url' => 'http://demo.zipwp.to/',
+            'allow_http' => true,
+            'hmac_client' => new \Site_Export_HMAC_Client('zipwp-test-secret'),
+            'connect_timeout' => 2,
+            'stall_timeout' => 2,
+            'response_timeout' => 2,
+        ]);
+        try {
+            $push_session_id = str_repeat('a', 32);
+            $parameters = ['push_session_id' => $push_session_id];
+            $result = $client->send_push_request('POST', 'push_create', $parameters, ['created']);
+            $this->assertSame('complete', $result['status'], json_encode($result));
+            $this->assertTrue($client->start_upload_request($push_session_id), (string) $client->get_last_error());
+            $this->assertTrue($client->send_part([
+                'type' => 'file',
+                'path' => 'uploaded.txt',
+                'total_bytes' => 5,
+                'offset' => 0,
+                'payload' => 'hello',
+            ]));
+            $result = $client->finish_request();
+            $this->assertSame('complete', $result['status'], json_encode($result));
+            $parameters['path_b64'] = base64_encode('uploaded.txt');
+            $result = $client->send_push_request('GET', 'push_status', $parameters, ['accepted']);
+            $this->assertSame('complete', $result['status'], json_encode($result));
+            $this->assertSame(5, $result['response']['path']['accepted_bytes']);
+        } finally {
+            $client->close();
+        }
+    }
+
+    private function create_client(string $remote_reprint_api_url, string $secret = 'zipwp-test-secret'): \ImportClient
+    {
+        $client = new \ImportClient($remote_reprint_api_url, $this->root . '/state', $this->root . '/local');
+        ( new \ReflectionProperty($client, 'hmac_client') )->setValue($client, new \Site_Export_HMAC_Client($secret));
+        return $client;
+    }
+
+    private function remove_directory(string $directory): void
+    {
+        foreach (scandir($directory) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->remove_directory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/fixtures/zipwp-access-router.php
+++ b/tests/Import/fixtures/zipwp-access-router.php
@@ -1,0 +1,43 @@
+<?php
+
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- This local fixture inspects the exact headers and request target sent over the wire.
+// phpcs:disable WordPress.Security.NonceVerification -- Requests use the real Reprint HMAC verifier below, not WordPress form nonces.
+
+// Model the reported ZipWP temporary-site page in front of the real router.
+file_put_contents('cookie.log', ( $_SERVER['HTTP_COOKIE'] ?? '' ) . "\n", FILE_APPEND);
+if (empty($_COOKIE['zipwp_access'])) {
+    header('Content-Type: text/html');
+    echo '<html><body>Continue with temporary site</body></html>';
+    return;
+}
+
+require_once __DIR__ . '/../../../packages/reprint-server/src/class-http-server.php';
+require_once __DIR__ . '/../../../packages/reprint-server/src/class-hmac-server.php';
+require_once __DIR__ . '/../../../packages/reprint-server/src/class-hmac-client.php';
+require_once __DIR__ . '/../../../packages/reprint-server/src/class-push-session.php';
+
+$reprint_authentication = new \WordPress\Reprint\Server\HMACServer('zipwp-test-secret');
+if (\WordPress\Reprint\Server\HTTPServer::is_push_endpoint($_GET['endpoint'] ?? '')) {
+    $reprint_authentication_error = $reprint_authentication->verify_envelope(
+        getallheaders(),
+        $_SERVER['REQUEST_METHOD'],
+        Site_Export_HMAC_Client::request_target($_SERVER['REQUEST_URI'])
+    );
+} else {
+    $reprint_authentication_error = $reprint_authentication->verify(getallheaders(), file_get_contents('php://input'), $_FILES);
+}
+if ($reprint_authentication_error !== null) {
+    http_response_code(401);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $reprint_authentication_error]);
+    return;
+}
+
+\WordPress\Reprint\Server\HTTPServer::serve([
+    'default_directory' => getcwd() . '/remote',
+    'push' => [
+        'reprint_directory' => getcwd() . '/push',
+        'docroot' => getcwd() . '/remote',
+        'excluded_paths' => [],
+    ],
+]);


### PR DESCRIPTION
Reprint now sends `zipwp_access` with API requests to `*.zipwp.to`, so ZipWP's temporary-site page no longer hides an installed Reprint Server plugin.

This is the cookie set by “continue with temporary site”: a random 12-character value. Send it on preflight, streaming pull, push control, and multipart upload requests. Match the parsed hostname, not text elsewhere in the URL. Reprint's connection-token checks stay unchanged.

## Testing

Local PHP endpoint tests put the reported HTML page in front of the real Reprint router. They cover hostname matching, repeated file downloads, push creation and upload, and rejection of a wrong token. The new tests fail against trunk. All 71 related tests pass with this change, as does static analysis. PHPCS counts do not increase.

For a live check, run preflight and a file pull against a temporary `*.zipwp.to` site with Reprint Server installed, without first clicking “continue with temporary site” in a browser. No live ZipWP site was available for this check.
