### PR TITLE
Keep child-site URLs remote during selected-site migration

### DIFF
--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -16,15 +16,11 @@ use WordPress\DataLiberation\URL\WPURL;
  * [vc_video link="https:\/\/source.example\/media\/video.mp4"]
  * ```
  *
- * Declared URL fields are final after parsing, including rejected values.
- * The fallback never scans them again. For example, with A -> B and B -> C
- * mappings, a parsed URL from A must stop at B.
- *
- * The fallback changes only source-base bytes inside unparsed values. HTML
- * attribute values and raw-text element bodies use the HTML decoder/setter,
- * so changed values can have different quotes, entities, or newline spelling.
- * Ordinary text and comments keep raw-token replacement: shortcode syntax
- * such as the example above never passes through the HTML text encoder.
+ * Decoding and serializing that URL could change its slashes, quotes,
+ * entities, query, or fragment. After structured URLs have been handled,
+ * replace_url_bases_in_current_token() changes only configured source-base
+ * bytes in the raw token. The surrounding bytes never pass through the HTML
+ * text encoder.
  *
  * @TODO Contribute this structured processor back to the PHP toolkit after
  *       its Reprint behavior has stabilized.
@@ -51,19 +47,8 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $css_url_processor;
 	private $css_url_processor_updated;
 
-	/** @var CSSURLProcessor|null CSS in the current STYLE body, separate from its style attribute. */
-	private $style_element_processor;
-	/** @var bool Whether a CSS URL edit must be written back to the current STYLE body. */
-	private $style_element_updated = false;
-	/**
-	 * Top-level block fields reserved for URL parsing in the current token.
-	 * For wp:image's `url`, a parse failure still excludes it from the fallback.
-	 * An unknown field is reserved only if its whole value parsed as a URL.
-	 * Nested fields stay with the caller's format inference.
-	 *
-	 * @var array<string, true>
-	 */
-	private $url_block_attribute_keys = array();
+	/** @var bool Whether the CSS parser reads a STYLE body instead of a style attribute. */
+	private $in_style_element = false;
 
 	/**
 	 * The list of names of URL-related HTML attributes that may be available on
@@ -92,14 +77,13 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		if ( $this->css_url_processor_updated ) {
 			if ( null !== $this->css_url_processor ) {
 				$updated_css = $this->css_url_processor->get_updated_css();
-				$this->set_attribute( 'style', $updated_css );
+				if ( $this->in_style_element ) {
+					$this->set_modifiable_text( $updated_css );
+				} else {
+					$this->set_attribute( 'style', $updated_css );
+				}
 			}
 			$this->css_url_processor_updated = false;
-		}
-
-		if ( $this->style_element_updated ) {
-			$this->set_modifiable_text( $this->style_element_processor->get_updated_css() );
-			$this->style_element_updated = false;
 		}
 
 		return parent::get_updated_html();
@@ -121,11 +105,10 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url                 = null;
 		$this->inspecting_html_attributes = null;
 		$this->css_url_processor          = null;
-		$this->style_element_processor    = null;
-		$this->url_block_attribute_keys = array();
+		$this->in_style_element           = false;
 		/*
-		 * The update flags are cleared by get_updated_html() above. Flush
-		 * before discarding the CSS processors, or their pending edits are lost.
+		 * The update flag is cleared by get_updated_html() above. Flush
+		 * before discarding the CSS parser, or its pending edits are lost.
 		 */
 
 		return parent::next_token();
@@ -146,7 +129,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->raw_url = null;
 		switch ( parent::get_token_type() ) {
 			case '#tag':
-				if ( null === $this->style_element_processor && $this->next_url_attribute() ) {
+				if ( ! $this->in_style_element && $this->next_url_attribute() ) {
 					return true;
 				}
 				return $this->next_url_in_style_element();
@@ -158,87 +141,44 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	}
 
 	/**
-	 * Rewrite only content which has no declared URL syntax.
+	 * Replace configured URL bases in the current raw token.
 	 *
-	 * Known URL attributes and CSS never enter the byte scanner, even when
-	 * their parser rejected a value or the mapping kept it unchanged. Other
-	 * attribute values use the HTML parser's decoder and setter: nested text
-	 * keeps its meaning, though the attribute's quote/entity spelling may change.
-	 * Text and comment tokens retain the raw-byte replacement path.
+	 * Applying pending structured changes first keeps the token span current.
+	 * The cautious processor then changes only configured source-base bytes in
+	 * opaque text and unsupported subsyntaxes, preserving every other byte.
 	 *
 	 * @param CautiousURLBaseRewriteMapping $prepared_url_mapping Prepared URL mapping.
-	 * @return bool Whether unparsed content changed.
+	 * @return bool Whether the token changed.
 	 */
 	public function replace_url_bases_in_current_token( CautiousURLBaseRewriteMapping $prepared_url_mapping ): bool {
-		if ( '#block-comment' === $this->get_token_type() ) {
-			// The caller visits the remaining parsed JSON fields individually.
-			return false;
-		}
-		if ( '#tag' === $this->get_token_type() ) {
-			$changed = false;
-			$url_attributes = self::HTML_ATTRIBUTES_TO_ACCEPT_RELATIVE_URLS_FROM[ $this->get_tag() ] ?? array();
-			foreach ( $this->get_attribute_names_with_prefix( '' ) ?? array() as $name ) {
-				if ( 'style' === $name || in_array( $name, $url_attributes, true ) ) {
-					continue;
-				}
-				$value = $this->get_attribute( $name );
-				if ( ! is_string( $value ) ) {
-					continue;
-				}
-				$rewritten = $this->replace_unparsed_url_bases( $value, $prepared_url_mapping );
-				if ( $rewritten !== $value ) {
-					$changed = $this->set_attribute( $name, $rewritten ) || $changed;
-				}
-			}
-			if ( 'STYLE' !== $this->get_tag() && ! $this->has_json_script_body() ) {
-				$value = $this->get_modifiable_text();
-				$rewritten = $this->replace_unparsed_url_bases( $value, $prepared_url_mapping );
-				if ( $rewritten !== $value ) {
-					$changed = $this->set_modifiable_text( $rewritten ) || $changed;
-				}
-			}
-			return $changed;
-		}
-
 		$html = $this->get_updated_html();
 		if ( ! $this->set_bookmark( 'cautious URL base replacement' ) ) {
 			return false;
 		}
+
 		$token_span = $this->bookmarks['cautious URL base replacement'];
 		$this->release_bookmark( 'cautious URL base replacement' );
 		$raw_token = substr( $html, $token_span->start, $token_span->length );
-		$updated_token = $this->replace_unparsed_url_bases( $raw_token, $prepared_url_mapping );
-		if ( $updated_token === $raw_token ) {
-			return false;
-		}
-		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $token_span->start, $token_span->length, $updated_token );
-		return true;
-	}
-
-	/** Identify script bodies whose declared media type requires JSON parsing. */
-	public function has_json_script_body(): bool {
-		if ( '#tag' !== $this->get_token_type() || $this->is_tag_closer() || 'SCRIPT' !== $this->get_tag() ) {
-			return false;
-		}
-		$type = $this->get_attribute( 'type' );
-		return is_string( $type ) && 1 === preg_match(
-			'/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
-			strtolower( trim( explode( ';', $type, 2 )[0] ) )
+		$processor = new CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules(
+			$raw_token,
+			$prepared_url_mapping
 		);
-	}
-
-	/** @return array<string, true> Current block fields which must not enter format inference. */
-	public function get_url_block_attribute_keys(): array {
-		return $this->url_block_attribute_keys;
-	}
-
-	/** Replace base bytes within one value whose inner syntax is unknown. */
-	private function replace_unparsed_url_bases( string $value, CautiousURLBaseRewriteMapping $mapping ): string {
-		$processor = new CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules( $value, $mapping );
 		while ( $processor->next_url() ) {
 			$processor->replace_url_base();
 		}
-		return $processor->get_updated_text();
+
+		$updated_token = $processor->get_updated_text();
+		if ( $updated_token === $raw_token ) {
+			return false;
+		}
+
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+			$token_span->start,
+			$token_span->length,
+			$updated_token
+		);
+
+		return true;
 	}
 
 	/** Visit declared CSS URLs in the STYLE body once, after the tag's attributes. */
@@ -246,24 +186,17 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		if ( 'STYLE' !== $this->get_tag() || $this->is_tag_closer() ) {
 			return false;
 		}
-		if ( null === $this->style_element_processor ) {
-			$this->style_element_processor = new CSSURLProcessor( $this->get_modifiable_text() );
+		if ( ! $this->in_style_element ) {
+			// Attribute edits were flushed before reaching the body. The same
+			// CSS loop can now read the body instead.
+			$this->css_url_processor = new CSSURLProcessor( $this->get_modifiable_text() );
+			$this->in_style_element = true;
 		}
-		while ( $this->style_element_processor->next_url() ) {
-			if ( $this->style_element_processor->is_data_uri() ) {
-				continue;
-			}
-			$this->raw_url = $this->style_element_processor->get_raw_url();
-			$this->parsed_url = WPURL::parse( $this->raw_url, $this->base_url_string );
-			if ( false !== $this->parsed_url ) {
-				return true;
-			}
-		}
-		return false;
+		return $this->next_url_in_css();
 	}
 
 	/**
-	 * Advances to the next CSS URL in the `style` attribute of the current tag token.
+	 * Advances to the next CSS URL in the style attribute or STYLE body.
 	 *
 	 * @return bool Whether a CSS URL was found.
 	 */
@@ -381,7 +314,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		return false;
 	}
 
-	/** Parse top-level block URL fields and record which fields the fallback must skip. */
+	/** Parse top-level block URL fields, resolving relative URLs only for known fields. */
 	private function next_url_block_attribute() {
 		while ( $this->next_block_attribute() ) {
 			$url_maybe = $this->get_block_attribute_value();
@@ -448,9 +381,6 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				$parsed_url = WPURL::parse( $url_maybe );
 			}
 
-			if ( $is_relative_url_block_attribute || false !== $parsed_url ) {
-				$this->url_block_attribute_keys[ $this->get_block_attribute_key() ] = true;
-			}
 			if ( false === $parsed_url ) {
 				continue;
 			}
@@ -481,10 +411,6 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url = $parsed_url;
 		switch ( parent::get_token_type() ) {
 			case '#tag':
-				if ( null !== $this->style_element_processor ) {
-					$this->style_element_updated = true;
-					return $this->style_element_processor->set_raw_url( $raw_url );
-				}
 				// Check if we're processing a CSS URL.
 				if ( null !== $this->css_url_processor ) {
 					$this->css_url_processor_updated = true;

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -134,7 +134,9 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 	/** Flush the current token, then discard its URL and CSS parser state. */
 	public function next_token(): bool {
-		$this->get_updated_html();
+		// The parent flushes this token through our get_updated_html() before
+		// moving on. Keep the CSS parser alive until that flush has finished.
+		$has_token = parent::next_token();
 
 		$this->raw_url                    = null;
 		$this->parsed_url                 = null;
@@ -142,12 +144,8 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->inspecting_html_attributes = null;
 		$this->css_url_processor          = null;
 		$this->in_style_element           = false;
-		/*
-		 * The update flag is cleared by get_updated_html() above. Flush
-		 * before discarding the CSS parser, or its pending edits are lost.
-		 */
-
-		return parent::next_token();
+		// get_updated_html() cleared the update flag before we dropped its parser.
+		return $has_token;
 	}
 
 	public function next_url() {
@@ -358,6 +356,24 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 	/** Parse top-level block URL fields, resolving relative URLs only for known fields. */
 	private function next_url_block_attribute() {
+		// Divi stores its strings below arrays such as module.content. This
+		// reader accepts only top-level strings; the rewriter visits nested
+		// values separately. Before starting the attribute iterator, avoid
+		// building paths to nested fields when none can be accepted here.
+		// Once the iterator has a path, do not repeat this scan for each URL.
+		if ( false === $this->get_block_attribute_path() ) {
+			$has_top_level_string = false;
+			foreach ( $this->get_block_attributes() ?: array() as $value ) {
+				if ( is_string( $value ) ) {
+					$has_top_level_string = true;
+					break;
+				}
+			}
+			if ( ! $has_top_level_string ) {
+				return false;
+			}
+		}
+
 		while ( $this->next_block_attribute() ) {
 			$url_maybe = $this->get_block_attribute_value();
 			if ( ! is_string( $url_maybe ) ||

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -16,11 +16,15 @@ use WordPress\DataLiberation\URL\WPURL;
  * [vc_video link="https:\/\/source.example\/media\/video.mp4"]
  * ```
  *
- * Decoding and serializing that URL could change its slashes, quotes,
- * entities, query, or fragment. After structured URLs have been handled,
- * replace_url_bases_in_current_token() changes only configured source-base
- * bytes in the raw token. The surrounding bytes never pass through the HTML
- * text encoder.
+ * Declared URL fields are final after parsing, including rejected values.
+ * The fallback never scans them again. For example, with A -> B and B -> C
+ * mappings, a parsed URL from A must stop at B.
+ *
+ * The fallback changes only source-base bytes inside unparsed values. HTML
+ * attribute values and raw-text element bodies use the HTML decoder/setter,
+ * so changed values can have different quotes, entities, or newline spelling.
+ * Ordinary text and comments keep raw-token replacement: shortcode syntax
+ * such as the example above never passes through the HTML text encoder.
  *
  * @TODO Contribute this structured processor back to the PHP toolkit after
  *       its Reprint behavior has stabilized.
@@ -47,6 +51,20 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $css_url_processor;
 	private $css_url_processor_updated;
 
+	/** @var CSSURLProcessor|null CSS in the current STYLE body, separate from its style attribute. */
+	private $style_element_processor;
+	/** @var bool Whether a CSS URL edit must be written back to the current STYLE body. */
+	private $style_element_updated = false;
+	/**
+	 * Top-level block fields reserved for URL parsing in the current token.
+	 * For wp:image's `url`, a parse failure still excludes it from the fallback.
+	 * An unknown field is reserved only if its whole value parsed as a URL.
+	 * Nested fields stay with the caller's format inference.
+	 *
+	 * @var array<string, true>
+	 */
+	private $url_block_attribute_keys = array();
+
 	/**
 	 * The list of names of URL-related HTML attributes that may be available on
 	 * the current token. They will be inspected by next_url_attribute().
@@ -69,6 +87,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->base_url_object = $base_url_string ? WPURL::parse( $base_url_string ) : null;
 	}
 
+	/** Flush CSS edits before the parent applies this token's HTML and block edits. */
 	public function get_updated_html(): string {
 		if ( $this->css_url_processor_updated ) {
 			if ( null !== $this->css_url_processor ) {
@@ -76,6 +95,11 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				$this->set_attribute( 'style', $updated_css );
 			}
 			$this->css_url_processor_updated = false;
+		}
+
+		if ( $this->style_element_updated ) {
+			$this->set_modifiable_text( $this->style_element_processor->get_updated_css() );
+			$this->style_element_updated = false;
 		}
 
 		return parent::get_updated_html();
@@ -89,6 +113,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		return $this->parsed_url;
 	}
 
+	/** Flush the current token, then discard its URL and CSS parser state. */
 	public function next_token(): bool {
 		$this->get_updated_html();
 
@@ -96,9 +121,11 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url                 = null;
 		$this->inspecting_html_attributes = null;
 		$this->css_url_processor          = null;
+		$this->style_element_processor    = null;
+		$this->url_block_attribute_keys = array();
 		/*
-		 * Do not reset css_url_processor_updated – it is reset in
-		 * get_updated_html() which is called in parent::next_token().
+		 * The update flags are cleared by get_updated_html() above. Flush
+		 * before discarding the CSS processors, or their pending edits are lost.
 		 */
 
 		return parent::next_token();
@@ -114,11 +141,15 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		return false;
 	}
 
