### PR TITLE
[PHP] Append one final command report with --report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,10 @@ progress snapshot, and `audit.log` remains available for troubleshooting.
 Use `--progress=jsonl` when the caller wants the full progress stream.
 With `--sql-output=stdout`, SQL stays on stdout and compact progress goes to stderr.
 
+Add `--report` to append one versioned JSON result for the invoked command.
+See [CLI reporting](docs/CLI-REPORTING.md) for the schema, preflight checks,
+pipeline boundaries, and handling a missing report.
+
 The files-push terminal presentation uses one stage-weighted progress bar. The
 percentage comes first, followed by a major stage such as `Indexing`, `Pushing`,
 or `Committing`. While pushing local paths, the line also shows target-confirmed

--- a/docs/CLI-REPORTING.md
+++ b/docs/CLI-REPORTING.md
@@ -9,9 +9,10 @@ php reprint.phar pull "$URL" --state-dir="$STATE_DIR" \
 ```
 
 The CLI appends one JSON line after a command returns or throws a handled
-exception. Existing progress and command data remain unchanged. In particular,
-`preflight` without `--report` still prints its single JSON result. With
-`--report`, it prints that result followed by the report.
+exception. Existing progress and command records stay in place; preflight
+assertion checks gain the stable codes described below. `preflight` without
+`--report` still prints its single JSON result. With `--report`, it prints
+that result followed by the report.
 
 The report goes to stdout, except when stdout carries SQL; then it goes to
 stderr with the other progress records. `progress.json` remains the source for

--- a/docs/CLI-REPORTING.md
+++ b/docs/CLI-REPORTING.md
@@ -1,0 +1,74 @@
+# CLI reporting
+
+Add `--report` when a caller needs a final command result without interpreting
+progress messages:
+
+```sh
+php reprint.phar pull "$URL" --state-dir="$STATE_DIR" \
+    --fs-root="$FS_ROOT" --secret="$SECRET" --report
+```
+
+The CLI appends one JSON line after a command returns or throws a handled
+exception. Existing progress and command data remain unchanged. In particular,
+`preflight` without `--report` still prints its single JSON result. With
+`--report`, it prints that result followed by the report.
+
+The report goes to stdout, except when stdout carries SQL; then it goes to
+stderr with the other progress records. `progress.json` remains the source for
+live progress. A caller does not need its last update to read the final error.
+
+```json
+{
+  "type": "reprint_report",
+  "schema_version": 1,
+  "command": "pull-files",
+  "status": "error",
+  "exit_code": 1,
+  "failed_stage": "preflight",
+  "error": "The remote server returned HTTP 401: Invalid signature",
+  "error_code": "AUTH_FAILED"
+}
+```
+
+`command` is the outer command the caller invoked. Preflight inside `pull`,
+`pull-files`, or `pull-db` does not produce a separate final report.
+
+`status` is `complete`, `partial`, `error`, or `aborted`. Files-push also retains
+its `interrupted`, `restart`, and `failed` outcomes and its `reason` and `detail`.
+`exit_code` is the actual exit code; reporting does not choose retry timing or
+change command outcomes. Exit 2 is unfinished work, not success. A successful
+`--abort` reports `aborted`, not `complete`.
+
+`failed_stage`, `error`, and `error_code` are null when unavailable. Failed
+commands which have no specific error code still provide their error message.
+HTTP and cURL details, including `http_code`, `curl_errno`, and
+`consecutive_failures_without_progress`, are included when the command reports
+them. Callers must not depend on every failure having those fields.
+
+`preflight-assert` also includes `checks`. Each check retains its `label`, `pass`,
+and `detail`, with a stable `code`: `SERVER_RESPONDED`, `PREFLIGHT_OK`,
+`PROTOCOL_COMPATIBLE`, `FILESYSTEM_ACCESSIBLE`, or `DATABASE_ACCESSIBLE`.
+Translate codes, not English labels or error messages. Unknown codes need a
+generic fallback.
+
+## Reading a ticket
+
+Split the captured output into lines. Decode each whole line as JSON, ignore
+non-JSON lines, and select records with `type: "reprint_report"` and a supported
+`schema_version`. Do not match JSON prefixes or assume field order.
+
+Each report describes one invocation. A ticket containing separately invoked
+preflight and download commands can contain several reports. The adapter must
+associate those reports with its steps and produce the overall migration
+result. Selecting the last success without checking which command ran can
+mistake a preflight success for a completed migration.
+
+There is no report if PHP cannot load the program, argument parsing exits
+before command setup, the process is killed, or its output pipe breaks. An
+OOM or an uncatchable signal cannot reliably print a final line. Missing or
+truncated reports mean the final result is unavailable; use the host job's
+status, never an earlier success or the last progress tick.
+
+The report is emitted at the CLI boundary. Library users calling
+`ImportClient::run()` directly still receive the command's regular output and
+can read its exit code or catch its exception.

--- a/docs/CLI-REPORTING.md
+++ b/docs/CLI-REPORTING.md
@@ -31,6 +31,10 @@ live progress. A caller does not need its last update to read the final error.
 }
 ```
 
