### PR TITLE
[PHP] Stop downloads on invalid received paths

### DIFF
--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2851,8 +2851,8 @@ class ImportClient
      * preserving their directory structure.
      *
      * Issues one file_fetch request per parent directory so that an
-     * inaccessible directory doesn't block the others.  All errors
-     * are caught and logged as non-fatal.
+     * inaccessible directory doesn't block the others. Download failures
+     * are logged as non-fatal; invalid received paths stop the caller.
      *
      * @return int Number of files successfully downloaded.
      */
@@ -2904,8 +2904,6 @@ class ImportClient
                         return;
                     }
 
-                    // The requested paths also come from the source's preflight response.
-                    assert_valid_path($remote_absolute_path, "remote runtime file path");
                     if (!in_array($remote_absolute_path, $dir_files, true)) {
                         // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This exception is logged as CLI text.
                         throw new \RuntimeException("The source returned an unrequested runtime file: {$remote_absolute_path}");
@@ -2949,17 +2947,17 @@ class ImportClient
 
             try {
                 $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
-            } catch (\RuntimeException | \InvalidArgumentException $e) {
+            } catch (\RuntimeException $e) {
                 $this->audit_log(
                     "Fetch failed for directory {$directory} (non-fatal): " .
                         substr($e->getMessage(), 0, 200),
                 );
-            }
+            } finally {
+                @unlink($tmp);
 
-            @unlink($tmp);
-
-            if ($context->file_handle) {
-                fclose($context->file_handle);
+                if ($context->file_handle) {
+                    fclose($context->file_handle);
+                }
             }
         }
 