+	/** Visit URL attributes, then a STYLE body; block fields use their own parser. */
 	public function next_url_in_current_token() {
 		$this->raw_url = null;
 		switch ( parent::get_token_type() ) {
 			case '#tag':
-				return $this->next_url_attribute();
+				if ( null === $this->style_element_processor && $this->next_url_attribute() ) {
+					return true;
+				}
+				return $this->next_url_in_style_element();
 			case '#block-comment':
 				return $this->next_url_block_attribute();
 			default:
@@ -127,44 +158,108 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	}
 
 	/**
-	 * Replace configured URL bases in the current raw token.
+	 * Rewrite only content which has no declared URL syntax.
 	 *
-	 * Applying pending structured changes first keeps the token span current.
-	 * The cautious processor then changes only configured source-base bytes in
-	 * opaque text and unsupported subsyntaxes, preserving every other byte.
+	 * Known URL attributes and CSS never enter the byte scanner, even when
+	 * their parser rejected a value or the mapping kept it unchanged. Other
+	 * attribute values use the HTML parser's decoder and setter: nested text
+	 * keeps its meaning, though the attribute's quote/entity spelling may change.
+	 * Text and comment tokens retain the raw-byte replacement path.
 	 *
 	 * @param CautiousURLBaseRewriteMapping $prepared_url_mapping Prepared URL mapping.
-	 * @return bool Whether the token changed.
+	 * @return bool Whether unparsed content changed.
 	 */
 	public function replace_url_bases_in_current_token( CautiousURLBaseRewriteMapping $prepared_url_mapping ): bool {
+		if ( '#block-comment' === $this->get_token_type() ) {
+			// The caller visits the remaining parsed JSON fields individually.
+			return false;
+		}
+		if ( '#tag' === $this->get_token_type() ) {
+			$changed = false;
+			$url_attributes = self::HTML_ATTRIBUTES_TO_ACCEPT_RELATIVE_URLS_FROM[ $this->get_tag() ] ?? array();
+			foreach ( $this->get_attribute_names_with_prefix( '' ) ?? array() as $name ) {
+				if ( 'style' === $name || in_array( $name, $url_attributes, true ) ) {
+					continue;
+				}
+				$value = $this->get_attribute( $name );
+				if ( ! is_string( $value ) ) {
+					continue;
+				}
+				$rewritten = $this->replace_unparsed_url_bases( $value, $prepared_url_mapping );
+				if ( $rewritten !== $value ) {
+					$changed = $this->set_attribute( $name, $rewritten ) || $changed;
+				}
+			}
+			if ( 'STYLE' !== $this->get_tag() && ! $this->has_json_script_body() ) {
+				$value = $this->get_modifiable_text();
+				$rewritten = $this->replace_unparsed_url_bases( $value, $prepared_url_mapping );
+				if ( $rewritten !== $value ) {
+					$changed = $this->set_modifiable_text( $rewritten ) || $changed;
+				}
+			}
+			return $changed;
+		}
+
 		$html = $this->get_updated_html();
 		if ( ! $this->set_bookmark( 'cautious URL base replacement' ) ) {
 			return false;
 		}
-
 		$token_span = $this->bookmarks['cautious URL base replacement'];
 		$this->release_bookmark( 'cautious URL base replacement' );
 		$raw_token = substr( $html, $token_span->start, $token_span->length );
-		$processor = new CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules(
-			$raw_token,
-			$prepared_url_mapping
-		);
-		while ( $processor->next_url() ) {
-			$processor->replace_url_base();
-		}
-
-		$updated_token = $processor->get_updated_text();
+		$updated_token = $this->replace_unparsed_url_bases( $raw_token, $prepared_url_mapping );
 		if ( $updated_token === $raw_token ) {
 			return false;
 		}
-
-		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
-			$token_span->start,
-			$token_span->length,
-			$updated_token
-		);
-
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $token_span->start, $token_span->length, $updated_token );
 		return true;
