### PR TITLE
[PHP] Keep screen snapshots and file counters outside ImportClient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,14 @@ current byte-bounded phase, `current_file` reports base64 path plus file byte
 progress during files-pull, and `current_table` reports table row progress
 during db-pull.
 
+`ProgressReporter` retains one screen snapshot and handles JSONL output and
+progress-file writes. Ordinary log messages do not replace the screen label.
+`FilesPullProgress` rebuilds file counters from the fetch list and its saved
+cursor, including completed paths inside a resumed batch. The fetch list stores
+only the base64 path and content size; directories and symlinks have size zero.
+These counters add no fields to the pull checkpoint. The current table's row
+estimate is cached only while `fetch_sql()` runs.
+
 During the file fetch phase, progress and heartbeat records keep the legacy
 `files_done` and `files_total` fields and also report them through
 `progress.items`. The current file byte count changes while one large file is

--- a/README.md
+++ b/README.md
@@ -776,6 +776,8 @@ immediately. A polling UI can therefore read this file without parsing JSONL.
 The JSONL records that report screen progress carry the same `schema_version`
 and nested `progress` object, while their event-specific top-level fields stay
 available for existing consumers.
+Ordinary log events, such as a skipped path, do not replace the screen's action
+label. File counts and bytes include completed paths inside a resumed batch.
 
 Every command run by `ImportClient` accepts `--progress=auto|tty|jsonl`. The
 default `auto` mode uses terminal progress when its output stream is a TTY and

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -15,8 +15,10 @@ use Reprint\Importer\Database\DatabaseConnection;
 use Reprint\Importer\Database\MysqliDatabaseConnection;
 use Reprint\Importer\Database\PdoDatabaseConnection;
 use Reprint\Importer\DatabaseUrlRewriteProcessor;
+use Reprint\Importer\FilesPullProgress;
 use Reprint\Importer\NullableSpatialColumnStatementRewriter;
 use Reprint\Importer\PreserveLocalSkipException;
+use Reprint\Importer\ProgressReporter;
 use Reprint\Importer\Pull\PullFailureReportedException;
 use Reprint\Importer\SpatialSridGuard;
 use Reprint\Importer\State\DatabaseApplyCommandState;
@@ -189,15 +191,6 @@ class ImportClient
     /** Progress output modes accepted by every command. */
     public const PROGRESS_OUTPUT_MODES = ['auto', 'tty', 'jsonl'];
 
-    private const PROGRESS_SCHEMA_VERSION = 1;
-
-    /** Stable progress-screen keys used when a phase has no reported counters. */
-    private const EMPTY_PROGRESS_DETAILS = [
-        'items' => null,
-        'bytes' => null,
-        'current_file' => null,
-        'current_table' => null,
-    ];
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const DATABASE_IMPORT_POSITION_TABLE_PREFIX = "__reprint_db_pull_progress_";
@@ -264,29 +257,8 @@ class ImportClient
     /** @var string Pull state file which persists command, cursor, and stage across invocations. */
     private $pull_state_file;
 
-    /**
-     * @var float Monotonic timestamp of last progress JSON line emitted.
-     * Used with $progress_throttle to rate-limit stdout progress output.
-     */
-    private $last_progress_output = 0;
-
-    /** @var float Timestamp of the last successful progress.json write. */
-    private $last_progress_file_write = 0;
-
-    /** @var float Minimum seconds between recurring progress reports. */
-    private $progress_throttle = 1.0;
-
-    /** @var string|null Latest message associated with the progress-screen counters. */
-    private $progress_message = null;
-
-    /** @var array|null Latest progress-screen counters emitted by the active command. */
-    private $progress_details = null;
-
-    /** @var string|null Command whose counters are stored in $progress_details. */
-    private $progress_details_command = null;
-
-    /** @var string|null Phase whose counters are stored in $progress_details. */
-    private $progress_details_phase = null;
+    /** @var ProgressReporter Screen snapshots, JSONL output and write throttling. */
+    private ProgressReporter $progress_reporter;
 
     /** @var string Retained filesystem-root snapshot for this remote state directory. */
     private $local_index_file;
@@ -334,33 +306,8 @@ class ImportClient
     /** @var string Progress output mode for this invocation: auto, tty, or jsonl. */
     private $progress_output_mode = 'auto';
 
-    /** @var int Running count of files pulled in the current invocation. */
-    private $files_pulled = 0;
-
-    /** @var int Running byte count of completed files in the current fetch batch. */
-    private $files_pulled_bytes = 0;
-
-    /** @var int|null Total entries in the current fetch list. Set once
-     *  at the start of fetch_files_from_list() while reading byte totals. */
-    private $fetch_list_total = null;
-
-    /** @var int|null Entries already processed (before the current offset)
-     *  in the fetch list.  Computed at list start and incremented after
-     *  each batch completes.  This is the cumulative, restart-safe counter
-     *  that consumers should display as "files done". */
-    private $fetch_list_done = null;
-
-    /** @var int|null Regular-file bytes represented by the current fetch list. */
-    private $fetch_list_bytes_total = null;
-
-    /** @var int|null Regular-file bytes before the current fetch-list offset. */
-    private $fetch_list_bytes_done = null;
-
-    /** @var string|null Table whose row estimate is cached for progress output. */
-    private $database_progress_table_name = null;
-
-    /** @var int|null Estimated rows in the cached progress table. */
-    private $database_progress_table_rows_total = null;
+    /** @var FilesPullProgress Rebuildable counters for the selected file list. */
+    private FilesPullProgress $files_pull_progress;
 
     /** @var PullState Persistent pull state loaded from / saved to $pull_state_file. */
     private PullState $state;
@@ -502,9 +449,6 @@ class ImportClient
     /** @var int|null Total number of pipeline steps. Set via --steps. */
     private $pipeline_steps = null;
 
-    /** @var string Path to progress.json — machine-readable progress for external readers. */
-    private $progress_file;
-
     /** @var string SQL output mode: 'file' (default), 'stdout', or 'mysql'. */
     private $sql_output_mode = 'file';
 
@@ -588,7 +532,10 @@ class ImportClient
             wp_join_unix_paths($this->pull_state_directory, "fetch-list.jsonl.new");
         $this->audit_log_file = wp_join_unix_paths($this->state_dir, "audit.log");
         $this->volatile_files_file = wp_join_unix_paths($this->pull_state_directory, "volatile-files.json");
-        $this->progress_file = wp_join_unix_paths($this->state_dir, "progress.json");
+        $this->progress_reporter = new ProgressReporter(
+            wp_join_unix_paths($this->state_dir, "progress.json")
+        );
+        $this->files_pull_progress = new FilesPullProgress();
 
         // Detect TTY for progress display and terminal colors. In stdout mode
         // this is re-evaluated against STDERR in run() once the output mode is
@@ -1891,26 +1838,15 @@ class ImportClient
             }
         }
         $progress_details = $this->files_push_progress_details($sender_progress);
-        $result['schema_version'] = self::PROGRESS_SCHEMA_VERSION;
+        $result['schema_version'] = ProgressReporter::SCHEMA_VERSION;
         $result['progress'] = $progress_details;
 
         // Write the files-push progress snapshot without consulting pull state.