@@ -11915,8 +11913,22 @@ class ImportClient
         &$current_chunk
     ): callable {
         return function ($event) use ($context, &$current_chunk) {
+            $headers = $event["headers"];
+            if (!$current_chunk) {
+                // Entry paths must be checked even when this caller ignores
+                // the part. Symlink targets are different: ../ may be valid
+                // there, and the symlink handler checks the resolved target.
+                foreach ([
+                    "x-file-path", "x-directory-path", "x-symlink-path",
+                    "x-index-path", "x-filesystem-root",
+                ] as $path_header) {
+                    if (isset($headers[$path_header]) && $headers[$path_header] !== "") {
+                        $this->assert_valid_received_path($headers[$path_header], $path_header);
+                    }
+                }
+            }
+
             if ($event["type"] === "body") {
-                $headers = $event["headers"];
                 $chunk_type = $headers["x-chunk-type"] ?? "";
                 if ($chunk_type === "file") {
                     if (!$current_chunk) {
@@ -11958,8 +11970,13 @@ class ImportClient
                         $event["data"];
                 }
             } elseif ($event["type"] === "complete") {
-                $headers = $event["headers"];
                 $chunk_type = $headers["x-chunk-type"] ?? "";
+                if ($chunk_type === "error") {
+                    $error = json_decode($current_chunk["body"] ?? "", true);
+                    if (is_array($error) && isset($error["path"]) && $error["path"] !== "") {
+                        $this->assert_valid_received_path($error["path"], "remote error path");
+                    }
+                }
                 if ($chunk_type === "file" && !empty($current_chunk["body_streamed"])) {
                     if ($context->on_chunk) {
                         $close_headers = $headers;
@@ -11993,6 +12010,24 @@ class ImportClient
                 $current_chunk = null;
             }
         };
+    }
+
+    /**
+     * Validate one base64-encoded entry path before dispatching its part.
+     *
+     * @param mixed  $encoded_path Path field received in a header or JSON body.
+     * @param string $label        Name of the received path field.
+     */
+    private function assert_valid_received_path($encoded_path, string $label): void
+    {
+        $path = is_string($encoded_path) ? base64_decode($encoded_path, true) : false;
+        if ($path === false) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Protocol validation error rendered as CLI text.
+            throw new \InvalidArgumentException("{$label} must contain a base64-encoded path; received " . json_encode($encoded_path, JSON_INVALID_UTF8_SUBSTITUTE));
+        }
+        // Runtime-file requests also come from the source's preflight response,
+        // so matching a request does not replace path validation.
+        assert_valid_path($path, $label);
     }
 
     /**

--- a/packages/reprint-client/src/import.php
+++ b/packages/reprint-client/src/import.php
@@ -2894,7 +2894,7 @@ class ImportClient
             $context->file_path = null;
             $context->file_ctime = null;
 
-            $context->on_chunk = function ($chunk) use ($path, $context, &$downloaded) {
+            $context->on_chunk = function ($chunk) use ($path, $dir_files, $context, &$downloaded) {
                 $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                 if ($chunk_type === "file") {
@@ -2902,6 +2902,13 @@ class ImportClient
                     $remote_absolute_path = base64_decode($raw, true);
                     if ($remote_absolute_path === false || $remote_absolute_path === "") {
                         return;
+                    }
+
+                    // The requested paths also come from the source's preflight response.
+                    assert_valid_path($remote_absolute_path, "remote runtime file path");
+                    if (!in_array($remote_absolute_path, $dir_files, true)) {
+                        // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This exception is logged as CLI text.
+                        throw new \RuntimeException("The source returned an unrequested runtime file: {$remote_absolute_path}");
                     }
 
                     $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
@@ -2942,7 +2949,7 @@ class ImportClient
 
             try {
                 $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException | \InvalidArgumentException $e) {
                 $this->audit_log(
                     "Fetch failed for directory {$directory} (non-fatal): " .
                         substr($e->getMessage(), 0, 200),

--- a/tests/Import/FilesPullLocalIndexTest.php
+++ b/tests/Import/FilesPullLocalIndexTest.php
@@ -129,6 +129,20 @@ final class FilesPullLocalIndexTest extends TestCase
         ]], $this->filesDiffRecords($diff['stdout']));
     }
 
+    public function testInvalidRemoteIndexPathStopsThePullBeforeFetchingFiles(): void
+    {
+        $this->writeRemoteOverrides([
+            'added_files' => ['../../../../outside.txt' => 'must not be downloaded'],
+        ]);
+
+        $pull = $this->runFilesPull();
+
+        $this->assertSame(1, $pull['exit'], $pull['output']);
+        $this->assertStringContainsString('must not contain dot-segments', $pull['output']);
+        $this->assertFileDoesNotExist($this->root . '/outside.txt');
+        $this->assertFileDoesNotExist($this->localTree . '/' . self::PULLED_PATH);
+    }
+
     public function testFilesPullTransfersAPathContainingInvalidUtf8Bytes(): void
     {
         $path = "binary-\xff.txt";

--- a/tests/Import/RuntimeFilesRootPathTest.php
+++ b/tests/Import/RuntimeFilesRootPathTest.php
@@ -87,8 +87,8 @@ final class RuntimeFilesRootPathTest extends TestCase
         $this->assertSame(['/'], $request['directory']);
     }
 
-    /** @dataProvider rejected_runtime_paths */
-    public function testPreflightRejectsInvalidOrUnrequestedRuntimeFiles(
+    /** @dataProvider invalid_runtime_paths */
+    public function testPreflightStopsOnInvalidRuntimePaths(
         string $returned_path,
         string $requested_path,
         string $reason
@@ -107,7 +107,12 @@ final class RuntimeFilesRootPathTest extends TestCase
             $this->filesystem_root,
         );
 
-        $client->run_preflight();
+        try {
+            $client->run_preflight();
+            $this->fail('An invalid received path must stop preflight.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString($reason, $exception->getMessage());
+        }
 
         $this->assertSame(
             'keep this local file',
@@ -115,19 +120,10 @@ final class RuntimeFilesRootPathTest extends TestCase
             'A source response must not overwrite files outside runtime_files.',
         );
         $runtime_directory = $this->state_directory . '/runtime_files';
-        $this->assertSame(['.', '..', 'append'], scandir($runtime_directory));
-        $this->assertSame(
-            'runtime file at root',
-            file_get_contents($runtime_directory . '/append/runtime.php'),
-            'Rejecting one directory must not block a valid runtime file in another.',
-        );
-        $this->assertStringContainsString(
-            $reason,
-            file_get_contents($this->state_directory . '/audit.log'),
-        );
+        $this->assertSame(['.', '..'], scandir($runtime_directory));
 
         $requests = file($this->request_log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        $this->assertCount(3, $requests);
+        $this->assertCount(2, $requests, 'No further directory may be fetched after an invalid path.');
         $request = json_decode($requests[1], true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame('file_fetch', $request['endpoint']);
         $this->assertSame([['path' => base64_encode($requested_path)]], $request['files']);
@@ -136,16 +132,80 @@ final class RuntimeFilesRootPathTest extends TestCase
     /**
      * @return array<string,array{string,string,string}> Returned path, requested path, and rejection reason.
      */
-    public static function rejected_runtime_paths(): array
+    public static function invalid_runtime_paths(): array
     {
         return [
             'relative traversal' => ['../../outside.txt', '/runtime.php', 'must be an absolute path'],
             'absolute traversal' => ['/../../outside.txt', '/runtime.php', 'must not contain dot-segments'],
             'traversal also listed in preflight' => ['/../../outside.txt', '/../../outside.txt', 'must not contain dot-segments'],
             'dot segment also listed in preflight' => ['/./runtime.php', '/./runtime.php', 'must not contain dot-segments'],
-            'unrequested file in the requested directory' => ['/unexpected.php', '/runtime.php', 'unrequested runtime file'],
             'relative filename' => ['relative.php', '/runtime.php', 'must be an absolute path'],
             'NUL byte' => ["/runtime.php\0suffix", '/runtime.php', 'must not contain NUL bytes'],
+        ];
+    }
+
+    public function testPreflightKeepsDownloadingAfterAnUnrequestedFile(): void
+    {
+        $client = new \ImportClient(
+            $this->target_url . '&' . http_build_query([
+                'returned_path' => base64_encode('/unexpected.php'),
+                'requested_path' => base64_encode('/runtime.php'),
+            ]),
+            $this->state_directory,
+            $this->filesystem_root,
+        );
+
+        $client->run_preflight();
+
+        $runtime_directory = $this->state_directory . '/runtime_files';
+        $this->assertSame(['.', '..', 'append'], scandir($runtime_directory));
+        $this->assertSame(
+            'runtime file at root',
+            file_get_contents($runtime_directory . '/append/runtime.php'),
+        );
+        $this->assertStringContainsString(
+            'unrequested runtime file',
+            file_get_contents($this->state_directory . '/audit.log'),
+        );
+    }
+
+    /** @dataProvider received_path_fields */
+    public function testInvalidPathsStopEvenWhenTheRuntimeDownloaderIgnoresThePart(
+        string $chunk_type,
+        string $path_header
+    ): void {
+        $client = new \ImportClient(
+            $this->target_url . '&' . http_build_query([
+                'returned_path' => base64_encode('/../../outside.txt'),
+                'requested_path' => base64_encode('/runtime.php'),
+                'chunk_type' => $chunk_type,
+                'path_header' => $path_header,
+            ]),
+            $this->state_directory,
+            $this->filesystem_root,
+        );
+
+        try {
+            $client->run_preflight();
+            $this->fail('Every received entry path must be checked before dispatch.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString('must not contain dot-segments', $exception->getMessage());
+        }
+
+        $this->assertSame(['.', '..'], scandir($this->state_directory . '/runtime_files'));
+        $this->assertCount(2, file($this->request_log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
+    }
+
+    /** @return array<string,list<string>> Part type and path header for each case. */
+    public static function received_path_fields(): array
+    {
+        return [
+            'directory' => ['directory', 'X-Directory-Path'],
+            'symlink entry' => ['symlink', 'X-Symlink-Path'],
+            'index entry' => ['index', 'X-Index-Path'],
+            'missing file' => ['missing', 'X-File-Path'],
+            'filesystem root' => ['metadata', 'X-Filesystem-Root'],
+            'error path' => ['error', ''],
         ];
     }
 
@@ -210,6 +270,19 @@ $write_part = static function (array $headers, string $body = '') use ($boundary
 };
 
 header('Content-Type: multipart/mixed; boundary=' . $boundary);
+if (isset($_GET['chunk_type'])) {
+    $headers = array('X-Chunk-Type' => $_GET['chunk_type']);
+    $body = '';
+    if ($_GET['chunk_type'] === 'error') {
+        $body = json_encode(array('path' => $returned_path, 'error_type' => 'file_missing'));
+    } else {
+        $headers[$_GET['path_header']] = $returned_path;
+    }
+    $write_part($headers, $body);
+    echo "--{$boundary}--\r\n";
+    return;
+}
+
 $write_part(array(
     'X-Chunk-Type' => 'file',
     'X-File-Path' => $returned_path,

--- a/tests/Import/RuntimeFilesRootPathTest.php
+++ b/tests/Import/RuntimeFilesRootPathTest.php
@@ -87,6 +87,68 @@ final class RuntimeFilesRootPathTest extends TestCase
         $this->assertSame(['/'], $request['directory']);
     }
 
+    /** @dataProvider rejected_runtime_paths */
+    public function testPreflightRejectsInvalidOrUnrequestedRuntimeFiles(
+        string $returned_path,
+        string $requested_path,
+        string $reason
+    ): void {
+        if (!function_exists('curl_init')) {
+            $this->markTestSkipped('Runtime file fetching requires the curl extension.');
+        }
+
+        file_put_contents($this->root . '/outside.txt', 'keep this local file');
+        $client = new \ImportClient(
+            $this->target_url . '&' . http_build_query([
+                'returned_path' => base64_encode($returned_path),
+                'requested_path' => base64_encode($requested_path),
+            ]),
+            $this->state_directory,
+            $this->filesystem_root,
+        );
+
+        $client->run_preflight();
+
+        $this->assertSame(
+            'keep this local file',
+            file_get_contents($this->root . '/outside.txt'),
+            'A source response must not overwrite files outside runtime_files.',
+        );
+        $runtime_directory = $this->state_directory . '/runtime_files';
+        $this->assertSame(['.', '..', 'append'], scandir($runtime_directory));
+        $this->assertSame(
+            'runtime file at root',
+            file_get_contents($runtime_directory . '/append/runtime.php'),
+            'Rejecting one directory must not block a valid runtime file in another.',
+        );
+        $this->assertStringContainsString(
+            $reason,
+            file_get_contents($this->state_directory . '/audit.log'),
+        );
+
+        $requests = file($this->request_log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $this->assertCount(3, $requests);
+        $request = json_decode($requests[1], true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('file_fetch', $request['endpoint']);
+        $this->assertSame([['path' => base64_encode($requested_path)]], $request['files']);
+    }
+
+    /**
+     * @return array<string,array{string,string,string}> Returned path, requested path, and rejection reason.
+     */
+    public static function rejected_runtime_paths(): array
+    {
+        return [
+            'relative traversal' => ['../../outside.txt', '/runtime.php', 'must be an absolute path'],
+            'absolute traversal' => ['/../../outside.txt', '/runtime.php', 'must not contain dot-segments'],
+            'traversal also listed in preflight' => ['/../../outside.txt', '/../../outside.txt', 'must not contain dot-segments'],
+            'dot segment also listed in preflight' => ['/./runtime.php', '/./runtime.php', 'must not contain dot-segments'],
+            'unrequested file in the requested directory' => ['/unexpected.php', '/runtime.php', 'unrequested runtime file'],
+            'relative filename' => ['relative.php', '/runtime.php', 'must be an absolute path'],
+            'NUL byte' => ["/runtime.php\0suffix", '/runtime.php', 'must not contain NUL bytes'],
+        ];
+    }
+
     private function start_server(): string
     {
         $router = $this->root . '/runtime-files-root-router.php';
@@ -97,6 +159,9 @@ $request = array(
     'directory' => isset($_GET['directory'])
         ? (array) $_GET['directory']
         : null,
+    'files' => isset($_FILES['file_list'])
+        ? json_decode(file_get_contents($_FILES['file_list']['tmp_name']), true)
+        : null,
 );
 file_put_contents(
     %s,
@@ -104,14 +169,34 @@ file_put_contents(
     FILE_APPEND
 );
 
+if ($request['endpoint'] === 'preflight') {
+    header('Content-Type: application/json');
+    echo json_encode(array(
+        'ok' => true,
+        'protocol_version' => 2,
+        'runtime' => array(
+            'ini_get_all' => array(
+                'auto_prepend_file' => base64_decode($_GET['requested_path'], true),
+                'auto_append_file' => '/append/runtime.php',
+            ),
+        ),
+    ));
+    return;
+}
+
 if (
     $request['endpoint'] !== 'file_fetch'
     || !is_array($request['directory'])
-    || ($request['directory'][0] ?? null) !== '/'
+    || !is_array($request['files'])
 ) {
     http_response_code(400);
-    echo 'file_fetch must receive the filesystem root as its directory';
+    echo 'file_fetch must receive a directory and a file list';
     return;
+}
+
+$returned_path = $request['files'][0]['path'];
+if ($request['directory'] !== array('/append') && isset($_GET['returned_path'])) {
+    $returned_path = $_GET['returned_path'];
 }
 
 $boundary = 'runtime-files-root-path-test';
@@ -127,10 +212,16 @@ $write_part = static function (array $headers, string $body = '') use ($boundary
 header('Content-Type: multipart/mixed; boundary=' . $boundary);
 $write_part(array(
     'X-Chunk-Type' => 'file',
-    'X-File-Path' => base64_encode('/runtime.php'),
+    'X-File-Path' => $returned_path,
     'X-First-Chunk' => '1',
+    'X-Last-Chunk' => '0',
+), 'runtime file ');
+$write_part(array(
+    'X-Chunk-Type' => 'file',
+    'X-File-Path' => $returned_path,
+    'X-First-Chunk' => '0',
     'X-Last-Chunk' => '1',
-), 'runtime file at root');
+), 'at root');
 $write_part(array(
     'X-Chunk-Type' => 'completion',
     'X-Status' => 'complete',


### PR DESCRIPTION
Stops the pull if the source sends a file-transfer entry path containing `.` or `..` segments, a relative entry path, or a NUL byte. Multipart path fields are checked before passing the part to its handler, including parts the caller would otherwise ignore. Runtime-file downloads also reject files that were not requested.

Ordinary runtime-file download failures remain non-fatal. Symlink targets may still contain `../`; their existing resolved-target checks remain in place.

The HTTP tests check that invalid paths stop further requests, valid multipart downloads still work, and an invalid remote index path stops the pull before files are fetched.
