### PR TITLE
Report per-case URL rewrite speed on every PR

### DIFF
--- a/.github/workflows/perf-history-backfill.yml
+++ b/.github/workflows/perf-history-backfill.yml
@@ -142,7 +142,7 @@ jobs:
               cd host/tests/e2e
               sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file
               sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock
-              CLIENT_PATH="$GITHUB_WORKSPACE/src-historical/reprint.phar" \
+              IMPORTER_PATH="$GITHUB_WORKSPACE/src-historical/reprint.phar" \
               E2E_SERVER_PROJECT_ROOT="$GITHUB_WORKSPACE/src-historical" \
               BENCH_LABEL=backfill \
               BENCH_JSON_OUT="$GITHUB_WORKSPACE/bench.json" \

--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Bench trunk
         working-directory: tests/e2e
         env:
-          CLIENT_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
+          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
           BENCH_LABEL: trunk
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -121,6 +121,9 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Test benchmark reporting
+        run: node --test tests/e2e/benchmark/*.test.mjs
+
       # PHP comes from the runner's pre-cached toolcache via this
       # action; we don't try to apt-install ondrej/php ourselves
       # because every Launchpad endpoint flakes regularly.
@@ -150,7 +153,7 @@ jobs:
       - name: Bench PR
         working-directory: tests/e2e
         env:
-          CLIENT_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
           BENCH_LABEL: pr
           BENCH_JSON_OUT: bench-pr.json
           BENCH_MD_OUT: bench-pr.md
@@ -174,7 +177,7 @@ jobs:
       - name: Bench trunk
         working-directory: tests/e2e
         env:
-          CLIENT_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
+          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
           BENCH_LABEL: trunk
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md
@@ -182,7 +185,7 @@ jobs:
           E2E_SERVER_PROJECT_ROOT: ${{ github.workspace }}
           BENCH_SEED_POSTS: '10000'
           BENCH_SEED_POSTMETA: '25000'
-          BENCH_PREFLIGHT_CLIENT_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_PREFLIGHT_IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
           BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
           PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
           PLAYGROUND_PHP_VERSION: '8.3'

--- a/tests/UrlRewriting/BenchmarkCorpusTest.php
+++ b/tests/UrlRewriting/BenchmarkCorpusTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../packages/reprint-client/src/lib/url-rewrite/load.php';
+require_once __DIR__ . '/../e2e/benchmark/url-rewrite-fixtures.php';
+
+class BenchmarkCorpusTest extends TestCase {
+    /** Each measured case must produce its complete expected target value. */
+    #[DataProvider('benchmarkCases')]
+    public function testBenchmarkCorpusRewritesWithoutLosingContent(string $scenario): void
+    {
+        $fixture = reprint_url_rewrite_benchmark_fixture($scenario, 7);
+        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://destination.example']);
+        $output = $scenario === 'serialized-options'
+            ? $rewriter->rewrite($fixture['input'])
+            : $rewriter->rewrite_known_block_markup_value($fixture['input']);
+
+        reprint_check_url_rewrite_benchmark_output($output, $fixture['expected']);
+        $next = reprint_url_rewrite_benchmark_fixture($scenario, 8);
+        $this->assertNotSame($fixture['input'], $next['input'], 'Rows must not become whole-value cache hits.');
+    }
+
+    /** Skipped rewrites and changed non-URL text cannot earn a fast result. */
+    #[DataProvider('benchmarkCases')]
+    public function testBenchmarkRejectsIncorrectOutput(string $scenario): void
+    {
+        $fixture = reprint_url_rewrite_benchmark_fixture($scenario, 7);
+        $incorrect = $scenario === 'blocks-no-source-urls'
+            ? str_replace('Article', 'Changed', $fixture['input'])
+            : $fixture['input'];
+        $this->expectException(RuntimeException::class);
+        reprint_check_url_rewrite_benchmark_output($incorrect, $fixture['expected']);
+    }
+
+    /** Duplicate or omitted blocks are invalid even when their URLs are correct. */
+    public function testBenchmarkRejectsDuplicateAndMissingBlocks(): void
+    {
+        $fixture = reprint_url_rewrite_benchmark_fixture('blocks-no-source-urls', 7);
+        foreach (['', $fixture['input'] . $fixture['input']] as $output) {
+            try {
+                reprint_check_url_rewrite_benchmark_output($output, $fixture['expected']);
+                $this->fail('The benchmark accepted missing or duplicate blocks.');
+            } catch (RuntimeException $error) {
+                $this->assertStringContainsString('expected target content', $error->getMessage());
+            }
+        }
+    }
+
+    /** Keep the runner's case list and the corpus checks aligned. */
+    public static function benchmarkCases(): array
+    {
+        $output = [];
+        foreach (REPRINT_URL_REWRITE_BENCHMARK_CASES as $scenario) {
+            $output[$scenario] = [$scenario];
+        }
+        return $output;
+    }
+}

--- a/tests/e2e/benchmark/README.md
+++ b/tests/e2e/benchmark/README.md
@@ -5,6 +5,11 @@ Every PR runs these cases in addition to the pipeline stages selected by
 change in the existing performance comment. JSON artifacts retain all five
 samples and the path of the implementation loaded from each build.
 
+Changes above 5% in either direction stay visible. Changes of 5% or less go in
+a collapsed second table. Each row's detailed metrics are also collapsed.
+Failed or unavailable comparisons stay visible. This is a display threshold,
+not a CI failure threshold.
+
 | Case | What it measures |
 | --- | --- |
 | `html` | HTML links with distinct URLs. |