-        $progress_payload = [
-            'schema_version' => self::PROGRESS_SCHEMA_VERSION,
+        $this->progress_reporter->update($result + [
             'step' => $this->pipeline_step,
             'steps' => $this->pipeline_steps,
-            'command' => 'files-push',
-            'status' => $status,
-            'phase' => $phase,
-            'message' => $message,
-            'progress' => $progress_details,
-            'error' => null,
-            'error_code' => null,
-            'reason' => $reason,
-            'detail' => $detail,
-            'ts' => microtime(true),
-        ];
-        $this->write_files_push_progress_file($progress_payload, true);
+        ], $result);
+        $this->progress_reporter->write_file(true);
 
         // Emit the final JSON line after any preceding progress records.
         if ($this->uses_terminal_progress() && !$this->verbose_mode) {
@@ -2094,27 +2030,12 @@ class ImportClient
 
         $progress_record = [
             'type' => 'push_progress',
-            'schema_version' => self::PROGRESS_SCHEMA_VERSION,
+            'schema_version' => ProgressReporter::SCHEMA_VERSION,
             'command' => 'files-push',
             'status' => 'in_progress',
             'phase' => $phase,
             'message' => $message,
             'progress' => $this->files_push_progress_details($sender_progress),
-        ];
-        $progress_payload = [
-            'schema_version' => self::PROGRESS_SCHEMA_VERSION,
-            'step' => $this->pipeline_step,
-            'steps' => $this->pipeline_steps,
-            'command' => 'files-push',
-            'status' => 'in_progress',
-            'phase' => $phase,
-            'message' => $message,
-            'progress' => $progress_record['progress'],
-            'error' => null,
-            'error_code' => null,
-            'reason' => null,
-            'detail' => null,
-            'ts' => microtime(true),
         ];
         foreach (['files_done', 'files_total'] as $progress_field) {
             if (isset($sender_progress[$progress_field])) {
@@ -2122,7 +2043,6 @@ class ImportClient
             }
         }
         $this->output_progress($progress_record, $force_output);
-        $this->write_files_push_progress_file($progress_payload);
     }
 
     /**
@@ -2140,7 +2060,7 @@ class ImportClient
      */
     private function files_push_progress_details(array $sender_progress): array
     {
-        $progress = self::EMPTY_PROGRESS_DETAILS;
+        $progress = ProgressReporter::EMPTY_DETAILS;
         if (isset($sender_progress['files_done'], $sender_progress['files_total'])) {
             $progress['items'] = [
                 'unit' => 'local_paths',
@@ -2185,27 +2105,6 @@ class ImportClient
             return 1.0;
         }
         return max(0.0, min(1.0, $done / $total));
-    }
-
-    /**
-     * Writes the files-push progress snapshot when its active-write limit allows it.
-     *
-     * @param array<string,mixed> $progress_payload Complete progress-file payload.
-     * @param bool                $force            Whether to write without waiting for the active-write interval.
-     */
-    private function write_files_push_progress_file(
-        array $progress_payload,
-        bool $force = false
-    ): void
-    {
-        if (
-            !$force
-            && microtime(true) - $this->last_progress_file_write <
-                $this->progress_throttle
-        ) {
-            return;
-        }
-        $this->write_progress_payload($progress_payload);
     }
 
     // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- These exceptions are CLI text, not HTML.
@@ -3338,10 +3237,10 @@ class ImportClient
 
         // Resuming an in-progress sync
         if ($has_progress) {
-            // Don't reset files_pulled here — it counts files within
-            // the current batch and is only reset when a batch completes
-            // (in fetch_files_from_list). Resetting it on entry would
-            // cause the progress counter to dip between pull retries.
+            // Keep the current batch counters across requests in this invocation.
+            // They reset only when the batch completes or is rebuilt in
+            // fetch_files_from_list(). Resetting them on entry would make the
+            // progress counter dip between pull retries.
             $remote_index_entry_count = $this->remote_index_entry_count();
 
 
@@ -3394,10 +3293,10 @@ class ImportClient
             $this->get_state()->index = new RemoteFileIndexCursorState();
             $this->get_state()->fetch = new FetchListProgressState();
             $this->get_state()->files_pull_summary = new FilesPullSummaryState();
+            $this->files_pull_progress = new FilesPullProgress();
             $this->save_state();
 
             if ($is_delta) {
-                $this->files_pulled = 0;
                 $remote_index_entry_count = $this->remote_index_entry_count();
 
                 $this->audit_log(
@@ -3607,23 +3506,7 @@ class ImportClient
 
         $this->progress->show_lifecycle_line("{$label} complete: {$remote_index_entry_count} remote index entries\n");
         $this->progress->show_lifecycle_line("Audit log: {$this->audit_log_file}\n");
-        $progress = self::EMPTY_PROGRESS_DETAILS;
-        if ($this->fetch_list_done !== null && $this->fetch_list_total !== null) {
-            $progress['items'] = [
-                'unit' => 'files',
-                'done' => $this->fetch_list_done,
-                'total' => $this->fetch_list_total,
-            ];
-        }
-        if (
-            $this->fetch_list_bytes_done !== null
-            && $this->fetch_list_bytes_total !== null
-        ) {
-            $progress['bytes'] = [
-                'done' => $this->fetch_list_bytes_done,
-                'total' => $this->fetch_list_bytes_total,
-            ];
-        }
+        $progress = $this->files_pull_progress->get_details();
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
@@ -6373,7 +6256,7 @@ class ImportClient
     private function database_rewrite_progress_details(
         int $records_processed
     ): array {
-        $progress = self::EMPTY_PROGRESS_DETAILS;
+        $progress = ProgressReporter::EMPTY_DETAILS;
         $progress['items'] = [
             'unit' => 'records',
             'done' => $records_processed,
@@ -7139,7 +7022,7 @@ class ImportClient
         int $bytes_read,
         int $bytes_total
     ): array {
-        $progress = self::EMPTY_PROGRESS_DETAILS;
+        $progress = ProgressReporter::EMPTY_DETAILS;
         $progress['items'] = [
             'unit' => 'statements',
             'done' => $statements_executed,
@@ -8386,52 +8269,8 @@ class ImportClient
             return true;
         }
 
-        // Compute fetch list counters once at the start of each list.
-        // These survive across batches within one invocation and are
-        // recomputed on restart from the state file's byte offset.
-        if ($this->fetch_list_total === null) {
-            $offset = $this->get_state()->fetch->offset;
-            $this->fetch_list_total = 0;
-            $this->fetch_list_done = 0;
-            $this->fetch_list_bytes_total = 0;
-            $this->fetch_list_bytes_done = 0;
-            $has_sizes_for_every_fetch_entry = true;
-            $fetch_list_handle = fopen($list_file, 'rb');
-            if (!is_resource($fetch_list_handle)) {
-                throw new RuntimeException('Failed to open the fetch list for progress totals.');
-            }
-            while (true) {
-                $fetch_list_line = fgets($fetch_list_handle);
-                if ($fetch_list_line === false) {
-                    break;
-                }
-                $fetch_list_entry = json_decode($fetch_list_line, true);
-                if (!is_array($fetch_list_entry)) {
-                    continue;
-                }
-                ++$this->fetch_list_total;
-                $fetch_list_position = ftell($fetch_list_handle);
-                if (is_int($fetch_list_position) && $fetch_list_position <= $offset) {
-                    ++$this->fetch_list_done;
-                }
-                if (!isset($fetch_list_entry['type'], $fetch_list_entry['size'])) {
-                    $has_sizes_for_every_fetch_entry = false;
-                    continue;
-                }
-                if ($fetch_list_entry['type'] === 'file') {
-                    $fetch_entry_size = (int) $fetch_list_entry['size'];
-                    $this->fetch_list_bytes_total += $fetch_entry_size;
-                    if (is_int($fetch_list_position) && $fetch_list_position <= $offset) {
-                        $this->fetch_list_bytes_done += $fetch_entry_size;
-                    }
-                }
-            }
-            fclose($fetch_list_handle);
-            if (!$has_sizes_for_every_fetch_entry) {
-                $this->fetch_list_bytes_total = null;
-                $this->fetch_list_bytes_done = null;
-            }
-        }
+        // Compute totals once, reconstructing completed paths from the saved cursor.
+        $this->files_pull_progress->load_list($list_file, $this->get_state()->fetch);
         $fetch_state = $this->get_state()->fetch;
         $batch_file = $fetch_state->batch_file;
         $batch_offset = $fetch_state->offset;
@@ -8455,8 +8294,7 @@ class ImportClient
             // Clear this batch's progress tracking, as it's going to be rebuilt & restarted.
             $this->get_state()->current_file = null;
             $this->get_state()->current_file_bytes = null;
-            $this->files_pulled = 0;
-            $this->files_pulled_bytes = 0;
+            $this->files_pull_progress->restart_batch();
         }
 
         if ($batch_file === null || !file_exists($batch_file)) {
@@ -8497,19 +8335,8 @@ class ImportClient
             $this->audit_log("FILE DELETE | {$batch_file} | fetch batch complete");
         }
 
-        // Advance the done counter by the known batch size and reset
-        // the per-batch file counter. files_pulled counted files within
-        // this batch; now that the batch is complete, those files are
-        // accounted for in fetch_list_done.
-        if ($this->fetch_list_done !== null) {
-            $this->fetch_list_done += $batch_entries;
-        }
-        if ($this->fetch_list_bytes_done !== null) {
-            $this->fetch_list_bytes_done += $this->files_pulled_bytes;
-        }
+        $this->files_pull_progress->complete_batch($batch_entries);
         $this->get_state()->files_pull_summary->files_pulled += $batch_entries;
-        $this->files_pulled = 0;
-        $this->files_pulled_bytes = 0;
 
         $this->get_state()->fetch = FetchListProgressState::from_array([
             "offset" => $next_offset,
@@ -8671,7 +8498,6 @@ class ImportClient
         $fetch_list_json_line = json_encode(
             [
                 "path" => base64_encode($remote_absolute_path),
-                "type" => $remote_path_type,
                 "size" => $remote_path_type === 'file' ? $remote_file_size : 0,
             ],
             JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
@@ -8885,8 +8711,7 @@ class ImportClient
         $cursor = $this->get_state()->active_resumable_command->remote_cursor ?? null;
         $complete = false;
         $mode = $this->sql_output_mode;
-        $this->database_progress_table_name = null;
-        $this->database_progress_table_rows_total = null;
+        $progress_table = null;
 
         // ── Set up write strategy based on output mode ──────────────
 
@@ -9062,6 +8887,7 @@ class ImportClient
                     $spatial_srid_guard,
                     $session_setup_file,
                     &$sql_bytes_written,
+                    &$progress_table,
                     $context,
                     $query_stream,
                     &$sql_statements_counted,
@@ -9226,7 +9052,8 @@ class ImportClient
                             'message' => 'Downloading SQL dump',
                             'progress' => $this->database_pull_progress_details(
                                 $cursor,
-                                $sql_bytes_written
+                                $sql_bytes_written,
+                                $progress_table
                             ),
                         ]);
 
@@ -9394,13 +9221,19 @@ class ImportClient
      *
      * @param string|null $cursor Base64-encoded exporter cursor.
      * @param int         $sql_bytes_written SQL bytes written by this pull.
+     * @param array|null  $progress_table {
+     *     Cached estimate for the current table, retained only while fetch_sql() runs.
+     *     @type string   $name       Table name.
+     *     @type int|null $rows_total Estimated rows, or null when absent from db-index.
+     * }
      * @return array<string,mixed> Stable progress-screen details.
      */
     private function database_pull_progress_details(
         ?string $cursor,
-        int $sql_bytes_written
+        int $sql_bytes_written,
+        ?array &$progress_table
     ): array {
-        $progress = self::EMPTY_PROGRESS_DETAILS;
+        $progress = ProgressReporter::EMPTY_DETAILS;
         $progress['bytes'] = [
             'done' => $sql_bytes_written,
             // INFORMATION_SCHEMA only supplies a rough estimate,
@@ -9441,9 +9274,8 @@ class ImportClient
         }
 
         $table_name = $current_table['name'];
-        if ($this->database_progress_table_name !== $table_name) {
-            $this->database_progress_table_name = $table_name;
-            $this->database_progress_table_rows_total = null;
+        if (($progress_table['name'] ?? null) !== $table_name) {
+            $progress_table = ['name' => $table_name, 'rows_total' => null];
             $tables_file = wp_join_unix_paths($this->state_dir, 'db-tables.jsonl');
             $tables_handle = @fopen($tables_file, 'rb');
             if (is_resource($tables_handle)) {
@@ -9459,7 +9291,7 @@ class ImportClient
                         && isset($table['rows'])
                         && is_numeric($table['rows'])
                     ) {
-                        $this->database_progress_table_rows_total = (int) $table['rows'];
+                        $progress_table['rows_total'] = (int) $table['rows'];
                         break;
                     }
                 }
@@ -9470,7 +9302,7 @@ class ImportClient
         $progress['current_table'] = [
             'name' => $table_name,
             'rows_done' => (int) $current_table['rows_done'],
-            'rows_total' => $this->database_progress_table_rows_total,
+            'rows_total' => $progress_table['rows_total'],
             'rows_total_is_estimate' => true,
         ];
         return $progress;
@@ -10673,6 +10505,10 @@ class ImportClient
         if ($context->remote_file_path === null) {
             $context->remote_file_path = $path;
             $context->remote_file_size = $file_size;
+            if (!$is_first) {
+                // A resumed handle has no ctime yet; the continuation part supplies it.
+                $context->file_ctime = (int) ($headers["x-file-ctime"] ?? 0);
+            }
         }
 
         // Open file on first chunk
@@ -10712,8 +10548,9 @@ class ImportClient
                 false,
             );
 
-            $files_done = ($this->fetch_list_done ?? 0) + $this->files_pulled;
-            $files_total = $this->fetch_list_total;
+            $file_progress = $this->files_pull_progress->get_details($context);
+            $files_done = $file_progress['items']['done'];
+            $files_total = $file_progress['items']['total'];
             $file_fraction = ($files_total !== null && $files_total > 0)
                 ? $files_done / $files_total
                 : null;
@@ -10813,8 +10650,7 @@ class ImportClient
                     "file",
                     $context->file_path,
                 );
-                $this->files_pulled++; // Count completed files only
-                $this->files_pulled_bytes += $file_size;
+                $this->files_pull_progress->complete_file($file_size);
                 $this->clear_volatile_file($path);
                 $this->audit_log(
                     sprintf("  Indexed (wrote %d bytes)", $final_size),
@@ -10853,35 +10689,9 @@ class ImportClient
         ?string $event_path = null,
         ?int $event_size = null
     ): array {
-        $files_done = ($this->fetch_list_done ?? 0) + $this->files_pulled;
-        $files_total = $this->fetch_list_total;
-        $progress = self::EMPTY_PROGRESS_DETAILS;
-        $progress['items'] = [
-            'unit' => 'files',
-            'done' => $files_done,
-            'total' => $files_total,
-        ];
-        if (
-            $this->fetch_list_bytes_done !== null
-            && $this->fetch_list_bytes_total !== null
-        ) {
-            $progress['bytes'] = [
-                'done' => $this->fetch_list_bytes_done
-                    + $this->files_pulled_bytes
-                    + $context->file_bytes_written,
-                'total' => $this->fetch_list_bytes_total,
-            ];
-        }
-        if (
-            $context->remote_file_path !== null
-            && $context->remote_file_size !== null
-        ) {
-            $progress['current_file'] = [
-                'path_b64' => base64_encode($context->remote_file_path),
-                'bytes_done' => $context->file_bytes_written,
-                'bytes_total' => $context->remote_file_size,
-            ];
-        }
+        $progress = $this->files_pull_progress->get_details($context);
+        $files_done = $progress['items']['done'];
+        $files_total = $progress['items']['total'];
 
         $record = [
             'type' => 'file_progress',
@@ -12498,8 +12308,8 @@ class ImportClient
                     // been counted (fetch phase).  During indexing the
                     // list doesn't exist yet and emitting files_done:0
                     // without files_total confuses consumers.
-                    if ($this->fetch_list_total !== null) {
-                        $file_progress = $this->files_pull_progress_record($context);
+                    $file_progress = $this->files_pull_progress_record($context);
+                    if (isset($file_progress['files_total'])) {
                         $heartbeat['command'] = $file_progress['command'];
                         $heartbeat['phase'] = $file_progress['phase'];
                         $heartbeat['files_done'] = $file_progress['files_done'];
@@ -12953,7 +12763,7 @@ class ImportClient
             throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->pull_state_file}");
         }
 
-        $files_pulled = $this->files_pulled; // Completed in this run
+        $files_pulled = $this->files_pull_progress->get_batch_files_done(); // Completed in this batch
         $has_cursor =
             !empty($state["active_resumable_command"]["remote_cursor"] ?? null) ||
             !empty($state["index"]["cursor"] ?? null) ||
@@ -12991,81 +12801,44 @@ class ImportClient
         $this->write_progress_file_if_due();
     }
 
-    /**
-     * Write a flat progress file for external consumers (e.g. web UI polling).
-     *
-     * Derives a simple JSON object from the current state and pipeline
-     * position. Written atomically via temp file + rename so readers
-     * never see a partial write.
-     */
+    /** Immediately write the latest screen snapshot, including on shutdown or error. */
     public function write_progress_file(?string $error = null): void
     {
-        $state = $this->state;
-        $command = $state->active_resumable_command->command_name;
-        $status = $error !== null ? "error" : ($state->active_resumable_command->completion_state ?? "in_progress");
-
-        // Derive phase from the state's stage field
-        $phase = $state->active_resumable_command->current_stage;
-        $progress_details_are_current =
-            $this->progress_details_command === $command
-            && $this->progress_details_phase === $phase;
-
-        $payload = [
-            "schema_version" => self::PROGRESS_SCHEMA_VERSION,
-            "step" => $this->pipeline_step,
-            "steps" => $this->pipeline_steps,
-            "command" => $command,
-            "status" => $status,
-            "phase" => $phase,
-            "message" => $progress_details_are_current
-                ? $this->progress_message
-                : null,
-            "progress" => $progress_details_are_current
-                && $this->progress_details !== null
-                    ? $this->progress_details
-                    : self::EMPTY_PROGRESS_DETAILS,
-            "error" => $error,
-            "error_code" => $error !== null ? $this->last_error_code : null,
-            "reason" => null,
-            "detail" => null,
-            "ts" => microtime(true),
-        ];
-
-        $this->write_progress_payload($payload);
+        $this->progress_reporter->update($this->progress_context($error));
+        $this->progress_reporter->write_file(true);
     }
 
     /** Writes an active progress snapshot at most once per second. */
     private function write_progress_file_if_due(): void
     {
-        $completion_state =
-            $this->state->active_resumable_command->completion_state;
-        if (
-            $completion_state !== "in_progress"
-            || microtime(true) - $this->last_progress_file_write >=
-                $this->progress_throttle
-        ) {
-            $this->write_progress_file();
-        }
+        $this->progress_reporter->update($this->progress_context());
+        $this->progress_reporter->write_file();
     }
 
-    /** Atomically replaces progress.json with one complete snapshot. */
-    private function write_progress_payload(array $payload): void
+    /**
+     * @return array {
+     *     Command fields shared by screen updates and pull checkpoints.
+     *     @type int|null    $step       Pipeline position.
+     *     @type int|null    $steps      Pipeline length.
+     *     @type string|null $command    Active pull command.
+     *     @type string|null $status     Active command's completion state.
+     *     @type string|null $phase      Active command's durable stage.
+     *     @type string|null $error      Terminal error, when supplied.
+     *     @type string|null $error_code Terminal error classification.
+     * }
+     */
+    private function progress_context(?string $error = null): array
     {
-        $json = json_encode(
-            $payload,
-            JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE
-        );
-
-        if ($json === false) {
-            return; // Best-effort — don't crash the pull over a progress file
-        }
-        $tmp = $this->progress_file . ".tmp";
-        if (
-            file_put_contents($tmp, $json) !== false
-            && rename($tmp, $this->progress_file)
-        ) {
-            $this->last_progress_file_write = microtime(true);
-        }
+        $command = $this->state->active_resumable_command;
+        return [
+            'step' => $this->pipeline_step,
+            'steps' => $this->pipeline_steps,
+            'command' => $command->command_name,
+            'status' => $error !== null ? 'error' : $command->completion_state,
+            'phase' => $command->current_stage,
+            'error' => $error,
+            'error_code' => $error !== null ? $this->last_error_code : null,
+        ];
     }
 
     /**
@@ -13113,7 +12886,7 @@ class ImportClient
 
         // Log final progress before exit
         $remote_index_entry_count = $this->remote_index_entry_count();
-        $files_pulled = $this->files_pulled; // Files completed in this run
+        $files_pulled = $this->files_pull_progress->get_batch_files_done(); // Files completed in this batch
         $current_command =
             $active_resumable_command->command_name ?? "unknown";
 
@@ -13184,67 +12957,21 @@ class ImportClient
      */
     public function output_progress(array $data, bool $force = false): void
     {
-        if (isset($data['progress']) && is_array($data['progress'])) {
-            $data['schema_version'] = self::PROGRESS_SCHEMA_VERSION;
-        }
-        // progress.json may reuse these fields only while the state still
-        // names the same command and phase as this JSONL record.
-        $has_message = isset($data['message']) && is_string($data['message']);
-        $has_progress = isset($data['progress']) && is_array($data['progress']);
-        if ($has_message || $has_progress) {
-            $active_command = $this->state->active_resumable_command;
-            $command = $active_command->command_name;
-            $phase = $active_command->current_stage;
-            if (
-                $command !== $this->progress_details_command
-                || $phase !== $this->progress_details_phase
-            ) {
-                $this->progress_details = null;
-                $this->progress_message = null;
-            }
-            $this->progress_details_command = $command;
-            $this->progress_details_phase = $phase;
-            if ($has_message) {
-                $this->progress_message = $data['message'];
-            }
-            if ($has_progress) {
-                $this->progress_details = $data['progress'];
-            }
-        }
-        if (($data['command'] ?? null) !== 'files-push') {
-            $this->write_progress_file_if_due();
-        }
+        $context = ($data['command'] ?? null) === 'files-push'
+            ? $data + ['step' => $this->pipeline_step, 'steps' => $this->pipeline_steps]
+            : $this->progress_context();
+        $this->progress_reporter->update($context, $data);
+        $this->progress_reporter->write_file();
 
         // The non-verbose terminal presentation uses show_progress_line() instead.
         if ($this->uses_terminal_progress() && !$this->verbose_mode) {
             return;
         }
-
-        $now = microtime(true);
-
-        // Always output status changes
-        $is_status_change =
-            isset($data["status"]) &&
-            in_array($data["status"], ["starting", "complete", "error"]);
-
-        // Output if forced, status change, or throttle time passed
-        if (
-            $force ||
-            $is_status_change ||
-            $now - $this->last_progress_output >= $this->progress_throttle
-        ) {
-            $written = @fwrite(
-                $this->progress_fd,
-                json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . "\n"
-            );
-            if ($written === false) {
-                // Broken pipe — save state and exit cleanly
-                $this->save_state();
-                $this->write_progress_file();
-                exit(0);
-            }
-            @flush();
-            $this->last_progress_output = $now;
+        if (!$this->progress_reporter->output_jsonl($data, $this->progress_fd, $force)) {
+            // Broken pipe — save state and exit cleanly.
+            $this->save_state();
+            $this->write_progress_file();
+            exit(0);
         }
     }
 }

--- a/packages/reprint-client/src/lib/import/class-files-pull-progress.php
+++ b/packages/reprint-client/src/lib/import/class-files-pull-progress.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Reprint\Importer;
+
+use Reprint\Importer\State\FetchListProgressState;
+use RuntimeException;
+
+/** Rebuildable file counters. Resume positions remain in the pull checkpoint. */
+class FilesPullProgress {
+    private ?int $files_total = null;
+    private int $files_before_batch = 0;
+    private int $files_in_batch = 0;
+    private ?int $bytes_total = null;
+    private int $bytes_before_batch = 0;
+    private int $bytes_in_batch = 0;
+
+    /**
+     * Reads the list once per invocation. Totals survive across batches in memory;
+     * a new process rebuilds them from the fetch-list byte offset and saved cursor.
+     * FileTreeProducer sorts each batch by remote absolute path, regardless of list order.
+     */
+    public function load_list(string $list_file, FetchListProgressState $fetch): void {
+        if ($this->files_total !== null) {
+            return;
+        }
+        $handle = fopen($list_file, 'rb');
+        if (!is_resource($handle)) {
+            throw new RuntimeException('Failed to open the fetch list for progress totals.');
+        }
+        $cursor = json_decode(base64_decode($fetch->cursor ?? '', true) ?: '', true);
+        $cursor_path = isset($cursor['path']) ? base64_decode($cursor['path'], true) : false;
+        $cursor_finishes_file = ( $cursor['bytes'] ?? 0 ) === 0;
+        $this->files_total = 0;
+        $this->bytes_total = 0;
+        while (true) {
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $entry = json_decode($line, true);
+            if (!is_array($entry)) {
+                continue;
+            }
+            ++$this->files_total;
+            $size = (int) ( $entry['size'] ?? 0 );
+            if (!isset($entry['size'])) {
+                $this->bytes_total = null;
+            } elseif ($this->bytes_total !== null) {
+                $this->bytes_total += $size;
+            }
+            $position = ftell($handle);
+            if ($position <= $fetch->offset) {
+                ++$this->files_before_batch;
+                $this->bytes_before_batch += $size;
+            } elseif ($position <= $fetch->next_offset) {
+                $entry_path = base64_decode($entry['path'], true);
+                if (
+                    ( $cursor['phase'] ?? null ) === 'finished'
+                    || ( $cursor_path !== false && (
+                        strcmp($entry_path, $cursor_path) < 0
+                        || ( $entry_path === $cursor_path && $cursor_finishes_file )
+                    ) )
+                ) {
+                    ++$this->files_in_batch;
+                    $this->bytes_in_batch += $size;
+                }
+            }
+        }
+        fclose($handle);
+    }
+
+    public function restart_batch(): void {
+        $this->files_in_batch = 0;
+        $this->bytes_in_batch = 0;
+    }
+
+    public function complete_file(int $file_size): void {
+        ++$this->files_in_batch; // Count completed files only.
+        $this->bytes_in_batch += $file_size;
+    }
+
+    public function complete_batch(int $batch_entries): void {
+        // Use the known batch size, including directories and skipped paths.
+        // Completed files move into the preceding-batch counters only once.
+        $this->files_before_batch += $batch_entries;
+        $this->bytes_before_batch += $this->bytes_in_batch;
+        $this->restart_batch();
+    }
+
+    public function get_batch_files_done(): int {
+        return $this->files_in_batch;
+    }
+
+    /**
+     * @return array {
+     *     Current file-download progress; totals stay unknown until the list is loaded.
+     *     @type array|null $items         Files processed and selected path count.
+     *     @type array|null $bytes         Completed file bytes plus the open file position.
+     *     @type array|null $current_file  Remote path and current file byte position and size.
+     *     @type null       $current_table Unused during files-pull.
+     * }
+     */
+    public function get_details(?StreamingContext $context = null): array {
+        $progress = ProgressReporter::EMPTY_DETAILS;
+        if ($this->files_total === null && $context === null) {
+            return $progress;
+        }
+        $progress['items'] = [
+            'unit' => 'files',
+            'done' => $this->files_before_batch + $this->files_in_batch,
+            'total' => $this->files_total,
+        ];
+        if ($this->bytes_total !== null) {
+            $progress['bytes'] = [
+                'done' => $this->bytes_before_batch + $this->bytes_in_batch
+                    + ( $context !== null && $context->remote_file_path !== null ? $context->file_bytes_written : 0 ),
+                'total' => $this->bytes_total,
+            ];
+        }
+        if ($context !== null && $context->remote_file_path !== null && $context->remote_file_size !== null) {
+            $progress['current_file'] = [
+                'path_b64' => base64_encode($context->remote_file_path),
+                'bytes_done' => $context->file_bytes_written,
+                'bytes_total' => $context->remote_file_size,
+            ];
+        }
+        return $progress;
+    }
+}

--- a/packages/reprint-client/src/lib/import/class-progress-reporter.php
+++ b/packages/reprint-client/src/lib/import/class-progress-reporter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Reprint\Importer;
+
+/** Keeps the latest screen snapshot separate from the JSONL event log. */
+class ProgressReporter {
+    public const SCHEMA_VERSION = 1;
+    /** Stable screen keys when a phase has no reported counters. */
+    public const EMPTY_DETAILS = [
+        'items' => null,
+        'bytes' => null,
+        'current_file' => null,
+        'current_table' => null,
+    ];
+    private const REPORT_INTERVAL = 1.0;
+
+    private string $progress_file;
+    private array $snapshot = [];
+    /** Timestamp of the last successful progress.json replacement. */
+    private float $last_file_write = 0;
+    /** Timestamp of the last emitted JSONL record, independent of file writes. */
+    private float $last_output = 0;
+
+    public function __construct(string $progress_file) {
+        $this->progress_file = $progress_file;
+    }
+
+    /**
+     * Updates one screen snapshot. Ordinary log messages leave its label alone.
+     *
+     * @param array $context {
+     *     Current command state, independent of the event's legacy field names.
+     *     @type string|null $command    Command being reported.
+     *     @type string|null $phase      Current phase.
+     *     @type string|null $status     Command status; null means cleared.
+     *     @type int|null    $step       Optional pipeline position.
+     *     @type int|null    $steps      Optional pipeline length.
+     *     @type string|null $error      Optional terminal error.
+     *     @type string|null $error_code Optional error classification.
+     *     @type string|null $reason     Optional files-push terminal reason.
+     *     @type string|null $detail     Optional files-push terminal detail.
+     * }
+     * @param array $event {
+     *     JSONL event. Other event-specific keys are not part of the screen snapshot.
+     *     @type array  $progress Optional screen counters, replaced together.
+     *     @type string $message  Optional screen label on progress or lifecycle events.
+     *     @type string $type     Optional event type.
+     *     @type string $status   Optional lifecycle status.
+     * }
+     */
+    public function update(array $context, array $event = []): void {
+        // A saved label and its counters may be reused only in the same command and phase.
+        $same_phase = $this->snapshot !== []
+            && $this->snapshot['command'] === $context['command']
+            && $this->snapshot['phase'] === $context['phase'];
+        $has_progress = isset($event['progress']) && is_array($event['progress']);
+        $has_screen_message = $has_progress
+            || in_array($event['type'] ?? null, ['lifecycle', 'interrupt'], true)
+            || isset($event['status']);
+        $this->snapshot = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'step' => $context['step'] ?? null,
+            'steps' => $context['steps'] ?? null,
+            'command' => $context['command'],
+            'status' => $context['status'],
+            'phase' => $context['phase'],
+            'message' => $has_screen_message && isset($event['message'])
+                ? $event['message']
+                : ( $same_phase ? $this->snapshot['message'] : null ),
+            'progress' => $has_progress
+                ? $event['progress']
+                : ( $same_phase ? $this->snapshot['progress'] : self::EMPTY_DETAILS ),
+            'error' => $context['error'] ?? null,
+            'error_code' => $context['error_code'] ?? null,
+            'reason' => $context['reason'] ?? null,
+            'detail' => $context['detail'] ?? null,
+            'ts' => microtime(true),
+        ];
+    }
+
+    /** Active updates are throttled; terminal, cleared and forced updates are immediate. */
+    public function write_file(bool $force = false): void {
+        if (
+            !$force
+            && $this->snapshot['status'] === 'in_progress'
+            && microtime(true) - $this->last_file_write < self::REPORT_INTERVAL
+        ) {
+            return;
+        }
+        // Preserve the existing status label for cleared pull checkpoints, while
+        // their null completion state still bypasses the active-write interval.
+        $payload = array_replace($this->snapshot, ['status' => $this->snapshot['status'] ?? 'in_progress']);
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE);
+        if ($json === false) {
+            return; // Best-effort — don't crash the pull over a progress file.
+        }
+        // Readers must see either complete snapshot, never a partial JSON write.
+        $temporary_file = $this->progress_file . '.tmp';
+        if (
+            file_put_contents($temporary_file, $json) !== false
+            && rename($temporary_file, $this->progress_file)
+        ) {
+            $this->last_file_write = microtime(true);
+        }
+    }
+
+    /**
+     * Emits a JSONL event. False lets the caller save its checkpoint on a broken pipe.
+     *
+     * @param array $event {
+     *     Progress event, retaining its event-specific fields.
+     *     @type array  $progress Optional screen counters; adds schema_version when present.
+     *     @type string $status   Optional lifecycle status; starting, complete and error bypass throttling.
+     * }
+     * @param resource $stream Progress output stream.
+     * @param bool     $force  Whether this event bypasses JSONL throttling.
+     */
+    public function output_jsonl(array $event, $stream, bool $force = false): bool {
+        $is_status_change = in_array($event['status'] ?? null, ['starting', 'complete', 'error'], true);
+        $now = microtime(true);
+        if (!$force && !$is_status_change && $now - $this->last_output < self::REPORT_INTERVAL) {
+            return true;
+        }
+        if (isset($event['progress']) && is_array($event['progress'])) {
+            $event['schema_version'] = self::SCHEMA_VERSION;
+        }
+        if (@fwrite($stream, json_encode($event, JSON_INVALID_UTF8_SUBSTITUTE) . "\n") === false) {
+            return false;
+        }
+        @flush();
+        $this->last_output = $now;
+        return true;
+    }
+}

--- a/packages/reprint-client/src/lib/import/load.php
+++ b/packages/reprint-client/src/lib/import/load.php
@@ -8,3 +8,5 @@ require_once __DIR__ . '/class-transient-interruption-exception.php';
 require_once __DIR__ . '/class-curl-timeout-exception.php';
 require_once __DIR__ . '/class-nullable-spatial-column-statement-rewriter.php';
 require_once __DIR__ . '/class-spatial-srid-guard.php';
+require_once __DIR__ . '/class-progress-reporter.php';
+require_once __DIR__ . '/class-files-pull-progress.php';

--- a/tests/Import/FetchListProgressTest.php
+++ b/tests/Import/FetchListProgressTest.php
@@ -81,7 +81,7 @@ class FetchListProgressTest extends TestCase
                 json_encode(
                     array_merge(
                         ["path" => base64_encode("/file-{$i}.txt")],
-                        $includeSizes ? ["type" => "file", "size" => ( $i + 1 ) * 100] : []
+                        $includeSizes ? ["size" => ( $i + 1 ) * 100] : []
                     )
                 ) . "\n"
             );
@@ -119,8 +119,8 @@ class FetchListProgressTest extends TestCase
     private function readCounters(\ImportClient $client, \ReflectionClass $reflection): array
     {
         return [
-            'total' => $reflection->getProperty('fetch_list_total')->getValue($client),
-            'done' => $reflection->getProperty('fetch_list_done')->getValue($client),
+            'total' => $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['items']['total'],
+            'done' => $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['items']['done'],
         ];
     }
 
@@ -231,11 +231,11 @@ class FetchListProgressTest extends TestCase
 
         $this->assertSame(
             1000,
-            $reflection->getProperty('fetch_list_bytes_total')->getValue($client)
+            $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['bytes']['total'] ?? null
         );
         $this->assertSame(
             300,
-            $reflection->getProperty('fetch_list_bytes_done')->getValue($client)
+            $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['bytes']['done'] ?? null
         );
     }
 
@@ -258,10 +258,10 @@ class FetchListProgressTest extends TestCase
         }
 
         $this->assertNull(
-            $reflection->getProperty('fetch_list_bytes_total')->getValue($client)
+            $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['bytes']['total'] ?? null
         );
         $this->assertNull(
-            $reflection->getProperty('fetch_list_bytes_done')->getValue($client)
+            $reflection->getProperty('files_pull_progress')->getValue($client)->get_details()['bytes']['done'] ?? null
         );
     }
 
@@ -440,6 +440,56 @@ class FetchListProgressTest extends TestCase
         }
     }
 