+	}
+
+	/** Identify script bodies whose declared media type requires JSON parsing. */
+	public function has_json_script_body(): bool {
+		if ( '#tag' !== $this->get_token_type() || $this->is_tag_closer() || 'SCRIPT' !== $this->get_tag() ) {
+			return false;
+		}
+		$type = $this->get_attribute( 'type' );
+		return is_string( $type ) && 1 === preg_match(
+			'/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
+			strtolower( trim( explode( ';', $type, 2 )[0] ) )
+		);
+	}
+
+	/** @return array<string, true> Current block fields which must not enter format inference. */
+	public function get_url_block_attribute_keys(): array {
+		return $this->url_block_attribute_keys;
+	}
+
+	/** Replace base bytes within one value whose inner syntax is unknown. */
+	private function replace_unparsed_url_bases( string $value, CautiousURLBaseRewriteMapping $mapping ): string {
+		$processor = new CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules( $value, $mapping );
+		while ( $processor->next_url() ) {
+			$processor->replace_url_base();
+		}
+		return $processor->get_updated_text();
+	}
+
+	/** Visit declared CSS URLs in the STYLE body once, after the tag's attributes. */
+	private function next_url_in_style_element(): bool {
+		if ( 'STYLE' !== $this->get_tag() || $this->is_tag_closer() ) {
+			return false;
+		}
+		if ( null === $this->style_element_processor ) {
+			$this->style_element_processor = new CSSURLProcessor( $this->get_modifiable_text() );
+		}
+		while ( $this->style_element_processor->next_url() ) {
+			if ( $this->style_element_processor->is_data_uri() ) {
+				continue;
+			}
+			$this->raw_url = $this->style_element_processor->get_raw_url();
+			$this->parsed_url = WPURL::parse( $this->raw_url, $this->base_url_string );
+			if ( false !== $this->parsed_url ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -286,6 +381,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		return false;
 	}
 
+	/** Parse top-level block URL fields and record which fields the fallback must skip. */
 	private function next_url_block_attribute() {
 		while ( $this->next_block_attribute() ) {
 			$url_maybe = $this->get_block_attribute_value();
@@ -352,6 +448,9 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				$parsed_url = WPURL::parse( $url_maybe );
 			}
 
+			if ( $is_relative_url_block_attribute || false !== $parsed_url ) {
+				$this->url_block_attribute_keys[ $this->get_block_attribute_key() ] = true;
+			}
 			if ( false === $parsed_url ) {
 				continue;
 			}
@@ -382,6 +481,10 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url = $parsed_url;
 		switch ( parent::get_token_type() ) {
 			case '#tag':
+				if ( null !== $this->style_element_processor ) {
+					$this->style_element_updated = true;
+					return $this->style_element_processor->set_raw_url( $raw_url );
+				}
 				// Check if we're processing a CSS URL.
 				if ( null !== $this->css_url_processor ) {
 					$this->css_url_processor_updated = true;

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -44,6 +44,14 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $parsed_url;
 	private $base_url_string;
 	private $base_url_object;
+	/**
+	 * Base allowed by the current field, or null when only absolute URLs count.
+	 * `/photo.jpg` in an HTML href uses the site base; the same string in an
+	 * unknown block setting does not. Retain that context until URL parsing.
+	 *
+	 * @var string|null
+	 */
+	private $current_url_base;
 	private $css_url_processor;
 	private $css_url_processor_updated;
 
@@ -93,8 +101,23 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		return $this->raw_url;
 	}
 
+	/** Parse a cache miss; repeated links can be replaced without another URL parse. */
 	public function get_parsed_url() {
+		if ( null === $this->parsed_url && null !== $this->raw_url ) {
+			// Full HTTP(S) URLs need no base. Shorthand such as `https:photo.jpg`
+			// still does: with an HTTPS base at /shop/, it means /shop/photo.jpg.
+			// This prefix check selects the base argument; WPURL validates the URL.
+			$this->parsed_url = WPURL::parse(
+				$this->raw_url,
+				$this->has_absolute_http_url_prefix( $this->raw_url ) ? null : $this->current_url_base
+			);
+		}
 		return $this->parsed_url;
+	}
+
+	/** Include the field's relative-URL context in cache keys, even before parsing. */
+	public function get_url_base(): ?string {
+		return $this->current_url_base;
 	}
 
 	/** Flush the current token, then discard its URL and CSS parser state. */
@@ -103,6 +126,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 		$this->raw_url                    = null;
 		$this->parsed_url                 = null;
+		$this->current_url_base           = null;
 		$this->inspecting_html_attributes = null;
 		$this->css_url_processor          = null;
 		$this->in_style_element           = false;
@@ -126,7 +150,25 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 	/** Visit URL attributes, then a STYLE body; block fields use their own parser. */
 	public function next_url_in_current_token() {
+		while ( $this->next_raw_url_in_current_token() ) {
+			if ( false !== $this->get_parsed_url() ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Read the next decoded URL field without parsing the URL itself.
+	 *
+	 * HTML, CSS, and block parsers still identify and decode the field. The
+	 * rewriter checks its bounded cache next, then calls get_parsed_url() on a
+	 * miss. Call next_url_in_current_token() when invalid URLs must be skipped.
+	 */
+	public function next_raw_url_in_current_token() {
 		$this->raw_url = null;
+		$this->parsed_url = null;
+		$this->current_url_base = $this->base_url_string;
 		switch ( parent::get_token_type() ) {
 			case '#tag':
 				if ( ! $this->in_style_element && $this->next_url_attribute() ) {
@@ -223,11 +265,6 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				continue;
 			}
 			$this->raw_url    = $this->css_url_processor->get_raw_url();
-			$this->parsed_url = WPURL::parse( $this->raw_url, $this->base_url_string );
-			if ( false === $this->parsed_url ) {
-				continue;
-			}
-
 			return true;
 		}
 
@@ -299,14 +336,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			 * be correctly recognized as a URL.
 			 * Without a base URL, this Processor would incorrectly skip it.
 			 */
-			$parsed_url = WPURL::parse( $url_maybe, $this->base_url_string );
-
-			if ( false === $parsed_url ) {
-				array_pop( $this->inspecting_html_attributes );
-				continue;
-			}
 			$this->raw_url    = $url_maybe;
-			$this->parsed_url = $parsed_url;
 
 			return true;
 		}
@@ -372,21 +402,15 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				)
 			);
 
-			$parsed_url = false;
 			if ( $is_relative_url_block_attribute ) {
 				// Known relative URL attribute – let's parse with the base URL.
-				$parsed_url = WPURL::parse( $url_maybe, $this->base_url_string );
+				$this->current_url_base = $this->base_url_string;
 			} else {
 				// Other attributes – let's parse without a base URL (and only detect absolute URLs).
-				$parsed_url = WPURL::parse( $url_maybe );
-			}
-
-			if ( false === $parsed_url ) {
-				continue;
+				$this->current_url_base = null;
 			}
 
 			$this->raw_url    = $url_maybe;
-			$this->parsed_url = $parsed_url;
 			return true;
 		}
 
@@ -450,7 +474,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				'old_base_url' => $base_url,
 				'new_base_url' => $to_url,
 				'raw_url'      => $this->get_raw_url(),
-				'is_relative'  => ! WPURL::can_parse( $this->get_raw_url() ),
+				'is_relative'  => ! $this->is_url_absolute(),
 			)
 		);
 
@@ -469,7 +493,20 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	 * @return bool Whether the currently matched URL is absolute.
 	 */
 	public function is_url_absolute() {
-		return WPURL::can_parse( $this->get_raw_url() );
+		if ( ! $this->get_parsed_url() ) {
+			return false;
+		}
+		// The current URL has already passed the parser. A full HTTP(S)
+		// prefix proves it is absolute without parsing the same URL again.
+		return $this->has_absolute_http_url_prefix( $this->get_raw_url() )
+			|| WPURL::can_parse( $this->get_raw_url() );
+	}
+
+	/**
+	 * Recognize a full HTTP(S) prefix, not shorthand such as `https:photo.jpg`.
+	 */
+	private function has_absolute_http_url_prefix( string $url ): bool {
+		return 0 === strncasecmp( $url, 'https://', 8 ) || 0 === strncasecmp( $url, 'http://', 7 );
 	}
 
 	public function get_inspected_attribute_name() {

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-block-markup-url-processor.php
@@ -58,6 +58,9 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	/** @var bool Whether the CSS parser reads a STYLE body instead of a style attribute. */
 	private $in_style_element = false;
 
+	/** @var bool Whether to parse STYLE bodies as CSS instead of leaving them to raw-text rewriting. */
+	private $parse_style_elements;
+
 	/**
 	 * The list of names of URL-related HTML attributes that may be available on
 	 * the current token. They will be inspected by next_url_attribute().
@@ -74,9 +77,18 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	 */
 	private $inspecting_html_attributes;
 
-	public function __construct( $html, ?string $base_url_string = null ) {
+	/**
+	 * @param string      $html                 HTML or block markup to visit.
+	 * @param string|null $base_url_string      Base for known relative URL fields.
+	 * @param bool        $parse_style_elements Decode CSS URLs in STYLE bodies.
+	 *     False preserves the ordinary import's raw-text path; selected-site
+	 *     imports need decoded CSS paths to distinguish child-site links.
+	 *     Inline style attributes are parsed in either mode.
+	 */
+	public function __construct( $html, ?string $base_url_string = null, bool $parse_style_elements = false ) {
 		parent::__construct( $html );
 		$this->base_url_string = $base_url_string;
+		$this->parse_style_elements = $parse_style_elements;
 		$this->base_url_object = $base_url_string ? WPURL::parse( $base_url_string ) : null;
 	}
 
@@ -174,7 +186,7 @@ class StructuredBlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				if ( ! $this->in_style_element && $this->next_url_attribute() ) {
 					return true;
 				}
-				return $this->next_url_in_style_element();
+				return $this->parse_style_elements && $this->next_url_in_style_element();
 			case '#block-comment':
 				return $this->next_url_block_attribute();
 			default:

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -768,12 +768,15 @@ class StructuredDataUrlRewriter
                     }
 
                     $token_type = $p->get_token_type() ?? '';
-                    while ( $p->next_url_in_current_token() ) {
+                    while ( $p->next_raw_url_in_current_token() ) {
                         $raw_url = $p->get_raw_url();
 
                         $url_cache_key = null;
                         if (strlen($raw_url) <= self::URL_REWRITE_CACHE_MAX_INPUT_BYTES) {
-                            $url_cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+                            // `/photo.jpg` in a known href can use the site base;
+                            // the same string in an unknown block field cannot.
+                            $url_cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type
+                                . "\0" . $p->get_url_base() . "\0" . $raw_url;
 
                             $cached = $this->get_cached_url_rewrite($url_cache_key);
                             if ($cached !== null) {
@@ -785,6 +788,12 @@ class StructuredDataUrlRewriter
                         }
 
                         $parsed_url = $p->get_parsed_url();
+                        if ( $parsed_url === false ) {
+                            if ( $url_cache_key !== null ) {
+                                $this->set_cached_url_rewrite($url_cache_key, false);
+                            }
+                            continue;
+                        }
                         $decoded_path = rawurldecode($parsed_url->pathname);
                         $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
                         $converted = false;
@@ -812,7 +821,7 @@ class StructuredDataUrlRewriter
                                     'raw_url'      => $raw_url,
                                     // Identity rules retain the source origin. A relative
                                     // sibling link would otherwise point into the target.
-                                    'is_relative'  => !$excluded && ! WPURL::can_parse($raw_url)
+                                    'is_relative'  => !$excluded && ! $p->is_url_absolute()
                                         && $from_url->toString() !== $mapping['to_url']->toString(),
                                 )
                             );
@@ -900,6 +909,13 @@ class StructuredDataUrlRewriter
      * validate those two guesses before changing nested values.
      */
     private function rewrite_inferred_block_attribute_string( string $value ): string {
+        // Divi settings include many labels, colors, and sizes. Apply the same
+        // quick reject as rewrite() before trying their possible formats.
+        if ( ! $this->maybe_contains_rewritable_urls( $value )
+            && ! $this->value_might_contain_hidden_shortcode_url( $value ) ) {
+            return $value;
+        }
+
         // 1. Serialized PHP is a complete outer format. Check it before HTML,
         // JSON, or CSS that may appear inside one of its string values. The
         // coarse existing gate checks only the first `a`, `s`, `O`, or `C`

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -3,7 +3,6 @@
 use WordPress\DataLiberation\URL\WPURL;
 use WordPress\DataLiberation\Shortcode\ShortcodeProcessor;
 
-use function WordPress\DataLiberation\URL\is_child_url_of;
 /**
  * Rewrites URLs in a single decoded database value by detecting the data
  * format and applying the appropriate rewriting strategy.
@@ -52,9 +51,8 @@ class StructuredDataUrlRewriter
      * Pre-parsed url_mapping: each entry is
      *   [ 'from_url' => <parsed URL>, 'to_url' => <parsed URL> ]
      * where <parsed URL> is whatever WPURL::parse() returns (declared as
-     * mixed here because is_child_url_of() and WPURL::replace_base_url()
-     * both accept either a string or the parsed object form — we pass the
-     * object form for performance).
+     * mixed here because WPURL::replace_base_url() accepts either a string
+     * or the parsed object form — we pass the object form for performance).
      *
      * Parsing is pure, deterministic work that used to happen inside
      * rewrite_urls() on every leaf-value call. With N mappings and L leaves
@@ -99,10 +97,12 @@ class StructuredDataUrlRewriter
 
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
+     * @param array<string, string[]> $excluded_paths Source HTTP(S) origin =>
+     *     child-site paths. Prepared once and shared by HTML and text rewriting.
      */
-    public function __construct(array $url_mapping)
+    public function __construct(array $url_mapping, array $excluded_paths = [])
     {
-        $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping);
+        $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping, $excluded_paths);
         $wpbakery_url_rewriter = new WPBakeryUrlRewriter(
             function (string $value): string {
                 return $this->rewrite($value, self::BLOCK_MARKUP);
@@ -135,6 +135,17 @@ class StructuredDataUrlRewriter
         }
         $this->source_domains = array_keys($domains);
 
+        // The first source is the site's base for relative links, not an asset
+        // rule. A base path describes a directory even without a trailing slash.
+        $from_urls = array_keys($url_mapping);
+        $this->base_url = isset($from_urls[0]) ? rtrim($from_urls[0], '/') . '/' : '';
+
+        // A sibling or media rule must win over its containing site URL, just
+        // as it does in the cautious plain-text rewriter. Keep the base above.
+        uksort($url_mapping, static function (string $first, string $second): int {
+            return strlen($second) <=> strlen($first);
+        });
+
         // Parse the mapping once. Each WPURL::parse() does non-trivial work
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
@@ -146,11 +157,6 @@ class StructuredDataUrlRewriter
             ];
         }
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
-
-        // Default base_url: first from-url in the mapping. Preserves the
-        // behaviour of the previous per-call default so outputs are unchanged.
-        $from_urls = array_keys($url_mapping);
-        $this->base_url = $from_urls[0] ?? '';
     }
 
     /**
@@ -502,13 +508,15 @@ class StructuredDataUrlRewriter
      * Quick-reject check: returns false when the value certainly doesn't
      * contain any rewritable URLs, avoiding expensive parsing.
      *
-     * A value is considered potentially rewritable if it contains an HTML URL
-     * attribute, a literal source domain, or an encoding marker which may hide
-     * a source-domain byte.
+     * Attribute/CSS signals admit values without literal source-domain bytes.
+     * `style` is deliberately broad: `STYLE = "url(...)"` is valid HTML, and
+     * CSS escapes can hide the host. The parsers decide whether it is CSS.
+     * Literal domains and supported encoding markers also pass this gate.
      */
     private function maybe_contains_rewritable_urls(string $value): bool
     {
-        if (stripos($value, 'href=') !== false || stripos($value, 'src=') !== false) {
+        if (stripos($value, 'href=') !== false || stripos($value, 'src=') !== false
+            || stripos($value, 'style') !== false) {
             return true;
         }
 
@@ -623,10 +631,10 @@ class StructuredDataUrlRewriter
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * Block markup owns HTML attributes, block-comment JSON, and CSS url()
-     * values. After exact URL handling, cautious source-base replacement runs
-     * on the current raw token. This covers opaque text, unknown attributes,
-     * URL subsyntaxes, and nested block JSON without re-encoding the token.
+     * HTML attributes, block-comment JSON, and CSS URL fields use their
+     * parsers. Only unparsed values enter cautious source-base replacement;
+     * a parsed URL is not scanned again for URLs inside its query or fragment.
+     * Block string leaves use the existing format inference before fallback.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -689,8 +697,18 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Migrate URLs in post content. See WPRewriteUrlsTests for
-     * specific examples. TODO: A better description.
+     * Rewrite declared URL fields once, then visit only unparsed content.
+     *
+     * The HTML, CSS and block parsers supply complete URLs for child-path
+     * checks. A parser rejection or a URL outside the source base is final.
+     * For example, an external href with a source URL in its query remains
+     * one external URL; its query does not become another rewrite input.
+     *
+     * Block attributes are already decoded by BlockMarkupProcessor. Visit
+     * their remaining string leaves rather than scan the raw JSON again.
+     * This costs a walk of one block's attribute tree, not the whole export.
+     * Changed attributes use the block encoder, including its whitespace
+     * and escaping rules. There is no raw-comment fast path alongside it.
      *
      * Example:
      *
@@ -729,72 +747,16 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
-                $may_contain_json_script = false !== stripos( $content, '<script' );
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
                     $resolve_relative_urls ? $base_url : null
                 );
                 while ( $p->next_token() ) {
-                    $parsed_nested_block_attributes = false;
-                    $block_comment_may_hide_rewritable_url = false;
-                    $block_comment_text = '';
-                    if ( '#block-comment' === $p->get_token_type() ) {
-                        $block_comment_text = $p->get_modifiable_text();
-                        $block_comment_may_hide_rewritable_url =
-                            $this->value_might_contain_source_domain( $block_comment_text )
-                            || $this->value_might_contain_hidden_shortcode_url( $block_comment_text );
-                    }
-                    if ( $block_comment_may_hide_rewritable_url ) {
-                        // The fast check includes supported encoding markers
-                        // and registered shortcode signals. Parsed string
-                        // leaves still decide whether a URL exists.
-                        $block_attributes = $p->get_block_attributes();
-                        // A Unicode-escaped quote leaves an alphanumeric byte
-                        // immediately before a raw URL. The cautious scanner
-                        // rejects that boundary, so parse the decoded value.
-                        $block_comment_uses_unicode_escaped_quotes = false !== stripos( $block_comment_text, '\\u0022' )
-                            || false !== stripos( $block_comment_text, '\\u0027' );
-                        if (
-                            is_array( $block_attributes )
-                            && (
-                                $block_comment_uses_unicode_escaped_quotes
-                                || $this->block_attribute_values_need_format_inference( $block_attributes )
-                            )
-                        ) {
-                            $parsed_nested_block_attributes = true;
-                            $rewritten_block_attributes = $this->rewrite_inferred_block_attribute_values( $block_attributes );
-                            if ( $rewritten_block_attributes !== $block_attributes ) {
-                                $p->set_block_attributes( $rewritten_block_attributes );
-                            }
-                        }
-                    }
-
-                    // A JSON media type makes the script body safe to parse as
-                    // JSON. Other script bodies keep the cautious byte scan.
-                    if (
-                        $may_contain_json_script
-                        && '#tag' === $p->get_token_type()
-                        && ! $p->is_tag_closer()
-                        && 'SCRIPT' === $p->get_tag()
-                    ) {
-                        $script_type = $p->get_attribute('type');
-                        if (is_string($script_type)) {
-                            $script_media_type = strtolower(trim(explode(';', $script_type, 2)[0]));
-                            if (
-                                preg_match(
-                                    '/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
-                                    $script_media_type
-                                ) === 1
-                            ) {
-                                $script_body = $p->get_modifiable_text();
-                                $rewritten_script_body = $this->rewrite(
-                                    $script_body,
-                                    self::BLOCK_MARKUP
-                                );
-                                if ($rewritten_script_body !== $script_body) {
-                                    $p->set_modifiable_text($rewritten_script_body);
-                                }
-                            }
+                    if ( $p->has_json_script_body() ) {
+                        $script_body = $p->get_modifiable_text();
+                        $rewritten_script_body = $this->rewrite( $script_body, self::BLOCK_MARKUP );
+                        if ( $rewritten_script_body !== $script_body ) {
+                            $p->set_modifiable_text( $rewritten_script_body );
                         }
                     }
 
@@ -816,20 +778,38 @@ class StructuredDataUrlRewriter
                         }
 
                         $parsed_url = $p->get_parsed_url();
+                        $decoded_path = rawurldecode($parsed_url->pathname);
+                        $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
                         $converted = false;
                         foreach ( $parsed_mapping as $mapping ) {
-                            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                                $converted = WPURL::replace_base_url(
-                                    $parsed_url,
-                                    array(
-                                        'old_base_url' => $base_url,
-                                        'new_base_url' => $mapping['to_url'],
-                                        'raw_url'      => $raw_url,
-                                        'is_relative'  => ! WPURL::can_parse($raw_url),
-                                    )
-                                );
-                                break;
+                            $from_url = $mapping['from_url'];
+                            if (!$from_url || !$mapping['to_url']
+                                || $parsed_url->hostname !== $from_url->hostname
+                                || $parsed_url->protocol !== $from_url->protocol
+                                || $parsed_url->port !== $from_url->port) {
+                                continue;
                             }
+                            // A base names a whole path segment: /sites/7 must
+                            // not select /sites/70. URL paths keep literal + bytes;
+                            // they do not use form-query decoding (+ becomes space).
+                            $source_path = rtrim(rawurldecode($from_url->pathname), '/');
+                            if ($decoded_path !== $source_path
+                                && strncmp($decoded_path, $source_path . '/', strlen($source_path) + 1) !== 0) {
+                                continue;
+                            }
+                            $converted = WPURL::replace_base_url(
+                                $parsed_url,
+                                array(
+                                    'old_base_url' => $from_url,
+                                    'new_base_url' => $excluded ? $from_url : $mapping['to_url'],
+                                    'raw_url'      => $raw_url,
+                                    // Identity rules retain the source origin. A relative
+                                    // sibling link would otherwise point into the target.
+                                    'is_relative'  => !$excluded && ! WPURL::can_parse($raw_url)
+                                        && $from_url->toString() !== $mapping['to_url']->toString(),
+                                )
+                            );
+                            break;
                         }
 
                         $cache_value = false;
@@ -844,7 +824,29 @@ class StructuredDataUrlRewriter
                             $this->set_cached_url_rewrite($url_cache_key, $cache_value);
                         }
                     }
-                    if ( ! $parsed_nested_block_attributes ) {
+                    if ( '#block-comment' === $p->get_token_type() ) {
+                        // The block parser already knows the JSON field boundaries.
+                        // URL fields consumed above must not be rewritten a second
+                        // time when a target is also another mapping's source.
+                        $attributes = $p->get_block_attributes();
+                        if ( is_array( $attributes ) ) {
+                            $url_keys = $p->get_url_block_attribute_keys();
+                            $rewritten_attributes = $attributes;
+                            foreach ( $attributes as $key => $value ) {
+                                if ( isset( $url_keys[ $key ] ) ) {
+                                    continue;
+                                }
+                                if ( is_array( $value ) ) {
+                                    $rewritten_attributes[ $key ] = $this->rewrite_inferred_block_attribute_values( $value );
+                                } elseif ( is_string( $value ) ) {
+                                    $rewritten_attributes[ $key ] = $this->rewrite_inferred_block_attribute_string( $value );
+                                }
+                            }
+                            if ( $rewritten_attributes !== $attributes ) {
+                                $p->set_block_attributes( $rewritten_attributes );
+                            }
+                        }
+                    } else {
                         $p->replace_url_bases_in_current_token( $this->cautious_url_base_rewrite_mapping );
                     }
                 }
@@ -891,73 +893,6 @@ class StructuredDataUrlRewriter
         }
 
         return $values;
-    }
-
-    /**
-     * Return whether any nested string needs its enclosing format parsed.
-     *
-     * When one string needs parsing, all strings in that block are rewritten
-     * through the same attribute tree. This avoids mixing a re-encoded block
-     * comment with raw byte replacements queued against its old byte offsets.
-     * Most Divi blocks only contain literal ASCII URLs, so they stay on the
-     * existing raw-token path and avoid the expensive recursive rewrite.
-     *
-     * @param array<int|string, mixed> $values Block attribute values.
-     */
-    private function block_attribute_values_need_format_inference( array $values ): bool {
-        foreach ( $values as $value ) {
-            if ( is_array( $value ) ) {
-                if ( $this->block_attribute_values_need_format_inference( $value ) ) {
-                    return true;
-                }
-            } elseif ( is_string( $value ) && $this->nested_block_string_needs_format_inference( $value ) ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Return whether a nested block string needs its enclosing format parsed.
-     *
-     * The cautious raw-token pass already handles literal ASCII source hosts
-     * in HTML, CSS, JSON, shortcodes, and plain text. Parsing those values
-     * again only changes their encoding and makes Divi imports slower.
-     *
-     * Parsing is still needed when an escape, character reference, or registered
-     * shortcode codec may hide part or all of the URL, or when serialized PHP
-     * length fields must be updated. A JSON value may contain serialized PHP at
-     * a deeper level, so its raw text is also checked for a serialization token.
-     * Non-ASCII values keep the structured path because the cautious raw-token
-     * pass supports ASCII and punycode domains, but not literal Unicode domains.
-     *
-     * These are coarse signals, not proof of a content type. The format
-     * hierarchy below still validates PHP serialization and JSON before use.
-     */
-    private function nested_block_string_needs_format_inference( string $value ): bool {
-        if ( $this->value_might_contain_hidden_shortcode_url( $value ) ) {
-            return true;
-        }
-
-        if ( ! $this->maybe_contains_rewritable_urls( $value ) ) {
-            return false;
-        }
-
-        if ( $this->could_be_php_serialization_with_strings( $value ) ) {
-            return true;
-        }
-
-        if ( false !== strpos( $value, '\\u' ) || false !== strpos( $value, '&' ) ) {
-            return true;
-        }
-
-        $contains_serialized_value = 1 === preg_match( '/(?:a|s|O|C):\d+:/', $value );
-        if ( $this->could_be_json_with_strings( $value ) && $contains_serialized_value ) {
-            return true;
-        }
-
-        return 1 === preg_match( '/[^\x00-\x7F]/', $value );
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -632,9 +632,9 @@ class StructuredDataUrlRewriter
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
      * HTML attributes, block-comment JSON, and CSS URL fields use their
-     * parsers. Only unparsed values enter cautious source-base replacement;
-     * a parsed URL is not scanned again for URLs inside its query or fragment.
-     * Block string leaves use the existing format inference before fallback.
+     * parsers. Block string leaves use format inference; other token content
+     * keeps the cautious source-base replacement from the plain-text path.
+     * That fallback leaves hosts with child-site exclusions unchanged.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -697,15 +697,14 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Rewrite declared URL fields once, then visit only unparsed content.
+     * Rewrite parsed URLs while keeping child-site links at the source.
      *
      * The HTML, CSS and block parsers supply complete URLs for child-path
-     * checks. A parser rejection or a URL outside the source base is final.
-     * For example, an external href with a source URL in its query remains
-     * one external URL; its query does not become another rewrite input.
+     * checks. The text fallback cannot determine where a path ends, so it
+     * leaves all URLs on a source host with child-site exclusions unchanged.
      *
      * Block attributes are already decoded by BlockMarkupProcessor. Visit
-     * their remaining string leaves rather than scan the raw JSON again.
+     * their string leaves rather than scan the raw JSON again.
      * This costs a walk of one block's attribute tree, not the whole export.
      * Changed attributes use the block encoder, including its whitespace
      * and escaping rules. There is no raw-comment fast path alongside it.
@@ -752,11 +751,19 @@ class StructuredDataUrlRewriter
                     $resolve_relative_urls ? $base_url : null
                 );
                 while ( $p->next_token() ) {
-                    if ( $p->has_json_script_body() ) {
-                        $script_body = $p->get_modifiable_text();
-                        $rewritten_script_body = $this->rewrite( $script_body, self::BLOCK_MARKUP );
-                        if ( $rewritten_script_body !== $script_body ) {
-                            $p->set_modifiable_text( $rewritten_script_body );
+                    // A declared JSON media type supplies the script body's format.
+                    // Other script bodies keep the cautious raw-token scan below.
+                    if ( 'SCRIPT' === $p->get_tag() && ! $p->is_tag_closer() ) {
+                        $type = $p->get_attribute( 'type' );
+                        if ( is_string( $type ) && 1 === preg_match(
+                            '/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
+                            strtolower( trim( explode( ';', $type, 2 )[0] ) )
+                        ) ) {
+                            $script_body = $p->get_modifiable_text();
+                            $rewritten_script_body = $this->rewrite( $script_body, self::BLOCK_MARKUP );
+                            if ( $rewritten_script_body !== $script_body ) {
+                                $p->set_modifiable_text( $rewritten_script_body );
+                            }
                         }
                     }
 
@@ -825,23 +832,12 @@ class StructuredDataUrlRewriter
                         }
                     }
                     if ( '#block-comment' === $p->get_token_type() ) {
-                        // The block parser already knows the JSON field boundaries.
-                        // URL fields consumed above must not be rewritten a second
-                        // time when a target is also another mapping's source.
+                        // BlockMarkupProcessor supplies one decoded attribute tree.
+                        // Use its setter for nested values too; mixing those edits
+                        // with raw replacements can duplicate the block comment.
                         $attributes = $p->get_block_attributes();
                         if ( is_array( $attributes ) ) {
-                            $url_keys = $p->get_url_block_attribute_keys();
-                            $rewritten_attributes = $attributes;
-                            foreach ( $attributes as $key => $value ) {
-                                if ( isset( $url_keys[ $key ] ) ) {
-                                    continue;
-                                }
-                                if ( is_array( $value ) ) {
-                                    $rewritten_attributes[ $key ] = $this->rewrite_inferred_block_attribute_values( $value );
-                                } elseif ( is_string( $value ) ) {
-                                    $rewritten_attributes[ $key ] = $this->rewrite_inferred_block_attribute_string( $value );
-                                }
-                            }
+                            $rewritten_attributes = $this->rewrite_inferred_block_attribute_values( $attributes );
                             if ( $rewritten_attributes !== $attributes ) {
                                 $p->set_block_attributes( $rewritten_attributes );
                             }

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -1,6 +1,7 @@
 <?php
 
 use WordPress\DataLiberation\URL\WPURL;
+use WordPress\DataLiberation\URL\CSSURLProcessor;
 use WordPress\DataLiberation\Shortcode\ShortcodeProcessor;
 use function WordPress\DataLiberation\URL\is_child_url_of;
 
@@ -20,14 +21,14 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
  * 4. Shortcode markup → ShortcodeProcessor (block_markup hint), including
  *    builder-specific body codecs selected by shortcode tag
- * 5. Leaf text → StructuredBlockMarkupUrlProcessor (block_markup hint)
+ * 5. Leaf text → HTML/block parsers (block_markup hint)
  *    or CautiousURLBaseProcessorInTextWithMixedUnknownEscapeRules (default)
  *
  * Top-level HTML is never auto-detected — the caller must explicitly pass
  * content_type='block_markup' for values known to contain HTML/block markup.
  * The hint propagates through recursive calls so that leaf strings inside
- * serialized PHP, JSON, or base64 eventually reach the same block-markup
- * parser. Strings found in block attributes use naive syntax hints because no
+ * serialized PHP, JSON, or base64 eventually reach the HTML/block-markup
+ * path. Strings found in block attributes use naive syntax hints because no
  * builder-specific schema is available there.
  */
 class StructuredDataUrlRewriter
@@ -54,6 +55,13 @@ class StructuredDataUrlRewriter
      * network can have no child sites under the selected site's URL.
      */
     private bool $is_selected_site_migration;
+
+    /**
+     * A literal < or > in a source base can cross HTML token boundaries.
+     * Keep those mappings on the per-token path. Other source bases can use
+     * one raw-text pass after a complete, comment-free HTML parse.
+     */
+    private bool $source_bases_contain_html_syntax = false;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -168,6 +176,8 @@ class StructuredDataUrlRewriter
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
+            $this->source_bases_contain_html_syntax = $this->source_bases_contain_html_syntax
+                || strpbrk($from_url_string, '<>') !== false;
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
@@ -757,17 +767,68 @@ class StructuredDataUrlRewriter
      * TODO: Migrate these changes back into the php-toolkit repo
      */
     private function rewrite_urls( string $content, string $content_type, bool $resolve_relative_urls = true ): string {
-        // $this->parsed_mapping is built once in the constructor and reused
-        // here on every call, avoiding a fresh round of WPURL::parse() per
-        // leaf value.
-        $parsed_mapping = $this->parsed_mapping;
-        $base_url       = $this->base_url;
+        $base_url = $resolve_relative_urls ? $this->base_url : null;
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                // Plain HTML needs no block-attribute tree. Parse its URL fields,
+                // then scan the final text once instead of copying, reparsing and
+                // scanning each tag. Block comments keep their separate path:
+                // scanning their raw JSON would also change attribute names.
+                if ($this->is_selected_site_migration && !$this->source_bases_contain_html_syntax
+                    && strpos($content, '<!--') === false) {
+                    $p = new WP_HTML_Tag_Processor($content);
+                    $has_document_wrapper = false;
+                    while ($p->next_token()) {
+                        if ($p->get_token_type() !== '#tag') {
+                            continue;
+                        }
+                        $tag = $p->get_tag();
+                        if (in_array($tag, ['HTML', 'HEAD', 'BODY'], true)) {
+                            // The block processor does not expose these tokens.
+                            // Use it for documents so their attributes stay intact.
+                            $has_document_wrapper = true;
+                            break;
+                        }
+                        if ($p->is_tag_closer()) {
+                            continue;
+                        }
+                        foreach (StructuredBlockMarkupUrlProcessor::HTML_ATTRIBUTES_TO_ACCEPT_RELATIVE_URLS_FROM[$tag] ?? [] as $name) {
+                            $raw_url = $p->get_attribute($name);
+                            if (!is_string($raw_url)) {
+                                continue;
+                            }
+                            $rewritten = $this->rewrite_url_field($raw_url, $base_url);
+                            if ($rewritten !== false) {
+                                $p->set_attribute($name, $rewritten['raw_url']);
+                            }
+                        }
+                        $style = $p->get_attribute('style');
+                        if (is_string($style)) {
+                            $rewritten_style = $this->rewrite_css($style, $base_url);
+                            if ($rewritten_style !== $style) {
+                                $p->set_attribute('style', $rewritten_style);
+                            }
+                        }
+                        if ($tag === 'STYLE') {
+                            $style = $p->get_modifiable_text();
+                            $rewritten_style = $this->rewrite_css($style, $base_url);
+                            if ($rewritten_style !== $style) {
+                                $p->set_modifiable_text($rewritten_style);
+                            }
+                        }
+                        $this->rewrite_json_script_body($p);
+                    }
+                    if (!$has_document_wrapper && !$p->paused_at_incomplete_token()) {
+                        return $this->rewrite_urls($p->get_updated_html(), self::PLAIN_TEXT);
+                    }
+                    // The raw pass must not touch an unread, incomplete token.
+                    // Discard this attempt and use the token-by-token path below.
+                    // Its URL cache can reuse fields already checked above.
+                }
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
-                    $resolve_relative_urls ? $base_url : null,
+                    $base_url,
                     $this->is_selected_site_migration
                 );
                 while ( $p->next_token() ) {
@@ -805,117 +866,12 @@ class StructuredDataUrlRewriter
                         }
                     }
 
-                    // A declared JSON media type supplies the script body's format.
-                    // Other script bodies keep the cautious raw-token scan below.
-                    if ( 'SCRIPT' === $p->get_tag() && ! $p->is_tag_closer() ) {
-                        $type = $p->get_attribute( 'type' );
-                        if ( is_string( $type ) && 1 === preg_match(
-                            '/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
-                            strtolower( trim( explode( ';', $type, 2 )[0] ) )
-                        ) ) {
-                            $script_body = $p->get_modifiable_text();
-                            $rewritten_script_body = $this->rewrite( $script_body, self::BLOCK_MARKUP );
-                            if ( $rewritten_script_body !== $script_body ) {
-                                $p->set_modifiable_text( $rewritten_script_body );
-                            }
-                        }
-                    }
+                    $this->rewrite_json_script_body($p);
 
-                    $token_type = $p->get_token_type() ?? '';
                     while ( $p->next_raw_url_in_current_token() ) {
-                        $raw_url = $p->get_raw_url();
-
-                        $url_cache_key = null;
-                        if (strlen($raw_url) <= self::URL_REWRITE_CACHE_MAX_INPUT_BYTES) {
-                            // `/photo.jpg` in a known href can use the site base;
-                            // the same string in an unknown block field cannot.
-                            $url_cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type
-                                . "\0" . $p->get_url_base() . "\0" . $raw_url;
-
-                            $cached = $this->get_cached_url_rewrite($url_cache_key);
-                            if ($cached !== null) {
-                                if ($cached !== false) {
-                                    $p->set_url($cached['raw_url'], $cached['parsed_url']);
-                                }
-                                continue;
-                            }
-                        }
-
-                        $parsed_url = $p->get_parsed_url();
-                        if ( $parsed_url === false ) {
-                            if ( $url_cache_key !== null ) {
-                                $this->set_cached_url_rewrite($url_cache_key, false);
-                            }
-                            continue;
-                        }
-                        $converted = false;
-                        if (!$this->is_selected_site_migration) {
-                            foreach ($parsed_mapping as $mapping) {
-                                if (is_child_url_of($parsed_url, $mapping['from_url'])) {
-                                    $converted = WPURL::replace_base_url($parsed_url, [
-                                        'old_base_url' => $base_url,
-                                        'new_base_url' => $mapping['to_url'],
-                                        'raw_url' => $raw_url,
-                                        'is_relative' => !$p->is_url_absolute(),
-                                    ]);
-                                    break;
-                                }
-                            }
-                        } else {
-                            $decoded_path = rawurldecode($parsed_url->pathname);
-                            $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
-                            // A canonical absolute child URL is already final. Do
-                            // not clone it or rewrite its HTML/CSS/JSON container.
-                            // Relative links and dot segments still use the normal
-                            // conversion below to keep the child at the source.
-                            if ($excluded && $raw_url === $parsed_url->toString()) {
-                                if ($url_cache_key !== null) {
-                                    $this->set_cached_url_rewrite($url_cache_key, false);
-                                }
-                                continue;
-                            }
-                            foreach ($parsed_mapping as $mapping) {
-                                $from_url = $mapping['from_url'];
-                                if (!$from_url || !$mapping['to_url']
-                                    || $parsed_url->hostname !== $from_url->hostname
-                                    || $parsed_url->protocol !== $from_url->protocol
-                                    || $parsed_url->port !== $from_url->port) {
-                                    continue;
-                                }
-                                // A base names a whole path segment: /sites/7 must
-                                // not select /sites/70. URL paths keep literal + bytes;
-                                // they do not use form-query decoding (+ becomes space).
-                                $source_path = rtrim(rawurldecode($from_url->pathname), '/');
-                                if ($decoded_path !== $source_path
-                                    && strncmp($decoded_path, $source_path . '/', strlen($source_path) + 1) !== 0) {
-                                    continue;
-                                }
-                                $converted = WPURL::replace_base_url(
-                                    $parsed_url,
-                                    array(
-                                        'old_base_url' => $from_url,
-                                        'new_base_url' => $excluded ? $from_url : $mapping['to_url'],
-                                        'raw_url'      => $raw_url,
-                                        // Identity rules retain the source origin. A relative
-                                        // sibling link would otherwise point into the target.
-                                        'is_relative'  => !$excluded && ! $p->is_url_absolute()
-                                            && $from_url->toString() !== $mapping['to_url']->toString(),
-                                    )
-                                );
-                                break;
-                            }
-                        }
-
-                        $cache_value = false;
-                        if ($converted !== false) {
-                            $cache_value = [
-                                'raw_url'    => (string) $converted,
-                                'parsed_url' => $converted->new_url,
-                            ];
-                            $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
-                        }
-                        if ($url_cache_key !== null) {
-                            $this->set_cached_url_rewrite($url_cache_key, $cache_value);
+                        $rewritten = $this->rewrite_url_field($p->get_raw_url(), $p->get_url_base());
+                        if ($rewritten !== false) {
+                            $p->set_url($rewritten['raw_url'], $rewritten['parsed_url']);
                         }
                     }
                     if ( $this->is_selected_site_migration && '#block-comment' === $p->get_token_type() ) {
@@ -956,6 +912,162 @@ class StructuredDataUrlRewriter
                 return $content;
         }
     }
+    /**
+     * A declared JSON media type supplies the script body's format.
+     * Other script bodies keep the cautious raw-text pass. The HTML and block
+     * paths share this check so application/ld+json is decoded in either case.
+     */
+    private function rewrite_json_script_body(WP_HTML_Tag_Processor $processor): void
+    {
+        if ($processor->get_tag() !== 'SCRIPT' || $processor->is_tag_closer()) {
+            return;
+        }
+        $type = $processor->get_attribute('type');
+        if (!is_string($type) || preg_match(
+            '/\Aapplication\/(?:[a-z0-9!#$&^_.+-]+\+)?json\z/',
+            strtolower(trim(explode(';', $type, 2)[0]))
+        ) !== 1) {
+            return;
+        }
+        $body = $processor->get_modifiable_text();
+        $rewritten_body = $this->rewrite($body, self::BLOCK_MARKUP);
+        if ($rewritten_body !== $body) {
+            $processor->set_modifiable_text($rewritten_body);
+        }
+    }
+
+    /**
+     * Rewrite declared CSS URLs, including escaped url(), @import and image-set().
+     * STYLE bodies and style attributes share this parser and URL policy. The
+     * enclosing HTML serializer handles attribute escaping after CSS is complete.
+     */
+    private function rewrite_css(string $value, ?string $field_base_url): string {
+        $p = new CSSURLProcessor($value);
+        while ($p->next_url()) {
+            if ($p->is_data_uri()) {
+                continue;
+            }
+            $rewritten = $this->rewrite_url_field($p->get_raw_url(), $field_base_url);
+            if ($rewritten !== false) {
+                $p->set_raw_url($rewritten['raw_url']);
+            }
+        }
+        return $p->get_updated_css();
+    }
+
+    /**
+     * Rewrite one decoded HTML, CSS or block URL with its field's base.
+     *
+     * A known href may resolve /photo.jpg against the site. An unknown block
+     * string has no base and must contain an absolute URL. Both use the same
+     * child-path checks and bounded result cache.
+     *
+     * @return array|false {
+     *     A replacement, or false when the field must not change.
+     *     @type string $raw_url    Replacement in the original relative/absolute form.
+     *     @type mixed  $parsed_url Parsed absolute replacement for the URL reader.
+     * }
+     */
+    private function rewrite_url_field(string $raw_url, ?string $field_base_url)
+    {
+        $url_cache_key = null;
+        if (strlen($raw_url) <= self::URL_REWRITE_CACHE_MAX_INPUT_BYTES) {
+            // `/photo.jpg` in a known href can use the site base;
+            // the same string in an unknown block field cannot.
+            $url_cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP
+                . "\0" . $field_base_url . "\0" . $raw_url;
+
+            $cached = $this->get_cached_url_rewrite($url_cache_key);
+            if ($cached !== null) {
+                return $cached;
+            }
+        }
+
+        // A complete HTTP(S) prefix needs no base. Shorthand such as
+        // https:photo.jpg still resolves against the field's base directory.
+        $has_absolute_prefix = 0 === strncasecmp($raw_url, 'https://', 8) || 0 === strncasecmp($raw_url, 'http://', 7);
+        $parsed_url = WPURL::parse($raw_url, $has_absolute_prefix ? null : $field_base_url);
+        if ( $parsed_url === false ) {
+            if ( $url_cache_key !== null ) {
+                $this->set_cached_url_rewrite($url_cache_key, false);
+            }
+            return false;
+        }
+        $is_absolute = $has_absolute_prefix || WPURL::can_parse($raw_url);
+        // Mapping URLs were parsed once in the constructor. Reuse those
+        // objects for every field instead of parsing each source and target
+        // again for every leaf value.
+        $converted = false;
+        if (!$this->is_selected_site_migration) {
+            foreach ($this->parsed_mapping as $mapping) {
+                if (is_child_url_of($parsed_url, $mapping['from_url'])) {
+                    $converted = WPURL::replace_base_url($parsed_url, [
+                        'old_base_url' => $this->base_url,
+                        'new_base_url' => $mapping['to_url'],
+                        'raw_url' => $raw_url,
+                        'is_relative' => !$is_absolute,
+                    ]);
+                    break;
+                }
+            }
+        } else {
+            $decoded_path = rawurldecode($parsed_url->pathname);
+            $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
+            // A canonical absolute child URL is already final. Do
+            // not clone it or rewrite its HTML/CSS/JSON container.
+            // Relative links and dot segments still use the normal
+            // conversion below to keep the child at the source.
+            if ($excluded && $raw_url === $parsed_url->toString()) {
+                if ($url_cache_key !== null) {
+                    $this->set_cached_url_rewrite($url_cache_key, false);
+                }
+                return false;
+            }
+            foreach ($this->parsed_mapping as $mapping) {
+                $from_url = $mapping['from_url'];
+                if (!$from_url || !$mapping['to_url']
+                    || $parsed_url->hostname !== $from_url->hostname
+                    || $parsed_url->protocol !== $from_url->protocol
+                    || $parsed_url->port !== $from_url->port) {
+                    continue;
+                }
+                // A base names a whole path segment: /sites/7 must
+                // not select /sites/70. URL paths keep literal + bytes;
+                // they do not use form-query decoding (+ becomes space).
+                $source_path = rtrim(rawurldecode($from_url->pathname), '/');
+                if ($decoded_path !== $source_path
+                    && strncmp($decoded_path, $source_path . '/', strlen($source_path) + 1) !== 0) {
+                    continue;
+                }
+                $converted = WPURL::replace_base_url(
+                    $parsed_url,
+                    array(
+                        'old_base_url' => $from_url,
+                        'new_base_url' => $excluded ? $from_url : $mapping['to_url'],
+                        'raw_url'      => $raw_url,
+                        // Identity rules retain the source origin. A relative
+                        // sibling link would otherwise point into the target.
+                        'is_relative'  => !$excluded && ! $is_absolute
+                            && $from_url->toString() !== $mapping['to_url']->toString(),
+                    )
+                );
+                break;
+            }
+        }
+
+        $cache_value = false;
+        if ($converted !== false) {
+            $cache_value = [
+                'raw_url'    => (string) $converted,
+                'parsed_url' => $converted->new_url,
+            ];
+        }
+        if ($url_cache_key !== null) {
+            $this->set_cached_url_rewrite($url_cache_key, $cache_value);
+        }
+        return $cache_value;
+    }
+
     /**
      * Rewrite every string in a block attribute array.
      *

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -2,6 +2,7 @@
 
 use WordPress\DataLiberation\URL\WPURL;
 use WordPress\DataLiberation\Shortcode\ShortcodeProcessor;
+use function WordPress\DataLiberation\URL\is_child_url_of;
 
 /**
  * Rewrites URLs in a single decoded database value by detecting the data
@@ -46,6 +47,13 @@ class StructuredDataUrlRewriter
 
     /** Prepared URL mapping shared by cautious text processors. */
     private CautiousURLBaseRewriteMapping $cautious_url_base_rewrite_mapping;
+
+    /**
+     * Whether this rewriter was given a selected site's child-path list.
+     * An empty list still means a selected-site migration: a domain-based
+     * network can have no child sites under the selected site's URL.
+     */
+    private bool $is_selected_site_migration;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -97,12 +105,18 @@ class StructuredDataUrlRewriter
 
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
-     * @param array<string, string[]> $excluded_paths Source HTTP(S) origin =>
-     *     child-site paths. Prepared once and shared by HTML and text rewriting.
+     * @param array<string, string[]>|null $selected_site_child_paths Source HTTP(S)
+     *     origin => child-site paths, for a selected-site migration. For example,
+     *     ['https://network.test' => ['/shop/news/']] keeps that child site remote.
+     *     Pass [] when the selected site has no child paths. Null means an
+     *     ordinary import, which keeps the cheaper raw-text paths for block
+     *     attributes and STYLE bodies. The importer chooses from its selection.
+     *     Paths are prepared once and shared by HTML and text rewriting.
      */
-    public function __construct(array $url_mapping, array $excluded_paths = [])
+    public function __construct(array $url_mapping, ?array $selected_site_child_paths = null)
     {
-        $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping, $excluded_paths);
+        $this->is_selected_site_migration = $selected_site_child_paths !== null;
+        $this->cautious_url_base_rewrite_mapping = new CautiousURLBaseRewriteMapping($url_mapping, $selected_site_child_paths ?? []);
         $wpbakery_url_rewriter = new WPBakeryUrlRewriter(
             function (string $value): string {
                 return $this->rewrite($value, self::BLOCK_MARKUP);
@@ -135,16 +149,19 @@ class StructuredDataUrlRewriter
         }
         $this->source_domains = array_keys($domains);
 
-        // The first source is the site's base for relative links, not an asset
-        // rule. A base path describes a directory even without a trailing slash.
         $from_urls = array_keys($url_mapping);
-        $this->base_url = isset($from_urls[0]) ? rtrim($from_urls[0], '/') . '/' : '';
+        $this->base_url = $from_urls[0] ?? '';
+        if ($this->is_selected_site_migration) {
+            // The first source is the site's base for relative links, not an asset
+            // rule. A base path describes a directory even without a trailing slash.
+            $this->base_url = $this->base_url !== '' ? rtrim($this->base_url, '/') . '/' : '';
 
-        // A sibling or media rule must win over its containing site URL, just
-        // as it does in the cautious plain-text rewriter. Keep the base above.
-        uksort($url_mapping, static function (string $first, string $second): int {
-            return strlen($second) <=> strlen($first);
-        });
+            // A sibling or media rule must win over its containing site URL, just
+            // as it does in the cautious plain-text rewriter. Keep the base above.
+            uksort($url_mapping, static function (string $first, string $second): int {
+                return strlen($second) <=> strlen($first);
+            });
+        }
 
         // Parse the mapping once. Each WPURL::parse() does non-trivial work
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
@@ -508,15 +525,16 @@ class StructuredDataUrlRewriter
      * Quick-reject check: returns false when the value certainly doesn't
      * contain any rewritable URLs, avoiding expensive parsing.
      *
-     * Attribute/CSS signals admit values without literal source-domain bytes.
-     * `style` is deliberately broad: `STYLE = "url(...)"` is valid HTML, and
-     * CSS escapes can hide the host. The parsers decide whether it is CSS.
+     * Attribute signals admit values without literal source-domain bytes.
+     * Selected-site imports also admit CSS. `style` is deliberately broad:
+     * `STYLE = "url(...)"` is valid HTML, and CSS escapes can hide the host.
+     * The parsers decide whether it is CSS.
      * Literal domains and supported encoding markers also pass this gate.
      */
     private function maybe_contains_rewritable_urls(string $value): bool
     {
         if (stripos($value, 'href=') !== false || stripos($value, 'src=') !== false
-            || stripos($value, 'style') !== false) {
+            || ( $this->is_selected_site_migration && stripos($value, 'style') !== false )) {
             return true;
         }
 
@@ -703,11 +721,12 @@ class StructuredDataUrlRewriter
      * checks. The text fallback cannot determine where a path ends, so it
      * leaves all URLs on a source host with child-site exclusions unchanged.
      *
-     * Block attributes are already decoded by BlockMarkupProcessor. Visit
-     * their string leaves rather than scan the raw JSON again.
+     * Selected-site migrations visit the decoded block attribute strings so
+     * child paths are checked after each enclosing format has been decoded.
      * This costs a walk of one block's attribute tree, not the whole export.
-     * Changed attributes use the block encoder, including its whitespace
-     * and escaping rules. There is no raw-comment fast path alongside it.
+     * Changed attributes use the block encoder, including its whitespace and
+     * escaping rules. Ordinary imports keep the raw-comment fast path when
+     * no string needs format decoding or a serialized length update.
      *
      * Example:
      *
@@ -748,9 +767,44 @@ class StructuredDataUrlRewriter
             case self::BLOCK_MARKUP:
                 $p = new StructuredBlockMarkupUrlProcessor(
                     $content,
-                    $resolve_relative_urls ? $base_url : null
+                    $resolve_relative_urls ? $base_url : null,
+                    $this->is_selected_site_migration
                 );
                 while ( $p->next_token() ) {
+                    $parsed_nested_block_attributes = false;
+                    $block_comment_may_hide_rewritable_url = false;
+                    $block_comment_text = '';
+                    if ( ! $this->is_selected_site_migration && '#block-comment' === $p->get_token_type() ) {
+                        $block_comment_text = $p->get_modifiable_text();
+                        $block_comment_may_hide_rewritable_url =
+                            $this->value_might_contain_source_domain( $block_comment_text )
+                            || $this->value_might_contain_hidden_shortcode_url( $block_comment_text );
+                    }
+                    if ( $block_comment_may_hide_rewritable_url ) {
+                        // The fast check includes supported encoding markers
+                        // and registered shortcode signals. Parsed string
+                        // leaves still decide whether a URL exists.
+                        $block_attributes = $p->get_block_attributes();
+                        // A Unicode-escaped quote leaves an alphanumeric byte
+                        // immediately before a raw URL. The cautious scanner
+                        // rejects that boundary, so parse the decoded value.
+                        $block_comment_uses_unicode_escaped_quotes = false !== stripos( $block_comment_text, '\\u0022' )
+                            || false !== stripos( $block_comment_text, '\\u0027' );
+                        if (
+                            is_array( $block_attributes )
+                            && (
+                                $block_comment_uses_unicode_escaped_quotes
+                                || $this->block_attribute_values_need_format_inference( $block_attributes )
+                            )
+                        ) {
+                            $parsed_nested_block_attributes = true;
+                            $rewritten_block_attributes = $this->rewrite_inferred_block_attribute_values( $block_attributes );
+                            if ( $rewritten_block_attributes !== $block_attributes ) {
+                                $p->set_block_attributes( $rewritten_block_attributes );
+                            }
+                        }
+                    }
+
                     // A declared JSON media type supplies the script body's format.
                     // Other script bodies keep the cautious raw-token scan below.
                     if ( 'SCRIPT' === $p->get_tag() && ! $p->is_tag_closer() ) {
@@ -794,38 +848,52 @@ class StructuredDataUrlRewriter
                             }
                             continue;
                         }
-                        $decoded_path = rawurldecode($parsed_url->pathname);
-                        $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
                         $converted = false;
-                        foreach ( $parsed_mapping as $mapping ) {
-                            $from_url = $mapping['from_url'];
-                            if (!$from_url || !$mapping['to_url']
-                                || $parsed_url->hostname !== $from_url->hostname
-                                || $parsed_url->protocol !== $from_url->protocol
-                                || $parsed_url->port !== $from_url->port) {
-                                continue;
+                        if (!$this->is_selected_site_migration) {
+                            foreach ($parsed_mapping as $mapping) {
+                                if (is_child_url_of($parsed_url, $mapping['from_url'])) {
+                                    $converted = WPURL::replace_base_url($parsed_url, [
+                                        'old_base_url' => $base_url,
+                                        'new_base_url' => $mapping['to_url'],
+                                        'raw_url' => $raw_url,
+                                        'is_relative' => !$p->is_url_absolute(),
+                                    ]);
+                                    break;
+                                }
                             }
-                            // A base names a whole path segment: /sites/7 must
-                            // not select /sites/70. URL paths keep literal + bytes;
-                            // they do not use form-query decoding (+ becomes space).
-                            $source_path = rtrim(rawurldecode($from_url->pathname), '/');
-                            if ($decoded_path !== $source_path
-                                && strncmp($decoded_path, $source_path . '/', strlen($source_path) + 1) !== 0) {
-                                continue;
+                        } else {
+                            $decoded_path = rawurldecode($parsed_url->pathname);
+                            $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
+                            foreach ($parsed_mapping as $mapping) {
+                                $from_url = $mapping['from_url'];
+                                if (!$from_url || !$mapping['to_url']
+                                    || $parsed_url->hostname !== $from_url->hostname
+                                    || $parsed_url->protocol !== $from_url->protocol
+                                    || $parsed_url->port !== $from_url->port) {
+                                    continue;
+                                }
+                                // A base names a whole path segment: /sites/7 must
+                                // not select /sites/70. URL paths keep literal + bytes;
+                                // they do not use form-query decoding (+ becomes space).
+                                $source_path = rtrim(rawurldecode($from_url->pathname), '/');
+                                if ($decoded_path !== $source_path
+                                    && strncmp($decoded_path, $source_path . '/', strlen($source_path) + 1) !== 0) {
+                                    continue;
+                                }
+                                $converted = WPURL::replace_base_url(
+                                    $parsed_url,
+                                    array(
+                                        'old_base_url' => $from_url,
+                                        'new_base_url' => $excluded ? $from_url : $mapping['to_url'],
+                                        'raw_url'      => $raw_url,
+                                        // Identity rules retain the source origin. A relative
+                                        // sibling link would otherwise point into the target.
+                                        'is_relative'  => !$excluded && ! $p->is_url_absolute()
+                                            && $from_url->toString() !== $mapping['to_url']->toString(),
+                                    )
+                                );
+                                break;
                             }
-                            $converted = WPURL::replace_base_url(
-                                $parsed_url,
-                                array(
-                                    'old_base_url' => $from_url,
-                                    'new_base_url' => $excluded ? $from_url : $mapping['to_url'],
-                                    'raw_url'      => $raw_url,
-                                    // Identity rules retain the source origin. A relative
-                                    // sibling link would otherwise point into the target.
-                                    'is_relative'  => !$excluded && ! $p->is_url_absolute()
-                                        && $from_url->toString() !== $mapping['to_url']->toString(),
-                                )
-                            );
-                            break;
                         }
 
                         $cache_value = false;
@@ -840,7 +908,7 @@ class StructuredDataUrlRewriter
                             $this->set_cached_url_rewrite($url_cache_key, $cache_value);
                         }
                     }
-                    if ( '#block-comment' === $p->get_token_type() ) {
+                    if ( $this->is_selected_site_migration && '#block-comment' === $p->get_token_type() ) {
                         // BlockMarkupProcessor supplies one decoded attribute tree.
                         // Use its setter for nested values too; mixing those edits
                         // with raw replacements can duplicate the block comment.
@@ -851,7 +919,7 @@ class StructuredDataUrlRewriter
                                 $p->set_block_attributes( $rewritten_attributes );
                             }
                         }
-                    } else {
+                    } elseif ( ! $parsed_nested_block_attributes ) {
                         $p->replace_url_bases_in_current_token( $this->cautious_url_base_rewrite_mapping );
                     }
                 }
@@ -898,6 +966,73 @@ class StructuredDataUrlRewriter
         }
 
         return $values;
+    }
+
+    /**
+     * Return whether any nested string needs its enclosing format parsed.
+     *
+     * When one string needs parsing, all strings in that block are rewritten
+     * through the same attribute tree. This avoids mixing a re-encoded block
+     * comment with raw byte replacements queued against its old byte offsets.
+     * Most Divi blocks only contain literal ASCII URLs, so they stay on the
+     * existing raw-token path and avoid the expensive recursive rewrite.
+     *
+     * @param array<int|string, mixed> $values Block attribute values.
+     */
+    private function block_attribute_values_need_format_inference( array $values ): bool {
+        foreach ( $values as $value ) {
+            if ( is_array( $value ) ) {
+                if ( $this->block_attribute_values_need_format_inference( $value ) ) {
+                    return true;
+                }
+            } elseif ( is_string( $value ) && $this->nested_block_string_needs_format_inference( $value ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return whether a nested block string needs its enclosing format parsed.
+     *
+     * The cautious raw-token pass already handles literal ASCII source hosts
+     * in HTML, CSS, JSON, shortcodes, and plain text. Parsing those values
+     * again only changes their encoding and makes Divi imports slower.
+     *
+     * Parsing is still needed when an escape, character reference, or registered
+     * shortcode codec may hide part or all of the URL, or when serialized PHP
+     * length fields must be updated. A JSON value may contain serialized PHP at
+     * a deeper level, so its raw text is also checked for a serialization token.
+     * Non-ASCII values keep the structured path because the cautious raw-token
+     * pass supports ASCII and punycode domains, but not literal Unicode domains.
+     *
+     * These are coarse signals, not proof of a content type. The format
+     * hierarchy below still validates PHP serialization and JSON before use.
+     */
+    private function nested_block_string_needs_format_inference( string $value ): bool {
+        if ( $this->value_might_contain_hidden_shortcode_url( $value ) ) {
+            return true;
+        }
+
+        if ( ! $this->maybe_contains_rewritable_urls( $value ) ) {
+            return false;
+        }
+
+        if ( $this->could_be_php_serialization_with_strings( $value ) ) {
+            return true;
+        }
+
+        if ( false !== strpos( $value, '\\u' ) || false !== strpos( $value, '&' ) ) {
+            return true;
+        }
+
+        $contains_serialized_value = 1 === preg_match( '/(?:a|s|O|C):\d+:/', $value );
+        if ( $this->could_be_json_with_strings( $value ) && $contains_serialized_value ) {
+            return true;
+        }
+
+        return 1 === preg_match( '/[^\x00-\x7F]/', $value );
     }
 
     /**

--- a/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-client/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -864,6 +864,16 @@ class StructuredDataUrlRewriter
                         } else {
                             $decoded_path = rawurldecode($parsed_url->pathname);
                             $excluded = $this->cautious_url_base_rewrite_mapping->excludes_path($parsed_url->host, $parsed_url->pathname);
+                            // A canonical absolute child URL is already final. Do
+                            // not clone it or rewrite its HTML/CSS/JSON container.
+                            // Relative links and dot segments still use the normal
+                            // conversion below to keep the child at the source.
+                            if ($excluded && $raw_url === $parsed_url->toString()) {
+                                if ($url_cache_key !== null) {
+                                    $this->set_cached_url_rewrite($url_cache_key, false);
+                                }
+                                continue;
+                            }
                             foreach ($parsed_mapping as $mapping) {
                                 $from_url = $mapping['from_url'];
                                 if (!$from_url || !$mapping['to_url']

--- a/packages/reprint-client/src/lib/wp-stubs.php
+++ b/packages/reprint-client/src/lib/wp-stubs.php
@@ -60,22 +60,18 @@ if (!function_exists('wp_kses_uri_attributes')) {
 
 if (!function_exists('esc_url')) {
     /**
-     * Stub: minimal URL escaping for attribute output.
-     * In our context we trust the URLs from the rewriter, so we just
-     * clean obvious bad protocols and encode entities.
+     * Escape a decoded URL for the HTML tag processor's attribute setter.
+     * URL parsing happens before this call. Quotes in a valid URL must become
+     * entities here, or they can end the surrounding HTML attribute.
      */
     function esc_url($url, $protocols = null, $_context = 'display') {
         if (empty($url)) {
             return '';
         }
         $url = str_replace(' ', '%20', $url);
-        $url = str_replace("'", '&#039;', $url);
-        if ($_context === 'display') {
-            $url = str_replace('&', '&amp;', $url);
-            // Don't double-encode
-            $url = str_replace('&amp;amp;', '&amp;', $url);
-        }
-        return $url;
+        return $_context === 'display'
+            ? htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            : $url;
     }
 }
 

--- a/tests/UrlRewriting/BenchmarkCorpusTest.php
+++ b/tests/UrlRewriting/BenchmarkCorpusTest.php
@@ -13,7 +13,11 @@ class BenchmarkCorpusTest extends TestCase {
     public function testBenchmarkCorpusRewritesWithoutLosingContent(string $scenario): void
     {
         $fixture = reprint_url_rewrite_benchmark_fixture($scenario, 7);
-        foreach ([null, []] as $selected_site_child_paths) {
+        $selections = [null, []];
+        if (in_array($scenario, REPRINT_URL_REWRITE_CHILD_PATH_BENCHMARK_CASES, true)) {
+            $selections[] = ['https://source.example' => ['/news/']];
+        }
+        foreach ($selections as $selected_site_child_paths) {
             $rewriter = new StructuredDataUrlRewriter(
                 ['https://source.example' => 'https://destination.example'],
                 $selected_site_child_paths

--- a/tests/UrlRewriting/BenchmarkCorpusTest.php
+++ b/tests/UrlRewriting/BenchmarkCorpusTest.php
@@ -13,12 +13,17 @@ class BenchmarkCorpusTest extends TestCase {
     public function testBenchmarkCorpusRewritesWithoutLosingContent(string $scenario): void
     {
         $fixture = reprint_url_rewrite_benchmark_fixture($scenario, 7);
-        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://destination.example']);
-        $output = $scenario === 'serialized-options'
-            ? $rewriter->rewrite($fixture['input'])
-            : $rewriter->rewrite_known_block_markup_value($fixture['input']);
+        foreach ([null, []] as $selected_site_child_paths) {
+            $rewriter = new StructuredDataUrlRewriter(
+                ['https://source.example' => 'https://destination.example'],
+                $selected_site_child_paths
+            );
+            $output = $scenario === 'serialized-options'
+                ? $rewriter->rewrite($fixture['input'])
+                : $rewriter->rewrite_known_block_markup_value($fixture['input']);
 
-        reprint_check_url_rewrite_benchmark_output($output, $fixture['expected']);
+            reprint_check_url_rewrite_benchmark_output($output, $fixture['expected']);
+        }
         $next = reprint_url_rewrite_benchmark_fixture($scenario, 8);
         $this->assertNotSame($fixture['input'], $next['input'], 'Rows must not become whole-value cache hits.');
     }

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -359,7 +359,7 @@ class SqlStatementRewriterTest extends TestCase
             'CSS escaped slashes, a protocol-relative URL, and entity quotes' => [
                 '<style>.hero{background:url(https\:\/\/old-site.com\/hero.jpg)} @import url(//old-site.com/theme.css);</style>'
                     . '<div style="background:url(&quot;https://old-site.com/card.jpg&quot;)">Card</div>',
-                '<style>.hero{background:url(https\:\/\/new-site.com\/hero.jpg)} @import url(//new-site.com/theme.css);</style>'
+                '<style>.hero{background:url("https://new-site.com/hero.jpg")} @import url("/theme.css");</style>'
                     . '<div style="background:url(&quot;https://new-site.com/card.jpg&quot;)">Card</div>',
             ],
             'JavaScript strings, split pieces, and a URL constructor' => [

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -359,7 +359,7 @@ class SqlStatementRewriterTest extends TestCase
             'CSS escaped slashes, a protocol-relative URL, and entity quotes' => [
                 '<style>.hero{background:url(https\:\/\/old-site.com\/hero.jpg)} @import url(//old-site.com/theme.css);</style>'
                     . '<div style="background:url(&quot;https://old-site.com/card.jpg&quot;)">Card</div>',
-                '<style>.hero{background:url("https://new-site.com/hero.jpg")} @import url("/theme.css");</style>'
+                '<style>.hero{background:url(https\:\/\/new-site.com\/hero.jpg)} @import url(//new-site.com/theme.css);</style>'
                     . '<div style="background:url(&quot;https://new-site.com/card.jpg&quot;)">Card</div>',
             ],
             'JavaScript strings, split pieces, and a URL constructor' => [

--- a/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
+++ b/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
@@ -8,6 +8,33 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.php';
 
 class StructuredBlockMarkupUrlProcessorTest extends TestCase {
+    /** Full HTTP URLs need no base; shorthand and relative forms still use it. */
+    public function testAbsoluteUrlShortcutKeepsBaseResolutionAndValidation(): void
+    {
+        foreach ([
+            ['https://source.example/photo.jpg', 'https://source.example/photo.jpg', true],
+            ['HTTPS://source.example/photo.jpg', 'https://source.example/photo.jpg', true],
+            ['https:photo.jpg', 'https://source.example/shop/photo.jpg', true],
+            ['//source.example/photo.jpg', 'https://source.example/photo.jpg', false],
+            ['../photo.jpg', 'https://source.example/photo.jpg', false],
+            ['https://invalid host/photo.jpg', false, false],
+        ] as [$rawUrl, $absoluteUrl, $isAbsolute]) {
+            foreach ([
+                '<a href="' . $rawUrl . '"></a>',
+                '<style>a{background:url("' . $rawUrl . '")}</style>',
+                '<!-- wp:image ' . json_encode(['url' => $rawUrl]) . ' /-->',
+            ] as $markup) {
+                $processor = new StructuredBlockMarkupUrlProcessor($markup, 'https://source.example/shop/');
+                $this->assertSame($absoluteUrl !== false, $processor->next_url(), $markup);
+                if ($absoluteUrl !== false) {
+                    $this->assertSame($absoluteUrl, $processor->get_parsed_url()->toString(), $markup);
+                    $this->assertSame($isAbsolute, $processor->is_url_absolute(), $markup);
+                    $this->assertFalse($processor->next_url(), $markup);
+                }
+            }
+        }
+    }
+
     public function testNextUrlInCurrentTokenReturnsFalseWithoutAStructuredUrl(): void
     {
         $processor = new StructuredBlockMarkupUrlProcessor('Text without structured URLs');

--- a/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
+++ b/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
@@ -404,7 +404,7 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
         );
     }
 
-    public function testReplacesOpaqueTokenUrlBasesAfterStructuredUrls(): void
+    public function testReplacesUnparsedAttributeValuesAfterStructuredUrls(): void
     {
         $processor = new StructuredBlockMarkupUrlProcessor(
             '<a href="https://old.example/image.jpg" data-shortcode=' .
@@ -434,7 +434,7 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
 
         $this->assertSame(
             '<a href="https://new.example/image.jpg" data-shortcode=' .
-            '"[video src=\'https://new.example/video.mp4\']">Link</a>',
+            '"[video src=&#039;https://new.example/video.mp4&#039;]">Link</a>',
             $processor->get_updated_html()
         );
     }

--- a/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
+++ b/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
@@ -404,7 +404,7 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
         );
     }
 
-    public function testReplacesUnparsedAttributeValuesAfterStructuredUrls(): void
+    public function testReplacesOpaqueTokenUrlBasesAfterStructuredUrls(): void
     {
         $processor = new StructuredBlockMarkupUrlProcessor(
             '<a href="https://old.example/image.jpg" data-shortcode=' .
@@ -434,7 +434,7 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
 
         $this->assertSame(
             '<a href="https://new.example/image.jpg" data-shortcode=' .
-            '"[video src=&#039;https://new.example/video.mp4&#039;]">Link</a>',
+            '"[video src=\'https://new.example/video.mp4\']">Link</a>',
             $processor->get_updated_html()
         );
     }

--- a/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
+++ b/tests/UrlRewriting/StructuredBlockMarkupUrlProcessorTest.php
@@ -24,7 +24,7 @@ class StructuredBlockMarkupUrlProcessorTest extends TestCase {
                 '<style>a{background:url("' . $rawUrl . '")}</style>',
                 '<!-- wp:image ' . json_encode(['url' => $rawUrl]) . ' /-->',
             ] as $markup) {
-                $processor = new StructuredBlockMarkupUrlProcessor($markup, 'https://source.example/shop/');
+                $processor = new StructuredBlockMarkupUrlProcessor($markup, 'https://source.example/shop/', true);
                 $this->assertSame($absoluteUrl !== false, $processor->next_url(), $markup);
                 if ($absoluteUrl !== false) {
                     $this->assertSame($absoluteUrl, $processor->get_parsed_url()->toString(), $markup);

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -13,6 +15,117 @@ class StructuredDataUrlRewriterTest extends TestCase
         return new StructuredDataUrlRewriter($mapping ?? [
             'https://old-site.com' => 'https://new-site.com',
         ]);
+    }
+
+    /** Destination characters are escaped by the known format, not rejected globally. */
+    public function testTargetHostRestrictionsStayInTheUnknownTextFallback(): void
+    {
+        foreach (['a"b.test', "a'b.test", 'a&b.test', '[::1]', 'target.test.'] as $host) {
+            $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://' . $host]);
+            foreach ([
+                '<a href="https://source.test/page">link</a>',
+                '<style>a{background:url("https://source.test/page")}</style>',
+                '<div style="background:url(https://source.test/page)"></div>',
+                '<!-- wp:image {"url":"https://source.test/page"} /-->',
+            ] as $input) {
+                $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
+                $parser = new StructuredBlockMarkupUrlProcessor($output);
+                $this->assertTrue($parser->next_url(), $output);
+                $this->assertSame('https://' . $host . '/page', $parser->get_raw_url(), $output);
+                $this->assertFalse($parser->next_url(), $output);
+            }
+
+            $input = '[unknown link="https://source.test/page"]';
+            $expected = $host === 'target.test.' ? '[unknown link="https://target.test./page"]' : $input;
+            $this->assertSame($expected, $rewriter->rewrite($input));
+        }
+    }
+
+    /** Each parsed field uses the original mapping once, including unchanged URLs. */
+    public function testParsedUrlsAreNotRewrittenAgainByTheTextFallback(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter([
+            'https://old.example' => 'https://middle.example',
+            'https://middle.example' => 'https://last.example',
+        ]);
+        foreach ([
+            '<a href="https://old.example/page">link</a>',
+            '<img src="https://old.example/image.png" srcset="https://old.example/small.png 1x">',
+            '<div style="background:url(https://old.example/image.png)"></div>',
+            '<style>.hero{background:url(https://old.example/image.png)}</style>',
+            '<style style="background:url(https://old.example/inline.png)">.hero{background:url(https://old.example/body.png)}</style><img src="https://old.example/after.png">',
+            '<script type="application/json">{"url":"https://old.example/page"}</script>',
+            '<!-- wp:image {"url":"https://old.example/image.png","settings":{"url":"https://old.example/nested.png"}} /-->',
+        ] as $input) {
+            $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
+            $this->assertStringContainsString('middle.example', $output, $input);
+            $this->assertStringNotContainsString('old.example', $output, $input);
+            $this->assertStringNotContainsString('last.example', $output, $input);
+        }
+        $input = '<a href="https://archive.example/?url=https://old.example/page">archive</a>';
+        $this->assertSame($input, $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+    }
+
+    /** The CSS parser resolves escapes before selecting a child site or the target. */
+    public function testStyleElementUsesTheCssAndUrlParsers(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://network.test' => 'https://target.test'], [
+            'https://network.test' => ['/news/'],
+        ]);
+        $input = '<style>.child{background:url("https://network\\2e test/a;b/../news/image.png")}'
+            . '.selected{background:url("https://network\\2e test/a;b/../selected/image.png")}</style>';
+        $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
+        $this->assertStringContainsString('https://network.test/news/image.png', $output);
+        $this->assertStringContainsString('https://target.test/selected/image.png', $output);
+    }
+
+    /** Rejected URL fields and non-URL CSS tokens must not receive a second guess. */
+    public function testDeclaredUrlFieldsDoNotFallBackAfterParserRejection(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://old.example' => 'https://new.example']);
+        foreach ([
+            '<a href="http://[invalid]/?url=https://old.example/page">link</a>',
+            '<!-- wp:image {"url":"http://[invalid]/?url=https://old.example/page"} /-->',
+            '<style>/* https://old.example/page */.a{content:"https://old.example/page"}</style>',
+            '<div style="content:\'https://old.example/page\'"></div>',
+        ] as $input) {
+            $this->assertSame($input, $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+        }
+    }
+
+    /** CSS escapes need parsing even when HTML permits spaces around the equals sign. */
+    public function testStyleAttributeWithWhitespaceReachesTheCssParser(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://network.test' => 'https://target.test']);
+        $input = '<div STYLE = "background:url(https://network\\2e test/image.png)"></div>';
+        $this->assertStringContainsString('target.test/image.png', $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+    }
+
+    /** Mixed URL fields and nested HTML must not queue overlapping block-comment edits. */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testManyBlocksDoNotDuplicateMarkupOrExhaustMemory(): void
+    {
+        // Isolate the memory ceiling from the other tests. Three blocks catch
+        // duplicated output directly; 5,000 cover one large database value.
+        ini_set('memory_limit', '64M');
+        foreach ([3, 5000] as $block_count) {
+            $content = '';
+            for ($index = 0; $index < $block_count; ++$index) {
+                $content .= '<!-- wp:divi/text ' . json_encode([
+                    'settings' => [
+                        'html' => '<a href="https://old.example/page-' . $index . '">Text ' . $index . '</a>',
+                        'label' => 'Distinct label ' . $index,
+                    ],
+                    'url' => 'https://old.example/image-' . $index,
+                ]) . ' /-->';
+            }
+            $rewriter = new StructuredDataUrlRewriter(['https://old.example' => 'https://new.example']);
+            $output = $rewriter->rewrite($content, StructuredDataUrlRewriter::BLOCK_MARKUP);
+            $this->assertSame($block_count, substr_count($output, '<!-- wp:divi/text '));
+            $this->assertSame(2 * $block_count, substr_count($output, 'new.example'));
+            $this->assertStringNotContainsString('old.example', $output);
+        }
     }
 
     // --- HTML content ---
@@ -41,6 +154,30 @@ class StructuredDataUrlRewriterTest extends TestCase
         $result = $rewriter->rewrite($input);
         $this->assertStringContainsString('https://new-site.com/page1', $result);
         $this->assertStringContainsString('https://new-site.com/page2', $result);
+    }
+
+    /** A site or media base ends at a full path segment and includes its port. */
+    public function testStructuredSourceBasesRequirePathBoundariesAndMatchingPorts(): void
+    {
+        foreach ([
+            ['https://network.test/sites/7', 'https://network.test/sites/7/photo.jpg', 'https://target.test/photo.jpg'],
+            ['https://network.test/sites/7', 'https://network.test/sites/70/photo.jpg', null],
+            ['https://network.test/sites/7', 'https://network.test/sites/700/photo.jpg', null],
+            ['https://network.test/sites/7', 'https://network.test/sites/7-other/photo.jpg', null],
+            ['https://network.test/sites/7', 'https://network.test/sites/%37/photo.jpg', 'https://target.test/photo.jpg'],
+            ['https://network.test/sites/7', 'https://network.test/sites/%37%30/photo.jpg', null],
+            ['https://network.test/sites/7', 'https://network.test:444/sites/7/photo.jpg', null],
+            ['https://network.test:443/sites/7', 'https://network.test/sites/7/photo.jpg', 'https://target.test/photo.jpg'],
+            ['https://network.test:8443/sites/7', 'https://network.test:8443/sites/7/photo.jpg', 'https://target.test/photo.jpg'],
+            ['https://network.test:8443/sites/7', 'https://network.test/sites/7/photo.jpg', null],
+            ['https://network.test/a+b', 'https://network.test/a%20b/photo.jpg', null],
+            ['https://network.test/a+b', 'https://network.test/a+b/photo.jpg', 'https://target.test/photo.jpg'],
+        ] as [$source, $input, $expected]) {
+            $rewriter = new StructuredDataUrlRewriter([$source => 'https://target.test']);
+            $this->assertSame('<img src="' . ($expected ?? $input) . '">', $rewriter->rewrite(
+                '<img src="' . $input . '">', StructuredDataUrlRewriter::BLOCK_MARKUP
+            ), $input);
+        }
     }
 
     // --- Block markup ---
@@ -459,15 +596,15 @@ class StructuredDataUrlRewriterTest extends TestCase
         );
     }
 
-    public function testLiteralDiviUrlUsesRawRewriteWithoutReencodingBlockJson(): void
+    /** Block fields retain their values through JSON and HTML parsing, not a raw-token scan. */
+    public function testLiteralDiviUrlUsesTheParsedBlockFields(): void
     {
         $rewriter = $this->createRewriter([
             'https://old-site.com' => 'https://much-longer.example',
         ]);
         $input = '<!-- wp:divi/text { "module": { "content": { "value": "<a href=\"https:\/\/old-site.com\/about\">Read</a>" } } } /-->';
-        $expected = str_replace('old-site.com', 'much-longer.example', $input);
-
-        $this->assertSame($expected, $rewriter->rewrite($input, 'block_markup'));
+        $attributes = $this->getBlockAttributes($rewriter->rewrite($input, 'block_markup'), 'wp:divi/text');
+        $this->assertSame('<a href="https://much-longer.example/about">Read</a>', $attributes['module']['content']['value']);
     }
 
     public function testNamespacedBlockAttributeStringsReuseStructuredFormatInference(): void
@@ -1049,7 +1186,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ],
             'style element body' => [
                 '<style>.hero{background-image:url(https://old-site.com/hero.jpg)}</style>',
-                '<style>.hero{background-image:url(https://new-site.com/hero.jpg)}</style>',
+                '<style>.hero{background-image:url("https://new-site.com/hero.jpg")}</style>',
             ],
             'meta content attribute' => [
                 '<meta property="og:image" content="https://old-site.com/social.jpg">',
@@ -1395,11 +1532,12 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
-    public function testKnownBlockMarkupCautiouslyRewritesEmbeddedQueryUrl(): void
+    /** A query value is not declared to contain a second URL; keep it as URL data. */
+    public function testKnownBlockMarkupKeepsEmbeddedQueryUrl(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
-        $expected = '<a href="https://webarchive.org?url=https://new-site.com/about">Archive</a>';
+        $expected = $input;
 
         $this->assertSame($expected, $rewriter->rewrite_known_block_markup_value($input));
     }
@@ -1678,7 +1816,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             'protocol-relative' => ['//old-site.com/uploads/c.jpg', '/uploads/c.jpg'],
             'relative no-slash' => ['uploads/d.jpg', '/uploads/d.jpg'],
             'relative dotted'   => ['../uploads/e.jpg', '/uploads/e.jpg'],
-            'query embedded'    => ['/page?ref=https://old-site.com/x', '/page?ref=https://new-site.com/x'],
+            'query embedded'    => ['/page?ref=https://old-site.com/x', '/page?ref=https://old-site.com/x'],
         ];
 
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -69,6 +69,66 @@ class StructuredDataUrlRewriterTest extends TestCase
         }
     }
 
+    /** The faster HTML pass must keep the block reader's token boundaries. */
+    public function testHtmlFastPathKeepsDocumentWrappersIncompleteTokensAndBlockKeys(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://target.example'], []);
+        foreach ([
+            [
+                '<body data-url="https://source.example/a"><p>https://source.example/b</p></body>',
+                '<body data-url="https://source.example/a"><p>https://target.example/b</p></body>',
+            ],
+            [
+                '<p data-url="https://source.example/a">Text</p><a href="https://source.example/b',
+                '<p data-url="https://target.example/a">Text</p><a href="https://source.example/b',
+            ],
+            [
+                '<!-- wp:test {"https://source.example/key":"https://source.example/value"} /-->',
+                '<!-- wp:test {"https:\/\/source.example\/key":"https:\/\/target.example\/value"} /-->',
+            ],
+        ] as [$input, $expected]) {
+            $this->assertSame($expected, $rewriter->rewrite_known_block_markup_value($input));
+        }
+    }
+
+    /** A configured source path cannot join two HTML text tokens into one URL. */
+    public function testSourceBaseContainingMarkupUsesSeparateHtmlTokens(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter([
+            'https://source.example/a</p><p>b' => 'https://target.example',
+        ], []);
+        $input = '<p>https://source.example/a</p><p>b</p>';
+        $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
+    }
+
+    /** An unchanged CSS value needs no HTML attribute edit or quote conversion. */
+    public function testUnchangedStyleAttributeKeepsItsOriginalQuotes(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://target.example'], []);
+        $input = '<div style=\'background:url("/news/a")\'>Text</div>';
+        $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
+    }
+
+    /** Cross the HTML parser's edit-batch limit, with and without an incomplete tail. */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testManyStyleElementsKeepChildLinksAndIncompleteMarkup(): void
+    {
+        ini_set('memory_limit', '64M');
+        $input = '';
+        for ($index = 0; $index < 3000; ++$index) {
+            $input .= '<style>.selected{background:url("https://source.example/article/' . $index . '")}'
+                . '.child{background:url("https://source.example/news/' . $index . '")}</style>';
+        }
+        $expected = str_replace('https://source.example/article/', 'https://target.example/article/', $input);
+        foreach (['', '<a href="https://source.example/incomplete'] as $tail) {
+            $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://target.example'], [
+                'https://source.example' => ['/news/'],
+            ]);
+            $this->assertSame($expected . $tail, $rewriter->rewrite_known_block_markup_value($input . $tail));
+        }
+    }
+
     /** A canonical absolute child URL already has its final bytes. */
     public function testCanonicalChildUrlsDoNotReserializeTheirEnclosingFormat(): void
     {

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -41,29 +41,42 @@ class StructuredDataUrlRewriterTest extends TestCase
         }
     }
 
-    /** Each parsed field uses the original mapping once, including unchanged URLs. */
-    public function testParsedUrlsAreNotRewrittenAgainByTheTextFallback(): void
+    /** A child-site link stays remote, including a selected-site URL in its query. */
+    public function testChildSiteUrlsKeepTheirQueryData(): void
     {
-        $rewriter = new StructuredDataUrlRewriter([
-            'https://old.example' => 'https://middle.example',
-            'https://middle.example' => 'https://last.example',
+        $rewriter = new StructuredDataUrlRewriter(['https://network.test/shop' => 'https://target.test'], [
+            'https://network.test' => ['/shop/news/'],
         ]);
+        $child_url = 'https://network.test/shop/news/article?return=https://network.test/shop/article';
         foreach ([
-            '<a href="https://old.example/page">link</a>',
-            '<img src="https://old.example/image.png" srcset="https://old.example/small.png 1x">',
-            '<div style="background:url(https://old.example/image.png)"></div>',
-            '<style>.hero{background:url(https://old.example/image.png)}</style>',
-            '<style style="background:url(https://old.example/inline.png)">.hero{background:url(https://old.example/body.png)}</style><img src="https://old.example/after.png">',
-            '<script type="application/json">{"url":"https://old.example/page"}</script>',
-            '<!-- wp:image {"url":"https://old.example/image.png","settings":{"url":"https://old.example/nested.png"}} /-->',
+            '<a href="' . $child_url . '">child</a>',
+            '<!-- wp:image {"url":"' . $child_url . '"} /-->',
         ] as $input) {
             $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
-            $this->assertStringContainsString('middle.example', $output, $input);
-            $this->assertStringNotContainsString('old.example', $output, $input);
-            $this->assertStringNotContainsString('last.example', $output, $input);
+            $parser = new StructuredBlockMarkupUrlProcessor($output);
+            $this->assertTrue($parser->next_url(), $output);
+            $this->assertSame($child_url, $parser->get_raw_url());
+            $this->assertFalse($parser->next_url(), $output);
         }
-        $input = '<a href="https://archive.example/?url=https://old.example/page">archive</a>';
-        $this->assertSame($input, $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+    }
+
+    /** Finishing a style attribute must not discard the STYLE body or the next tag. */
+    public function testStyleAttributeAndStyleBodyKeepSeparateUrls(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://target.test']);
+        $input = '<style style="background:url(https://source.test/inline.png)">'
+            . '.hero{background:url(https://source.test/body.png)}</style>'
+            . '<img src="https://source.test/after.png">';
+        $parser = new StructuredBlockMarkupUrlProcessor($rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+        $urls = [];
+        while ($parser->next_url()) {
+            $urls[] = $parser->get_raw_url();
+        }
+        $this->assertSame([
+            'https://target.test/inline.png',
+            'https://target.test/body.png',
+            'https://target.test/after.png',
+        ], $urls);
     }
 
     /** The CSS parser resolves escapes before selecting a child site or the target. */
@@ -77,20 +90,6 @@ class StructuredDataUrlRewriterTest extends TestCase
         $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
         $this->assertStringContainsString('https://network.test/news/image.png', $output);
         $this->assertStringContainsString('https://target.test/selected/image.png', $output);
-    }
-
-    /** Rejected URL fields and non-URL CSS tokens must not receive a second guess. */
-    public function testDeclaredUrlFieldsDoNotFallBackAfterParserRejection(): void
-    {
-        $rewriter = new StructuredDataUrlRewriter(['https://old.example' => 'https://new.example']);
-        foreach ([
-            '<a href="http://[invalid]/?url=https://old.example/page">link</a>',
-            '<!-- wp:image {"url":"http://[invalid]/?url=https://old.example/page"} /-->',
-            '<style>/* https://old.example/page */.a{content:"https://old.example/page"}</style>',
-            '<div style="content:\'https://old.example/page\'"></div>',
-        ] as $input) {
-            $this->assertSame($input, $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
-        }
     }
 
     /** CSS escapes need parsing even when HTML permits spaces around the equals sign. */
@@ -1532,12 +1531,11 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
-    /** A query value is not declared to contain a second URL; keep it as URL data. */
-    public function testKnownBlockMarkupKeepsEmbeddedQueryUrl(): void
+    public function testKnownBlockMarkupCautiouslyRewritesEmbeddedQueryUrl(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
-        $expected = $input;
+        $expected = '<a href="https://webarchive.org?url=https://new-site.com/about">Archive</a>';
 
         $this->assertSame($expected, $rewriter->rewrite_known_block_markup_value($input));
     }
@@ -1816,7 +1814,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             'protocol-relative' => ['//old-site.com/uploads/c.jpg', '/uploads/c.jpg'],
             'relative no-slash' => ['uploads/d.jpg', '/uploads/d.jpg'],
             'relative dotted'   => ['../uploads/e.jpg', '/uploads/e.jpg'],
-            'query embedded'    => ['/page?ref=https://old-site.com/x', '/page?ref=https://old-site.com/x'],
+            'query embedded'    => ['/page?ref=https://old-site.com/x', '/page?ref=https://new-site.com/x'],
         ];
 
         $rewriter = $this->createRewriter();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -69,6 +69,32 @@ class StructuredDataUrlRewriterTest extends TestCase
         }
     }
 
+    /** A canonical absolute child URL already has its final bytes. */
+    public function testCanonicalChildUrlsDoNotReserializeTheirEnclosingFormat(): void
+    {
+        $rewriter = new StructuredDataUrlRewriter(['https://network.test' => 'https://target.test'], [
+            'https://network.test' => ['/news/'],
+        ]);
+        foreach ([
+            '<style>.child{background:url(https://network.test/news/photo.png)}</style>',
+            "<a href='https://network.test/news/article'>Child</a>",
+            '<!-- wp:image { "url": "https://network.test/news/photo.png" } /-->',
+        ] as $input) {
+            $this->assertSame($input, $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+        }
+
+        // These still need a changed URL: relative child links must stay on
+        // the source host, and dot segments must be resolved before the lookup.
+        $this->assertSame(
+            '<a href="https://network.test/news/article">Child</a>',
+            $rewriter->rewrite('<a href="/news/article">Child</a>', StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+        $this->assertSame(
+            '<a href="https://network.test/news/article">Child</a>',
+            $rewriter->rewrite('<a href="https://network.test/shop/../news/article">Child</a>', StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+    }
+
     /** A child-site link stays remote, including a selected-site URL in its query. */
     public function testChildSiteUrlsKeepTheirQueryData(): void
     {

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -17,11 +17,39 @@ class StructuredDataUrlRewriterTest extends TestCase
         ]);
     }
 
+    /** An empty child-path list still selects the multisite parser path. */
+    public function testOrdinaryImportsKeepTheRawStyleAndBlockPaths(): void
+    {
+        $mapping = ['https://source.test' => 'https://target.test'];
+        $ordinary = new StructuredDataUrlRewriter($mapping);
+        $selected_site = new StructuredDataUrlRewriter($mapping, []);
+        $style = '<style>.hero{background:url(//source.test/photo.png)}</style>';
+        $this->assertSame(
+            '<style>.hero{background:url(//target.test/photo.png)}</style>',
+            $ordinary->rewrite($style, StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+        $this->assertSame(
+            '<style>.hero{background:url("/photo.png")}</style>',
+            $selected_site->rewrite($style, StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+
+        // Ordinary Divi values need only source-base replacement. The selected
+        // site must parse the path before deciding whether a child site matches.
+        $block = '<!-- wp:divi/text { "settings": {"text":"https://source.test/page"} } /-->';
+        $this->assertSame(
+            str_replace('source.test', 'target.test', $block),
+            $ordinary->rewrite($block, StructuredDataUrlRewriter::BLOCK_MARKUP)
+        );
+        $parser = new StructuredBlockMarkupUrlProcessor($selected_site->rewrite($block, StructuredDataUrlRewriter::BLOCK_MARKUP));
+        $this->assertTrue($parser->next_token());
+        $this->assertSame(['settings' => ['text' => 'https://target.test/page']], $parser->get_block_attributes());
+    }
+
     /** Destination characters are escaped by the known format, not rejected globally. */
     public function testTargetHostRestrictionsStayInTheUnknownTextFallback(): void
     {
         foreach (['a"b.test', "a'b.test", 'a&b.test', '[::1]', 'target.test.'] as $host) {
-            $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://' . $host]);
+            $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://' . $host], []);
             foreach ([
                 '<a href="https://source.test/page">link</a>',
                 '<style>a{background:url("https://source.test/page")}</style>',
@@ -29,7 +57,7 @@ class StructuredDataUrlRewriterTest extends TestCase
                 '<!-- wp:image {"url":"https://source.test/page"} /-->',
             ] as $input) {
                 $output = $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP);
-                $parser = new StructuredBlockMarkupUrlProcessor($output);
+                $parser = new StructuredBlockMarkupUrlProcessor($output, null, true);
                 $this->assertTrue($parser->next_url(), $output);
                 $this->assertSame('https://' . $host . '/page', $parser->get_raw_url(), $output);
                 $this->assertFalse($parser->next_url(), $output);
@@ -63,11 +91,11 @@ class StructuredDataUrlRewriterTest extends TestCase
     /** Finishing a style attribute must not discard the STYLE body or the next tag. */
     public function testStyleAttributeAndStyleBodyKeepSeparateUrls(): void
     {
-        $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://target.test']);
+        $rewriter = new StructuredDataUrlRewriter(['https://source.test' => 'https://target.test'], []);
         $input = '<style style="background:url(https://source.test/inline.png)">'
             . '.hero{background:url(https://source.test/body.png)}</style>'
             . '<img src="https://source.test/after.png">';
-        $parser = new StructuredBlockMarkupUrlProcessor($rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
+        $parser = new StructuredBlockMarkupUrlProcessor($rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP), null, true);
         $urls = [];
         while ($parser->next_url()) {
             $urls[] = $parser->get_raw_url();
@@ -95,7 +123,7 @@ class StructuredDataUrlRewriterTest extends TestCase
     /** CSS escapes need parsing even when HTML permits spaces around the equals sign. */
     public function testStyleAttributeWithWhitespaceReachesTheCssParser(): void
     {
-        $rewriter = new StructuredDataUrlRewriter(['https://network.test' => 'https://target.test']);
+        $rewriter = new StructuredDataUrlRewriter(['https://network.test' => 'https://target.test'], []);
         $input = '<div STYLE = "background:url(https://network\\2e test/image.png)"></div>';
         $this->assertStringContainsString('target.test/image.png', $rewriter->rewrite($input, StructuredDataUrlRewriter::BLOCK_MARKUP));
     }
@@ -119,7 +147,7 @@ class StructuredDataUrlRewriterTest extends TestCase
                     'url' => 'https://old.example/image-' . $index,
                 ]) . ' /-->';
             }
-            $rewriter = new StructuredDataUrlRewriter(['https://old.example' => 'https://new.example']);
+            $rewriter = new StructuredDataUrlRewriter(['https://old.example' => 'https://new.example'], []);
             $output = $rewriter->rewrite($content, StructuredDataUrlRewriter::BLOCK_MARKUP);
             $this->assertSame($block_count, substr_count($output, '<!-- wp:divi/text '));
             $this->assertSame(2 * $block_count, substr_count($output, 'new.example'));
@@ -172,7 +200,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ['https://network.test/a+b', 'https://network.test/a%20b/photo.jpg', null],
             ['https://network.test/a+b', 'https://network.test/a+b/photo.jpg', 'https://target.test/photo.jpg'],
         ] as [$source, $input, $expected]) {
-            $rewriter = new StructuredDataUrlRewriter([$source => 'https://target.test']);
+            $rewriter = new StructuredDataUrlRewriter([$source => 'https://target.test'], []);
             $this->assertSame('<img src="' . ($expected ?? $input) . '">', $rewriter->rewrite(
                 '<img src="' . $input . '">', StructuredDataUrlRewriter::BLOCK_MARKUP
             ), $input);
@@ -1185,7 +1213,7 @@ class StructuredDataUrlRewriterTest extends TestCase
             ],
             'style element body' => [
                 '<style>.hero{background-image:url(https://old-site.com/hero.jpg)}</style>',
-                '<style>.hero{background-image:url("https://new-site.com/hero.jpg")}</style>',
+                '<style>.hero{background-image:url(https://new-site.com/hero.jpg)}</style>',
             ],
             'meta content attribute' => [
                 '<meta property="og:image" content="https://old-site.com/social.jpg">',

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -1707,6 +1707,43 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     // --- cache bounds ---
 
+    /** The same relative string may be an href, a URL field, or an unrelated setting. */
+    public function testUrlCacheKeepsRelativeUrlContextsSeparate(): void
+    {
+        // The caption's href takes these values through the block parser,
+        // rather than the existing quick reject for URL-free database values.
+        $caption = '<a href="https://other.example/">Other</a>';
+        $cases = [
+            ['<a href="/shop/photo.jpg">Photo</a>', '<a href="/photo.jpg">Photo</a>'],
+            [
+                '<!-- wp:image ' . json_encode(['url' => '/shop/photo.jpg', 'caption' => $caption]) . ' /-->',
+                ['url' => '/photo.jpg', 'caption' => $caption],
+            ],
+            [
+                '<!-- wp:custom ' . json_encode(['label' => '/shop/photo.jpg', 'caption' => $caption]) . ' /-->',
+                ['label' => '/shop/photo.jpg', 'caption' => $caption],
+            ],
+            [
+                '<!-- wp:custom ' . json_encode(['html' => '<a href="/shop/photo.jpg">Photo</a>']) . ' /-->',
+                ['html' => '<a href="/shop/photo.jpg">Photo</a>'],
+            ],
+        ];
+        foreach ([$cases, array_reverse($cases)] as $orderedCases) {
+            $rewriter = new StructuredDataUrlRewriter(['https://source.example/shop' => 'https://target.example']);
+            foreach ($orderedCases as [$input, $expected]) {
+                $output = $rewriter->rewrite_known_block_markup_value($input);
+                if (is_array($expected)) {
+                    $parser = new StructuredBlockMarkupUrlProcessor($output);
+                    $this->assertTrue($parser->next_token());
+                    $this->assertSame($expected, $parser->get_block_attributes());
+                    $this->assertFalse($parser->next_token());
+                } else {
+                    $this->assertSame($expected, $output);
+                }
+            }
+        }
+    }
+
     /** Reads a private member so the bound itself is asserted, not a proxy for it. */
     private function readPrivate(StructuredDataUrlRewriter $rewriter, string $member)
     {

--- a/tests/e2e/benchmark/README.md
+++ b/tests/e2e/benchmark/README.md
@@ -15,12 +15,21 @@ not a CI failure threshold.
 | `html` | HTML links with distinct URLs. |
 | `style-elements` | CSS URLs inside STYLE elements. |
 | `blocks-literal-urls` | Plain URLs inside nested Divi attributes. |
-| `blocks-nested-html` | HTML in `module.content.value`, with distinct URLs. This exercised the raw-JSON fast path removed in #795. |
+| `blocks-nested-html` | HTML in `module.content.value`, with distinct URLs. Ordinary imports keep the raw-JSON fast path; selected-site imports parse the nested strings. |
 | `blocks-repeated-urls` | The same HTML shape with one repeated URL and distinct surrounding text. |
 | `blocks-escaped-quotes` | Nested HTML with JSON `\u0022` quotes. This already needed parsing before #795. |
 | `blocks-encoded-shortcodes` | A nested WPBakery shortcode whose base64 body hides HTML links. |
 | `blocks-no-source-urls` | Distinct block values that need no URL changes. |
 | `serialized-options` | PHP-serialized options, including string-length updates. |
+
+Each corpus runs twice. `url-rewrite-*` uses ordinary import settings.
+`url-rewrite-selected-site-*` selects a multisite migration with no child paths,
+so the report shows the extra format parsing separately. Both modes receive the
+same inputs and must produce the same target content.
+
+Until selected-site rewriting lands on trunk, the trunk side of those extra rows
+uses its ordinary rewrite path as a reference. It does not claim that trunk can
+keep child-site links remote. The URL correctness tests cover those links.
 
 ## Reading the numbers
 
@@ -48,6 +57,7 @@ From the repository root, with dependencies installed:
 ```sh
 node tests/e2e/benchmark/bench-url-rewrite.mjs /absolute/path/to/reprint.phar > urls.json
 php tests/e2e/benchmark/bench-url-rewrite.php /absolute/path/to/checkout blocks-nested-html
+php tests/e2e/benchmark/bench-url-rewrite.php /absolute/path/to/checkout selected-site-blocks-nested-html
 ```
 
 To compare two builds, run the same harness against each PHAR. Do not copy the

--- a/tests/e2e/benchmark/README.md
+++ b/tests/e2e/benchmark/README.md
@@ -31,6 +31,13 @@ Until selected-site rewriting lands on trunk, the trunk side of those extra rows
 uses its ordinary rewrite path as a reference. It does not claim that trunk can
 keep child-site links remote. The URL correctness tests cover those links.
 
+The three `selected-site-child-paths-*` cases also supply a child site at
+`/news/`. Their content points to `/article/...`, so each parsed URL must pass
+the child-path lookup before it can move. Trunk ignores the child-path argument;
+these particular outputs remain comparable because no input points to `/news/`.
+The URL tests separately check matched child links, relative links and dot segments.
+These cases measure lookup misses, not the cost of loading a large site directory.
+
 ## Reading the numbers
 
 Each case contains 128 distinct values with 32 entries each. One PHP process

--- a/tests/e2e/benchmark/README.md
+++ b/tests/e2e/benchmark/README.md
@@ -14,6 +14,7 @@ not a CI failure threshold.
 | --- | --- |
 | `html` | HTML links with distinct URLs. |
 | `style-elements` | CSS URLs inside STYLE elements. |
+| `style-large-value` | 8,192 STYLE elements in one value, exposing repeated whole-value copies. |
 | `blocks-literal-urls` | Plain URLs inside nested Divi attributes. |
 | `blocks-nested-html` | HTML in `module.content.value`, with distinct URLs. Ordinary imports keep the raw-JSON fast path; selected-site imports parse the nested strings. |
 | `blocks-repeated-urls` | The same HTML shape with one repeated URL and distinct surrounding text. |
@@ -40,8 +41,9 @@ These cases measure lookup misses, not the cost of loading a large site director
 
 ## Reading the numbers
 
-Each case contains 128 distinct values with 32 entries each. One PHP process
-runs five samples; the report uses the median. Each sample starts a new rewriter
+Most cases contain 128 distinct values with 32 entries each. `style-large-value`
+uses one value with 8,192 distinct URLs. One PHP process runs five samples; the
+report uses the median. Each sample starts a new rewriter
 and reuses it across the values, as SQL apply does. This includes building the
 URL mapping. PHP startup, fixture creation and output validation are not timed.
 

--- a/tests/e2e/benchmark/bench-url-rewrite.php
+++ b/tests/e2e/benchmark/bench-url-rewrite.php
@@ -7,7 +7,10 @@
 
 require __DIR__ . '/url-rewrite-fixtures.php';
 if (( $argv[1] ?? '' ) === '--list') {
-    echo json_encode(REPRINT_URL_REWRITE_BENCHMARK_CASES) . "\n";
+    echo json_encode(array_merge(
+        REPRINT_URL_REWRITE_BENCHMARK_CASES,
+        array_map(static function ($scenario) { return 'selected-site-' . $scenario; }, REPRINT_URL_REWRITE_BENCHMARK_CASES)
+    )) . "\n";
     exit;
 }
 reprint_benchmark_url_rewrite($argv[1] ?? '', $argv[2] ?? '');
@@ -23,13 +26,16 @@ function reprint_benchmark_url_rewrite(string $build_path, string $scenario): vo
     require $root . '/vendor/autoload.php';
     require $root . '/packages/reprint-client/src/lib/url-rewrite/load.php';
 
+    $selected_site = strpos($scenario, 'selected-site-') === 0;
+    $corpus = $selected_site ? substr($scenario, strlen('selected-site-')) : $scenario;
+
     // Fixed-size corpus; generation, loading PHP and output checks are not timed.
     // Each sample uses fresh caches, then reuses one rewriter across distinct rows,
     // as SQL apply does. Repeating one value would mostly benchmark cache hits.
     $fixtures = [];
     $input_bytes = 0;
     for ($row = 0; $row < 128; ++$row) {
-        $fixture = reprint_url_rewrite_benchmark_fixture($scenario, $row);
+        $fixture = reprint_url_rewrite_benchmark_fixture($corpus, $row);
         $input_bytes += strlen($fixture['input']);
         $fixtures[] = $fixture;
     }
@@ -37,9 +43,15 @@ function reprint_benchmark_url_rewrite(string $build_path, string $scenario): vo
     for ($sample = 0; $sample < 5; ++$sample) {
         $outputs = [];
         $start = hrtime(true);
-        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://destination.example']);
+        $mapping = ['https://source.example' => 'https://destination.example'];
+        // [] selects the multisite parser path even without child paths. Trunk
+        // predates that argument and PHP ignores it there: its ordinary rewrite
+        // is the reference time for the same input and expected output.
+        $rewriter = $selected_site
+            ? new StructuredDataUrlRewriter($mapping, [])
+            : new StructuredDataUrlRewriter($mapping);
         foreach ($fixtures as $fixture) {
-            $outputs[] = $scenario === 'serialized-options'
+            $outputs[] = $corpus === 'serialized-options'
                 ? $rewriter->rewrite($fixture['input'])
                 : $rewriter->rewrite_known_block_markup_value($fixture['input']);
         }

--- a/tests/e2e/benchmark/bench-url-rewrite.php
+++ b/tests/e2e/benchmark/bench-url-rewrite.php
@@ -38,7 +38,8 @@ function reprint_benchmark_url_rewrite(string $build_path, string $scenario): vo
     // as SQL apply does. Repeating one value would mostly benchmark cache hits.
     $fixtures = [];
     $input_bytes = 0;
-    for ($row = 0; $row < 128; ++$row) {
+    $row_count = $corpus === 'style-large-value' ? 1 : 128;
+    for ($row = 0; $row < $row_count; ++$row) {
         $fixture = reprint_url_rewrite_benchmark_fixture($corpus, $row);
         $input_bytes += strlen($fixture['input']);
         $fixtures[] = $fixture;

--- a/tests/e2e/benchmark/bench-url-rewrite.php
+++ b/tests/e2e/benchmark/bench-url-rewrite.php
@@ -9,7 +9,8 @@ require __DIR__ . '/url-rewrite-fixtures.php';
 if (( $argv[1] ?? '' ) === '--list') {
     echo json_encode(array_merge(
         REPRINT_URL_REWRITE_BENCHMARK_CASES,
-        array_map(static function ($scenario) { return 'selected-site-' . $scenario; }, REPRINT_URL_REWRITE_BENCHMARK_CASES)
+        array_map(static function ($scenario) { return 'selected-site-' . $scenario; }, REPRINT_URL_REWRITE_BENCHMARK_CASES),
+        array_map(static function ($scenario) { return 'selected-site-child-paths-' . $scenario; }, REPRINT_URL_REWRITE_CHILD_PATH_BENCHMARK_CASES)
     )) . "\n";
     exit;
 }
@@ -27,7 +28,10 @@ function reprint_benchmark_url_rewrite(string $build_path, string $scenario): vo
     require $root . '/packages/reprint-client/src/lib/url-rewrite/load.php';
 
     $selected_site = strpos($scenario, 'selected-site-') === 0;
-    $corpus = $selected_site ? substr($scenario, strlen('selected-site-')) : $scenario;
+    $with_child_paths = strpos($scenario, 'selected-site-child-paths-') === 0;
+    $prefix = $with_child_paths ? 'selected-site-child-paths-' : 'selected-site-';
+    $corpus = $selected_site ? substr($scenario, strlen($prefix)) : $scenario;
+    $child_paths = $with_child_paths ? ['https://source.example' => ['/news/']] : [];
 
     // Fixed-size corpus; generation, loading PHP and output checks are not timed.
     // Each sample uses fresh caches, then reuses one rewriter across distinct rows,
@@ -44,11 +48,11 @@ function reprint_benchmark_url_rewrite(string $build_path, string $scenario): vo
         $outputs = [];
         $start = hrtime(true);
         $mapping = ['https://source.example' => 'https://destination.example'];
-        // [] selects the multisite parser path even without child paths. Trunk
+        // An array selects the multisite parser path, even when empty. Trunk
         // predates that argument and PHP ignores it there: its ordinary rewrite
         // is the reference time for the same input and expected output.
         $rewriter = $selected_site
-            ? new StructuredDataUrlRewriter($mapping, [])
+            ? new StructuredDataUrlRewriter($mapping, $child_paths)
             : new StructuredDataUrlRewriter($mapping);
         foreach ($fixtures as $fixture) {
             $outputs[] = $corpus === 'serialized-options'

--- a/tests/e2e/benchmark/url-rewrite-fixtures.php
+++ b/tests/e2e/benchmark/url-rewrite-fixtures.php
@@ -5,6 +5,7 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupProcessor;
 const REPRINT_URL_REWRITE_BENCHMARK_CASES = [
     'html',
     'style-elements',
+    'style-large-value',
     'blocks-literal-urls',
     'blocks-nested-html',
     'blocks-repeated-urls',
@@ -37,7 +38,10 @@ function reprint_url_rewrite_benchmark_fixture(string $scenario, int $row): arra
     $expected = strpos($scenario, 'blocks-') === 0 ? [] : '';
     $source_values = [];
     $target_values = [];
-    for ($block = 0; $block < 32; ++$block) {
+    // One large value exposes repeated whole-HTML copies which small rows hide.
+    // It also crosses the HTML parser's 1,000-edit batch limit several times.
+    $entry_count = $scenario === 'style-large-value' ? 8192 : 32;
+    for ($block = 0; $block < $entry_count; ++$block) {
         $id = $row * 32 + $block;
         $url_id = $scenario === 'blocks-repeated-urls' ? 0 : $id;
         $source = 'https://source.example/article/' . $url_id;
@@ -51,6 +55,7 @@ function reprint_url_rewrite_benchmark_fixture(string $scenario, int $row): arra
                 $expected .= $target_html;
                 continue 2;
             case 'style-elements':
+            case 'style-large-value':
                 $input .= '<style>.article-' . $id . '{background:url("' . $source . '")}</style>';
                 $expected .= '<style>.article-' . $id . '{background:url("' . $target . '")}</style>';
                 continue 2;

--- a/tests/e2e/benchmark/url-rewrite-fixtures.php
+++ b/tests/e2e/benchmark/url-rewrite-fixtures.php
@@ -14,6 +14,14 @@ const REPRINT_URL_REWRITE_BENCHMARK_CASES = [
     'serialized-options',
 ];
 
+// These corpora use declared URL fields. A child-path lookup can distinguish
+// /article/... from /news/...; opaque strings deliberately cannot do that.
+const REPRINT_URL_REWRITE_CHILD_PATH_BENCHMARK_CASES = [
+    'style-elements',
+    'blocks-nested-html',
+    'blocks-repeated-urls',
+];
+
 /**
  * Build one post or option. IDs vary both the value and its URLs so whole-value
  * cache hits cannot hide parsing costs. The repeated-URL case varies only text.


### PR DESCRIPTION
Keeps child-site links at the source when migrating one network site, without sending ordinary imports through the extra parsers.

## Example

Move `https://network.test/shop` to `https://target.test`. `/shop/news` is a separate site:

```html
<!-- Before -->
<a href="https://network.test/shop/article">Shop</a>
<a href="https://network.test/shop/news/article">News</a>

<!-- After -->
<a href="https://target.test/article">Shop</a>
<a href="https://network.test/shop/news/article">News</a>
```

Selected-site imports parse CSS bodies and nested block strings before checking child paths. Path segments and ports must match; `/sites/7` cannot select `/sites/70`. Unknown text on a host with child-path exclusions stays unchanged.

Selected-site block comments use one rewrite walk through their decoded attributes. The same walk handles top-level URL fields and nested strings, then gives the changed tree back to the block parser. The known relative-URL rules and extension hook stay shared with ordinary imports. There is no list of nested attribute paths.

Ordinary imports keep trunk's raw-text paths for STYLE bodies and ordinary block attributes. Encoded block values still use the existing format checks. PR #770 will pass the saved multisite selection to this rewriter, even when the selected site has no child paths. Until then, importer calls keep the ordinary path. No new CLI option or saved mode flag.

JSON script bodies are selected using MIME type and subtype rules, including `text/json` and `model/gltf+json`. Parameters do not affect that choice. Invalid type names stay on the raw-text path. The type check does not copy or parse the parameter tail.

The bounded URL cache is checked before parsing. HTML attributes still escape target quotes at the output boundary. Both are shared with ordinary imports; neither requires the extra CSS or nested-block walk.

## Performance

Selected-site HTML without block comments now uses the HTML parser directly. URL fields share one rewrite function and the existing bounded cache. The cautious text scan runs once on the completed HTML, rather than copying and scanning each token. Documents, incomplete markup and source bases containing literal HTML syntax keep the token-by-token path.

Local PHP 8.5.10 measurements use the same inputs and five checked samples for each build:

| Case | Previous PR head | This change | Trunk |
| --- | ---: | ---: | ---: |
| STYLE bodies, small values | 82 ms | 66 ms | 22 ms |
| 8,192 STYLE elements in one value | 327 ms | 222 ms | 202 ms |
| Nested Divi HTML | 111 ms | 76 ms | 39 ms |
| Repeated nested links | 91 ms | 59 ms | 39 ms |

The large-value case is now in CI. There are 23 checked URL cases, including ordinary imports and selected-site imports. Three cases also supply a child at `/news/` while rewriting `/article/...`; these measure lookup misses. Trunk cannot keep child-site links remote, so its ordinary rewrite is the reference for these identical inputs and expected outputs.

[CI on PHP 8.5.10](https://github.com/WordPress/reprint/actions/runs/34752690258) passes all 23 URL cases. In that run, the large-value case takes 590 ms against trunk's 629 ms. Small STYLE values remain 3.7 times trunk's time; nested HTML is 2.3 times and repeated nested links 1.8 times. Ordinary cases range from 26.8% faster to 0.1% slower than trunk.

The repeated HTML-copy cost is reduced; CSS parsing still costs more than trunk's raw scan on small values. The [full CI comparison](https://github.com/WordPress/reprint/pull/795#issuecomment-5626690274) includes all five samples and peak memory. The local before/after table above isolates the HTML-copy optimization; separate CI runs have different baseline speeds.

The subsequent one-walk block change was also compared locally against `82d3653c` on PHP 8.5.10. All 23 existing benchmark outputs match. A selected-site probe with top-level URLs and nested HTML takes 109 ms instead of 129 ms; with child-path exclusions it takes 111 ms instead of 130 ms. Peak memory stays at 46 MiB. Ordinary benchmark cases stay within 3.1% of the previous head.

## Checks

538 local URL tests, 3,350 assertions, on PHP 8.4 and 8.5. Seven skips and three incomplete tests remain. All 23 benchmark outputs match on the previous head, this change and trunk. PHPStan passes and PHPCS counts do not increase.

Tests cover CSS escapes, child paths, ports, relative-URL cache separation, unchanged attribute quoting, incomplete HTML, 5,000 blocks and 3,000 STYLE elements under a 64 MiB limit. No new cache. The source-base HTML delimiter check uses a byte count instead of copying the matching suffix. Rewriting still holds one complete database value. Cache budgets remain 4 MiB for URLs and 32 MiB for values.

Stack: **#795** → #796 → #797 → #770 → #798 → #774 → #775 → #778.