+`--progress=compact --report` prints short progress followed by the final report.
+Compact mode alone does not enable reports. Neither option creates an additional
+progress log; `progress.json` snapshots and `audit.log` are unchanged.
+
 `command` is the outer command the caller invoked. Preflight inside `pull`,
 `pull-files`, or `pull-db` does not produce a separate final report.
 

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -457,6 +457,9 @@ class ImportClient
     /** Monotonic seconds at the last compact update or stage change. */
     private float $last_compact_progress_time = 0;
 
+    /** @var array<string,mixed> Final error or preflight checks for the current invocation, independent of progress throttling. */
+    public array $command_report_details = [];
+
     /** @var TerminalProgress Renders progress and lifecycle output to the terminal. */
     private TerminalProgress $progress;
 
@@ -1334,7 +1337,7 @@ class ImportClient
         }
 
         // preflight fetches a new report; preflight-assert reads the saved one.
-        // Both exit directly, including when the saved report contains an error.
+        // Both return their exit code to the CLI so it can append a command report.
         if ($command === "preflight") {
             $this->run_preflight();
             $this->run_preflight_report();
@@ -1977,6 +1980,11 @@ class ImportClient
             'steps' => $this->pipeline_steps,
         ], $result);
         $this->progress_reporter->write_file(true);
