### PR TITLE
Preserve excluded URL bases and retain forward scan positions

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-processor-in-text-with-mixed-unknown-escape-rules.php
@@ -33,7 +33,10 @@
  * Instead, the processor performs one narrow operation: find the configured
  * source base as bytes and replace that entire slice with a target domain and
  * optional path. It replaces the literal protocol separately when the mapping
- * changes it. It does not decode, normalize, or re-encode the input.
+ * changes it. A source host with child-site exclusions stays unchanged in this
+ * fallback, including selected-site links. Only callers with parsed URL fields
+ * can decide which site a complete path selects; this scanner does not guess
+ * path boundaries or copy the remaining text into a temporary URL.
  *
  * Supported sources:
  *
@@ -67,8 +70,12 @@
  *   protocol-relative or scheme-less candidate has no scheme colon to copy, so
  *   its target port uses a literal `:`. This may not match the escaping rules
  *   of the surrounding text.
- * - Target user information, queries, fragments, IPv4/IPv6 addresses, and
- *   Unicode domains are not supported. Punycode domains are supported.
+ * - A same-URL mapping is an exclusion: it wins over shorter source bases and
+ *   retains the matched bytes, including IP hosts and original slash escaping.
+ * - Target user information, queries, fragments, IPv6 addresses, and
+ *   Unicode domains are not supported. Punycode domains, IPv4 addresses, and
+ *   hosts with a trailing dot are supported. These limits apply only to this
+ *   fallback; they do not restrict the migration destination.
  * - Unicode source domains and paths are not supported.
  *
  * CSS hexadecimal escapes such as https\3a \2f \2f ... and percent-encoded
@@ -119,6 +126,20 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
      */
     private array $url_mappings = [];
 
+    /** Prepared rules and the shared child-site path set; never copied per value. */
+    private CautiousURLBaseRewriteMapping $url_mapping;
+
+    /**
+     * One lookahead match per mapping, not a list of all URLs in the value.
+     * A missing entry has not been searched; null means no match remains.
+     * Input text does not change while scanning: replacements are queued.
+     * Keep each match until the cursor passes it, and do not repeat a search
+     * which already reached the end of the value.
+     *
+     * @var array<int, array<int|string, array{string, int}>|null>
+     */
+    private array $next_matches = [];
+
     private string $text;
 
     private int $bytes_already_scanned = 0;
@@ -157,6 +178,7 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     )
     {
         $this->text = $text;
+        $this->url_mapping = $url_mapping;
         $this->url_mappings = $url_mapping->get_entries();
     }
 