--- a/tests/e2e/benchmark/README.md
+++ b/tests/e2e/benchmark/README.md
@@ -1,0 +1,54 @@
+# URL rewriting in the performance report
+
+Every PR runs these cases in addition to the pipeline stages selected by
+`focused-stages.txt`. Each case has its own PR time, trunk time and percentage
+change in the existing performance comment. JSON artifacts retain all five
+samples and the path of the implementation loaded from each build.
+
+| Case | What it measures |
+| --- | --- |
+| `html` | HTML links with distinct URLs. |
+| `style-elements` | CSS URLs inside STYLE elements. |
+| `blocks-literal-urls` | Plain URLs inside nested Divi attributes. |
+| `blocks-nested-html` | HTML in `module.content.value`, with distinct URLs. This exercised the raw-JSON fast path removed in #795. |
+| `blocks-repeated-urls` | The same HTML shape with one repeated URL and distinct surrounding text. |
+| `blocks-escaped-quotes` | Nested HTML with JSON `\u0022` quotes. This already needed parsing before #795. |
+| `blocks-encoded-shortcodes` | A nested WPBakery shortcode whose base64 body hides HTML links. |
+| `blocks-no-source-urls` | Distinct block values that need no URL changes. |
+| `serialized-options` | PHP-serialized options, including string-length updates. |
+
+## Reading the numbers
+
+Each case contains 128 distinct values with 32 entries each. One PHP process
+runs five samples; the report uses the median. Each sample starts a new rewriter
+and reuses it across the values, as SQL apply does. This includes building the
+URL mapping. PHP startup, fixture creation and output validation are not timed.
+
+Every result must match the expected target content. Blocks are compared after
+JSON decoding so harmless JSON formatting changes are allowed. Missing blocks,
+duplicate blocks, changed labels and skipped rewrites fail the benchmark. Failed
+results get no speed delta. These checks do not replace the URL correctness suite.
+
+The inputs use one source-to-target mapping. They do not measure child-path list
+construction, large mapping sets, database I/O or full imports. Peak memory is for
+the whole case process, including fixtures and validation. Timings use native PHP;
+they do not establish PHP.wasm speed. Compare individual rows and their five
+samples, not just the combined total. There is no hard slowdown threshold: runner
+noise still needs review.
+
+## Run without WordPress or MySQL
+
+From the repository root, with dependencies installed:
+
+```sh
+node tests/e2e/benchmark/bench-url-rewrite.mjs /absolute/path/to/reprint.phar > urls.json
+php tests/e2e/benchmark/bench-url-rewrite.php /absolute/path/to/checkout blocks-nested-html
+```
+
+To compare two builds, run the same harness against each PHAR. Do not copy the
+benchmark from each build: that could compare different inputs. The CI pipeline
+uses `IMPORTER_PATH` to select the actual build; it must not silently benchmark the
+checked-out source for both PR and trunk.
+
+Save the two runs as `bench-pr.json` and `bench-trunk.json`, then run
+`node tests/e2e/benchmark/render-diff.mjs` to produce the comparison table.

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -25,6 +25,7 @@ import { performance } from 'node:perf_hooks';
 import { createConnection } from 'mysql2/promise';
 import { ensureSite } from '../lib/site-setup.js';
 import { HmacClient } from '../lib/hmac-client.js';
+import { runUrlRewriteBenchmarks } from './bench-url-rewrite.mjs';
 import {
     getSiteUrl, getSiteSecret, getSiteDir, fsRootDir,
 } from '../lib/test-helpers.js';
@@ -612,8 +613,8 @@ async function main() {
 
     // Optional stage filter — when BENCH_STAGES is set (comma-separated
     // list of stage names), only those stages run on both sides of the
-    // PR-vs-trunk comparison. This is how each PR limits its perf comment
-    // to the single scenario it actually changes.
+    // PR-vs-trunk comparison. URL cases below always run; a focused pipeline
+    // measurement must not remove the URL comparison from other PRs.
     const stageFilter = (process.env.BENCH_STAGES || '')
         .split(',')
         .map((s) => s.trim())
@@ -718,6 +719,15 @@ async function main() {
         });
         results.push(largePartPull);
         console.log(`   ${largePartPull.ok ? 'ok' : 'FAIL'} in ${fmtMs(largePartPull.elapsedMs)} (${fmtDetails(largePartPull.details)})`);
