### PR TITLE
[PHP] Report preflight failures with shared error fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,19 @@ php reprint.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" 
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `$STATE_DIR/remotes/<md5-of-trimmed-remote-reprint-api-url>/pull/state.json` under the `preflight` key.
 
+The command's JSON result keeps the response data and HTTP details, and includes
+`status`, `error`, `error_code`, and `message`. On failure, `status` is `error`,
+`error` contains the failure detail, and `message` is the same detail prefixed
+with `Error: `. HTTP failures use the same codes as downloads, such as
+`SERVER_ERROR`, `AUTH_FAILED`, and `REDIRECT`. Connection failures use
+`CURL_ERROR`; malformed JSON uses `INVALID_JSON`; a response without a preflight
+object uses `INVALID_PREFLIGHT_RESPONSE`. Failed preflight checks use
+`PREFLIGHT_FAILED`. On success, `status` is `complete`, and both error fields
+are null. Failures exit with code 1.
+
+`progress.json` receives the same `error` and `error_code` as the command's
+JSON result, rather than a generic "Preflight failed" message.
+
 Some hosts, including [Hostinger](https://www.hostinger.com/support/2489693-how-to-access-your-website-content-without-a-domain-in-hostinger/),
 provide preview domains so you can browse a site before its real domain points
 at the host. They replace the real domain in outgoing pages so links and assets
@@ -240,6 +253,13 @@ sound-looking filesystem and a database connection, run:
 ```bash
 php reprint.phar preflight-assert "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
+
+`preflight-assert` reads the saved report without making another preflight
+request. Its JSONL result includes the same error fields alongside the existing
+`checks` list. Request failures retain their saved detail and code. Assertion
+failures report the failed check details with `PREFLIGHT_FAILED`. If no report
+has been saved, it reports `PREFLIGHT_REQUIRED` and asks you to run `preflight`.
+The terminal summary and `progress.json` also include the failure detail.
 
 For hosting platform-specific checks, such as database version compatibility or
 php version compatibility, you might need your own custom logic. See the 
@@ -1079,7 +1099,7 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 ```
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
-* `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary in terminal mode or one structured result in JSONL mode. Exits with code 0 if migration looks feasible, code 1 if not.
+* `preflight-assert` — Checks the saved preflight report and prints a human-readable pass/fail summary in terminal mode or one structured result in JSONL mode. Exits with code 0 if migration looks feasible, code 1 if not.
 * `pull-files` — Runs `preflight` and `files-pull` as one resumable high-level command.
 * `pull-db` — Runs `preflight`, `db-pull`, and `db-apply` as one resumable high-level command.
 * `files-pull` — Pull all files (initial) or a delta. Catch-up mode applies remote changes; mirror mode makes the selected local paths match the current remote index. Runs files-index if needed.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ request. Its JSONL result includes the same error fields alongside the existing
 failures report the failed check details with `PREFLIGHT_FAILED`. If no report
 has been saved, it reports `PREFLIGHT_REQUIRED` and asks you to run `preflight`.
 The terminal summary and `progress.json` also include the failure detail.
+The preflight stage inside `pull`, `pull-files`, and `pull-db` uses the same
+failure details and codes. Download errors use the same four fields; their
+`message` may add the failed stage, while `error` and `progress.json` retain
+the failure detail. cURL failures use `CURL_ERROR` for both preflight and downloads.
 
 For hosting platform-specific checks, such as database version compatibility or
 php version compatibility, you might need your own custom logic. See the 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -438,7 +438,7 @@ class ImportClient
     /** @var bool Whether the last curl request timed out. */
     private $last_curl_timeout = false;
 
-    /** @var string|null Machine-readable error code from the last diagnose_http_error() call. */
+    /** @var string|null Machine-readable HTTP, cURL, or preflight error code for reporting. */
     public $last_error_code = null;
 
     /** @var TerminalProgress Renders progress and lifecycle output to the terminal. */
@@ -1263,6 +1263,7 @@ class ImportClient
                 $this->output_progress([
                     "status" => "error",
                     "error" => $e->getMessage(),
+                    "error_code" => $this->last_error_code,
                     "message" => "Error: " . $e->getMessage(),
                 ]);
                 $this->write_progress_file($e->getMessage());
@@ -3146,7 +3147,7 @@ class ImportClient
      *     @type string $message Failure detail for display.
      * }
      */
-    private function get_preflight_error(): ?array
+    public function get_preflight_error(): ?array
     {
         $entry = $this->get_state()->preflight_record();
         if ($entry === null) {
@@ -11819,7 +11820,7 @@ class ImportClient
     }
 
     /**
-     * Check for cURL errors after curl_exec and record timeout state.
+     * Check for cURL errors after curl_exec and record the error code and timeout state.
      *
      * @throws CurlTimeoutException          When the request times out.
      * @throws TransientInterruptionException When the response ends early.
@@ -11840,6 +11841,7 @@ class ImportClient
             ? CURLE_OPERATION_TIMEDOUT
             : 28;
 
+        $this->last_error_code = "CURL_ERROR";
         $this->last_curl_errno = $error_number;
         $this->last_curl_timeout = $error_number === $timeout_error_number;
 
@@ -12226,7 +12228,7 @@ class ImportClient
                 "body" => null,
                 "json" => null,
                 "error" => $e->getMessage(),
-                "error_code" => "CURL_ERROR",
+                "error_code" => $this->last_error_code,
                 "curl_errno" => $this->last_curl_errno,
                 "timeout" => $this->last_curl_timeout,
             ];

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -1271,11 +1271,16 @@ class ImportClient
             return;
         }
 
-        // preflight and preflight-assert run the preflight themselves and
-        // exit directly — they do not go through the normal command dispatch.
+        // preflight fetches a new report; preflight-assert reads the saved one.
+        // Both exit directly, including when the saved report contains an error.
         if ($command === "preflight") {
             $this->run_preflight();
             $this->run_preflight_report();
+            return;
+        }
+
+        if ($command === "preflight-assert") {
+            $this->run_preflight_assert();
             return;
         }
 
@@ -1366,10 +1371,6 @@ class ImportClient
         // Dispatch to appropriate command handler
         try {
             switch ($command) {
-                case "preflight-assert":
-                    $this->run_preflight_assert();
-                    return;
-
                 case "files-pull":
                     $this->run_files_pull();
                     break;
@@ -2670,6 +2671,7 @@ class ImportClient
             "ok" => is_array($payload) ? ($payload["ok"] ?? null) : null,
             "data" => $payload,
             "error" => $domain_error ?? $result["error"] ?? null,
+            "error_code" => $domain_error !== null ? "PREFLIGHT_FAILED" : ( $result["error_code"] ?? null ),
             "response_body_preview" => $payload === null && isset($result["body"])
                 ? substr((string) $result["body"], 0, 200)
                 : null,
@@ -2973,11 +2975,16 @@ class ImportClient
             echo "No preflight data available.\n";
             exit(1);
         }
+        $error = $this->get_preflight_error();
+        $this->last_error_code = $error['code'] ?? null;
+        $entry["status"] = $error === null ? "complete" : "error";
+        $entry["error"] = $error['message'] ?? null;
+        $entry["error_code"] = $this->last_error_code;
+        $entry["message"] = $error === null ? "Preflight passed." : "Error: " . $error['message'];
         // @TODO: Store paths as base64 strings, not raw strings, since paths can contain arbitrary bytes
         echo json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n";
-        $ok = ($entry["http_code"] ?? 0) === 200 && !empty($entry["data"]["ok"]);
-        $this->write_progress_file($ok ? null : "Preflight failed");
-        exit($ok ? 0 : 1);
+        $this->write_progress_file($entry["error"]);
+        exit($error === null ? 0 : 1);
     }
 
     /**
@@ -2992,8 +2999,9 @@ class ImportClient
     {
         $entry = $this->get_state()->preflight_record();
         $data = $entry["data"] ?? null;
+        $error = $this->get_preflight_error();
         $checks = [];
-        $all_pass = true;
+        $all_pass = $error === null;
 
         // 1. Server responded OK
         $http_ok = ($entry["http_code"] ?? 0) === 200;
@@ -3002,7 +3010,7 @@ class ImportClient
             "pass" => $http_ok,
             "detail" => $http_ok
                 ? "HTTP 200"
-                : "HTTP " . ($entry["http_code"] ?? "no response"),
+                : ( $error['message'] ?? "HTTP " . ( $entry["http_code"] ?? "no response" ) ),
         ];
         if (!$http_ok) {
             $all_pass = false;
@@ -3015,7 +3023,7 @@ class ImportClient
             "pass" => $top_ok,
             "detail" => $top_ok
                 ? "passed"
-                : ($data["error"] ?? "preflight not ok"),
+                : ( $error['message'] ?? $data["error"] ?? "preflight not ok" ),
         ];
         if (!$top_ok) {
             $all_pass = false;
@@ -3095,14 +3103,22 @@ class ImportClient
 
         // Print the terminal summary or emit one structured result.
         $human_summary = "";
+        $failed_checks = [];
         foreach ($checks as $check) {
             $icon = $check["pass"] ? "PASS" : "FAIL";
             $human_summary .= "[{$icon}] {$check["label"]}: {$check["detail"]}\n";
+            if (!$check["pass"]) {
+                $failed_checks[] = "{$check["label"]}: {$check["detail"]}";
+            }
         }
+        if (!$all_pass && $error === null) {
+            $error = ['code' => 'PREFLIGHT_FAILED', 'message' => implode("\n", $failed_checks)];
+        }
+        $this->last_error_code = $error['code'] ?? null;
 
         $message = $all_pass
             ? "Migration looks feasible."
-            : "Migration may not be feasible. Review the failures above.";
+            : "Error: " . $error['message'];
         $human_summary .= "\n{$message}\n";
         $this->progress->show_lifecycle_line($human_summary);
         $this->output_progress([
@@ -3110,11 +3126,57 @@ class ImportClient
             "command" => "preflight-assert",
             "status" => $all_pass ? "complete" : "error",
             "checks" => $checks,
+            "error" => $error['message'] ?? null,
+            "error_code" => $this->last_error_code,
             "message" => $message,
         ], true);
 
-        $this->write_progress_file($all_pass ? null : "Preflight assertions failed");
+        $this->write_progress_file($error['message'] ?? null);
         exit($all_pass ? 0 : 1);
+    }
+
+    /**
+     * Read the failure from the saved report without changing its raw data.
+     *
+     * The saved error also rejects low-level downloads. Do not store display-only
+     * database check failures there: files-pull can run without a database.
+     *
+     * @return array|null { Failure details, or null when the preflight passed.
+     *     @type string $code    Machine-readable failure code.
+     *     @type string $message Failure detail for display.
+     * }
+     */
+    private function get_preflight_error(): ?array
+    {
+        $entry = $this->get_state()->preflight_record();
+        if ($entry === null) {
+            return ['code' => 'PREFLIGHT_REQUIRED', 'message' => "No preflight data found. Run 'preflight' first."];
+        }
+        if ( ( $entry["http_code"] ?? 0 ) !== 200 ) {
+            $diagnosis = $this->diagnose_http_error($entry["http_code"] ?? 0, $entry["response_body_preview"] ?? null);
+            return [
+                'code' => $entry["error_code"] ?? $diagnosis['code'],
+                'message' => $entry["error"] ?? $diagnosis['message'],
+            ];
+        }
+        if (!empty($entry["error"])) {
+            return ['code' => $entry["error_code"] ?? 'PREFLIGHT_FAILED', 'message' => $entry["error"]];
+        }
+        $data = $entry["data"] ?? null;
+        if (!is_array($data) || !array_key_exists("ok", $data)) {
+            return [
+                'code' => 'INVALID_PREFLIGHT_RESPONSE',
+                'message' => "The remote server returned HTTP 200 without a preflight JSON object containing an 'ok' field.",
+            ];
+        }
+        if (!empty($data["ok"])) {
+            return null;
+        }
+        return [
+            'code' => 'PREFLIGHT_FAILED',
+            'message' => $data["error"] ?? $data["filesystem"]["error"] ?? $data["database"]["error"]
+                ?? "The remote server reported that preflight did not pass (ok=false).",
+        ];
     }
 
     /**
@@ -12164,6 +12226,7 @@ class ImportClient
                 "body" => null,
                 "json" => null,
                 "error" => $e->getMessage(),
+                "error_code" => "CURL_ERROR",
                 "curl_errno" => $this->last_curl_errno,
                 "timeout" => $this->last_curl_timeout,
             ];

--- a/packages/reprint-client/src/lib/pull/class-pull.php
+++ b/packages/reprint-client/src/lib/pull/class-pull.php
@@ -416,6 +416,7 @@ class Pull
         // even when this pipeline has already completed its preflight stage.
         $preflight_error = $this->client->get_state()->preflight_record()["error"] ?? null;
         if ($stage !== 'preflight' && !empty($preflight_error)) {
+            $this->client->last_error_code = $this->client->get_preflight_error()['code'];
             $this->client->exit_code = 1;
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error, never HTML.
             throw new RuntimeException($preflight_error);
@@ -424,14 +425,15 @@ class Pull
         switch ($stage) {
             case 'preflight':
                 $this->client->run_preflight();
-                $preflight = $this->client->get_state()->preflight_record();
-                $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
-                if (!$ok) {
+                $error = $this->client->get_preflight_error();
+                $this->client->last_error_code = $error['code'] ?? null;
+                if ($error !== null) {
                     $this->client->exit_code = 1;
-                    throw new RuntimeException($preflight["error"] ?? "Preflight check failed");
+                    // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error, never HTML.
+                    throw new RuntimeException($error['message']);
                 }
                 $summary = null;
-                $data = $preflight["data"] ?? null;
+                $data = $this->client->get_state()->preflight_record()["data"] ?? null;
                 if (is_array($data)) {
                     $parts = [];
                     $wp = $data["database"]["wp"]["wp_version"] ?? null;
@@ -1028,7 +1030,7 @@ class Pull
             "error" => $e->getMessage(),
             "message" => $message,
         ] + $this->client->get_error_details($e));
-        $this->client->write_progress_file($message);
+        $this->client->write_progress_file($e->getMessage());
 
         $red = "\033[31m";
         $dim = "\033[2m";

--- a/tests/Import/PreflightErrorOutputTest.php
+++ b/tests/Import/PreflightErrorOutputTest.php
@@ -74,6 +74,12 @@ final class PreflightErrorOutputTest extends TestCase {
         $this->assertSame($error_code, $assertion['error_code']);
         $this->assertNotEmpty($assertion['checks']);
         $this->assert_error_output($assertion);
+
+        $pull = $this->run_command('pull-files', 1);
+        $this->assertSame('preflight', $pull['failed_stage']);
+        $this->assertSame($preflight['error'], $pull['error']);
+        $this->assertSame($error_code, $pull['error_code']);
+        $this->assert_error_output($pull);
     }
 
     public static function failed_responses(): array
@@ -108,6 +114,59 @@ final class PreflightErrorOutputTest extends TestCase {
         $this->assertSame($preflight['error'], $assertion['error']);
         $this->assertSame('CURL_ERROR', $assertion['error_code']);
         $this->assert_error_output($assertion);
+
+        $pull = $this->run_command('pull-files', 1);
+        $this->assertSame('preflight', $pull['failed_stage']);
+        $this->assertSame('CURL_ERROR', $pull['error_code']);
+        $this->assertStringContainsString('cURL error', $pull['error']);
+        $this->assert_error_output($pull);
+    }
+
+    /** @dataProvider download_commands */
+    public function testDownloadFailuresUseTheSameErrorFields(string $command, bool $connection_failure): void
+    {
+        $preflight_body = json_encode([
+            'ok' => true,
+            'protocol_version' => PULL_PROTOCOL_VERSION,
+            'filesystem' => ['ok' => true],
+            'database' => ['connected' => true],
+            'wp_detect' => ['roots' => [['path' => '/site']]],
+        ]);
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 200,
+            'body' => $preflight_body,
+        ]));
+        $this->run_command('preflight', 0);
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 401,
+            'body' => '{"error":"Invalid signature"}',
+            'preflight_body' => $preflight_body,
+        ]));
+        if ($connection_failure) {
+            proc_terminate($this->server_process);
+            proc_close($this->server_process);
+            $this->server_process = null;
+        }
+        // A signed request's unmarked HTTP 401 can come from a gateway; it is
+        // retryable. A refused connection still exits with code 1.
+        $download = $this->run_command($command, $connection_failure ? 1 : 3);
+        $this->assertSame($connection_failure ? 'CURL_ERROR' : 'AUTH_FAILED', $download['error_code']);
+        $this->assertStringContainsString($connection_failure ? 'cURL error' : 'Invalid signature', $download['error']);
+        $this->assert_error_output($download);
+    }
+
+    public static function download_commands(): array
+    {
+        return [
+            'files-pull HTTP error' => ['files-pull', false],
+            'db-pull HTTP error' => ['db-pull', false],
+            'pull-files HTTP error' => ['pull-files', false],
+            'pull-db HTTP error' => ['pull-db', false],
+            'files-pull connection error' => ['files-pull', true],
+            'db-pull connection error' => ['db-pull', true],
+            'pull-files connection error' => ['pull-files', true],
+            'pull-db connection error' => ['pull-db', true],
+        ];
     }
 
     public function testRealEndpointFailureReportsItsReason(): void
@@ -199,13 +258,18 @@ final class PreflightErrorOutputTest extends TestCase {
      *     @type string $status     Command status.
      *     @type string $error      Failure detail.
      *     @type string $message    Display message.
-     *     @type string $error_code Machine-readable failure code.
+     *     @type string $error_code   Machine-readable failure code.
+     *     @type string $failed_stage Optional failed pipeline stage.
      * }
      */
     private function assert_error_output(array $result): void
     {
         $this->assertSame('error', $result['status']);
-        $this->assertSame('Error: ' . $result['error'], $result['message']);
+        if (isset($result['failed_stage'])) {
+            $this->assertStringContainsString($result['error'], $result['message']);
+        } else {
+            $this->assertSame('Error: ' . $result['error'], $result['message']);
+        }
         $progress = json_decode(file_get_contents($this->root . '/state/progress.json'), true);
         $this->assertSame('error', $progress['status']);
         $this->assertSame($result['error'], $progress['error']);
@@ -214,21 +278,29 @@ final class PreflightErrorOutputTest extends TestCase {
 
     private function run_command(string $command, int $exit_code): array
     {
-        $process = proc_open(
-            [PHP_BINARY, __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
-                $command, $this->remote_url, '--secret=preflight-test-secret',
-                '--state-dir=' . $this->root . '/state', '--fs-root=' . $this->root . '/files',
-                '--progress=jsonl'],
-            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
-            $pipes
-        );
-        $this->assertIsResource($process);
-        fclose($pipes[0]);
-        $stdout = stream_get_contents($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[1]);
-        fclose($pipes[2]);
-        $this->assertSame($exit_code, proc_close($process), $stdout . $stderr);
+        // Continue healthy partial work according to the exit-code-2 contract.
+        // Request failures return to the caller without retrying here.
+        for ($attempt = 0; $attempt < 3; $attempt++) {
+            $process = proc_open(
+                [PHP_BINARY, __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
+                    $command, $this->remote_url, '--secret=preflight-test-secret',
+                    '--state-dir=' . $this->root . '/state', '--fs-root=' . $this->root . '/files',
+                    '--progress=jsonl'],
+                [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+                $pipes
+            );
+            $this->assertIsResource($process);
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $actual_exit_code = proc_close($process);
+            if ($actual_exit_code !== 2) {
+                break;
+            }
+        }
+        $this->assertSame($exit_code, $actual_exit_code, $stdout . $stderr);
         $records = array_map(static function (string $line): array {
             return json_decode($line, true, 512, JSON_THROW_ON_ERROR);
         }, array_filter(explode("\n", trim($stdout))));

--- a/tests/Import/PreflightErrorOutputTest.php
+++ b/tests/Import/PreflightErrorOutputTest.php
@@ -1,0 +1,250 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Match the existing importer test namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+final class PreflightErrorOutputTest extends TestCase {
+    private string $root;
+    private string $remote_url;
+    /** @var resource|null */
+    private $server_process;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/reprint-preflight-errors-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/remote', 0755, true);
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error);
+        $this->assertIsResource($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $this->remote_url = 'http://' . $address . '/?reprint-api';
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-S', $address, __DIR__ . '/fixtures/preflight-errors-router.php'],
+            [0 => ['pipe', 'r'], 1 => ['file', $this->root . '/server.log', 'a'], 2 => ['file', $this->root . '/server.log', 'a']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($this->server_process);
+        fclose($pipes[0]);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $error_number, $error, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                break;
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $this->assertNotFalse($connection, file_get_contents($this->root . '/server.log'));
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->server_process)) {
+            proc_terminate($this->server_process);
+            proc_close($this->server_process);
+        }
+        $this->remove_directory($this->root);
+    }
+
+    /** @dataProvider failed_responses */
+    public function testFailureSurvivesStandalonePreflightAndSavedAssertion(
+        int $http_code,
+        string $body,
+        string $error_code,
+        string $detail
+    ): void {
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => $http_code,
+            'body' => $body,
+        ]));
+        $preflight = $this->run_command('preflight', 1);
+        $this->assertSame($http_code, $preflight['http_code']);
+        $this->assertSame($error_code, $preflight['error_code'] ?? null);
+        $this->assertStringContainsString($detail, $preflight['error']);
+        $this->assert_error_output($preflight);
+
+        $assertion = $this->run_command('preflight-assert', 1);
+        $this->assertSame('preflight_assertion', $assertion['type'] ?? null);
+        $this->assertSame($preflight['error'], $assertion['error']);
+        $this->assertSame($error_code, $assertion['error_code']);
+        $this->assertNotEmpty($assertion['checks']);
+        $this->assert_error_output($assertion);
+    }
+
+    public static function failed_responses(): array
+    {
+        return [
+            'gateway error' => [520, '<html>Unknown error</html>', 'SERVER_ERROR', 'HTTP 520'],
+            'authentication' => [401, '{"error":"Invalid signature"}', 'AUTH_FAILED', 'Invalid signature'],
+            'redirect' => [302, '', 'REDIRECT', 'https://example.test/reprint-api'],
+            'HTML instead of JSON' => [200, '<html>Sign in</html>', 'HTML_RESPONSE', 'HTML page'],
+            'malformed JSON' => [200, '{', 'INVALID_JSON', 'Invalid JSON'],
+            'empty response' => [200, '', 'INVALID_PREFLIGHT_RESPONSE', "'ok' field"],
+            'JSON null' => [200, 'null', 'INVALID_PREFLIGHT_RESPONSE', "'ok' field"],
+            'JSON scalar' => [200, '42', 'INVALID_PREFLIGHT_RESPONSE', "'ok' field"],
+            'server preflight failure' => [200, '{"ok":false,"error":"WordPress was not found."}', 'PREFLIGHT_FAILED', 'WordPress was not found.'],
+            'database failure' => [200, '{"ok":false,"error":null,"database":{"connected":false,"error":"Access denied for migration user."}}', 'PREFLIGHT_FAILED', 'Access denied for migration user.'],
+            'filesystem failure' => [200, '{"ok":false,"filesystem":{"ok":false,"error":"The directory /site is not readable."}}', 'PREFLIGHT_FAILED', 'The directory /site is not readable.'],
+            'rewritten domain' => [200, '{"ok":true,"database":{"wp":{"home":"https://preview.test","home_domain_b64":"ZXhhbXBsZS50ZXN0"}}}', 'PREFLIGHT_FAILED', "changed the site domain from 'example.test' to 'preview.test'"],
+        ];
+    }
+
+    public function testConnectionFailureKeepsItsCodeAndDetail(): void
+    {
+        proc_terminate($this->server_process);
+        proc_close($this->server_process);
+        $this->server_process = null;
+
+        $preflight = $this->run_command('preflight', 1);
+        $this->assertSame('CURL_ERROR', $preflight['error_code'] ?? null);
+        $this->assertStringContainsString('cURL error', $preflight['error']);
+        $this->assert_error_output($preflight);
+        $assertion = $this->run_command('preflight-assert', 1);
+        $this->assertSame($preflight['error'], $assertion['error']);
+        $this->assertSame('CURL_ERROR', $assertion['error_code']);
+        $this->assert_error_output($assertion);
+    }
+
+    public function testRealEndpointFailureReportsItsReason(): void
+    {
+        $preflight = $this->run_command('preflight', 1);
+        $this->assertSame('PREFLIGHT_FAILED', $preflight['error_code'] ?? null);
+        $this->assertSame($preflight['data']['database']['error'], $preflight['error']);
+        $this->assertNotEmpty($preflight['error']);
+        $this->assert_error_output($preflight);
+    }
+
+    public function testReportingDatabaseFailureDoesNotRejectLowLevelFileCommands(): void
+    {
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 200,
+            'body' => '{"ok":false,"filesystem":{"ok":true},"database":{"connected":false,"error":"Access denied."}}',
+        ]));
+        $this->run_command('preflight', 1);
+        $client = new \ImportClient($this->remote_url, $this->root . '/state', $this->root . '/files');
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('state')->setValue($client, $reflection->getMethod('load_state')->invoke($client));
+        $reflection->getMethod('require_preflight')->invoke($client);
+        $this->assertNull($client->get_state()->preflight_record()['error']);
+        $this->assertSame('Access denied.', $client->get_state()->preflight_record()['data']['database']['error']);
+    }
+
+    public function testAssertionReadsAnOlderSavedHttpFailureWithoutAnErrorCode(): void
+    {
+        $client = new \ImportClient($this->remote_url, $this->root . '/state', $this->root . '/files');
+        \write_current_pull_state($client, [
+            'preflight' => [
+                'http_code' => 520,
+                'data' => null,
+                'error' => 'The remote server returned HTTP 520.',
+                'response_body_preview' => '<html>Unknown error</html>',
+            ],
+        ]);
+        $assertion = $this->run_command('preflight-assert', 1);
+        $this->assertSame('SERVER_ERROR', $assertion['error_code']);
+        $this->assertSame('The remote server returned HTTP 520.', $assertion['error']);
+        $this->assert_error_output($assertion);
+    }
+
+    public function testAssertionReportsFailedChecksAndSuccessClearsTheError(): void
+    {
+        $payload = [
+            'ok' => true,
+            'protocol_version' => PULL_PROTOCOL_VERSION + 1,
+            'filesystem' => ['ok' => true],
+            'database' => ['connected' => true],
+        ];
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 200,
+            'body' => json_encode($payload),
+        ]));
+        $this->run_command('preflight', 0);
+        $assertion = $this->run_command('preflight-assert', 1);
+        $this->assertSame('PREFLIGHT_FAILED', $assertion['error_code'] ?? null);
+        $this->assertStringContainsString('Update the Reprint client.', $assertion['error']);
+        $this->assert_error_output($assertion);
+
+        $payload['protocol_version'] = PULL_PROTOCOL_VERSION;
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 200,
+            'body' => json_encode($payload),
+        ]));
+        foreach (['preflight', 'preflight-assert'] as $command) {
+            $result = $this->run_command($command, 0);
+            $this->assertSame('complete', $result['status']);
+            $this->assertNull($result['error']);
+            $this->assertNull($result['error_code']);
+            $progress = json_decode(file_get_contents($this->root . '/state/progress.json'), true);
+            $this->assertNull($progress['error']);
+            $this->assertNull($progress['error_code']);
+        }
+    }
+
+    public function testAssertionWithoutSavedPreflightExplainsWhatToRun(): void
+    {
+        $assertion = $this->run_command('preflight-assert', 1);
+        $this->assertSame('PREFLIGHT_REQUIRED', $assertion['error_code'] ?? null);
+        $this->assertStringContainsString("Run 'preflight' first.", $assertion['error']);
+        $this->assert_error_output($assertion);
+    }
+
+    /**
+     * @param array $result {
+     *     Command result.
+     *     @type string $status     Command status.
+     *     @type string $error      Failure detail.
+     *     @type string $message    Display message.
+     *     @type string $error_code Machine-readable failure code.
+     * }
+     */
+    private function assert_error_output(array $result): void
+    {
+        $this->assertSame('error', $result['status']);
+        $this->assertSame('Error: ' . $result['error'], $result['message']);
+        $progress = json_decode(file_get_contents($this->root . '/state/progress.json'), true);
+        $this->assertSame('error', $progress['status']);
+        $this->assertSame($result['error'], $progress['error']);
+        $this->assertSame($result['error_code'], $progress['error_code']);
+    }
+
+    private function run_command(string $command, int $exit_code): array
+    {
+        $process = proc_open(
+            [PHP_BINARY, __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
+                $command, $this->remote_url, '--secret=preflight-test-secret',
+                '--state-dir=' . $this->root . '/state', '--fs-root=' . $this->root . '/files',
+                '--progress=jsonl'],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $this->assertSame($exit_code, proc_close($process), $stdout . $stderr);
+        $records = array_map(static function (string $line): array {
+            return json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        }, array_filter(explode("\n", trim($stdout))));
+        $this->assertNotEmpty($records, $stderr);
+        return end($records);
+    }
+
+    private function remove_directory(string $directory): void
+    {
+        foreach (scandir($directory) as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $name;
+            is_dir($path) ? $this->remove_directory($path) : unlink($path);
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/fixtures/preflight-errors-router.php
+++ b/tests/Import/fixtures/preflight-errors-router.php
@@ -4,6 +4,12 @@
 // over HTTP. Without a response fixture, exercise the real preflight endpoint.
 if (is_file('response.json')) {
     $reprint_response = json_decode(file_get_contents('response.json'), true);
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput -- Select the fixture for the endpoint the real client requested.
+    if ( ( $_GET['endpoint'] ?? '' ) === 'preflight' && isset($reprint_response['preflight_body'])) {
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is the fixture's JSON response.
+        echo $reprint_response['preflight_body'];
+        return;
+    }
     http_response_code($reprint_response['http_code']);
     if ($reprint_response['http_code'] === 302) {
         header('Location: https://example.test/reprint-api');

--- a/tests/Import/fixtures/preflight-errors-router.php
+++ b/tests/Import/fixtures/preflight-errors-router.php
@@ -1,0 +1,22 @@
+<?php
+
+// Model gateway failures and preflight responses from other server versions
+// over HTTP. Without a response fixture, exercise the real preflight endpoint.
+if (is_file('response.json')) {
+    $reprint_response = json_decode(file_get_contents('response.json'), true);
+    http_response_code($reprint_response['http_code']);
+    if ($reprint_response['http_code'] === 302) {
+        header('Location: https://example.test/reprint-api');
+    }
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Send the exact HTTP body the client must diagnose.
+    echo $reprint_response['body'];
+    return;
+}
+
+// Leave the real endpoint without database credentials, regardless of the
+// developer's or CI worker's database settings.
+putenv('DB_PASSWORD');
+require_once __DIR__ . '/../../../packages/reprint-server/src/class-http-server.php';
+\WordPress\Reprint\Server\HTTPServer::serve([
+    'default_directory' => getcwd() . '/remote',
+]);


### PR DESCRIPTION
Preflight failures now use the same error fields as download failures, so Migration Assistant can read an error code instead of guessing from the message.

For example, when the remote site reports that WordPress was not found, the preflight output includes:

```json
{
  "status": "error",
  "error_code": "PREFLIGHT_FAILED",
  "error": "WordPress was not found.",
  "message": "Error: WordPress was not found."
}
```

The same error code and detail appear in `preflight-assert`, preflight inside a pull, and `progress.json`. `preflight-assert` reads the saved response; it does not make another request.

Other failures keep their specific codes, such as `AUTH_FAILED` or `CURL_ERROR`. Existing preflight data and checks stay available. Retry policy is unchanged.

## Testing

Run `preflight` with a bad connection token, then `preflight-assert` using the same state directory. Check that both report the same error code and detail as `progress.json`. Repeat with a valid token and confirm that the error fields clear.