@@ -190,6 +212,14 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     public function replace_url_base(): bool
     {
         if ($this->matched_url === null) {
+            return false;
+        }
+
+        // A host shared with child sites needs a parsed path to select a site.
+        // This scanner knows only the source base, not where the URL ends or
+        // which escapes its surrounding format uses. Keep such URLs remote;
+        // the HTML, CSS and block URL parsers make path decisions elsewhere.
+        if ($this->url_mapping->has_excluded_paths_for_host($this->matched_url['source_authority'])) {
             return false;
         }
 
@@ -263,15 +293,21 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
     private function find_next_url_base(): ?array
     {
         $next_match = null;
-        foreach ($this->url_mappings as $mapping) {
-            $found = preg_match(
-                $mapping['pattern'],
-                $this->text,
-                $matches,
-                PREG_OFFSET_CAPTURE,
-                $this->bytes_already_scanned
-            );
-            if ($found !== 1) {
+        foreach ($this->url_mappings as $mapping_index => $mapping) {
+            if (!array_key_exists($mapping_index, $this->next_matches)
+                || ( $this->next_matches[$mapping_index] !== null
+                    && $this->next_matches[$mapping_index]['authority'][1] < $this->bytes_already_scanned )) {
+                $found = preg_match(
+                    $mapping['pattern'],
+                    $this->text,
+                    $matches,
+                    PREG_OFFSET_CAPTURE,
+                    $this->bytes_already_scanned
+                );
+                $this->next_matches[$mapping_index] = $found === 1 ? $matches : null;
+            }
+            $matches = $this->next_matches[$mapping_index];
+            if ($matches === null) {
                 continue;
             }
 
@@ -297,12 +333,17 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules {
                 $target_port = $target_port_colon . $mapping['target_port'];
             }
 
+            // An exclusion must preserve the actual matched bytes, including
+            // mixed slash escaping. Rebuilding an equal URL base can change them.
+            $unchanged_base = $mapping['source_authority'] === $mapping['target_domain']
+                    . ( $mapping['target_port'] === null ? '' : ':' . $mapping['target_port'] )
+                && $mapping['source_path'] === $mapping['target_path'];
             $next_match = array_merge(
                 $mapping,
                 [
                     'start'         => $authority_start,
                     'base_length'   => strlen($matches['base'][0]),
-                    'replacement'   => $mapping['target_domain'] . $target_port . str_replace(
+                    'replacement'   => $unchanged_base ? $matches['base'][0] : $mapping['target_domain'] . $target_port . str_replace(
                         '/',
                         $target_path_slash,
                         $mapping['target_path']

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -72,8 +72,8 @@ class CautiousURLBaseRewriteMapping {
                 $hosts[] = $parsed->host;
                 $hosts[] = $authority;
             }
-            foreach (array_unique($hosts) as $host) {
-                if ($path_set !== []) {
+            if ($path_set !== []) {
+                foreach (array_unique($hosts) as $host) {
                     $this->excluded_paths[$host] = [
                         'paths' => isset($this->excluded_paths[$host])
                             ? $this->excluded_paths[$host]['paths'] + $path_set : $path_set,

--- a/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-cautious-url-base-rewrite-mapping.php
@@ -1,5 +1,7 @@
 <?php
 
+use WordPress\DataLiberation\URL\WPURL;
+
 /**
  * Prepares URL mappings used for cautious byte replacement.
  *
@@ -25,18 +27,75 @@ class CautiousURLBaseRewriteMapping {
     private array $entries = [];
 
     /**
+     * Host => decoded, ASCII-lowercase child-site path set and its longest key in bytes.
+     * For example, /shop/news is a hash key, with longest_path_bytes=10.
+     * The cached length stops a deep URL from hashing ever-longer prefixes.
+     * These are hash keys, not rewrite rules: a million sites must not mean a million regexes
+     * or a million comparisons for each URL. HTTP and HTTPS share each set.
+     *
+     * @var array<string, array{paths: array<string, true>, longest_path_bytes: int}>
+     */
+    private array $excluded_paths = [];
+
+    /**
      * Prepares source URL base => target URL pairs.
      *
      * Invalid pairs are skipped as a whole. They cannot produce a partial
      * domain replacement.
      *
      * @param array<string, string> $url_mapping Source URL base => target URL.
+     * @param array<string, string[]> $excluded_paths Source HTTP(S) origin =>
+     *     child-site paths, such as ['https://network.test' => ['/shop/news/']].
+     *     The importer checks this list at the preflight response boundary.
      */
-    public function __construct(array $url_mapping)
+    public function __construct(array $url_mapping, array $excluded_paths = [])
     {
+        foreach ($excluded_paths as $origin => $paths) {
+            $path_set = [];
+            $longest_path_bytes = 0;
+            foreach ($paths as $path) {
+                // WordPress's normal site-directory collation treats /news/
+                // and /NEWS/ alike. Fold lookup keys, never the emitted URL.
+                $path = strtolower(rtrim(rawurldecode($path), '/'));
+                $path_set[$path] = true;
+                $longest_path_bytes = max($longest_path_bytes, strlen($path));
+            }
+            // Use the same URL parser as HTML rewriting. Also retain the
+            // literal authority for the cautious scanner (e.g. an explicit
+            // :443). Assignments share the set through PHP copy-on-write.
+            $hosts = [];
+            foreach (['http:', 'https:'] as $protocol) {
+                $url = $protocol . substr($origin, strpos($origin, ':') + 1);
+                $parsed = WPURL::parse($url);
+                $parts = parse_url($url);
+                $authority = strtolower($parts['host']) . ( isset($parts['port']) ? ':' . $parts['port'] : '' );
+                $hosts[] = $parsed->host;
+                $hosts[] = $authority;
+            }
+            foreach (array_unique($hosts) as $host) {
+                if ($path_set !== []) {
+                    $this->excluded_paths[$host] = [
+                        'paths' => isset($this->excluded_paths[$host])
+                            ? $this->excluded_paths[$host]['paths'] + $path_set : $path_set,
+                        'longest_path_bytes' => max($longest_path_bytes, $this->excluded_paths[$host]['longest_path_bytes'] ?? 0),
+                    ];
+                }
+            }
+        }
         foreach ($url_mapping as $source_url => $target_url) {
             $entry = $this->create_entry($source_url, $target_url);
             if ($entry !== null) {
+                // Child paths may be stored under network.test while this rule
+                // matches network.test:443. Give that literal spelling the same
+                // lookup set. PHP shares its array until a write; no path list
+                // is copied or scanned here. Parse once per rule, not per URL.
+                if ($this->excluded_paths !== []) {
+                    $parsed = WPURL::parse($source_url);
+                    if ($parsed && !isset($this->excluded_paths[$entry['source_authority']])
+                        && isset($this->excluded_paths[$parsed->host])) {
+                        $this->excluded_paths[$entry['source_authority']] = $this->excluded_paths[$parsed->host];
+                    }
+                }
                 $this->entries[] = $entry;
             }
         }
@@ -68,6 +127,43 @@ class CautiousURLBaseRewriteMapping {
         return $this->entries;
     }
 
+    /** Let the text scanner skip path extraction when this host has no child sites. */
+    public function has_excluded_paths_for_host(string $host): bool
+    {
+        return isset($this->excluded_paths[strtolower($host)]);
+    }
+
+    /**
+     * Return true if the URL points to a child site and must stay on the source.
+     *
+     * For a child site at /shop/news/ on this host:
+     * - /shop/news returns true.
+     * - /shop/news/article returns true.
+     * - /shop/newsletter returns false.
+     *
+     * Look up path prefixes in this host's child-path set, without scanning all
+     * sites. Skip prefixes longer than the longest stored child path.
+     *
+     * The caller must resolve "." and ".." with the URL parser first.
+     * Decode percent escapes and ignore ASCII case for comparison only.
+     * This method does not change the URL.
+     */
+    public function excludes_path(string $host, string $path): bool
+    {
+        $host = strtolower($host);
+        if ($path === '' || !isset($this->excluded_paths[$host])) {
+            return false;
+        }
+        $path = strtolower(rawurldecode($path));
+        $longest_path_bytes = $this->excluded_paths[$host]['longest_path_bytes'];
+        for ($offset = strpos($path, '/', 1); $offset !== false && $offset <= $longest_path_bytes; $offset = strpos($path, '/', $offset + 1)) {
+            if (isset($this->excluded_paths[$host]['paths'][substr($path, 0, $offset)])) {
+                return true;
+            }
+        }
+        return strlen($path) <= $longest_path_bytes && isset($this->excluded_paths[$host]['paths'][$path]);
+    }
+
     /**
      * @return array{
      *     source_authority: string,
@@ -83,7 +179,9 @@ class CautiousURLBaseRewriteMapping {
     private function create_entry(string $source_url, string $target_url): ?array
     {
         $source = $this->get_supported_url_parts($source_url, true);
-        $target = $this->get_supported_url_parts($target_url, false);
+        // A same-URL rule keeps sibling pages or media at the source. Reuse
+        // the source parts: this rule does not insert a new host or path.
+        $target = $source_url === $target_url ? $source : $this->get_supported_url_parts($target_url, false);
         if ($source === null || $target === null) {
             return null;
         }
@@ -91,6 +189,7 @@ class CautiousURLBaseRewriteMapping {
         // A source URL ending at its authority uses / as the URL separator,
         // not as an initial path to remove. Leave its original spelling alone.
         $source_path = $source['path'] === '/' ? '' : $source['path'];
+        $target_path = $source_url === $target_url ? $source_path : $target['path'];
 
         return [
             'source_authority' => $source['authority'],
@@ -98,13 +197,13 @@ class CautiousURLBaseRewriteMapping {
             'source_base'      => $source['authority'] . $source_path,
             'target_domain'    => $target['host'],
             'target_scheme'    => $target['scheme'],
-            'target_path'      => $target['path'],
+            'target_path'      => $target_path,
             'target_port'      => $target['port'],
             'pattern'          => $this->create_url_candidate_pattern(
                 $source['scheme'],
                 $source['authority'],
                 $source_path,
-                $target['path'] !== ''
+                $target_path !== ''
             ),
         ];
     }
@@ -185,6 +284,11 @@ class CautiousURLBaseRewriteMapping {
             }
         }
 
+        $parsed = WPURL::parse($url);
+        if (!$parsed) {
+            return null;
+        }
+
         $scheme = strtolower( (string) $parts['scheme'] );
         $host = (string) $parts['host'];
         $path = isset($parts['path']) ? (string) $parts['path'] : '';
@@ -192,9 +296,17 @@ class CautiousURLBaseRewriteMapping {
             !$is_source_url
             && $path !== ''
             && preg_match('#^/[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*$#', $path) !== 1;
+        // These limits apply only to literal replacement in unknown text.
+        // A parsed HTTP host can contain quotes, but inserting one could end
+        // the surrounding value. Hostname syntax keeps output to letters,
+        // digits, hyphens and dots; IPv4 and a trailing dot need no escaping.
+        // IPv6 sources can be matched and removed without inserting brackets.
+        // Format-aware rewriters accept the full URL and use their serializers.
+        $literal_host = filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false;
+        $source_ip = $is_source_url && filter_var(trim($parsed->hostname, '[]'), FILTER_VALIDATE_IP) !== false;
         if (( $scheme !== 'http' && $scheme !== 'https' )
             || ( !$is_source_url && $has_unsupported_target_path )
-            || !( $this->is_alphanumeric_dot_hyphen_domain_name($host) || ( $is_source_url && $this->is_ip_address($host) ) )
+            || !( $literal_host || $source_ip )
             || !$this->contains_only_exclamation_mark_through_tilde_bytes($path)) {
             return null;
         }
@@ -206,17 +318,6 @@ class CautiousURLBaseRewriteMapping {
             'path'      => $path,
             'port'      => isset($parts['port']) ? (int) $parts['port'] : null,
         ];
-    }
-
-    private function is_ip_address(string $host): bool
-    {
-        return filter_var(trim($host, '[]'), FILTER_VALIDATE_IP) !== false;
-    }
-
-    private function is_alphanumeric_dot_hyphen_domain_name(string $domain): bool
-    {
-        return filter_var($domain, FILTER_VALIDATE_IP) === false
-            && preg_match('/^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/', $domain) === 1;
     }
 
     private function contains_only_exclamation_mark_through_tilde_bytes(string $path): bool

--- a/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
+++ b/tests/UrlRewriting/CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest.php
@@ -7,6 +7,38 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.php';
 
 class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends TestCase {
+    /** Child-site prefixes use complete path segments and normalized host keys. */
+    public function testChildPathLookupUsesSegmentsWithoutChangingUrlBytes(): void
+    {
+        $mapping = new CautiousURLBaseRewriteMapping(['https://network.test:443' => 'https://target.test'], [
+            'https://network.test' => ['/shop/news/'],
+        ]);
+        foreach (['network.test', 'NETWORK.TEST:443'] as $host) {
+            foreach (['/shop/news', '/shop/news/article', '/shop/NEWS/article', '/shop/%6eews/article'] as $path) {
+                $this->assertTrue($mapping->excludes_path($host, $path));
+            }
+            foreach (['/shop', '/shop/newsletter', '/shop/newspaper/article'] as $path) {
+                $this->assertFalse($mapping->excludes_path($host, $path));
+            }
+        }
+        $this->assertFalse($mapping->excludes_path('other.test', '/shop/news'));
+    }
+
+    /** Missing source bases must not rescan the remaining text for every match. */
+    public function testRepeatedUploadUrlsKeepTheNextMatchPerRule(): void
+    {
+        $input = str_repeat('https://network.test/uploads/sites/7/photo.jpg ', 16000);
+        $start = microtime(true);
+        $output = $this->rewrite($input, [
+            'https://network.test' => 'https://target.test',
+            'http://network.test' => 'https://target.test',
+            'https://network.test/uploads' => 'https://network.test/uploads',
+            'https://network.test/uploads/sites/7' => 'https://target.test/uploads/sites/7',
+        ]);
+        $this->assertSame(str_replace('network.test', 'target.test', $input), $output);
+        $this->assertLessThan(5, microtime(true) - $start);
+    }
+
     /**
      * These are opaque text leaves only. Do not add complete PHP serializations,
      * JSON documents, or known block markup: StructuredDataUrlRewriter handles
@@ -33,6 +65,65 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
         array $mapping
     ): void {
         $this->assertSame($expected, $this->rewrite($input, $mapping));
+    }
+
+    /** Match numeric sources as written; IPv4 targets need no new escaping characters. */
+    public function testNumericHostAliasesAreClassifiedByTheToolkitParser(): void
+    {
+        foreach (['127.1', '2130706433', '0x7f000001', '0177.0.0.1', '[::1]'] as $host) {
+            $this->assertSame('https://target.test/post', $this->rewrite('http://' . $host . '/post', [
+                'http://' . $host => 'https://target.test',
+            ]));
+            $this->assertSame($host === '[::1]' ? 'https://source.test/post' : 'http://' . $host . '/post', $this->rewrite('https://source.test/post', [
+                'https://source.test' => 'http://' . $host,
+            ]));
+        }
+        $this->assertSame('https://source.test/post', $this->rewrite('https://source.test/post', [
+            'https://source.test' => 'https://site.123',
+        ]));
+    }
+
+    /** An exclusion wins over a broader rule without rewriting the excluded bytes. */
+    public function testSameUrlRulesPreserveMixedSlashEscapes(): void
+    {
+        foreach (['https://network.test', 'http://127.0.0.1:8142'] as $origin) {
+            $input = $origin . '\\/wp-content/uploads/sites/8/photo.jpg';
+            $this->assertSame($input, $this->rewrite($input, [
+                $origin . '/wp-content' => 'https://target.test/wp-content',
+                $origin . '/wp-content/uploads/sites/8' => $origin . '/wp-content/uploads/sites/8',
+            ]));
+        }
+    }
+
+    /** Later matches stay available while earlier, overlapping rules are consumed. */
+    public function testRetainedMatchesStayInTextOrderAcrossOverlappingRules(): void
+    {
+        $source = 'https://network.test';
+        $target = 'https://target.test';
+        $input = implode(' ', [
+            $source . '/first', $source . '/uploads/sites/70/a.jpg',
+            $source . '/uploads/sites/7/b.jpg', $source . '/last',
+            $source . '/uploads/sites/7/c.jpg', $source . '/uploads/main.jpg',
+        ]);
+        $expected = implode(' ', [
+            $target . '/first', $source . '/uploads/sites/70/a.jpg',
+            $target . '/uploads/sites/7/b.jpg', $target . '/last',
+            $target . '/uploads/sites/7/c.jpg', $source . '/uploads/main.jpg',
+        ]);
+        $this->assertSame($expected, $this->rewrite($input, [
+            $source => $target,
+            $source . '/uploads' => $source . '/uploads',
+            $source . '/uploads/sites/7' => $target . '/uploads/sites/7',
+        ]));
+    }
+
+    /** A root slash belongs to the stored URL, including when a rule preserves it. */
+    public function testSameUrlRuleDoesNotDuplicateTheRootSlash(): void
+    {
+        $input = 'https://network.test/sibling/post';
+        $this->assertSame($input, $this->rewrite($input, [
+            'https://network.test/' => 'https://network.test/',
+        ]));
     }
 
     public function testPreparedMappingCanBeReusedForDifferentTextValues(): void
@@ -74,6 +165,16 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
         $eight_backslash_separator = str_repeat('\\', 8) . '/';
 
         return [
+            'target is an IPv4 address' => [
+                'https://source.example/media/logo.png',
+                'https://192.0.2.1/logo.png',
+                ['https://source.example/media' => 'https://192.0.2.1'],
+            ],
+            'target host ends in a dot' => [
+                'https://source.example/photo.png',
+                'https://target.example./photo.png',
+                ['https://source.example' => 'https://target.example.'],
+            ],
             'unquoted CSS URL preserves its terminator' => [
                 '.hero{background-image:url(https://source.example/wp-content/uploads/2026/01/hero.jpg);}',
                 '.hero{background-image:url(https://destination.example/wp-content/uploads/2026/01/hero.jpg);}',
@@ -408,11 +509,6 @@ class CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRulesTest extends Test
                 'https://source.example/media/logo.png',
                 'https://source.example/media/logo.png',
                 ['https://source.example/media' => 'https://destination.example/archive%2Fmedia'],
-            ],
-            'target is an IPv4 address' => [
-                'https://source.example/media/logo.png',
-                'https://source.example/media/logo.png',
-                ['https://source.example/media' => 'https://192.0.2.1'],
             ],
             'target is an IPv6 address' => [
                 'https://source.example/media/logo.png',

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1332,7 +1332,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ],
             'IPv4 address' => [
                 '<a href="https://old-site.com/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
-                '<a href="https://192.0.2.1/media/image.jpg">Image</a>[vc_video link="https:\/\/old-site.com\/media\/video.mp4"]',
+                '<a href="https://192.0.2.1/media/image.jpg">Image</a>[vc_video link="https:\/\/192.0.2.1\/media\/video.mp4"]',
                 ['https://old-site.com' => 'https://192.0.2.1'],
             ],
             'IPv6 address' => [


### PR DESCRIPTION
Keeps excluded URL bases unchanged and avoids searching the same remaining text again for every matched URL.

A mapping from `network.test/uploads` to itself preserves that subtree. A longer mapping for `network.test/uploads/sites/7` still moves site 7's uploads. Exclusions retain the matched bytes, including escaped slashes and IP hosts.

The prepared rules also accept a child-site path set. `/shop/news/` excludes `/shop/news/article`, but not `/shop/newsletter`. Each lookup checks path segments, not every site. Unknown text on a host with child-site paths stays unchanged because this scanner cannot determine the complete URL path.

Literal replacement accepts IPv4 and trailing-dot hosts. Hosts that need escaping stay out of this fallback. These are text-output limits, not destination URL validation.

Tests cover prefix boundaries, host aliases, unchanged exclusions, and 16,000 upload URLs with a five-second ceiling.

Extracted from #770. This is the first part of the selected-site migration stack; it does not change the CLI.

Stack: **#794** → #795 → #796 → #797 → #770 → #798 → #774 → #775 → #778.