+    }
+
+    // Load library code from the selected PHAR, not from this harness checkout.
+    // Local source runs use the checkout root instead of the CLI entry point.
+    const urlBuild = IMPORTER_PATH.endsWith('.phar') ? IMPORTER_PATH : join(dirname(IMPORTER_PATH), '../../..');
+    const urlResults = runUrlRewriteBenchmarks(urlBuild, PHP_BINARY);
+    results.push(...urlResults);
+    for (const result of urlResults) {
+        console.log(`-> ${result.stage}: ${result.ok ? fmtMs(result.elapsedMs) : result.stderr}`);
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();

--- a/tests/e2e/benchmark/bench-url-rewrite.mjs
+++ b/tests/e2e/benchmark/bench-url-rewrite.mjs
@@ -1,0 +1,34 @@
+/** Run the same URL corpus against the selected build, independently of stage filters. */
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Each case gets a new PHP process so its peak memory does not include other cases. */
+export function runUrlRewriteBenchmarks(build, phpBinary = process.env.PHP_BINARY || 'php') {
+    const script = resolve(dirname(fileURLToPath(import.meta.url)), 'bench-url-rewrite.php');
+    const urlRewriteCases = JSON.parse(execFileSync(phpBinary, [script, '--list'], { encoding: 'utf8' }));
+    return urlRewriteCases.map(scenario => {
+        try {
+            const output = execFileSync(phpBinary, ['-d', 'memory_limit=256M', script, resolve(build), scenario], {
+                encoding: 'utf8', timeout: 120_000, maxBuffer: 1024 * 1024,
+            });
+            return JSON.parse(output);
+        } catch (error) {
+            // A broken result is never a speed improvement. Keep the other cases
+            // in the report, but let the caller fail the benchmark job.
+            return {
+                stage: 'url-rewrite-' + scenario, elapsedMs: 0, attempts: 1,
+                ok: false, exitCode: error.status ?? 1,
+                stderr: String(error.stderr || error.message).slice(-2000),
+            };
+        }
+    });
+}
+
+// This entry point needs no WordPress, database or network setup.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    const results = runUrlRewriteBenchmarks(process.argv[2] || resolve(dirname(fileURLToPath(import.meta.url)), '../../..'));
+    const meta = { site: 'URL corpus', fileCount: 0, phpVersion: results.find(result => result.ok)?.phpVersion || 'unknown' };
+    console.log(JSON.stringify({ meta, results }, null, 2));
+    if (results.some(result => !result.ok)) process.exitCode = 1;
+}

--- a/tests/e2e/benchmark/bench-url-rewrite.php
+++ b/tests/e2e/benchmark/bench-url-rewrite.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Time one corpus against an explicit checkout or PHAR. The harness and inputs
+ * stay outside that build, so both sides use exactly the same benchmark.
+ * Usage: php bench-url-rewrite.php /absolute/path/to/reprint.phar blocks-nested-html
+ */
+
+require __DIR__ . '/url-rewrite-fixtures.php';
+if (( $argv[1] ?? '' ) === '--list') {
+    echo json_encode(REPRINT_URL_REWRITE_BENCHMARK_CASES) . "\n";
+    exit;
+}
+reprint_benchmark_url_rewrite($argv[1] ?? '', $argv[2] ?? '');
+
+/** Load one build and report five checked samples for one named corpus. */
+function reprint_benchmark_url_rewrite(string $build_path, string $scenario): void
+{
+    $build = realpath($build_path);
+    if (!$build) {
+        throw new InvalidArgumentException('The URL benchmark needs an existing checkout or PHAR path.');
+    }
+    $root = is_dir($build) ? $build : 'phar://' . $build;
+    require $root . '/vendor/autoload.php';
+    require $root . '/packages/reprint-client/src/lib/url-rewrite/load.php';
+
+    // Fixed-size corpus; generation, loading PHP and output checks are not timed.
+    // Each sample uses fresh caches, then reuses one rewriter across distinct rows,
+    // as SQL apply does. Repeating one value would mostly benchmark cache hits.
+    $fixtures = [];
+    $input_bytes = 0;
+    for ($row = 0; $row < 128; ++$row) {
+        $fixture = reprint_url_rewrite_benchmark_fixture($scenario, $row);
+        $input_bytes += strlen($fixture['input']);
+        $fixtures[] = $fixture;
+    }
+    $samples = [];
+    for ($sample = 0; $sample < 5; ++$sample) {
+        $outputs = [];
+        $start = hrtime(true);
+        $rewriter = new StructuredDataUrlRewriter(['https://source.example' => 'https://destination.example']);
+        foreach ($fixtures as $fixture) {
+            $outputs[] = $scenario === 'serialized-options'
+                ? $rewriter->rewrite($fixture['input'])
+                : $rewriter->rewrite_known_block_markup_value($fixture['input']);
+        }
+        $samples[] = ( hrtime(true) - $start ) / 1e6;
+        foreach ($fixtures as $row => $fixture) {
+            reprint_check_url_rewrite_benchmark_output($outputs[$row], $fixture['expected']);
+        }
+        unset($rewriter, $outputs);
+    }
+    $sorted_samples = $samples;
+    sort($sorted_samples);
+    echo json_encode([
+        'stage' => 'url-rewrite-' . $scenario,
+        'elapsedMs' => $sorted_samples[2],
+        'samplesMs' => $samples,
+        'attempts' => 1,
+        'ok' => true,
+        'phpVersion' => PHP_VERSION,
+        'details' => [
+            'rows' => count($fixtures),
+            'input_MiB' => round($input_bytes / 1048576, 2),
+            'MiB_per_second' => round($input_bytes / 1048576 / ( $sorted_samples[2] / 1000 ), 2),
+            'sample_ms' => implode(', ', array_map(static function ($ms) { return round($ms, 1); }, $samples)),
+            'peak_MiB' => round(memory_get_peak_usage(true) / 1048576, 2),
+        ],
+        'implementation' => ( new ReflectionClass(StructuredDataUrlRewriter::class) )->getFileName(),
+    ], JSON_THROW_ON_ERROR) . "\n";
+}

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -1,10 +1,8 @@
-# Stages this PR's perf comment will benchmark.
+# Pipeline stages the perf comment will benchmark, in addition to all URL cases.
 # One stage name per line; comments and blank lines ignored.
 # Both the PR build and the trunk baseline run the same set, so the
 # table shows two like-for-like wall-time numbers per row.
 #