+
+        $this->command_report_details = array_intersect_key($result, array_flip(['status', 'reason', 'detail']));
+        if (in_array($status, ['failed', 'error'], true)) {
+            $this->command_report_details['error'] = $message;
+        }
 
         // Emit the final JSON line after any preceding progress records.
         if ($this->uses_terminal_progress() && !$this->verbose_mode) {
@@ -3040,7 +3048,7 @@ class ImportClient
     /**
      * Command: preflight
      *
-     * Prints the full preflight response as pretty-printed JSON to stdout.
+     * Prints the full preflight response as one JSON line to stdout.
      * The preflight itself already ran in run_preflight() — this just
      * outputs the stored result.
      */
@@ -3048,8 +3056,7 @@ class ImportClient
     {
         $entry = $this->get_state()->preflight_record();
         if ($entry === null) {
-            echo "No preflight data available.\n";
-            exit(1);
+            throw new RuntimeException("No preflight data available.");
         }
         $error = $this->get_preflight_error();
         $this->last_error_code = $error['code'] ?? null;
@@ -3057,17 +3064,18 @@ class ImportClient
         $entry["error"] = $error['message'] ?? null;
         $entry["error_code"] = $this->last_error_code;
         $entry["message"] = $error === null ? "Preflight passed." : "Error: " . $error['message'];
+        $this->command_report_details = array_intersect_key($entry, array_flip(['error', 'error_code', 'http_code']));
         // @TODO: Store paths as base64 strings, not raw strings, since paths can contain arbitrary bytes
         echo json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n";
         $this->write_progress_file($entry["error"]);
-        exit($error === null ? 0 : 1);
+        $this->exit_code = $error === null ? 0 : 1;
     }
 
     /**
      * Command: preflight-assert
      *
      * Inspects the preflight response (already fetched by run_preflight())
-     * and exits with code 0 if migration looks feasible, code 1 if not.
+     * and sets exit code 0 if migration looks feasible, code 1 if not.
      * Prints a human-readable pass/fail summary in terminal mode or one
      * structured result in JSONL mode.
      */
@@ -3082,6 +3090,7 @@ class ImportClient
         // 1. Server responded OK
         $http_ok = ($entry["http_code"] ?? 0) === 200;
         $checks[] = [
+            "code" => "SERVER_RESPONDED",
             "label" => "Server responded",
             "pass" => $http_ok,
             "detail" => $http_ok
@@ -3095,6 +3104,7 @@ class ImportClient
         // 2. Top-level ok flag
         $top_ok = is_array($data) && !empty($data["ok"]);
         $checks[] = [
+            "code" => "PREFLIGHT_OK",
             "label" => "Preflight OK",
             "pass" => $top_ok,
             "detail" => $top_ok
@@ -3121,6 +3131,7 @@ class ImportClient
             $proto_detail = "remote v{$remote_ver}, client v" . PULL_PROTOCOL_VERSION;
         }
         $checks[] = [
+            "code" => "PROTOCOL_COMPATIBLE",
             "label" => "Protocol compatible",
             "pass" => $proto_ok,
             "detail" => $proto_detail,
@@ -3133,6 +3144,7 @@ class ImportClient
         $fs = $data["filesystem"] ?? null;
         $fs_ok = is_array($fs) && !empty($fs["ok"]);
         $checks[] = [
+            "code" => "FILESYSTEM_ACCESSIBLE",
             "label" => "Filesystem accessible",
             "pass" => $fs_ok,
             "detail" => $fs_ok
@@ -3147,6 +3159,7 @@ class ImportClient
         $db = $data["database"] ?? null;
         $db_ok = is_array($db) && !empty($db["connected"]);
         $checks[] = [
+            "code" => "DATABASE_ACCESSIBLE",
             "label" => "Database accessible",
             "pass" => $db_ok,
             "detail" => $db_ok
@@ -3208,7 +3221,7 @@ class ImportClient
         ], true);
 
         $this->write_progress_file($error['message'] ?? null);
-        exit($all_pass ? 0 : 1);
+        $this->exit_code = $all_pass ? 0 : 1;
     }
 
     /**
@@ -13536,6 +13549,12 @@ class ImportClient
         $this->progress_reporter->update($context, $data);
         $this->progress_reporter->write_file();
 
+        if (( $data['status'] ?? null ) === 'error' || ( $data['type'] ?? null ) === 'preflight_assertion') {
+            $this->command_report_details = array_intersect_key($data, array_flip([
+                'error', 'error_code', 'failed_stage', 'checks', 'http_code', 'curl_errno',
+                'consecutive_failures_without_progress',
+            ]));
+        }
         // The non-verbose terminal presentation uses show_progress_line() instead.
         if ($this->uses_terminal_progress() && !$this->verbose_mode) {
             return;
@@ -13616,6 +13635,61 @@ class ImportClient
 // ============================================================================
 // CLI Entry Point
 // ============================================================================
+
+/**
+ * Append the invocation result, never an inner pipeline stage's result.
+ *
+ * A missing client means construction or lock acquisition failed. Reports do
+ * not rely on shutdown callbacks: a killed process cannot promise a result.
+ *
+ * @param string            $command   Invoked command.
+ * @param int               $exit_code Actual process exit code.
+ * @param array             $options { Parsed CLI options.
+ *     @type bool   $report     Whether to append a final report.
+ *     @type bool   $abort      Whether this invocation clears saved work.
+ *     @type string $sql_output SQL destination; stdout reserves that stream for SQL.
+ * }
+ * @param ImportClient|null $client    Command client, when construction succeeded.
+ * @param Throwable|null    $exception Unhandled command failure, when present.
+ */
+function reprint_write_command_report(
+    string $command,
+    int $exit_code,
+    array $options,
+    ?ImportClient $client,
+    ?Throwable $exception = null
+): void {
+    if (empty($options['report'])) {
+        return;
+    }
+    $details = $client === null ? [] : $client->command_report_details;
+    $status = $details['status'] ?? ( $exit_code === 0 ? 'complete' : ( $exit_code === 2 ? 'partial' : 'error' ) );
+    if ($exit_code === 0 && !empty($options['abort'])) {
+        $status = 'aborted';
+    }
+    $error = null;
+    $error_code = null;
+    if ($exit_code !== 0 && $exit_code !== 2) {
+        $error = $exception === null ? ( $details['error'] ?? null ) : $exception->getMessage();
+        $error_code = $details['error_code'] ?? ( $client === null ? null : $client->last_error_code );
+    }
+    $report = [
+        'type' => 'reprint_report',
+        'schema_version' => 1,
+        'command' => $command,
+        'status' => $status,
+        'exit_code' => $exit_code,
+        'failed_stage' => $details['failed_stage'] ?? null,
+        'error' => $error,
+        'error_code' => $error_code,
+    ] + $details;
+    $stream = !in_array($command, ['files-push', 'files-diff'], true)
+        && ( $options['sql_output'] ?? ( $client === null ? null : $client->get_state()->sql_output ) ) === 'stdout'
+        ? STDERR : STDOUT;
+    // Error messages may contain arbitrary source bytes. Keep the record valid
+    // JSON; path fields in structured details use the protocol's base64 form.
+    fwrite($stream, json_encode($report, JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES) . "\n");
+}
 
 // Returns the importer version string. Inside the phar, reads the baked-in
 // VERSION file. In development, falls back to `git describe`.
@@ -13734,6 +13808,14 @@ if (
             'help_section' => 'global',
             'commands' => ImportClient::COMMANDS,
             'valid_values' => ImportClient::PROGRESS_OUTPUT_MODES,
+        ],
+        [
+            'name' => 'report',
+            'type' => 'flag',
+            'target' => 'report',
+            'help' => 'Append one versioned JSON command report to the progress stream',
+            'help_section' => 'global',
+            'commands' => ImportClient::COMMANDS,
         ],
         [
             'name' => 'abort',
@@ -15056,7 +15138,7 @@ if (
         foreach ($reprint_files_command_arguments as $reprint_files_push_command_argument) {
             $reprint_files_push_option_allowed = in_array(
                 $reprint_files_push_command_argument,
-                ['--force-http', '--verbose', '-v'],
+                ['--force-http', '--verbose', '-v', '--report'],
                 true
             )
                 || strpos($reprint_files_push_command_argument, '--state-dir=') === 0
@@ -15072,7 +15154,8 @@ if (
     } elseif ($command === 'files-diff') {
         foreach ($reprint_files_command_arguments as $reprint_files_diff_command_argument) {
             $reprint_files_diff_option_allowed =
-                strpos($reprint_files_diff_command_argument, '--progress=') === 0
+                $reprint_files_diff_command_argument === '--report'
+                || strpos($reprint_files_diff_command_argument, '--progress=') === 0
                 || strpos($reprint_files_diff_command_argument, '--state-dir=') === 0
                 || strpos($reprint_files_diff_command_argument, '--fs-root=') === 0;
             if (!$reprint_files_diff_option_allowed) {
@@ -15212,6 +15295,7 @@ if (
         // channel to surface as ndjson events. Stash the exit code on
         // a global so the embedder can read it.
         $GLOBALS['REPRINT_PULL_EXIT_CODE'] = (int) $client->exit_code;
+        reprint_write_command_report($command, (int) $client->exit_code, $options, $client);
         if (!defined('EXIT_AFTER_PULL') || EXIT_AFTER_PULL) {
             exit($client->exit_code);
         }
@@ -15242,6 +15326,7 @@ if (
         }
         $reprint_exit_code = $e instanceof RetryLaterException ? 3 : 1;
         $GLOBALS['REPRINT_PULL_EXIT_CODE'] = $reprint_exit_code;
+        reprint_write_command_report($command, (int) $GLOBALS['REPRINT_PULL_EXIT_CODE'], $options, $client ?? null, $e);
         if (!defined('EXIT_AFTER_PULL') || EXIT_AFTER_PULL) {
             exit( (int) $reprint_exit_code );
         }

--- a/tests/Import/CommandReportTest.php
+++ b/tests/Import/CommandReportTest.php
@@ -142,13 +142,14 @@ final class CommandReportTest extends TestCase {
             'body' => 'Upstream unavailable',
             'preflight_body' => json_encode($preflight_data),
         ]));
+        // Each invocation exhausts its own three-request retry allowance.
         for ($attempt = 1; $attempt <= 2; ++$attempt) {
             $report = $this->read_report($this->run_command($command, ['--report']));
             $this->assertSame(3, $report['exit_code']);
             $this->assertSame('error', $report['status']);
             $this->assertSame('SERVER_ERROR', $report['error_code']);
             $this->assertSame(520, $report['http_code']);
-            $this->assertSame($attempt, $report['consecutive_failures_without_progress']);
+            $this->assertSame(3, $report['consecutive_failures_without_progress']);
             $this->assertSame($command === 'pull-files' ? 'files-pull' : null, $report['failed_stage']);
             $this->assertArrayNotHasKey('retry_after_seconds', $report);
         }

--- a/tests/Import/CommandReportTest.php
+++ b/tests/Import/CommandReportTest.php
@@ -121,13 +121,46 @@ final class CommandReportTest extends TestCase {
         $this->assertSame('aborted', $aborted['status']);
     }
 
-    public function testPartialDownloadIsNotReportedAsComplete(): void
+    /** @dataProvider retryable_commands */
+    public function testRetryableReportKeepsExitCodeAndStalledRequestCount(string $command): void
     {
-        $this->run_command('preflight');
-        // db-pull first saves its db-index phase and returns to the caller.
-        $result = $this->run_command('db-pull', ['--report']);
-        $report = $this->read_report($result);
-        $this->assertSame(2, $report['exit_code'], $result['stdout'] . $result['stderr']);
+        $preflight = $this->run_command('preflight');
+        $preflight_data = json_decode($preflight['stdout'], true)['data'];
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 520,
+            'body' => 'Upstream unavailable',
+            'preflight_body' => json_encode($preflight_data),
+        ]));
+        for ($attempt = 1; $attempt <= 2; ++$attempt) {
+            $report = $this->read_report($this->run_command($command, ['--report']));
+            $this->assertSame(3, $report['exit_code']);
+            $this->assertSame('error', $report['status']);
+            $this->assertSame('SERVER_ERROR', $report['error_code']);
+            $this->assertSame(520, $report['http_code']);
+            $this->assertSame($attempt, $report['consecutive_failures_without_progress']);
+            $this->assertSame($command === 'pull-files' ? 'files-pull' : null, $report['failed_stage']);
+            $this->assertArrayNotHasKey('retry_after_seconds', $report);
+        }
+    }
+
+    public static function retryable_commands(): array
+    {
+        return [['files-pull'], ['pull-files']];
+    }
+
+    public function testPartialReportIsNotReportedAsComplete(): void
+    {
+        // Check the report's exit-code mapping directly. Low-level pulls now
+        // continue through healthy phase boundaries in the same process.
+        $script = 'require $argv[1]; reprint_write_command_report("db-pull", 2, ["report" => true], null); exit(2);';
+        exec(
+            escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($script) . ' '
+                . escapeshellarg(__DIR__ . '/../../packages/reprint-client/src/import.php'),
+            $output,
+            $exit_code
+        );
+        $report = $this->read_report(['exit_code' => $exit_code, 'stdout' => implode("\n", $output), 'stderr' => '']);
+        $this->assertSame(2, $report['exit_code']);
         $this->assertSame('partial', $report['status']);
         $this->assertNull($report['error']);
     }

--- a/tests/Import/CommandReportTest.php
+++ b/tests/Import/CommandReportTest.php
@@ -70,6 +70,17 @@ final class CommandReportTest extends TestCase {
         $this->assertTrue(json_decode($records[0], true)['data']['ok']);
     }
 
+    public function testCompactAddsAReportOnlyWhenRequestedWithoutCreatingAProgressLog(): void
+    {
+        $plain = $this->run_command('preflight', ['--progress=compact']);
+        $this->assertSame(0, $plain['exit_code'], $plain['stderr']);
+        $this->assertTrue(json_decode($plain['stdout'], true, 512, JSON_THROW_ON_ERROR)['data']['ok']);
+        $result = $this->run_command('preflight', ['--progress=compact', '--report']);
+        $this->read_report($result);
+        $this->assertCount(2, explode("\n", trim($result['stdout'])));
+        $this->assertFileDoesNotExist($this->root . '/state/progress.jsonl');
+    }
+
     public function testPipelineFailureProducesOnlyTheOuterReport(): void
     {
         file_put_contents($this->root . '/response.json', json_encode([

--- a/tests/Import/CommandReportTest.php
+++ b/tests/Import/CommandReportTest.php
@@ -1,0 +1,225 @@
+<?php
+
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Match the existing importer test namespace.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/bin/reprint-client';
+
+final class CommandReportTest extends TestCase {
+    private string $root;
+    private string $remote_url;
+    /** @var resource */
+    private $server_process;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/reprint-command-report-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/remote', 0755, true);
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error);
+        $this->assertIsResource($listener, (string) $error);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $this->remote_url = 'http://' . $address . '/?reprint-api&directory[]=' . rawurlencode($this->root . '/remote');
+        $this->server_process = proc_open(
+            [PHP_BINARY, '-S', $address, __DIR__ . '/fixtures/command-report-router.php'],
+            [0 => ['pipe', 'r'], 1 => ['file', $this->root . '/server.log', 'a'], 2 => ['file', $this->root . '/server.log', 'a']],
+            $pipes,
+            $this->root
+        );
+        $this->assertIsResource($this->server_process);
+        fclose($pipes[0]);
+        $deadline = microtime(true) + 5;
+        do {
+            $connection = @stream_socket_client('tcp://' . $address, $error_number, $error, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+                return;
+            }
+            usleep(20000);
+        } while (microtime(true) < $deadline);
+        $this->fail(file_get_contents($this->root . '/server.log'));
+    }
+
+    protected function tearDown(): void
+    {
+        proc_terminate($this->server_process);
+        proc_close($this->server_process);
+        $this->remove_directory($this->root);
+    }
+
+    public function testPreflightKeepsItsDataAndAppendsOneReportOnlyWhenRequested(): void
+    {
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 200,
+            'body' => '{"ok":true}',
+        ]));
+        $plain = $this->run_command('preflight');
+        $this->assertSame(0, $plain['exit_code'], $plain['stderr']);
+        $plain_data = json_decode($plain['stdout'], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertTrue($plain_data['data']['ok']);
+
+        $reported = $this->run_command('preflight', ['--report']);
+        $report = $this->read_report($reported);
+        $this->assertSame('preflight', $report['command']);
+        $this->assertSame('complete', $report['status']);
+        $this->assertNull($report['error']);
+        $this->assertNull($report['error_code']);
+        $records = explode("\n", trim($reported['stdout']));
+        $this->assertTrue(json_decode($records[0], true)['data']['ok']);
+    }
+
+    public function testPipelineFailureProducesOnlyTheOuterReport(): void
+    {
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 401,
+            'body' => '{"error":"Invalid signature"}',
+        ]));
+        $result = $this->run_command('pull-files', ['--report']);
+        $report = $this->read_report($result);
+        $this->assertSame(1, $result['exit_code']);
+        $this->assertSame('pull-files', $report['command']);
+        $this->assertSame('preflight', $report['failed_stage']);
+        $this->assertSame('error', $report['status']);
+        $this->assertSame('AUTH_FAILED', $report['error_code']);
+        $this->assertStringContainsString('Invalid signature', $report['error']);
+    }
+
+    public function testPreflightFailureAndSavedAssertionHaveTheSameReportError(): void
+    {
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 520,
+            'body' => '<html>Unknown error</html>',
+        ]));
+        $preflight = $this->read_report($this->run_command('preflight', ['--report']));
+        $assertion = $this->read_report($this->run_command('preflight-assert', ['--report']));
+        $this->assertSame('SERVER_ERROR', $preflight['error_code']);
+        $this->assertSame($preflight['error'], $assertion['error']);
+        $this->assertSame($preflight['error_code'], $assertion['error_code']);
+        $this->assertNotEmpty($assertion['checks']);
+        $this->assertSame('SERVER_RESPONDED', $assertion['checks'][0]['code']);
+    }
+
+    public function testRealFileDownloadReportsCompleteAndAbortIsNotSuccess(): void
+    {
+        file_put_contents($this->root . '/remote/example.txt', 'download me');
+        $this->run_command('preflight');
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $result = $this->run_command('files-pull', ['--report']);
+            $report = $this->read_report($result);
+            $this->assertSame($result['exit_code'] === 2 ? 'partial' : 'complete', $report['status'], $result['stdout'] . $result['stderr']);
+            if ($result['exit_code'] !== 2) {
+                break;
+            }
+        }
+        $this->assertSame(0, $result['exit_code'], $result['stderr']);
+        $downloaded_file = $this->root . '/files' . realpath($this->root . '/remote') . '/example.txt';
+        $this->assertFileExists($downloaded_file, $result['stdout']);
+        $this->assertSame('download me', file_get_contents($downloaded_file));
+        $aborted = $this->read_report($this->run_command('files-pull', ['--report', '--abort']));
+        $this->assertSame('aborted', $aborted['status']);
+    }
+
+    public function testPartialDownloadIsNotReportedAsComplete(): void
+    {
+        $this->run_command('preflight');
+        // db-pull first saves its db-index phase and returns to the caller.
+        $result = $this->run_command('db-pull', ['--report']);
+        $report = $this->read_report($result);
+        $this->assertSame(2, $report['exit_code'], $result['stdout'] . $result['stderr']);
+        $this->assertSame('partial', $report['status']);
+        $this->assertNull($report['error']);
+    }
+
+    public function testSqlStdoutRemainsReservedForSqlOnFailure(): void
+    {
+        $this->run_command('preflight');
+        file_put_contents($this->root . '/response.json', json_encode([
+            'http_code' => 401,
+            'body' => '{"error":"Invalid signature"}',
+        ]));
+        for ($attempt = 0; $attempt < 3; $attempt++) {
+            $result = $this->run_command('db-pull', ['--report', '--sql-output=stdout']);
+            if ($result['exit_code'] !== 2) {
+                break;
+            }
+        }
+        $this->assertSame('', $result['stdout']);
+        $report = $this->read_report(array_replace($result, ['stdout' => $result['stderr']]));
+        $this->assertSame('AUTH_FAILED', $report['error_code'], $result['stderr']);
+    }
+
+    public function testLockFailureStillProducesAReport(): void
+    {
+        mkdir($this->root . '/state');
+        $lock = new \ReprintProcessLock($this->root . '/state');
+        try {
+            $result = $this->run_command('preflight', ['--report']);
+            $report = $this->read_report($result);
+            $this->assertSame(1, $report['exit_code']);
+            $this->assertNotEmpty($report['error']);
+        } finally {
+            $lock->close();
+        }
+    }
+
+    /**
+     * @param array $options Extra CLI arguments.
+     * @return array { Captured process result.
+     *     @type int    $exit_code Process exit code.
+     *     @type string $stdout    Standard output.
+     *     @type string $stderr    Standard error.
+     * }
+     */
+    private function run_command(string $command, array $options = []): array
+    {
+        $process = proc_open(
+            array_merge([
+                PHP_BINARY, __DIR__ . '/../../packages/reprint-client/bin/reprint-client',
+                $command, $this->remote_url, '--secret=preflight-test-secret',
+                '--state-dir=' . $this->root . '/state', '--fs-root=' . $this->root . '/files',
+                '--progress=jsonl',
+            ], $options),
+            [0 => ['pipe', 'r'], 1 => ['file', $this->root . '/stdout', 'w'], 2 => ['file', $this->root . '/stderr', 'w']],
+            $pipes
+        );
+        $this->assertIsResource($process);
+        fclose($pipes[0]);
+        return [
+            'exit_code' => proc_close($process),
+            'stdout' => file_get_contents($this->root . '/stdout'),
+            'stderr' => file_get_contents($this->root . '/stderr'),
+        ];
+    }
+
+    /** @param array $result Process output from run_command(). */
+    private function read_report(array $result): array
+    {
+        $reports = [];
+        foreach (explode("\n", trim($result['stdout'])) as $line) {
+            $record = json_decode($line, true);
+            if (is_array($record) && ( $record['type'] ?? null ) === 'reprint_report') {
+                $reports[] = $record;
+            }
+        }
+        $this->assertCount(1, $reports, $result['stdout'] . $result['stderr']);
+        $this->assertSame(1, $reports[0]['schema_version']);
+        $this->assertSame($result['exit_code'], $reports[0]['exit_code']);
+        $lines = explode("\n", trim($result['stdout']));
+        $this->assertSame($reports[0], json_decode(end($lines), true));
+        return $reports[0];
+    }
+
+    private function remove_directory(string $directory): void
+    {
+        foreach (scandir($directory) as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $name;
+            is_dir($path) && !is_link($path) ? $this->remove_directory($path) : unlink($path);
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/fixtures/command-report-router.php
+++ b/tests/Import/fixtures/command-report-router.php
@@ -1,0 +1,17 @@
+<?php
+
+// Model preflight without installing WordPress. File transfers below still
+// use the real endpoint and its multipart protocol.
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput -- The fixture selects the endpoint requested by the real CLI.
+if (!is_file('response.json') && ( $_GET['endpoint'] ?? '' ) === 'preflight') {
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON fixture, not HTML.
+    echo json_encode([
+        'ok' => true,
+        'protocol_version' => 3,
+        'filesystem' => ['ok' => true],
+        'database' => ['connected' => true],
+        'wp_detect' => ['roots' => [['path' => getcwd() . '/remote']]],
+    ]);
+    return;
+}
+require __DIR__ . '/preflight-errors-router.php';


### PR DESCRIPTION
Adds `--report` to append one final command result, so a caller can read the outcome without interpreting progress messages.

#788 is merged; this PR now targets trunk. The two options work separately: `--progress=compact` shortens progress output; `--report` adds the final result. With both options, the short progress output is followed by the final report. No additional log file is written.

```sh
php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" \
    --fs-root="$FS_ROOT" --secret="$SECRET" --progress=compact --report
```

The last record identifies the command, status, actual exit code, and error. A pipeline reports its outer command and failed stage, not a separate report for each inner command. Exit 2 stays partial, abort stays separate from success, and exit 3 retains the HTTP error and the count of three failed requests without progress in the current invocation. Preflight checks gain stable codes. SQL stdout stays reserved for SQL.

A killed process or an early argument error can leave no report; the caller must use the host job status then. This does not group warnings or change retry scheduling. [CLI reporting](https://github.com/WordPress/reprint/blob/codex/cli-final-report/docs/CLI-REPORTING.md) describes the record and how to read several command reports in one ticket.

## Testing

Run preflight with and without `--report`, then with both `--progress=compact --report`. Check that the requested report appears once after the command result, with no additional log file. Run `pull-files --report` with a bad connection token and check that only the outer command has a final report naming the failed stage.