+    public function testRestartingBatchKeepsEarlierCounts(): void
+    {
+        $list_file = $this->writeFetchList(4, null, true);
+        $fetch = new \Reprint\Importer\State\FetchListProgressState();
+        $fetch->offset = $this->byteOffsetAfterLines($list_file, 1);
+        $fetch->next_offset = $this->byteOffsetAfterLines($list_file, 3);
+        $fetch->cursor = base64_encode(json_encode([
+            'path' => base64_encode('/file-1.txt'), 'bytes' => 0,
+        ]));
+        $progress = new \Reprint\Importer\FilesPullProgress();
+        $progress->load_list($list_file, $fetch);
+        $this->assertSame(300, $progress->get_details()['bytes']['done']);
+        $this->assertSame(2, $progress->get_details()['items']['done']);
+        $progress->complete_file(300);
+        $progress->restart_batch();
+        $this->assertSame(100, $progress->get_details()['bytes']['done']);
+        $this->assertSame(1, $progress->get_details()['items']['done']);
+        $progress->complete_file(200);
+        $progress->complete_file(300);
+        $progress->complete_batch(2);
+        $this->assertSame(600, $progress->get_details()['bytes']['done']);
+        $this->assertSame(3, $progress->get_details()['items']['done']);
+        $this->assertSame(0, $progress->get_batch_files_done());
+        $this->assertSame(1000, $progress->get_details()['bytes']['total']);
+    }
+
+    public function testResumedBatchUsesRemotePathOrder(): void
+    {
+        $list_file = $this->pullStateDirectory . '/fetch-list.jsonl';
+        foreach (['/z' => 100, '/a' => 200, '/m' => 300] as $path => $size) {
+            file_put_contents($list_file, json_encode([
+                'path' => base64_encode($path), 'size' => $size,
+            ]) . "\n", FILE_APPEND);
+        }
+        $fetch = new \Reprint\Importer\State\FetchListProgressState();
+        $fetch->next_offset = filesize($list_file);
+        $fetch->cursor = base64_encode(json_encode([
+            'path' => base64_encode('/m'), 'bytes' => 10,
+        ]));
+        $progress = new \Reprint\Importer\FilesPullProgress();
+        $progress->load_list($list_file, $fetch);
+        $context = new \Reprint\Importer\StreamingContext();
+        $context->remote_file_path = '/m';
+        $context->remote_file_size = 300;
+        $context->file_bytes_written = 10;
+        $this->assertSame(210, $progress->get_details($context)['bytes']['done']);
+        $this->assertSame(1, $progress->get_details($context)['items']['done']);
+        $this->assertSame(600, $progress->get_details($context)['bytes']['total']);
+    }
+
     public function testFilesDoneIncludesFilesPulled()
     {
         $listFile = $this->writeFetchList(100);
@@ -461,17 +511,14 @@ class FetchListProgressTest extends TestCase
                 ->invoke($client, $listFile);
         } catch (\Exception $e) {}
 