-# This PR loads the Rust wp_mysql_parser PHP.wasm extension for the PR side
-# and leaves it disabled for the trunk baseline. Both sides use the same
-# direct PHP.wasm runner so the wall-time delta isolates the extension.
+# Both builds use the same PHP.wasm runner and Rust parser extension settings.
 playground-sqlite-db-pull
 playground-sqlite-db-apply

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -68,15 +68,17 @@ if (base) {
         const t = baseByStage[r.stage];
         prTotal += r.elapsedMs;
         if (t) baseTotal += t.elapsedMs;
-        const delta = t ? fmtDelta(r.elapsedMs, t.elapsedMs) : '—';
-        const status = r.ok ? '✓' : '✗ exit ' + r.exitCode;
+        const delta = t && r.ok && t.ok ? fmtDelta(r.elapsedMs, t.elapsedMs) : '—';
+        const status = !r.ok ? '✗ PR exit ' + r.exitCode
+            : t && !t.ok ? '✗ ' + baselineLabel + ' exit ' + t.exitCode : '✓';
         const details = [
             fmtDetails(r.details),
             t && fmtDetails(t.details) ? `${baselineLabel}: ${fmtDetails(t.details)}` : '',
         ].filter(Boolean).join('<br>');
         lines.push(`| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${t ? fmtMs(t.elapsedMs) : '—'} | ${delta} | ${status} | ${details} |`);
     }
