### PR TITLE
[PHP] Bound selected-site user queries before filtering

### DIFF
--- a/packages/reprint-server/src/class-database-rows-reader.php
+++ b/packages/reprint-server/src/class-database-rows-reader.php
@@ -20,8 +20,9 @@ class DatabaseRowsReader {
     private $current_pk_columns = null;
 
     /**
-     * Cursor bookmark containing the primary key of the last returned record.
-     * The next SELECT starts strictly after these values.
+     * Primary key of the last returned record or completed candidate batch.
+     * For selected-site user reads, an empty filtered batch still moves this
+     * position past every checked ID. The next SELECT starts after it.
      *
      * @var array|null
      */
@@ -49,6 +50,17 @@ class DatabaseRowsReader {
      * @var int
      */
     private $rows_fetched_from_current_query = 0;
+
+    /**
+     * Last candidate ID in the open selected-user query, or null without one.
+     * For example, a metadata batch may check IDs 1–250 but return only row 7.
+     * After returning row 7, consume the query before moving the cursor to 250.
+     * This value stays in memory only. Resume reads a new bounded batch after
+     * the last returned row; it must not skip candidates that were not consumed.
+     *
+     * @var int|string|null
+     */
+    private $current_query_last_candidate_id = null;
 
     /**
      * Table names selected for SQL output, or null before table discovery.
@@ -359,10 +371,15 @@ class DatabaseRowsReader {
 
 
     /**
-     * Fetches the next row and advances the resume position.
+     * Fetches a row or finishes one filtered batch, then advances the cursor.
      *
-     * An exhausted batch opens another bounded query after the last primary
-     * key. A fresh query returning no rows means the table is complete.
+     * Selected-site user reads limit candidate IDs before applying filters.
+     * An empty result can therefore mean 250 rejected metadata rows, not EOF.
+     * Return control so the producer can emit a checkpoint and stop or resume.
+     * Other reads open the next LIMIT query when the previous one is consumed.
+     *
+     * @return bool|null True for a row, null after a selected-user batch was
+     *                   consumed without a row, false when no candidates remain.
      */
     public function next_record()
     {
@@ -380,7 +397,12 @@ class DatabaseRowsReader {
                     );
                 }
             }
-            $query = $this->build_select_query();
+            $query = $this->multisite_selection !== null && $this->multisite_selection->is_shared_user_table($this->current_table)
+                ? $this->read_candidate_ids_and_build_row_query()
+                : $this->build_select_query();
+            if ($query === null) {
+                return false;
+            }
             try {
                 $this->current_result_set = $this->db->query($query);
             } catch (\Exception $e) {
@@ -394,6 +416,12 @@ class DatabaseRowsReader {
         $record = $this->current_result_set->fetch(PdoConstants::fetch_assoc());
         if (!$record) {
             $this->current_result_set = null;
+            if ($this->current_query_last_candidate_id !== null) {
+                $this->last_pk_values = [$this->current_pk_columns[0] => $this->current_query_last_candidate_id];
+                $this->current_query_last_candidate_id = null;
+                $this->clear_current_record();
+                return null;
+            }
             if ($this->rows_fetched_from_current_query === 0) {
                 return false;
             }
@@ -429,8 +457,54 @@ class DatabaseRowsReader {
         if ($this->rows_fetched_from_current_query >= $this->batch_size) {
             $this->current_row_ends_query_batch = true;
             $this->release_current_result_set();
+            $this->current_query_last_candidate_id = null;
         }
         return true;
+    }
+
+    /**
+     * Reads one candidate-ID batch and builds the permitted user/profile row query.
+     *
+     * Users come from the site's saved ID table. Metadata walks the network's
+     * umeta_id primary key, including rejected keys. A per-user ORDER BY
+     * umeta_id can read and sort every profile row on MyISAM; its user_id index
+     * does not contain the primary key as InnoDB's secondary indexes do.
+     *
+     * The second query uses only these IDs and the primary index. Keep the
+     * normal filters and live reference checks, including for oversized rows.
+     * Only this bounded ID list is held in PHP; profile values are not read
+     * until the second query. Neither query adds or changes a WordPress index.
+     *
+     * @return string|null SQL for this batch, or null when no candidate IDs remain.
+     */
+    private function read_candidate_ids_and_build_row_query(): ?string
+    {
+        $is_usermeta = $this->current_table === $this->multisite_selection->get_usermeta_table_name();
+        $primary_key = $is_usermeta ? 'umeta_id' : 'ID';
+        $candidate_column = $is_usermeta ? 'umeta_id' : 'user_id';
+        $candidate_table = $is_usermeta ? $this->current_table : $this->multisite_selection->get_user_table_name();
+        $last_id = $this->last_pk_values[$primary_key] ?? '0';
+        if (!is_numeric($last_id)) {
+            throw new \InvalidArgumentException("Cannot compare numeric primary key '{$primary_key}': the cursor contains a non-numeric value, " . json_encode($last_id) . '.');
+        }
+        $last_id = $this->db->quote( (string) $last_id );
+        $query = $this->get_select_prefix() . " `{$candidate_column}` FROM `{$candidate_table}` FORCE INDEX (PRIMARY)" .
+            " WHERE `{$candidate_column}` > {$last_id} ORDER BY `{$candidate_column}` LIMIT {$this->batch_size}";
+        $result = $this->db->query($query);
+        $candidate_ids = $result->fetchAll(PdoConstants::fetch_column());
+        if (!$candidate_ids) {
+            return null;
+        }
+        $this->current_query_last_candidate_id = end($candidate_ids);
+        $quoted_ids = array_map(function ($id) {
+            return $this->db->quote( (string) $id );
+        }, $candidate_ids);
+        $where_conditions = $this->get_current_row_selection_conditions();
+        $where_conditions[] = "`{$primary_key}` IN (" . implode(',', $quoted_ids) . ')';
+        return $this->build_byte_preserving_select_from_current_table() .
+            ' FORCE INDEX (PRIMARY) WHERE ' . implode(' AND ', array_map(function ($condition) {
+                return "({$condition})";
+            }, $where_conditions)) . " ORDER BY `{$primary_key}`";
     }
 
     /** Drains unconsumed records and releases the active LIMIT-sized result set. */
@@ -1051,6 +1125,7 @@ class DatabaseRowsReader {
         if ($this->current_table) {
             $this->current_pk_columns = $this->get_primary_key_columns($this->current_table);
             $this->last_pk_values = null;
+            $this->current_query_last_candidate_id = null;
             $this->current_offset = 0;
             $this->current_column_types = $this->get_column_types($this->current_table);
             $this->current_column_names = array_keys($this->current_column_types);

--- a/packages/reprint-server/src/class-mysql-dump-producer.php
+++ b/packages/reprint-server/src/class-mysql-dump-producer.php
@@ -397,9 +397,17 @@ class MySQLDumpProducer
         $reader_cursor_before_current_record = $this->reader_cursor_before_retained_record;
         if ($this->row_reader->get_current_record() === null) {
             $reader_cursor_before_current_record = $this->row_reader->get_cursor_state();
-            if (!$this->row_reader->next_record()) {
+            $read_result = $this->row_reader->next_record();
+            if ($read_result === false) {
                 $this->state = self::STATE_NEXT_TABLE;
                 return false;
+            }
+            if ($read_result === null) {
+                // Rejected candidates still need a checkpoint. Do not search
+                // the next batch inside this step when no SQL row was found.
+                $this->current_sql_fragment = 'DO 0; /* selected-user batch complete */';
+                $this->current_fragment_must_be_its_own_part = true;
+                return true;
             }
         }
 
@@ -485,15 +493,16 @@ class MySQLDumpProducer
         return true;
     }
 
-    /** Emits one row with a leading comma, or closes the open INSERT when no row remains. */
+    /** Emits one row, or closes the INSERT at table EOF or a consumed candidate batch. */
     private function emit_row()
     {
         $reader_cursor_before_current_record = $this->row_reader->get_cursor_state();
-        if (!$this->row_reader->next_record()) {
+        $read_result = $this->row_reader->next_record();
+        if ($read_result !== true) {
             $this->current_sql_fragment = $this->on_duplicate_key() . ';';
             $this->current_statement_size = 0;
             $this->current_insert_has_nonzero_srid_context = false;
-            $this->state = self::STATE_NEXT_TABLE;
+            $this->state = $read_result === false ? self::STATE_NEXT_TABLE : self::STATE_START_INSERT;
             return true;
         }
 

--- a/tests/MySQLDumpProducer/MultisiteSelectionTest.php
+++ b/tests/MySQLDumpProducer/MultisiteSelectionTest.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/MySQLDumpProducerTestBase.php';
 
+use WordPress\Reprint\Server\DatabaseRowsReader;
 use WordPress\Reprint\Server\MultisiteDatabaseSelection;
 
 /** Exercises site selection against MySQL, including resumable oversized reads. */
@@ -210,7 +211,7 @@ class MultisiteSelectionTest extends MySQLDumpProducerTestBase
                 if (preg_match('/CREATE TABLE `([^`]+)`/', $fragment, $match)) {
                     $exported_tables[] = $match[1];
                 }
-                if (strpos($fragment, 'DO 0;') !== false) {
+                if ($cursor['state'] === 'collect_site_members' || strpos($fragment, '-- Begin user and profile export') === 0) {
                     $this->assertNull($cursor['current_table'], 'Membership work happens between table groups, not inside a user table');
                     $this->assertSame(['network_7_links', 'network_7_comments', 'network_7_posts'], $exported_tables);
                     $this->assertSame(['3', '4', '5'], array_map('strval', $this->pdo->query(
@@ -525,6 +526,172 @@ CHILD
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('selected multisite site changed');
         $this->createProducer($options + ['cursor' => json_encode($cursor)]);
+    }
+
+    /** Sparse users must cost saved-ID lookups, not a scan of unrelated accounts. */
+    public function test_sparse_users_bound_source_index_reads(): void
+    {
+        $this->create_network();
+        $values = [];
+        for ($id = 10; $id <= 2010; ++$id) {
+            $values[] = "({$id},'unrelated')";
+        }
+        $this->pdo->exec('INSERT INTO network_users VALUES ' . implode(',', $values));
+        $this->pdo->exec("INSERT INTO network_users VALUES (9000,'last-selected')");
+        $this->pdo->exec('INSERT INTO network_7_comments VALUES (2,9000)');
+        $reader = $this->open_shared_table_reader('network_users', 2);
+        $users = [];
+        do {
+            $before = $this->count_source_index_reads();
+            $result = $reader->next_record();
+            $reads = $this->count_source_index_reads() - $before;
+            $this->assertLessThan(60, $reads, 'One step must not scan unrelated network users.');
+            if ($result === true) {
+                $users[] = (string) $reader->get_current_record()['ID'];
+                $reader->clear_current_record();
+            }
+        } while ($result !== false);
+        $this->assertSame(['1', '2', '3', '4', '5', '9000'], $users);
+        $reader->close();
+    }
+
+    /** Rejected metadata still produces a bounded step and a durable row position. */
+    public function test_rejected_metadata_batches_resume_on_both_storage_engines(): void
+    {
+        $this->create_network();
+        $this->pdo->exec('DELETE FROM network_usermeta');
+        $values = [];
+        for ($id = 1; $id <= 1000; ++$id) {
+            $values[] = "({$id},3,'session_tokens','never-export')";
+        }
+        $this->pdo->exec('INSERT INTO network_usermeta VALUES ' . implode(',', $values));
+        // A sparse final key also checks that we page through actual IDs,
+        // rather than walking every integer between the first and last ID.
+        $this->pdo->exec("INSERT INTO network_usermeta VALUES (9000000000000000000,3,'nickname','selected')");
+        foreach (['InnoDB', 'MyISAM'] as $engine) {
+            $this->pdo->exec("ALTER TABLE network_usermeta ENGINE={$engine}");
+            $reader = $this->open_shared_table_reader('network_usermeta', 250);
+            $before = $this->count_source_index_reads();
+            $this->assertNull($reader->next_record(), 'An empty filtered batch must return control, not scan ahead.');
+            $this->assertLessThan(800, $this->count_source_index_reads() - $before);
+            $cursor = $reader->get_cursor_state();
+            $this->assertSame(['umeta_id' => 250], $cursor['last_pk_values']);
+            $reader->close();
+
+            // Resume a fresh reader after every empty batch. The ID is saved
+            // even though no row from that batch will appear in the dump.
+            for ($last_id = 500; $last_id <= 1000; $last_id += 250) {
+                $reader = new DatabaseRowsReader($this->pdo, [
+                    'multisite_selection' => new MultisiteDatabaseSelection('network_', 7, 1),
+                    'tables_to_process' => ['network_usermeta'], 'batch_size' => 250,
+                    'cursor' => $cursor,
+                ]);
+                $this->assertTrue($reader->restore_cursor_state($cursor));
+                $this->assertNull($reader->next_record());
+                $cursor = $reader->get_cursor_state();
+                $this->assertSame(['umeta_id' => $last_id], $cursor['last_pk_values']);
+                $reader->close();
+            }
+            $reader = new DatabaseRowsReader($this->pdo, [
+                'multisite_selection' => new MultisiteDatabaseSelection('network_', 7, 1),
+                'tables_to_process' => ['network_usermeta'], 'batch_size' => 250,
+                'cursor' => $cursor,
+            ]);
+            $reader->restore_cursor_state($cursor);
+            $this->assertTrue($reader->next_record());
+            $this->assertSame('selected', $reader->get_current_record()['meta_value']);
+            $reader->clear_current_record();
+            // Completing the final batch can yield once before table EOF.
+            $result = $reader->next_record();
+            if ($result === null) {
+                $result = $reader->next_record();
+            }
+            $this->assertFalse($result);
+            $reader->close();
+        }
+    }
+
+    /** Missing accounts and rejected tails must not end either table early. */
+    public function test_resume_each_fragment_keeps_rows_after_empty_user_batches(): void
+    {
+        $this->create_network();
+        $this->pdo->exec("INSERT INTO network_7_comments VALUES (2,8),(3,9),(4,10),(5,11),(6,12)");
+        $this->pdo->exec("INSERT INTO network_users VALUES (12,'last-user')");
+        $this->pdo->exec("INSERT INTO network_usermeta VALUES
+            (9,6,'session_tokens','private'),(10,12,'nickname','Last'),
+            (11,12,'session_tokens','private'),(12,12,'session_tokens','private')");
+        foreach ([true, false] as $buffered) {
+            $this->pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $buffered);
+            $options = [
+                'multisite_selection' => new MultisiteDatabaseSelection('network_', 7, 1),
+                'tables_to_process' => ['network_users', 'network_usermeta'], 'batch_size' => 2,
+            ];
+            $producer = $this->createProducer($options);
+            $sql = '';
+            $steps = 0;
+            while ($producer->next_sql_fragment()) {
+                $sql .= $producer->get_sql_fragment() . "\n";
+                $options['cursor'] = $producer->get_reentrancy_cursor();
+                $producer->close();
+                $producer = $this->createProducer($options);
+                $this->assertLessThan(100, ++$steps, 'Empty batches must make progress after resume.');
+            }
+            $producer->close();
+            $target = $this->executeDumpInNewDatabase($sql);
+            $this->assertSame(['1','2','3','4','5','12'], array_map('strval',
+                $target->query('SELECT ID FROM network_users ORDER BY ID')->fetchAll(PDO::FETCH_COLUMN)));
+            $this->assertSame(['1','2','4','10'], array_map('strval',
+                $target->query('SELECT umeta_id FROM network_usermeta ORDER BY umeta_id')->fetchAll(PDO::FETCH_COLUMN)));
+            $target = null;
+        }
+        $this->pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+    }
+
+    /** Candidate queries retain the existing rejection of non-numeric cursor IDs. */
+    public function test_tampered_shared_user_cursor_rejects_non_numeric_id(): void
+    {
+        $this->create_network();
+        foreach (['network_users' => 'ID', 'network_usermeta' => 'umeta_id'] as $table => $column) {
+            $reader = $this->open_shared_table_reader($table, 2);
+            $cursor = $reader->get_cursor_state();
+            $cursor['last_pk_values'] = $reader->encode_database_values_for_cursor([$column => '0 OR 1=1']);
+            $reader->restore_cursor_state($cursor);
+            try {
+                $reader->next_record();
+                $this->fail('A tampered shared-table ID must be rejected before reading candidates.');
+            } catch (InvalidArgumentException $error) {
+                $this->assertStringContainsString('non-numeric value', $error->getMessage());
+            } finally {
+                $reader->close();
+            }
+        }
+    }
+
+    /** Starts an actual selected-site reader after content and membership collection. */
+    private function open_shared_table_reader(string $table, int $batch_size): DatabaseRowsReader
+    {
+        $reader = new DatabaseRowsReader($this->pdo, [
+            'multisite_selection' => new MultisiteDatabaseSelection('network_', 7, 1),
+            'tables_to_process' => [$table], 'batch_size' => $batch_size,
+        ]);
+        while ($reader->move_to_next_table()) {
+            while ($reader->collect_content_user_ids_step()) {
+                $this->assertNotNull($reader->get_cursor_state()['last_pk_values']);
+            }
+        }
+        $this->assertTrue($reader->start_user_tables());
+        while ($reader->collect_site_members_step()) {
+            $this->assertNotSame('0', $reader->get_cursor_state()['last_scanned_usermeta_id']);
+        }
+        $this->assertTrue($reader->move_to_next_table());
+        $this->assertSame($table, $reader->get_current_table());
+        return $reader;
+    }
+
+    /** Counts storage-engine row reads on this connection without a fake transport. */
+    private function count_source_index_reads(): int
+    {
+        return array_sum($this->pdo->query("SHOW SESSION STATUS LIKE 'Handler_read_%'")->fetchAll(PDO::FETCH_KEY_PAIR));
     }
 
     /** Builds overlapping IDs, memberships, authors, and network records. */

--- a/tests/e2e/tests/import-71-multisite-query-budget.test.js
+++ b/tests/e2e/tests/import-71-multisite-query-budget.test.js
@@ -117,29 +117,38 @@ define('BLOG_ID_CURRENT_SITE', 1);
                 `${table} must finish within one request's time budget: ${JSON.stringify(first.chunks?.filter(chunk => chunk.type === 'error'))}`);
             const firstInsert = first.chunks.findIndex(chunk => chunk.type === 'sql' && chunk.body.includes(`INSERT INTO \`${table}\``));
             assert.ok(firstInsert >= 0, 'Resume from a real INSERT, not a fabricated cursor');
-            const resumed = await apiRequest(site, 'sql_chunk', {
-                ...params, cursor: first.chunks[firstInsert].headers['x-cursor'],
-            }, { url, signal: AbortSignal.timeout(20000) });
-            assert.equal(resumed.chunks?.find(chunk => chunk.type === 'completion')?.headers['x-status'], 'complete',
-                `Resumed ${table} must finish within one request's time budget: ${JSON.stringify(resumed.chunks?.filter(chunk => chunk.type === 'error'))}`);
-            // Keep only the confirmed prefix from the first request. The second
-            // request must supply every remaining row across multiple batches.
-            const sql = [...first.chunks.slice(0, firstInsert + 1), ...resumed.chunks]
-                .filter(chunk => ['sql', 'sql_session_setup'].includes(chunk.type))
-                .map(chunk => Buffer.from(chunk.body, 'binary'));
-            execFileSync('mysql', [`--host=${host}`, `--port=${port}`, `--user=${user}`, targetDatabase], {
-                env: { ...process.env, MYSQL_PWD: password }, input: Buffer.concat(sql),
-            });
-            if (table === 'network_users') {
-                const [users] = await connection.query(`SELECT ID FROM \`${targetDatabase}\`.network_users ORDER BY ID`);
-                assert.deepEqual(users.map(row => row.ID), expectedUserIds);
-            } else {
-                const [metadata] = await connection.query(`SELECT user_id,meta_key,meta_value FROM \`${targetDatabase}\`.network_usermeta ORDER BY umeta_id`);
-                assert.deepEqual([...new Set(metadata.map(row => row.user_id))].sort((a, b) => a - b), expectedUserIds);
-                assert.ok(metadata.every(row => !['network_8_capabilities','network_capabilities','session_tokens'].includes(row.meta_key)));
-                const [expected] = await connection.query(`SELECT user_id,meta_key,meta_value FROM network_usermeta
-                    WHERE user_id IN (${expectedUserIds.join(',')}) AND user_id>=1000 AND meta_key!='network_8_capabilities' ORDER BY umeta_id`);
-                assert.deepEqual(metadata.filter(row => row.user_id >= 1000), expected);
+            const resumePositions = [firstInsert];
+            if (table === 'network_usermeta') {
+                const emptyBatch = first.chunks.findIndex(chunk => chunk.type === 'sql' &&
+                    chunk.body.includes('DO 0; /* selected-user batch complete */'));
+                assert.ok(emptyBatch > firstInsert, 'Rejected metadata must produce a checkpoint before the next batch');
+                resumePositions.push(emptyBatch);
+            }
+            for (const resumePosition of resumePositions) {
+                const resumed = await apiRequest(site, 'sql_chunk', {
+                    ...params, cursor: first.chunks[resumePosition].headers['x-cursor'],
+                }, { url, signal: AbortSignal.timeout(20000) });
+                assert.equal(resumed.chunks?.find(chunk => chunk.type === 'completion')?.headers['x-status'], 'complete',
+                    `Resumed ${table} must finish within one request's time budget: ${JSON.stringify(resumed.chunks?.filter(chunk => chunk.type === 'error'))}`);
+                // Keep only the confirmed prefix from the first request. The second
+                // request must supply every remaining row across multiple batches.
+                const sql = [...first.chunks.slice(0, resumePosition + 1), ...resumed.chunks]
+                    .filter(chunk => ['sql', 'sql_session_setup'].includes(chunk.type))
+                    .map(chunk => Buffer.from(chunk.body, 'binary'));
+                execFileSync('mysql', [`--host=${host}`, `--port=${port}`, `--user=${user}`, targetDatabase], {
+                    env: { ...process.env, MYSQL_PWD: password }, input: Buffer.concat(sql),
+                });
+                if (table === 'network_users') {
+                    const [users] = await connection.query(`SELECT ID FROM \`${targetDatabase}\`.network_users ORDER BY ID`);
+                    assert.deepEqual(users.map(row => row.ID), expectedUserIds);
+                } else {
+                    const [metadata] = await connection.query(`SELECT user_id,meta_key,meta_value FROM \`${targetDatabase}\`.network_usermeta ORDER BY umeta_id`);
+                    assert.deepEqual([...new Set(metadata.map(row => row.user_id))].sort((a, b) => a - b), expectedUserIds);
+                    assert.ok(metadata.every(row => !['network_8_capabilities','network_capabilities','session_tokens'].includes(row.meta_key)));
+                    const [expected] = await connection.query(`SELECT user_id,meta_key,meta_value FROM network_usermeta
+                        WHERE user_id IN (${expectedUserIds.join(',')}) AND user_id>=1000 AND meta_key!='network_8_capabilities' ORDER BY umeta_id`);
+                    assert.deepEqual(metadata.filter(row => row.user_id >= 1000), expected);
+                }
             }
         });
     }


### PR DESCRIPTION
Limits selected-site `users` and `usermeta` reads to one batch of candidate IDs before applying row filters. The default is 250 IDs. A sparse selection can no longer make one query walk the whole network's users or metadata to fill its result limit.

User export reads IDs from the site's saved table, then fetches only those primary keys. For site 7:

```sql
SELECT user_id FROM network_7_reprint_users FORCE INDEX (PRIMARY)
WHERE user_id > '0' ORDER BY user_id LIMIT 250;

-- If the saved IDs are 7, 42 and 100000, fetch only those accounts.
SELECT ID, user_login FROM network_users FORCE INDEX (PRIMARY)
WHERE ID IN ('7', '42', '100000') ORDER BY ID;
```

Metadata uses the same two-query approach, but takes candidate IDs from `usermeta` in primary-key order. It still visits the network's metadata. Each batch can stop and resume, even when every row is rejected. The actual row queries keep the existing metadata filters and checks that each saved source reference still exists.

The existing row cursor advances past rejected IDs and missing accounts. An empty batch emits its own `DO 0` SQL part to carry that cursor. An interrupted batch resumes after its last returned row, not after IDs it has not consumed. There is no new persistent cursor field, table, or WordPress index.

## Query plans

Checked with `EXPLAIN` and `EXPLAIN ANALYZE` on MySQL 8.0.46. With 100,000 network users and one selected user, the old query scanned 100,000 accounts. The new queries read one saved ID and fetch that account. The final generated metadata query read 250 primary-key rows, with indexed reference checks, on both InnoDB and MyISAM.

A per-user metadata query looked simpler, but MyISAM read 100,000 rows and sorted them to return 250. Reading primary-key candidates first avoids that plan without changing source indexes.

## Tests

The MySQL tests count actual storage-engine reads and cover sparse users, rejected metadata batches, large ID gaps, missing accounts, malformed cursors, and resume after every SQL fragment with buffered and unbuffered PDO. The full SQL suite and selected-site MariaDB suite pass. The PHP 5.6 artifact build, PHP compatibility check and static analysis pass; per-file lint counts do not increase.

The real WordPress HTTP test also resumes from an empty metadata batch and imports the result into MySQL. The scan tests and this HTTP regression fail against the merged #760 implementation and pass with this change.

This follows #760 and targets `trunk` independently of the remaining migration stack. It bounds candidate rows per batch, not large field values or total export time.
