### PR TITLE
Fix BIT column handling

### DIFF
--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -840,11 +840,17 @@ class DatabaseRowsReader {
         return $columns;
     }
 
-    /** Identifies numeric types which the dump emits as bare literals. */
+    /**
+     * Identifies numeric types which the dump emits as bare literals.
+     *
+     * BIT is excluded on purpose: some drivers return it as raw bytes, which a
+     * bare literal would write into the SQL unquoted and break db-apply with a
+     * syntax error. It goes out base64-encoded like every other opaque value.
+     */
     public function is_numeric_type($data_type)
     {
         $data_type = strtoupper($data_type);
-        foreach (["TINYINT", "SMALLINT", "MEDIUMINT", "INTEGER", "INT", "BIGINT", "DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "REAL", "BIT", "YEAR"] as $type) {
+        foreach (["TINYINT", "SMALLINT", "MEDIUMINT", "INTEGER", "INT", "BIGINT", "DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "REAL", "YEAR"] as $type) {
             if (strpos($data_type, $type) === 0) {
                 return true;
             }

--- a/tests/MySQLDumpProducer/DataTypesTest.php
+++ b/tests/MySQLDumpProducer/DataTypesTest.php
@@ -209,9 +209,27 @@ class DataTypesTest extends MySQLDumpProducerTestBase
 
         $sql = $this->getDumpSQL();
 
-        // BIT should be output as numeric
-        $this->assertMatchesRegularExpression('/\(1,255,1\)/', $sql);
-        $this->assertMatchesRegularExpression('/\(2,170,0\)/', $sql);
+        // BIT carries opaque bytes, not a number the dump can write unquoted: the
+        // server sends BIT raw and only some drivers turn it into decimal text, so a
+        // bare literal would put those bytes straight into the SQL on the drivers
+        // that don't. It goes out base64-encoded like every other opaque value.
+        $this->assertStringNotContainsString('(1,255,1)', $sql);
+        $this->assertStringContainsString(
+            sprintf(
+                "(1,FROM_BASE64('%s'),FROM_BASE64('%s'))",
+                base64_encode("\xff"),
+                base64_encode("\x01")
+            ),
+            $sql
+        );
+        $this->assertStringContainsString(
+            sprintf(
+                "(2,FROM_BASE64('%s'),FROM_BASE64('%s'))",
+                base64_encode("\xaa"),
+                base64_encode("\x00")
+            ),
+            $sql
+        );
 
         // Round-trip test
         $importPdo = $this->executeDumpInNewDatabase($sql);


### PR DESCRIPTION
I saw `db-apply` die with a syntax error on a source that has a BIT column. The dump ended up having raw bytes where a literal belongs:

```
(1,…,1,<0x01>,'',FROM_BASE64('YWJvdmU='),<0x00>)
```

This happened because `is_numeric_type()` has BIT included, so a BIT column is exempt from the `CAST(… AS BINARY)` every other column gets in the SELECT, and `format_value()` writes it unquoted. MySQL
sends BIT as raw bytes and leaves the conversion to the client, and some client leave them raw.

### Fix
Remove `BIT` from `is_numeric_type()`. BIT then takes the same
`CAST(… AS BINARY)` + `FROM_BASE64()` route as every other opaque type, and a CASTed
binary string is bytes every driver returns verbatim.

This also fixes the same bug one layer over: `build_comparison()` was putting a
numeric-typed primary-key value in the resume cursor's WHERE clause unquoted.