-        // Simulate 5 files written in this invocation
-        $reflection->getProperty('files_pulled')->setValue($client, 5);
-
-        $done = $reflection->getProperty('fetch_list_done')->getValue($client);
-        $pulled = $reflection->getProperty('files_pulled')->getValue($client);
-        $total = $reflection->getProperty('fetch_list_total')->getValue($client);
-
-        // files_done as emitted in progress records = done + pulled
-        $filesDone = $done + $pulled;
-        $this->assertSame(45, $filesDone); // 40 from offset + 5 pulled
-        $this->assertSame(100, $total);
-        $this->assertLessThanOrEqual($total, $filesDone);
+        // Five completed files add to the paths before the saved batch offset.
+        $progress = $reflection->getProperty('files_pull_progress')->getValue($client);
+        for ($file = 0; $file < 5; ++$file) {
+            $progress->complete_file(0);
+        }
+        $items = $progress->get_details()['items'];
+        $this->assertSame(45, $items['done']); // 40 from offset + 5 pulled.
+        $this->assertSame(100, $items['total']);
+        $this->assertLessThanOrEqual($items['total'], $items['done']);
     }
 }

--- a/tests/Import/FilesPullProgressResumeTest.php
+++ b/tests/Import/FilesPullProgressResumeTest.php
@@ -1,0 +1,153 @@
+<?php
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound -- Existing importer test namespace.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Test-only stopping client lives with its process-death test.
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Quote literal filesystem paths in the generated test router.
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-client/src/import.php';
+
+/** A process may die after any saved multipart part, including inside a batch. */
+class StopDuringFileProgressClient extends \ImportClient {
+    public ?string $stop_after = null;
+
+    public function save_state(): void {
+        parent::save_state();
+        $cursor = json_decode(base64_decode($this->get_state()->fetch->cursor ?? ''), true);
+        if (
+            ( $this->stop_after === 'file' && basename(base64_decode($cursor['path'] ?? '')) === 'a.bin' && ( $cursor['bytes'] ?? 0 ) === 0 )
+            || ( $this->stop_after === 'part' && basename(base64_decode($cursor['path'] ?? '')) === 'b.bin' && ( $cursor['bytes'] ?? 0 ) > 0 )
+        ) {
+            posix_kill(getmypid(), SIGKILL);
+        }
+    }
+}
+
+class FilesPullProgressResumeTest extends TestCase {
+    /** @dataProvider interruptionBoundaries */
+    public function testProcessDeathInsideABatchRetainsCompletedFileBytes(string $boundary): void {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Process-death coverage requires PCNTL and POSIX.');
+        }
+        $root = sys_get_temp_dir() . '/file-progress-resume-' . bin2hex(random_bytes(6));
+        mkdir($root . '/source', 0700, true);
+        $source = realpath($root . '/source');
+        $file_size = 64 * 1024 + 1;
+        foreach (['a.bin', 'b.bin', 'c.bin'] as $name) {
+            file_put_contents($source . '/' . $name, str_repeat($name[0], $file_size));
+        }
+        $router = $root . '/router.php';
+        file_put_contents($router, '<?php require ' . var_export(dirname(__DIR__, 2) . '/vendor/autoload.php', true)
+            . '; require ' . var_export(dirname(__DIR__, 2) . '/packages/reprint-server/src/export.php', true)
+            . '; (new WordPress\\Reprint\\Server\\HTTPServer())->handle_request();');
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $error_number, $error_message);
+        $this->assertIsResource($listener, $error_message);
+        $address = stream_socket_get_name($listener, false);
+        fclose($listener);
+        $server = proc_open(
+            [PHP_BINARY, '-S', $address, $router],
+            [0 => ['pipe', 'r'], 1 => ['file', $root . '/server.log', 'a'], 2 => ['file', $root . '/server.log', 'a']],
+            $pipes
+        );
+        $this->assertIsResource($server);
+        fclose($pipes[0]);
+        $child_pid = null;
+        try {
+            $ready = false;
+            $deadline = microtime(true) + 5;
+            while (microtime(true) < $deadline) {
+                $connection = @stream_socket_client('tcp://' . $address, $error_number, $error_message, 0.1);
+                if (is_resource($connection)) {
+                    fclose($connection);
+                    $ready = true;
+                    break;
+                }
+                usleep(10000);
+            }
+            $this->assertTrue($ready, (string) file_get_contents($root . '/server.log'));
+            $url = 'http://' . $address . '/?chunk_size=16384';
+            $client = new StopDuringFileProgressClient($url, $root . '/state', $root . '/local');
+            \write_current_pull_state($client, [
+                'preflight' => ['data' => ['ok' => true, 'wp_detect' => ['roots' => [['path' => $source]]]], 'http_code' => 200],
+                'active_resumable_command' => ['command_name' => 'files-pull', 'completion_state' => 'in_progress', 'current_stage' => 'fetch'],
+            ]);
+            $list_file = $client->pull_state_directory . '/fetch-list.jsonl';
+            $list_handle = fopen($list_file, 'wb');
+            $append = ( new \ReflectionClass($client) )->getMethod('append_to_fetch_list');
+            foreach (['a.bin', 'b.bin', 'c.bin'] as $name) {
+                $append->invoke($client, $source . '/' . $name, 'file', $file_size, $list_handle);
+            }
+            fclose($list_handle);
+            $child_pid = pcntl_fork();
+            $this->assertNotSame(-1, $child_pid);
+            if ($child_pid === 0) {
+                $client->stop_after = $boundary;
+                $this->download_list($client, $list_file);
+                exit(1);
+            }
+            pcntl_waitpid($child_pid, $child_status);
+            $child_pid = null;
+            $this->assertTrue(pcntl_wifsignaled($child_status));
+            $this->assertSame(SIGKILL, pcntl_wtermsig($child_status));
+
+            $resumed = new \ImportClient($url, $root . '/state', $root . '/local');
+            $reflection = new \ReflectionClass($resumed);
+            $reflection->getProperty('state')->setValue($resumed, $reflection->getMethod('load_state')->invoke($resumed));
+            $this->assertSame(0, $resumed->get_state()->fetch->offset, 'The first batch is still active.');
+            $cursor = json_decode(base64_decode($resumed->get_state()->fetch->cursor), true);
+            $this->assertSame($source . ( $boundary === 'file' ? '/a.bin' : '/b.bin' ), base64_decode($cursor['path']));
+            $this->assertSame($boundary === 'part', $cursor['bytes'] > 0);
+            $this->download_list($resumed, $list_file);
+            $resumed->write_progress_file();
+            $snapshot = json_decode(file_get_contents($root . '/state/progress.json'), true);
+            $this->assertSame(3 * $file_size, $snapshot['progress']['bytes']['done']);
+            $this->assertSame(3, $snapshot['progress']['items']['done']);
+            foreach (['a.bin', 'b.bin', 'c.bin'] as $name) {
+                $this->assertSame(
+                    hash_file('sha256', $source . '/' . $name),
+                    hash_file('sha256', $root . '/local' . $source . '/' . $name)
+                );
+            }
+        } finally {
+            if (is_int($child_pid) && $child_pid > 0) {
+                posix_kill($child_pid, SIGKILL);
+                pcntl_waitpid($child_pid, $child_status);
+            }
+            proc_terminate($server);
+            proc_close($server);
+            $this->remove_directory($root);
+        }
+    }
+
+    public static function interruptionBoundaries(): array {
+        return [['file'], ['part']];
+    }
+
+    private function download_list(\ImportClient $client, string $list_file): void {
+        $reflection = new \ReflectionClass($client);
+        $download = $reflection->getMethod('fetch_files_from_list');
+        for ($request = 0; $request < 10; ++$request) {
+            if ($download->invoke($client, $list_file)) {
+                return;
+            }
+        }
+        $this->fail('The three-file download did not finish within ten requests.');
+    }
+
+    private function remove_directory(string $directory): void {
+        foreach (scandir($directory) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->remove_directory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Import/FilesPullStateTest.php
+++ b/tests/Import/FilesPullStateTest.php
@@ -202,70 +202,34 @@ class FilesPullStateTest extends TestCase
 
     public function testSavingStateThrottlesOnlyInProgressProgressFileWrites()
     {
-        $client = $this->getMockBuilder(\ImportClient::class)
-            ->setConstructorArgs([
-                'http://fake.url',
-                $this->stateDir,
-                $this->filesystem_root,
-            ])
-            ->onlyMethods(['write_progress_file'])
-            ->getMock();
-        $written_completion_states = [];
-        $client->method('write_progress_file')
-            ->willReturnCallback(function () use (
-                $client,
-                &$written_completion_states
-            ): void {
-                $written_completion_states[] =
-                    $client->get_state()
-                        ->active_resumable_command
-                        ->completion_state;
-            });
-
-        $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getProperty('last_progress_file_write')
-            ->setValue($client, microtime(true));
-        $client->get_state()->active_resumable_command->completion_state =
-            'in_progress';
+        $client = $this->makeClient();
+        $command = $client->get_state()->active_resumable_command;
+        $command->completion_state = 'in_progress';
+        $client->write_progress_file();
+        $progress_file = $this->stateDir . '/progress.json';
+        $first_write = file_get_contents($progress_file);
         $client->save_state();
+        $this->assertSame($first_write, file_get_contents($progress_file));
 
-        $client->get_state()->active_resumable_command->completion_state = null;
-        $client->save_state();
-
-        $client->get_state()->active_resumable_command->completion_state =
-            'partial';
-        $client->save_state();
-
-        $client->get_state()->active_resumable_command->completion_state =
-            'complete';
-        $client->save_state();
-
-        $this->assertSame(
-            [null, 'partial', 'complete'],
-            $written_completion_states
-        );
+        foreach ([null, 'partial', 'complete'] as $status) {
+            $command->completion_state = $status;
+            $client->save_state();
+            $snapshot = json_decode(file_get_contents($progress_file), true);
+            $this->assertSame($status ?? 'in_progress', $snapshot['status']);
+        }
     }
 
     public function testSavingStateRefreshesInProgressProgressAfterThrottle()
     {
-        $client = $this->getMockBuilder(\ImportClient::class)
-            ->setConstructorArgs([
-                'http://fake.url',
-                $this->stateDir,
-                $this->filesystem_root,
-            ])
-            ->onlyMethods(['write_progress_file'])
-            ->getMock();
-        $client->expects($this->once())
-            ->method('write_progress_file');
-
-        $reflection = new \ReflectionClass(\ImportClient::class);
-        $reflection->getProperty('last_progress_file_write')
-            ->setValue($client, microtime(true) - 1.1);
-        $client->get_state()->active_resumable_command->completion_state =
-            'in_progress';
-
+        $client = $this->makeClient();
+        $client->get_state()->active_resumable_command->completion_state = 'in_progress';
+        $client->write_progress_file();
+        $progress_file = $this->stateDir . '/progress.json';
+        $first_write = json_decode(file_get_contents($progress_file), true);
+        usleep(1100000);
         $client->save_state();
+        $next_write = json_decode(file_get_contents($progress_file), true);
+        $this->assertGreaterThan($first_write['ts'], $next_write['ts']);
     }
 
     public function testShutdownFlushesTheLatestProgressFile()

--- a/tests/Import/OnlyFilesPathPrefixDiffTest.php
+++ b/tests/Import/OnlyFilesPathPrefixDiffTest.php
@@ -308,7 +308,7 @@ class OnlyFilesPathPrefixDiffTest extends TestCase
             ['/wp-content/themes/flavor/style.css'],
             $fetchPaths
         );
-        $this->assertSame('file', $fetchEntries[0]['type']);
+        $this->assertSame(['path', 'size'], array_keys($fetchEntries[0]));
         $this->assertSame(100, $fetchEntries[0]['size']);
         $this->assertStringContainsString(
             base64_encode('/wp-content/uploads/photo.jpg'),

--- a/tests/Import/ProgressScreenTest.php
+++ b/tests/Import/ProgressScreenTest.php
@@ -40,10 +40,19 @@ class ProgressScreenTest extends TestCase {
         $command->current_stage = 'fetch';
 
         $reflection = new \ReflectionClass($client);
-        $reflection->getProperty('fetch_list_done')->setValue($client, 3);
-        $reflection->getProperty('fetch_list_total')->setValue($client, 10);
-        $reflection->getProperty('fetch_list_bytes_done')->setValue($client, 1024);
-        $reflection->getProperty('fetch_list_bytes_total')->setValue($client, 30 * 1024 * 1024);
+        $list_file = $client->pull_state_directory . '/fetch-list.jsonl';
+        $sizes = [1024, 0, 0, 20 * 1024 * 1024, 10 * 1024 * 1024 - 1024, 0, 0, 0, 0, 0];
+        $offset = 0;
+        foreach ($sizes as $index => $size) {
+            $line = json_encode(['path' => base64_encode('/file-' . $index), 'size' => $size]) . "\n";
+            file_put_contents($list_file, $line, FILE_APPEND);
+            if ($index < 3) {
+                $offset += strlen($line);
+            }
+        }
+        $client->get_state()->fetch->offset = $offset;
+        $reflection->getProperty('files_pull_progress')->getValue($client)
+            ->load_list($list_file, $client->get_state()->fetch);
         $progress_stream = fopen('php://memory', 'w+b');
         $this->assertIsResource($progress_stream);
         $reflection->getProperty('progress_fd')->setValue($client, $progress_stream);
@@ -145,11 +154,7 @@ class ProgressScreenTest extends TestCase {
         $this->assertSame(1024, $first_progress['progress']['bytes']['done']);
         $this->assertSame($first_progress, $throttled_progress);
 
-        $last_write = new \ReflectionProperty(
-            \ImportClient::class,
-            'last_progress_file_write'
-        );
-        $last_write->setValue($client, microtime(true) - 2.0);
+        usleep(1100000);
         $client->output_progress($this->byte_progress_record(3072), true);
         $updated_progress = $this->read_progress_file();
         $this->assertSame(3072, $updated_progress['progress']['bytes']['done']);
@@ -173,9 +178,10 @@ class ProgressScreenTest extends TestCase {
             ],
         ]));
 
+        $progress_table = null;
         $progress = ( new \ReflectionClass($client) )
             ->getMethod('database_pull_progress_details')
-            ->invoke($client, $cursor, 500100);
+            ->invokeArgs($client, [$cursor, 500100, &$progress_table]);
 
         $this->assertSame([
             'items' => [
@@ -195,6 +201,41 @@ class ProgressScreenTest extends TestCase {
                 'rows_total_is_estimate' => true,
             ],
         ], $progress);
+    }
+
+    public function testLogMessagesDoNotReplaceTheScreenLabel(): void
+    {
+        $client = $this->make_client();
+        $command = $client->get_state()->active_resumable_command;
+        $command->command_name = 'db-pull';
+        $command->completion_state = 'in_progress';
+        $command->current_stage = 'sql';
+        $client->output_progress($this->byte_progress_record(1024), true);
+        $client->output_progress(['type' => 'skip', 'message' => 'Skipped one path'], true);
+        $client->write_progress_file();
+
+        $this->assertSame('1024 bytes', $this->read_progress_file()['message']);
+        $this->assertSame(1024, $this->read_progress_file()['progress']['bytes']['done']);
+    }
+
+    public function testPhaseChangeClearsCountersAndTerminalWriteKeepsLatestUpdate(): void
+    {
+        $client = $this->make_client();
+        $command = $client->get_state()->active_resumable_command;
+        $command->command_name = 'db-pull';
+        $command->completion_state = 'in_progress';
+        $command->current_stage = 'sql';
+        $client->output_progress($this->byte_progress_record(1024), true);
+        $client->output_progress($this->byte_progress_record(2048), true);
+        $command->completion_state = 'partial';
+        $client->save_state();
+        $this->assertSame(2048, $this->read_progress_file()['progress']['bytes']['done']);
+        $this->assertSame('partial', $this->read_progress_file()['status']);
+
+        $command->current_stage = 'db-index';
+        $client->write_progress_file();
+        $this->assertNull($this->read_progress_file()['message']);
+        $this->assertNull($this->read_progress_file()['progress']['bytes']);
     }
 
     private function make_client(): \ImportClient

--- a/tests/Import/ReprintProcessLockTest.php
+++ b/tests/Import/ReprintProcessLockTest.php
@@ -65,7 +65,6 @@ final class ReprintProcessLockTest extends TestCase
             'fetch_list_file' => $pull_state_directory . '/fetch-list.jsonl',
             'volatile_files_file' => $pull_state_directory . '/volatile-files.json',
             'audit_log_file' => $this->root . '/state/audit.log',
-            'progress_file' => $this->root . '/state/progress.json',
         ];
         foreach ($expected_paths as $property_name => $expected_path) {
             $property = $reflection->getProperty($property_name);
@@ -73,6 +72,8 @@ final class ReprintProcessLockTest extends TestCase
             $this->assertSame($expected_path, $property->getValue($client), $property_name);
         }
 
+        $client->write_progress_file();
+        $this->assertFileExists($this->root . '/state/progress.json');
         $process_lock->close();
     }
 


### PR DESCRIPTION
Moves progress snapshots and file counters out of `ImportClient`, removing the scattered reporting fields added in #752.

This PR is based on #752. `ProgressReporter` keeps the screen snapshot and writes progress output. `FilesPullProgress` counts completed files and bytes. The current table estimate stays local to the SQL download, and fetch-list entries no longer repeat the path type. No new saved state fields are needed.

Resuming inside a fetch batch rebuilds completed file counts and bytes from the existing cursor. Ordinary log messages no longer replace the screen label.

## Testing

The importer suite passes: 852 tests, with 2 skipped. All 8 files-push CLI tests pass. PHPStan and PHP 7.4 compatibility checks pass, and per-file PHPCS counts do not increase.

The two process-death resume tests and the screen-label test fail against the original #752 implementation and pass with this change.