-    lines.push(`| **Total** | **${fmtMs(prTotal)}** | **${fmtMs(baseTotal)}** | **${fmtDelta(prTotal, baseTotal)}** | | |`);
+    const comparable = pr.results.every(result => result.ok && baseByStage[result.stage]?.ok);
+    lines.push(`| **Total** | **${fmtMs(prTotal)}** | **${fmtMs(baseTotal)}** | **${comparable ? fmtDelta(prTotal, baseTotal) : '—'}** | | |`);
 } else {
     lines.push(`_${baselineLabel} baseline unavailable — showing PR numbers only._`);
     lines.push('');
@@ -92,6 +94,10 @@ if (base) {
 
 lines.push('');
 lines.push('<sub>Numbers carry runner noise; treat single-run deltas as directional, not authoritative.</sub>');
+if (pr.results.some(result => result.stage.startsWith('url-rewrite-'))) {
+    lines.push('');
+    lines.push('URL rows show the median of five samples, using the same inputs and PHP binary for both builds. Each sample starts with fresh caches and reuses one rewriter across 128 distinct values. Input generation and output checks are outside the timer. Every output must pass before a speed is reported.');
+}
 
 const historyUrl = (() => {
     if (process.env.PERF_HISTORY_URL) return process.env.PERF_HISTORY_URL;

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -1,7 +1,7 @@
 /**
- * Combine PR and baseline bench results into a single markdown table with
- * per-stage deltas. Reads bench-pr.json and bench-base.json (legacy:
- * bench-trunk.json), writes bench-results.md. The baseline label defaults
+ * Compare PR and baseline timings, with changes of 5% or less collapsed.
+ * Reads bench-pr.json and bench-trunk.json, writes bench-results.md.
+ * The baseline label defaults
  * to "trunk" but can be overridden with BASELINE_LABEL — that's how stacked
  * PRs report their incremental impact against the parent branch.
  */
@@ -13,24 +13,33 @@ function fmtMs(ms) {
 }
 
 function fmtDelta(prMs, baseMs) {
+    if (baseMs <= 0) return '—';
     const diff = prMs - baseMs;
-    const pct = baseMs > 0 ? (diff / baseMs) * 100 : 0;
+    const pct = (diff / baseMs) * 100;
     const sign = diff >= 0 ? '+' : '';
     const abs = `${sign}${fmtMs(Math.abs(diff)).replace(/^/, diff < 0 ? '-' : '')}`;
-    // Simple visual cue: 🟢 ≥10% faster, 🔴 ≥10% slower, ⚪ otherwise.
+    // Match the table split: 🟢 more than 5% faster, 🔴 more than 5% slower.
     let marker = '⚪';
-    if (Math.abs(pct) >= 10 && Math.abs(diff) >= 50) {
+    if (Math.abs(pct) > 5) {
         marker = diff < 0 ? '🟢' : '🔴';
     }
     return `${marker} ${abs} (${sign}${pct.toFixed(1)}%)`;
 }
 
-function fmtDetails(details) {
-    if (!details || typeof details !== 'object') return '';
-    return Object.entries(details)
-        .filter(([, value]) => value !== null && value !== undefined && value !== '')
-        .map(([key, value]) => `${key}=${String(value).replaceAll('|', '/')}`)
-        .join('<br>');
+/** Keep both builds' metrics in one closed disclosure without breaking the table cell. */
+function fmtDetails(details, baselineDetails) {
+    const text = [['PR', details], [baselineLabel, baselineDetails]].map(([label, values]) => {
+        if (!values || typeof values !== 'object') return '';
+        const metrics = Object.entries(values)
+            .filter(([, value]) => value !== null && value !== undefined && value !== '')
+            .map(([key, value]) => `${key}=${String(value)}`)
+            .join('\n');
+        return metrics ? `${label}:\n${metrics}` : '';
+    }).filter(Boolean).join('\n');
+    if (!text) return '';
+    const html = text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+        .replaceAll('|', '&#124;').replace(/\r\n|\r|\n/g, '<br>');
+    return `<details><summary>Metrics</summary>${html}</details>`;
 }
 
 const prPath = process.env.PR_JSON || 'bench-pr.json';
@@ -58,9 +67,12 @@ lines.push('');
 lines.push('');
 
 if (base) {
-    lines.push('');
-    lines.push(`| Stage | PR | ${baselineLabel} | Δ | Status | Details |`);
-    lines.push('|---|---:|---:|---:|---|---|');
+    const tableHeader = [
+        `| Stage | PR | ${baselineLabel} | Δ | Status | Details |`,
+        '|---|---:|---:|---:|---|---|',
+    ];
+    const visibleRows = [];
+    const smallChangeRows = [];
     const baseByStage = Object.fromEntries(base.results.map((r) => [r.stage, r]));
     let prTotal = 0;
     let baseTotal = 0;
@@ -68,17 +80,32 @@ if (base) {
         const t = baseByStage[r.stage];
         prTotal += r.elapsedMs;
         if (t) baseTotal += t.elapsedMs;
-        const delta = t && r.ok && t.ok ? fmtDelta(r.elapsedMs, t.elapsedMs) : '—';
+        const comparable = t && r.ok && t.ok && t.elapsedMs > 0;
+        const delta = comparable ? fmtDelta(r.elapsedMs, t.elapsedMs) : '—';
         const status = !r.ok ? '✗ PR exit ' + r.exitCode
-            : t && !t.ok ? '✗ ' + baselineLabel + ' exit ' + t.exitCode : '✓';
-        const details = [
-            fmtDetails(r.details),
-            t && fmtDetails(t.details) ? `${baselineLabel}: ${fmtDetails(t.details)}` : '',
-        ].filter(Boolean).join('<br>');
-        lines.push(`| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${t ? fmtMs(t.elapsedMs) : '—'} | ${delta} | ${status} | ${details} |`);
+            : !t ? '— No ' + baselineLabel + ' result'
+            : !t.ok ? '✗ ' + baselineLabel + ' exit ' + t.exitCode
+            : t.elapsedMs <= 0 ? '— Zero ' + baselineLabel + ' time' : '✓';
+        const row = `| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${t ? fmtMs(t.elapsedMs) : '—'} | ${delta} | ${status} | ${fmtDetails(r.details, t?.details)} |`;
+        // Failed or missing comparisons need attention even when their recorded time is zero.
+        if (comparable && Math.abs((r.elapsedMs - t.elapsedMs) / t.elapsedMs * 100) <= 5) {
+            smallChangeRows.push(row);
+        } else {
+            visibleRows.push(row);
+        }
     }
-    const comparable = pr.results.every(result => result.ok && baseByStage[result.stage]?.ok);
-    lines.push(`| **Total** | **${fmtMs(prTotal)}** | **${fmtMs(baseTotal)}** | **${comparable ? fmtDelta(prTotal, baseTotal) : '—'}** | | |`);
+    if (visibleRows.length) {
+        lines.push('### Changes above 5% or unavailable comparisons', '', ...tableHeader, ...visibleRows);
+    } else {
+        lines.push('No changes above 5%.');
+    }
+    if (smallChangeRows.length) {
+        // Blank lines let GitHub parse the Markdown table inside the HTML disclosure.
+        lines.push('', '<details>', `<summary>Changes of 5% or less (${smallChangeRows.length})</summary>`,
+            '', ...tableHeader, ...smallChangeRows, '', '</details>');
+    }
+    const comparable = pr.results.every(result => result.ok && baseByStage[result.stage]?.ok && baseByStage[result.stage].elapsedMs > 0);
+    lines.push('', `**Total:** PR ${fmtMs(prTotal)} · ${baselineLabel} ${fmtMs(baseTotal)} · ${comparable ? fmtDelta(prTotal, baseTotal) : '—'}`);
 } else {
     lines.push(`_${baselineLabel} baseline unavailable — showing PR numbers only._`);
     lines.push('');

--- a/tests/e2e/benchmark/render-diff.test.mjs
+++ b/tests/e2e/benchmark/render-diff.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+/** Exercise the report CLI with saved measurements, without timing a fake rewriter. */
+function renderReport(context, prResult, baselineResult) {
+    const directory = mkdtempSync(join(tmpdir(), 'reprint-benchmark-report-'));
+    context.after(() => rmSync(directory, { recursive: true, force: true }));
+    const meta = { site: 'large-directory', fileCount: 2000, phpVersion: '8.5' };
+    writeFileSync(join(directory, 'pr.json'), JSON.stringify({ meta, results: [prResult] }));
+    if (baselineResult) {
+        writeFileSync(join(directory, 'baseline.json'), JSON.stringify({ meta, results: [baselineResult] }));
+    }
+    execFileSync(process.execPath, [fileURLToPath(new URL('./render-diff.mjs', import.meta.url))], {
+        env: {
+            ...process.env, PR_JSON: join(directory, 'pr.json'), TRUNK_JSON: join(directory, 'baseline.json'),
+            OUT_MD: join(directory, 'report.md'), BASELINE_LABEL: 'trunk',
+        },
+    });
+    return readFileSync(join(directory, 'report.md'), 'utf8');
+}
+
+test('URL cases display their own slowdown, not just the combined total', context => {
+    const report = renderReport(context,
+        { stage: 'url-rewrite-blocks-nested-html', elapsedMs: 900, ok: true },
+        { stage: 'url-rewrite-blocks-nested-html', elapsedMs: 60, ok: true });
+    assert.match(report, /url-rewrite-blocks-nested-html.*900 ms.*60 ms.*\+840 ms \(\+1400\.0%\)/);
+    assert.match(report, /median of five samples/);
+});
+
+for (const failedSide of ['pr', 'baseline']) {
+    test(`${failedSide} output failure cannot appear as a speed improvement`, context => {
+        const passed = { stage: 'url-rewrite-html', elapsedMs: 1000, ok: true };
+        const failed = { stage: 'url-rewrite-html', elapsedMs: 0, ok: false, exitCode: 1 };
+        const report = renderReport(context,
+            failedSide === 'pr' ? failed : passed, failedSide === 'baseline' ? failed : passed);
+        assert.match(report, /✗ (PR|trunk) exit 1/);
+        assert.doesNotMatch(report, /🟢|🔴|⚪/);
+    });
+}
+
+test('a missing baseline is reported without inventing a zero time', context => {
+    const report = renderReport(context, { stage: 'url-rewrite-html', elapsedMs: 1000, attempts: 1, ok: true });
+    assert.match(report, /trunk baseline unavailable/);
+    assert.doesNotMatch(report, /🟢|🔴|⚪/);
+});

--- a/tests/e2e/benchmark/render-diff.test.mjs
+++ b/tests/e2e/benchmark/render-diff.test.mjs
@@ -7,13 +7,13 @@ import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 
 /** Exercise the report CLI with saved measurements, without timing a fake rewriter. */
-function renderReport(context, prResult, baselineResult) {
+function renderReport(context, prResults, baselineResults) {
     const directory = mkdtempSync(join(tmpdir(), 'reprint-benchmark-report-'));
     context.after(() => rmSync(directory, { recursive: true, force: true }));
     const meta = { site: 'large-directory', fileCount: 2000, phpVersion: '8.5' };
-    writeFileSync(join(directory, 'pr.json'), JSON.stringify({ meta, results: [prResult] }));
-    if (baselineResult) {
-        writeFileSync(join(directory, 'baseline.json'), JSON.stringify({ meta, results: [baselineResult] }));
+    writeFileSync(join(directory, 'pr.json'), JSON.stringify({ meta, results: prResults }));
+    if (baselineResults) {
+        writeFileSync(join(directory, 'baseline.json'), JSON.stringify({ meta, results: baselineResults }));
     }
     execFileSync(process.execPath, [fileURLToPath(new URL('./render-diff.mjs', import.meta.url))], {
         env: {
@@ -26,8 +26,8 @@ function renderReport(context, prResult, baselineResult) {
 
 test('URL cases display their own slowdown, not just the combined total', context => {
     const report = renderReport(context,
-        { stage: 'url-rewrite-blocks-nested-html', elapsedMs: 900, ok: true },
-        { stage: 'url-rewrite-blocks-nested-html', elapsedMs: 60, ok: true });
+        [{ stage: 'url-rewrite-blocks-nested-html', elapsedMs: 900, ok: true }],
+        [{ stage: 'url-rewrite-blocks-nested-html', elapsedMs: 60, ok: true }]);
     assert.match(report, /url-rewrite-blocks-nested-html.*900 ms.*60 ms.*\+840 ms \(\+1400\.0%\)/);
     assert.match(report, /median of five samples/);
 });
@@ -37,14 +37,87 @@ for (const failedSide of ['pr', 'baseline']) {
         const passed = { stage: 'url-rewrite-html', elapsedMs: 1000, ok: true };
         const failed = { stage: 'url-rewrite-html', elapsedMs: 0, ok: false, exitCode: 1 };
         const report = renderReport(context,
-            failedSide === 'pr' ? failed : passed, failedSide === 'baseline' ? failed : passed);
+            [failedSide === 'pr' ? failed : passed], [failedSide === 'baseline' ? failed : passed]);
         assert.match(report, /✗ (PR|trunk) exit 1/);
         assert.doesNotMatch(report, /🟢|🔴|⚪/);
+        assert.doesNotMatch(report, /<summary>Changes of 5% or less/);
     });
 }
 
 test('a missing baseline is reported without inventing a zero time', context => {
-    const report = renderReport(context, { stage: 'url-rewrite-html', elapsedMs: 1000, attempts: 1, ok: true });
+    const report = renderReport(context, [{ stage: 'url-rewrite-html', elapsedMs: 1000, attempts: 1, ok: true }]);
     assert.match(report, /trunk baseline unavailable/);
     assert.doesNotMatch(report, /🟢|🔴|⚪/);
+    assert.doesNotMatch(report, /<summary>Changes of 5% or less/);
 });
+
+test('only changes above 5% stay visible, including small absolute time changes', context => {
+    const prResults = [
+        { stage: 'slower', elapsedMs: 106, ok: true },
+        { stage: 'faster', elapsedMs: 94, ok: true },
+        { stage: 'plus-five', elapsedMs: 105, ok: true },
+        { stage: 'minus-five', elapsedMs: 95, ok: true },
+        { stage: 'unchanged', elapsedMs: 100, ok: true },
+        { stage: 'below-five', elapsedMs: 104, ok: true },
+    ];
+    const report = renderReport(context, prResults, prResults.map(result => ({ ...result, elapsedMs: 100 })));
+    const [visible, collapsed] = report.split('<details>\n<summary>Changes of 5% or less (4)</summary>');
+
+    assert.ok(collapsed, 'The small changes must have a closed details section.');
+    assert.match(visible, /`slower`.*🔴 \+6 ms \(\+6\.0%\)/);
+    assert.match(visible, /`faster`.*🟢 -6 ms \(-6\.0%\)/);
+    for (const stage of ['plus-five', 'minus-five', 'unchanged', 'below-five']) {
+        assert.ok(!visible.includes(`\`${stage}\``), `${stage} must not stay visible.`);
+        assert.ok(collapsed.includes(`\`${stage}\``), `${stage} must stay available in the collapsed table.`);
+    }
+    for (const { stage } of prResults) {
+        assert.equal(report.split(`\`${stage}\``).length - 1, 1, `${stage} must appear exactly once.`);
+    }
+    assert.equal(report.match(/\| Stage \|/g).length, 2);
+});
+
+test('an all-small-change report has no empty visible table', context => {
+    const results = [{ stage: 'url-rewrite-html', elapsedMs: 1000, ok: true }];
+    const report = renderReport(context, results, results);
+    assert.match(report, /No changes above 5%\./);
+    assert.match(report, /<details>\n<summary>Changes of 5% or less \(1\)<\/summary>\n\n\| Stage/);
+    assert.equal(report.match(/\| Stage \|/g).length, 1);
+});
+
+test('a missing or zero-time baseline row stays visible beside collapsed comparisons', context => {
+    const report = renderReport(context, [
+        { stage: 'missing', elapsedMs: 100, ok: true },
+        { stage: 'zero-time', elapsedMs: 100, ok: true },
+        { stage: 'unchanged', elapsedMs: 100, ok: true },
+    ], [
+        { stage: 'zero-time', elapsedMs: 0, ok: true },
+        { stage: 'unchanged', elapsedMs: 100, ok: true },
+    ]);
+    const [visible, collapsed] = report.split('<details>\n<summary>Changes of 5% or less (1)</summary>');
+    assert.ok(collapsed);
+    assert.match(visible, /`missing`.*—.*No trunk result/);
+    assert.match(visible, /`zero-time`.*—.*Zero trunk time/);
+    assert.doesNotMatch(visible, /🟢|🔴|⚪/);
+    assert.match(report, /\*\*Total:\*\* PR 300 ms · trunk 100 ms · —/);
+});
+
+for (const withBaseline of [true, false]) {
+    test(`metrics stay in one closed table cell, ${withBaseline ? 'with' : 'without'} a baseline`, context => {
+        const pr = {
+            stage: 'url-rewrite-html', elapsedMs: 200, ok: true, attempts: 1,
+            details: { rows: 128, sample_ms: '200, 201, 199', note: '<value>|line\nnext & last', omitted: null },
+        };
+        const baseline = { ...pr, elapsedMs: 100, details: { rows: 128, sample_ms: '100, 101, 99' } };
+        const report = renderReport(context, [pr], withBaseline ? [baseline] : undefined);
+        const row = report.split('\n').find(line => line.startsWith('| `url-rewrite-html`'));
+
+        assert.match(row, /\| <details><summary>Metrics<\/summary>PR:<br>rows=128<br>sample_ms=200, 201, 199/);
+        assert.match(row, /note=&lt;value&gt;&#124;line<br>next &amp; last/);
+        if (withBaseline) {
+            assert.match(row, /trunk:<br>rows=128<br>sample_ms=100, 101, 99/);
+        }
+        assert.match(row, /<\/details> \|$/);
+        assert.equal(row.match(/<details>/g).length, 1);
+        assert.doesNotMatch(row, /omitted=/);
+    });
+}

--- a/tests/e2e/benchmark/url-rewrite-fixtures.php
+++ b/tests/e2e/benchmark/url-rewrite-fixtures.php
@@ -1,0 +1,119 @@
+<?php
+
+use WordPress\DataLiberation\BlockMarkup\BlockMarkupProcessor;
+
+const REPRINT_URL_REWRITE_BENCHMARK_CASES = [
+    'html',
+    'style-elements',
+    'blocks-literal-urls',
+    'blocks-nested-html',
+    'blocks-repeated-urls',
+    'blocks-escaped-quotes',
+    'blocks-encoded-shortcodes',
+    'blocks-no-source-urls',
+    'serialized-options',
+];
+
+/**
+ * Build one post or option. IDs vary both the value and its URLs so whole-value
+ * cache hits cannot hide parsing costs. The repeated-URL case varies only text.
+ *
+ * @return array {
+ *     @type string       $input    Source database value.
+ *     @type string|array $expected Target text, or decoded attributes in block order.
+ * }
+ */
+function reprint_url_rewrite_benchmark_fixture(string $scenario, int $row): array
+{
+    $input = '';
+    $expected = strpos($scenario, 'blocks-') === 0 ? [] : '';
+    $source_values = [];
+    $target_values = [];
+    for ($block = 0; $block < 32; ++$block) {
+        $id = $row * 32 + $block;
+        $url_id = $scenario === 'blocks-repeated-urls' ? 0 : $id;
+        $source = 'https://source.example/article/' . $url_id;
+        $target = 'https://destination.example/article/' . $url_id;
+        $source_html = '<p>Article ' . $id . ' <a href="' . $source . '">Read</a></p>';
+        $target_html = '<p>Article ' . $id . ' <a href="' . $target . '">Read</a></p>';
+
+        switch ($scenario) {
+            case 'html':
+                $input .= $source_html;
+                $expected .= $target_html;
+                continue 2;
+            case 'style-elements':
+                $input .= '<style>.article-' . $id . '{background:url("' . $source . '")}</style>';
+                $expected .= '<style>.article-' . $id . '{background:url("' . $target . '")}</style>';
+                continue 2;
+            case 'serialized-options':
+                $source_values[$id] = ['url' => $source, 'label' => 'Article ' . $id];
+                $target_values[$id] = ['url' => $target, 'label' => 'Article ' . $id];
+                continue 2;
+            case 'blocks-literal-urls':
+                $source_value = $source;
+                $target_value = $target;
+                break;
+            case 'blocks-nested-html':
+            case 'blocks-repeated-urls':
+            case 'blocks-escaped-quotes':
+                $source_value = $source_html;
+                $target_value = $target_html;
+                break;
+            case 'blocks-encoded-shortcodes':
+                $source_value = '[vc_raw_html]' . base64_encode($source_html) . '[/vc_raw_html]';
+                $target_value = '[vc_raw_html]' . base64_encode($target_html) . '[/vc_raw_html]';
+                break;
+            case 'blocks-no-source-urls':
+                $source_value = 'Article ' . $id . ': plain text with no source URL.';
+                $target_value = $source_value;
+                break;
+            default:
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI error text, not HTML output.
+                throw new InvalidArgumentException('Unknown URL benchmark case: ' . $scenario);
+        }
+
+        // Divi stores content inside module.content.value. Keep ordinary settings
+        // beside it: the removed fast path scanned these strings too.
+        $attributes = [
+            'module' => [
+                'content' => ['value' => $source_value],
+                'settings' => ['label' => 'Article ' . $id, 'color' => '#123456', 'spacing' => '16px'],
+            ],
+        ];
+        $flags = $scenario === 'blocks-escaped-quotes' ? JSON_HEX_QUOT : 0;
+        $input .= '<!-- wp:divi/text ' . json_encode($attributes, $flags) . ' /-->';
+        $attributes['module']['content']['value'] = $target_value;
+        $expected[] = $attributes;
+    }
+
+    if ($scenario === 'serialized-options') {
+        $input = serialize($source_values);
+        $expected = serialize($target_values);
+    }
+    return ['input' => $input, 'expected' => $expected];
+}
+
+/**
+ * Reject skipped rewrites, lost text and duplicate blocks before reporting speed.
+ * Block JSON may change whitespace or escaping; its decoded values must match.
+ *
+ * @param string|array $expected Target text, or decoded attributes in block order.
+ */
+function reprint_check_url_rewrite_benchmark_output(string $output, $expected): void
+{
+    $actual = $output;
+    if (is_array($expected)) {
+        $actual = [];
+        $parser = new BlockMarkupProcessor($output);
+        while ($parser->next_token()) {
+            if ($parser->get_token_type() !== '#block-comment' || $parser->get_block_name() !== 'wp:divi/text') {
+                throw new RuntimeException('The URL benchmark output contains an unexpected token.');
+            }
+            $actual[] = $parser->get_block_attributes();
+        }
+    }
+    if ($actual !== $expected) {
+        throw new RuntimeException('The URL benchmark output does not match the expected target content.');
+    }
+}


### PR DESCRIPTION
Adds nine URL rewriting cases to every PR's performance report, including the plain Divi blocks that used the fast path removed in #795.

Each case gets its own PR time, trunk time and percentage change. The same inputs run against both PHARs, using five samples and reporting the median. All output is checked outside the timer. Missing blocks, duplicate blocks and skipped rewrites fail; they cannot appear as speed improvements.

Changes above 5% in either direction stay visible. Smaller changes go in a collapsed table, and each row's metrics have their own toggle. Failed or unavailable comparisons stay visible.

The cases cover HTML, STYLE bodies, plain block URLs, nested Divi HTML, repeated URLs, escaped quotes, encoded shortcodes, unchanged blocks and serialized options. They always run, even when `focused-stages.txt` selects only SQLite stages.

The workflows now pass `IMPORTER_PATH`, which the runner actually reads. They previously passed `CLIENT_PATH`, leaving the runner on checked-out source instead of selecting the PR and trunk PHARs.

## Example: #795

Local comparison of CI-built PHARs on PHP 8.4.5, repeated in reverse order:

| Case | Trunk | #795 | Time ratio |
| --- | ---: | ---: | ---: |
| Nested Divi HTML | 61 ms | 928 ms | 15.1× |
| Nested HTML with repeated URLs | 60 ms | 454 ms | 7.5× |
| Escaped quotes in nested HTML | 1,067 ms | 936 ms | 0.9× |

These are URL rewrite times for 128 values with 32 entries each, not full import times. No production rewriter changes here.

## Testing

The URL suite and report tests pass. Both #795 and trunk passed every corpus check. The performance artifact contains all nine URL cases for both builds, with five samples each; the recorded implementation paths confirm that PR and trunk loaded their own PHARs. See [benchmark notes](tests/e2e/benchmark/README.md) for the inputs, timing limits and local commands.
